### PR TITLE
8387965: Incorrect line numbers for instanceof with pattern matching

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -1557,7 +1557,7 @@ public class TransPatterns extends TreeTranslator {
             //=>
             //(let T N; (let T' N$temp = E; N$temp instanceof T && (N = (T) N$temp == (T) N$temp)) && /*use of N*/)
             for (VarSymbol vsym : hoistedVarMap.values()) {
-                int pos = TreeInfo.getStartPos(expr); //XXXX: untested!
+                int pos = TreeInfo.getStartPos(expr);
                 expr = make.at(pos).LetExpr(makeHoistedVarDecl(pos, vsym), expr).setType(expr.type);
             }
             return expr;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -258,12 +258,14 @@ public class TransPatterns extends TreeTranslator {
                     extraConditions = translate(extraConditions);
                     resultExpression = makeBinary(Tag.AND, resultExpression, extraConditions);
                 }
-                if (currentValue != exprSym) {
-                    resultExpression =
-                            make.at(tree.pos).LetExpr(make.VarDef(currentValue, translatedExpr),
-                                                      resultExpression).setType(syms.booleanType);
-                    ((LetExpr) resultExpression).needsCond = true;
-                }
+                List<JCStatement> tempVars = currentValue != exprSym
+                        ? List.of(make.VarDef(currentValue, translatedExpr))
+                        : List.nil();
+                resultExpression =
+                        make.at(tree.pos).LetExpr(tempVars,
+                                                  resultExpression).setType(syms.booleanType);
+                ((LetExpr) resultExpression).needsCond = true;
+                ((LetExpr) resultExpression).needsLineNumberTableEntry = true;
                 result = bindingContext.decorateExpression(resultExpression);
             } finally {
                 currentValue = prevCurrentValue;
@@ -1555,7 +1557,8 @@ public class TransPatterns extends TreeTranslator {
             //=>
             //(let T N; (let T' N$temp = E; N$temp instanceof T && (N = (T) N$temp == (T) N$temp)) && /*use of N*/)
             for (VarSymbol vsym : hoistedVarMap.values()) {
-                expr = make.at(expr.pos).LetExpr(makeHoistedVarDecl(expr.pos, vsym), expr).setType(expr.type);
+                int pos = TreeInfo.getStartPos(expr); //XXXX: untested!
+                expr = make.at(pos).LetExpr(makeHoistedVarDecl(pos, vsym), expr).setType(expr.type);
             }
             return expr;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -741,6 +741,11 @@ public class Gen extends JCTree.Visitor {
             code.resolvePending();
 
             LetExpr tree = (LetExpr) inner_tree;
+
+            if (tree.needsLineNumberTableEntry) {
+                code.statBegin(tree.pos);
+            }
+
             int limit = code.nextreg;
             int prevLetExprStart = code.setLetExprStackPos(code.state.stacksize);
             try {
@@ -2434,6 +2439,10 @@ public class Gen extends JCTree.Visitor {
 
     public void visitLetExpr(LetExpr tree) {
         code.resolvePending();
+
+        if (tree.needsLineNumberTableEntry) {
+            code.statBegin(tree.pos);
+        }
 
         int limit = code.nextreg;
         int prevLetExprStart = code.setLetExprStackPos(code.state.stacksize);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -3448,6 +3448,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public JCExpression expr;
         /**true if a expr should be run through Gen.genCond:*/
         public boolean needsCond;
+        public boolean needsLineNumberTableEntry;
         protected LetExpr(List<JCStatement> defs, JCExpression expr) {
             this.defs = defs;
             this.expr = expr;

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/LineNumberTestBase.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/LineNumberTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/LineNumberTestBase.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/LineNumberTestBase.java
@@ -92,6 +92,7 @@ public class LineNumberTestBase extends TestBase {
 
                         if (expected != null) {
                             verifyCoveredLines(methodCoveredLines, expected);
+                            expected.validator().accept(classFile, m);
                         }
 
                         coveredLines.addAll(methodCoveredLines);

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/PatternMatching.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/PatternMatching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/PatternMatching.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/PatternMatching.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387965
+ * @summary Tests a line number table attribute for pattern matching
+ * @library /tools/lib /tools/javac/lib ../lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          java.base/jdk.internal.classfile.impl
+ * @build toolbox.ToolBox InMemoryFileManager TestBase
+ * @build LineNumberTestBase TestCase
+ * @run main PatternMatching
+ */
+
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeElement;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.Instruction;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.LineNumber;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import toolbox.ToolBox;
+
+public class PatternMatching extends LineNumberTestBase {
+    static ToolBox tb = new ToolBox();
+
+    public static void main(String[] args) throws Exception {
+        new PatternMatching().test();
+    }
+
+    public void test() throws Exception {
+        test(List.of(TEST_CASE));
+    }
+
+    private static final TestCase[] TEST_CASE = new TestCase[] {
+        new TestCase("""
+                     public class PatternMatching {                        // 1
+                         private void test(String s) {                     // 2
+                             Object obj = "abc";                           // 3
+                             boolean isLong = obj instanceof String str    // 4
+                                &&                                         // 5
+                                true;                                      // 6
+                         }                                                 // 7
+                     }                                                     // 8
+                     """,
+                     "PatternMatching",
+                     new TestCase.MethodData("test", List.of(3, 4, 7), true, new DetailedValidator(
+                         "line: 3",
+                         "LDC",
+                         "ASTORE_2",
+                         "line: 4",
+                         "ALOAD_2",
+                         "INSTANCEOF",
+                         "IFEQ",
+                         "ALOAD_2",
+                         "CHECKCAST",
+                         "ASTORE",
+                         "ICONST_1",
+                         "GOTO",
+                         "ICONST_0",
+                         "ISTORE_3",
+                         "line: 7",
+                         "RETURN"))),
+        new TestCase("""
+                     public class PatternMatching {                        // 1
+                         private void test(String s) {                     // 2
+                             Object obj = "abc";                           // 3
+                             boolean isLong = true                         // 4
+                                &&                                         // 5
+                                obj instanceof String str2;                // 6
+                         }                                                 // 7
+                     }                                                     // 8
+                     """,
+                     "PatternMatching",
+                     new TestCase.MethodData("test", List.of(3, 6, 7), true, new DetailedValidator(
+                         "line: 3",
+                         "LDC",
+                         "ASTORE_2",
+                         "line: 6",
+                         "ALOAD_2",
+                         "INSTANCEOF",
+                         "IFEQ",
+                         "ALOAD_2",
+                         "CHECKCAST",
+                         "ASTORE",
+                         "ICONST_1",
+                         "GOTO",
+                         "ICONST_0",
+                         "ISTORE_3",
+                         "line: 7",
+                         "RETURN"
+                     ))),
+        new TestCase("""
+                     public class PatternMatching {                        // 1
+                         private void test(String s) {                     // 2
+                             Object obj = "abc";                           // 3
+                             boolean isLong = obj instanceof String str1   // 4
+                                &&                                         // 5
+                                obj instanceof String str2;                // 6
+                         }                                                 // 7
+                     }                                                     // 8
+                     """,
+                     "PatternMatching",
+                     new TestCase.MethodData("test", List.of(3, 4, 6, 7), true, new DetailedValidator(
+                         "line: 3",
+                         "LDC",
+                         "ASTORE_2",
+                         "line: 4",
+                         "ALOAD_2",
+                         "INSTANCEOF",
+                         "IFEQ",
+                         "ALOAD_2",
+                         "CHECKCAST",
+                         "ASTORE",
+                         "line: 6",
+                         "ALOAD_2",
+                         "INSTANCEOF",
+                         "IFEQ",
+                         "ALOAD_2",
+                         "CHECKCAST",
+                         "ASTORE",
+                         "ICONST_1",
+                         "GOTO",
+                         "ICONST_0",
+                         "ISTORE_3",
+                         "line: 7",
+                         "RETURN"
+                     ))),
+        new TestCase("""
+                     public class PatternMatching {                        // 1
+                         private void test(String s) {                     // 2
+                             Object obj = "abc";                           // 3
+                             boolean isLong = obj instanceof String str    // 4
+                                &&                                         // 5
+                                check();                                   // 6
+                         }                                                 // 7
+                         private boolean check() { return true; }          // 8
+                     }                                                     // 9
+                     """,
+                     "PatternMatching",
+                     new TestCase.MethodData("test", List.of(3, 4, 6, 7), true, new DetailedValidator(
+                         "line: 3",
+                         "LDC",
+                         "ASTORE_2",
+                         "line: 4",
+                         "ALOAD_2",
+                         "INSTANCEOF",
+                         "IFEQ",
+                         "ALOAD_2",
+                         "CHECKCAST",
+                         "ASTORE",
+                         "ALOAD_0",
+                         "line: 6",
+                         "INVOKEVIRTUAL",
+                         "IFEQ",
+                         "ICONST_1",
+                         "GOTO",
+                         "ICONST_0",
+                         "ISTORE_3",
+                         "line: 7",
+                         "RETURN"))),
+        new TestCase("""
+                     public class PatternMatching {                        // 1
+                         private void test(String s) {                     // 2
+                             Object obj = "abc";                           // 3
+                             boolean isLong = check()                      // 4
+                                &&                                         // 5
+                                obj instanceof String str2;                // 6
+                         }                                                 // 7
+                         private boolean check() { return true; }          // 8
+                     }                                                     // 9
+                     """,
+                     "PatternMatching",
+                     new TestCase.MethodData("test", List.of(3, 4, 6, 7), true, new DetailedValidator(
+                        "line: 3",
+                        "LDC",
+                        "ASTORE_2",
+                        "line: 4",
+                        "ALOAD_0",
+                        "INVOKEVIRTUAL",
+                        "IFEQ",
+                        "line: 6",
+                        "ALOAD_2",
+                        "INSTANCEOF",
+                        "IFEQ",
+                        "ALOAD_2",
+                        "CHECKCAST",
+                        "ASTORE",
+                        "ICONST_1",
+                        "GOTO",
+                        "ICONST_0",
+                        "ISTORE_3",
+                        "line: 7",
+                         "RETURN"
+                     ))),
+        new TestCase("""
+                     public class PatternMatching {                        // 1
+                         private void test(String s) {                     // 2
+                             boolean isLong = obj() instanceof String str  // 3
+                                &&                                         // 4
+                                true;                                      // 5
+                         }                                                 // 6
+                         private Object obj() { return "abc"; }            // 7
+                     }                                                     // 8
+                     """,
+                     "PatternMatching",
+                     new TestCase.MethodData("test", List.of(3, 6), true, new DetailedValidator(
+                         "line: 3",
+                         "ALOAD_0",
+                         "INVOKEVIRTUAL",
+                         "ASTORE",
+                         "ALOAD",
+                         "INSTANCEOF",
+                         "IFEQ",
+                         "ALOAD",
+                         "CHECKCAST",
+                         "ASTORE_3",
+                         "ICONST_1",
+                         "GOTO",
+                         "ICONST_0",
+                         "ISTORE_2",
+                         "line: 6",
+                         "RETURN"))),
+        new TestCase("""
+                     public class PatternMatching {                        // 1
+                         private void test(String s) {                     // 2
+                             boolean isLong = true                         // 3
+                                &&                                         // 4
+                                obj() instanceof String str;               // 5
+                         }                                                 // 6
+                         private Object obj() { return "abc"; }            // 7
+                     }                                                     // 8
+                     """,
+                     "PatternMatching",
+                     new TestCase.MethodData("test", List.of(5, 6), true, new DetailedValidator(
+                         "line: 5",
+                         "ALOAD_0",
+                         "INVOKEVIRTUAL",
+                         "ASTORE",
+                         "ALOAD",
+                         "INSTANCEOF",
+                         "IFEQ",
+                         "ALOAD",
+                         "CHECKCAST",
+                         "ASTORE_3",
+                         "ICONST_1",
+                         "GOTO",
+                         "ICONST_0",
+                         "ISTORE_2",
+                         "line: 6",
+                         "RETURN"))),
+        new TestCase("""
+                     public class PatternMatching {                        // 1
+                         private void test(String s) {                     // 2
+                             boolean isLong = obj() instanceof String str1 // 3
+                                &&                                         // 4
+                                obj() instanceof String str2;              // 5
+                         }                                                 // 6
+                         private Object obj() { return "abc"; }            // 7
+                     }                                                     // 8
+                     """,
+                     "PatternMatching",
+                     new TestCase.MethodData("test", List.of(3, 5, 6), true, new DetailedValidator(
+                            "line: 3",
+                            "ALOAD_0",
+                            "INVOKEVIRTUAL",
+                            "ASTORE",
+                            "ALOAD",
+                            "INSTANCEOF",
+                            "IFEQ",
+                            "ALOAD",
+                            "CHECKCAST",
+                            "ASTORE",
+                            "line: 5",
+                            "ALOAD_0",
+                            "INVOKEVIRTUAL",
+                            "ASTORE",
+                            "ALOAD",
+                            "INSTANCEOF",
+                            "IFEQ",
+                            "ALOAD",
+                            "CHECKCAST",
+                            "ASTORE_3",
+                            "ICONST_1",
+                            "GOTO",
+                            "ICONST_0",
+                            "ISTORE_2",
+                            "line: 6",
+                            "RETURN"))),
+    };
+
+    private static final class DetailedValidator implements BiConsumer<ClassModel, MethodModel> {
+
+        private final List<String> expectedMethodContent;
+
+        public DetailedValidator(String... expectedMethodContent) {
+            this.expectedMethodContent = List.of(expectedMethodContent);
+        }
+
+        @Override
+        public void accept(ClassModel classFile, MethodModel m) {
+            CodeModel code = (CodeModel) m.code().get();
+            List<String> methodContent = new ArrayList<>();
+            for (CodeElement el : code) {
+                switch (el) {
+                    case Instruction instr -> methodContent.add(instr.opcode().name());
+                    case LineNumber ln -> methodContent.add("line: " + ln.line());
+                    case CodeElement _ -> {}
+                }
+            }
+            methodContent.forEach(System.err::println);
+            tb.checkEqual(expectedMethodContent, methodContent);
+        }
+    }
+}

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/TestCase.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/TestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/TestCase.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/TestCase.java
@@ -21,10 +21,13 @@
  * questions.
  */
 
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 /**
  * TestCase contains source code to be compiled
@@ -74,7 +77,11 @@ public class TestCase {
         return null;
     }
 
-    record MethodData(String methodName, Collection<Integer> expectedLines, boolean exactLines) {
+    record MethodData(String methodName, Collection<Integer> expectedLines, boolean exactLines, BiConsumer<ClassModel, MethodModel> validator) {
+
+        public MethodData(String methodName, Collection<Integer> expectedLines, boolean exactLines) {
+            this(methodName, expectedLines, exactLines, (_, _) -> {});
+        }
 
         public MethodData {
             expectedLines = new HashSet<>(expectedLines);


### PR DESCRIPTION
Consider code like:
```
public class Test1 {                                  // 1
    private void test(String s) {                     // 2
        Object obj = "abc";                           // 3
        boolean b = obj instanceof String str         // 4
                &&                                    // 5
                true;                                 // 6
    }                                                 // 7
}                                                     // 8
```

When this is compiled, the method's `LineNumberTable` will look like this:
```
  private void test(java.lang.String);
    descriptor: (Ljava/lang/String;)V
    flags: (0x0002) ACC_PRIVATE
    Code:
      stack=1, locals=5, args_size=2
         0: ldc           #7                  // String abc
         2: astore_2
         3: aload_2
         4: instanceof    #9                  // class java/lang/String
         7: ifeq          20
        10: aload_2
        11: checkcast     #9                  // class java/lang/String
        14: astore        4
        16: iconst_1
        17: goto          21
        20: iconst_0
        21: istore_3
        22: return
      LineNumberTable:
        line 3: 0
        line 5: 3
        line 4: 10
        line 7: 22
```

Note the line 5 starting at bytecode offset 3, where the actual `instanceof`, which is on line 4, starts. The reason for this is that we need to hoist `String str` to the beginning of the expression using a `LetExpr`, but when constructing the `LetExpr`, we use a position that corresponds to `JCBinary.pos`, which points to `&&`. This can be easily solved by using a start pos instead of the preferred pos (in `TransPatterns`):

```
  private void test(java.lang.String);
    descriptor: (Ljava/lang/String;)V
    flags: (0x0002) ACC_PRIVATE
    Code:
      stack=1, locals=5, args_size=2
         0: ldc           #7                  // String abc
         2: astore_2
         3: aload_2
         4: instanceof    #9                  // class java/lang/String
         7: ifeq          20
        10: aload_2
        11: checkcast     #9                  // class java/lang/String
        14: astore        4
        16: iconst_1
        17: goto          21
        20: iconst_0
        21: istore_3
        22: return
      LineNumberTable:
        line 3: 0
        line 4: 3
        line 7: 22
```

which looks much better.

But, even with this change, there's another problem, for code like:
```
public class Test2 {                                  // 1
    private void test(String s) {                     // 2
        Object obj = "abc";                           // 3
        boolean b = obj instanceof String str         // 4
                &&                                    // 5
                obj instanceof Integer i;             // 6
    }                                                 // 7
}                                                     // 8
```

we get:
```
  private void test(java.lang.String);
    descriptor: (Ljava/lang/String;)V
    flags: (0x0002) ACC_PRIVATE
    Code:
      stack=1, locals=6, args_size=2
         0: ldc           #7                  // String abc
         2: astore_2
         3: aload_2
         4: instanceof    #9                  // class java/lang/String
         7: ifeq          33
        10: aload_2
        11: checkcast     #9                  // class java/lang/String
        14: astore        5
        16: aload_2
        17: instanceof    #11                 // class java/lang/Integer
        20: ifeq          33
        23: aload_2
        24: checkcast     #11                 // class java/lang/Integer
        27: astore        4
        29: iconst_1
        30: goto          34
        33: iconst_0
        34: istore_3
        35: return
      LineNumberTable:
        line 3: 0
        line 4: 3
        line 6: 23
        line 7: 35
```

while we don't have the weird entry for line 5, the code for line 4 includes not only the `instanceof` for `String` (line 4), but also the `instanceof` for `Integer` (line 6). Line 6 effectively only starts when `obj` is cast to `Integer`. This seems not ideal.

The pattern matching `instanceof` is expanded to (another/different) `LetExpr`. The proposal here is to mark this `LetExpr` in a special way, that will ensure it will get a `LineNumberTable` entry if needed (similarly to method invocations). With this change, we get:
```
  private void test(java.lang.String);
    descriptor: (Ljava/lang/String;)V
    flags: (0x0002) ACC_PRIVATE
    Code:
      stack=1, locals=6, args_size=2
         0: ldc           #7                  // String abc
         2: astore_2
         3: aload_2
         4: instanceof    #9                  // class java/lang/String
         7: ifeq          33
        10: aload_2
        11: checkcast     #9                  // class java/lang/String
        14: astore        5
        16: aload_2
        17: instanceof    #11                 // class java/lang/Integer
        20: ifeq          33
        23: aload_2
        24: checkcast     #11                 // class java/lang/Integer
        27: astore        4
        29: iconst_1
        30: goto          34
        33: iconst_0
        34: istore_3
        35: return
      LineNumberTable:
        line 3: 0
        line 4: 3
        line 6: 16
        line 7: 35
```

which seems sensible to me.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387965](https://bugs.openjdk.org/browse/JDK-8387965): Incorrect line numbers for instanceof with pattern matching (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31879/head:pull/31879` \
`$ git checkout pull/31879`

Update a local copy of the PR: \
`$ git checkout pull/31879` \
`$ git pull https://git.openjdk.org/jdk.git pull/31879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31879`

View PR using the GUI difftool: \
`$ git pr show -t 31879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31879.diff">https://git.openjdk.org/jdk/pull/31879.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31879#issuecomment-4956443358)
</details>
