### PR TITLE
8321012: RISC-V: C2 ExtractUB

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -3295,6 +3295,17 @@ void C2_MacroAssembler::extract_v(Register dst, VectorRegister src,
   }
 }
 
+// Extract a scalar element from a vector at position 'idx'.
+// The input elements in src are expected to be of integral type.
+void C2_MacroAssembler::extract_v(Register dst, VectorRegister src,
+                                  BasicType bt, Register idx, VectorRegister vtmp) {
+  assert(is_integral_type(bt), "unsupported element type");
+  // Only need the first element after vector slidedown
+  vsetvli_helper(bt, 1);
+  vslidedown_vx(vtmp, src, idx);
+  vmv_x_s(dst, vtmp);
+}
+
 // Extract a scalar element from an vector at position 'idx'.
 // The input elements in src are expected to be of floating point type.
 void C2_MacroAssembler::extract_fp_v(FloatRegister dst, VectorRegister src,

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -299,6 +299,9 @@
   void extract_v(Register dst, VectorRegister src,
                  BasicType bt, int idx, VectorRegister vtmp);
 
+  void extract_v(Register dst, VectorRegister src,
+                 BasicType bt, Register idx, VectorRegister vtmp);
+
   void extract_fp_v(FloatRegister dst, VectorRegister src,
                     BasicType bt, int idx, VectorRegister vtmp);
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -4998,21 +4998,6 @@ instruct rearrange_masked(vReg dst, vReg src, vReg shuffle, vRegMask_V0 v0) %{
 
 // ------------------------------ Vector extract ---------------------------------
 
-instruct extractUB_index_imm(iRegINoSp dst, vReg src, immI idx, vReg tmp)
-%{
-  match(Set dst (ExtractUB src idx));
-  effect(TEMP tmp);
-  format %{ "extractUB_index_imm $dst, $src, $idx\t# KILL $tmp" %}
-  ins_encode %{
-    // Input "src" is a vector of boolean represented as
-    // bytes with 0x00/0x01 as element values.
-    // "idx" is expected to be in range.
-    __ extract_v($dst$$Register, as_VectorRegister($src$$reg), T_BOOLEAN,
-                 (int)($idx$$constant), as_VectorRegister($tmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 instruct extract(iRegINoSp dst, vReg src, immI idx, vReg tmp)
 %{
   match(Set dst (ExtractB src idx));
@@ -5024,21 +5009,6 @@ instruct extract(iRegINoSp dst, vReg src, immI idx, vReg tmp)
     __ extract_v($dst$$Register, as_VectorRegister($src$$reg),
                  Matcher::vector_element_basic_type(this, $src), (int)($idx$$constant),
                  as_VectorRegister($tmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct extractUB_index_reg(iRegINoSp dst, vReg src, iRegI idx, vReg tmp)
-%{
-  match(Set dst (ExtractUB src idx));
-  effect(TEMP tmp);
-  format %{ "extractUB_index_reg $dst, $src, $idx\t# KILL $tmp" %}
-  ins_encode %{
-    // Input "src" is a vector of boolean represented as
-    // bytes with 0x00/0x01 as element values.
-    // "idx" is expected to be in range.
-    __ extract_v($dst$$Register, as_VectorRegister($src$$reg), T_BOOLEAN,
-                 $idx$$Register, as_VectorRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5076,6 +5046,36 @@ instruct extractD(fRegD dst, vReg src, immI idx, vReg tmp)
   ins_encode %{
     __ extract_fp_v($dst$$FloatRegister, as_VectorRegister($src$$reg), T_DOUBLE,
                     (int)($idx$$constant), as_VectorRegister($tmp$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct extractUB_index_imm(iRegINoSp dst, vReg src, immI idx, vReg tmp)
+%{
+  match(Set dst (ExtractUB src idx));
+  effect(TEMP tmp);
+  format %{ "extractUB_index_imm $dst, $src, $idx\t# KILL $tmp" %}
+  ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    // "idx" is expected to be in range.
+    __ extract_v($dst$$Register, as_VectorRegister($src$$reg), T_BOOLEAN,
+                 (int)($idx$$constant), as_VectorRegister($tmp$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct extractUB_index_reg(iRegINoSp dst, vReg src, iRegI idx, vReg tmp)
+%{
+  match(Set dst (ExtractUB src idx));
+  effect(TEMP tmp);
+  format %{ "extractUB_index_reg $dst, $src, $idx\t# KILL $tmp" %}
+  ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    // "idx" is expected to be in range.
+    __ extract_v($dst$$Register, as_VectorRegister($src$$reg), T_BOOLEAN,
+                 $idx$$Register, as_VectorRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -4998,9 +4998,23 @@ instruct rearrange_masked(vReg dst, vReg src, vReg shuffle, vRegMask_V0 v0) %{
 
 // ------------------------------ Vector extract ---------------------------------
 
-instruct extract(iRegINoSp dst, vReg src, immI idx, vReg tmp)
+instruct extractUB_index_imm(iRegINoSp dst, vReg src, immI idx, vReg tmp)
 %{
   match(Set dst (ExtractUB src idx));
+  effect(TEMP tmp);
+  format %{ "extractUB_index_imm $dst, $src, $idx\t# KILL $tmp" %}
+  ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    // "idx" is expected to be in range.
+    __ extract_v($dst$$Register, as_VectorRegister($src$$reg), T_BOOLEAN,
+                 (int)($idx$$constant), as_VectorRegister($tmp$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct extract(iRegINoSp dst, vReg src, immI idx, vReg tmp)
+%{
   match(Set dst (ExtractB src idx));
   match(Set dst (ExtractS src idx));
   match(Set dst (ExtractI src idx));
@@ -5014,12 +5028,15 @@ instruct extract(iRegINoSp dst, vReg src, immI idx, vReg tmp)
   ins_pipe(pipe_slow);
 %}
 
-instruct extractUB_var(iRegINoSp dst, vReg src, iRegI idx, vReg tmp)
+instruct extractUB_index_reg(iRegINoSp dst, vReg src, iRegI idx, vReg tmp)
 %{
   match(Set dst (ExtractUB src idx));
   effect(TEMP tmp);
-  format %{ "extractUB_var $dst, $src, $idx\t# KILL $tmp" %}
+  format %{ "extractUB_index_reg $dst, $src, $idx\t# KILL $tmp" %}
   ins_encode %{
+    // Input "src" is a vector of boolean represented as
+    // bytes with 0x00/0x01 as element values.
+    // "idx" is expected to be in range.
     __ extract_v($dst$$Register, as_VectorRegister($src$$reg), T_BOOLEAN,
                  $idx$$Register, as_VectorRegister($tmp$$reg));
   %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -5000,6 +5000,7 @@ instruct rearrange_masked(vReg dst, vReg src, vReg shuffle, vRegMask_V0 v0) %{
 
 instruct extract(iRegINoSp dst, vReg src, immI idx, vReg tmp)
 %{
+  match(Set dst (ExtractUB src idx));
   match(Set dst (ExtractB src idx));
   match(Set dst (ExtractS src idx));
   match(Set dst (ExtractI src idx));
@@ -5009,6 +5010,18 @@ instruct extract(iRegINoSp dst, vReg src, immI idx, vReg tmp)
     __ extract_v($dst$$Register, as_VectorRegister($src$$reg),
                  Matcher::vector_element_basic_type(this, $src), (int)($idx$$constant),
                  as_VectorRegister($tmp$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct extractUB_var(iRegINoSp dst, vReg src, iRegI idx, vReg tmp)
+%{
+  match(Set dst (ExtractUB src idx));
+  effect(TEMP tmp);
+  format %{ "extractUB_var $dst, $src, $idx\t# KILL $tmp" %}
+  ins_encode %{
+    __ extract_v($dst$$Register, as_VectorRegister($src$$reg), T_BOOLEAN,
+                 $idx$$Register, as_VectorRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMaskLaneIsSetTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMaskLaneIsSetTest.java
@@ -68,8 +68,8 @@ public class VectorMaskLaneIsSetTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 6" }, applyIfCPUFeature = { "asimd", "true" })
-    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 6" }, applyIfCPUFeatureOr = { "avx2", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 6" }, applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 6" }, applyIfCPUFeature = { "avx2", "true" })
     public static void testVectorMaskLaneIsSetByte_const() {
         Asserts.assertEquals(ma[0], mask_b.laneIsSet(0));
         Asserts.assertEquals(ma[0], mask_s.laneIsSet(0));
@@ -80,8 +80,8 @@ public class VectorMaskLaneIsSetTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
-    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeatureOr = { "avx", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx", "true" })
     public static boolean testVectorMaskLaneIsSet_Byte_variable(int i) {
         return mask_b.laneIsSet(i);
     }
@@ -92,8 +92,8 @@ public class VectorMaskLaneIsSetTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
-    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeatureOr = { "avx", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx", "true" })
     public static boolean testVectorMaskLaneIsSet_Short_variable(int i) {
         return mask_s.laneIsSet(i);
     }
@@ -104,8 +104,8 @@ public class VectorMaskLaneIsSetTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
-    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeatureOr = { "avx", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx", "true" })
     public static boolean testVectorMaskLaneIsSet_Int_variable(int i) {
         return mask_i.laneIsSet(i);
     }
@@ -116,8 +116,8 @@ public class VectorMaskLaneIsSetTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
-    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeatureOr = { "avx2", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx2", "true" })
     public static boolean testVectorMaskLaneIsSet_Long_variable(int i) {
         return mask_l.laneIsSet(i);
     }
@@ -128,8 +128,8 @@ public class VectorMaskLaneIsSetTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
-    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeatureOr = { "avx", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx", "true" })
     public static boolean testVectorMaskLaneIsSet_Float_variable(int i) {
         return mask_f.laneIsSet(i);
     }
@@ -140,8 +140,8 @@ public class VectorMaskLaneIsSetTest {
     }
 
     @Test
-    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeature = { "asimd", "true" })
-    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeatureOr = { "avx2", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_LANE_IS_SET, "= 1" }, applyIfCPUFeatureOr = { "asimd", "true", "rvv", "true" })
+    @IR(counts = { IRNode.VECTOR_MASK_TO_LONG, "= 1" }, applyIfCPUFeature = { "avx2", "true" })
     public static boolean testVectorMaskLaneIsSet_Double_variable(int i) {
         return mask_d.laneIsSet(i);
     }


### PR DESCRIPTION
Hi, please consider.

As noted in the issue comments, the Vector API does not fall back to the Java implementation without ExtractUB as long as VectorMaskToLong is supported.

VectorMaskToLong is already implemented on RISC-V, so ExtractUB is not required for correctness. However, implementing it shows a clear performance improvement in VectorExtractBenchmark.java. This PR adds the RISC-V implementation.

The updated VectorMaskLaneIsSetTest was verified on SG2044 fastdebug.

### Testing
- [x] tier1 release on sg2044
- [x] jmh testing:
#### SG2044 (vlen=128bit) before
```
Benchmark                                                Mode  Cnt      Score       Error   Units
VectorExtractBenchmark.microMaskLaneIsSetByte128_con    thrpt    5  26597.575 ±  1532.913  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte128_var    thrpt    5  26406.291 ±  1484.326  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte256_con    thrpt    5   7648.522 ±   340.572  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte256_var    thrpt    5   7261.609 ±   405.649  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte512_con    thrpt    5   7687.041 ±   317.628  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte512_var    thrpt    5   7260.435 ±   306.761  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte64_con     thrpt    5  25909.858 ±  1006.706  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte64_var     thrpt    5  25943.955 ±  1114.350  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble128_con  thrpt    5  49600.348 ±  2015.452  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble128_var  thrpt    5  48697.225 ±  2004.608  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble256_con  thrpt    5  14087.640 ±   639.268  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble256_var  thrpt    5  13443.740 ±   469.528  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble512_con  thrpt    5   7607.526 ±   439.464  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble512_var  thrpt    5   7270.869 ±   310.000  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble64_con   thrpt    5  42982.474 ±  1180.116  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble64_var   thrpt    5  40175.981 ±  1781.762  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat128_con   thrpt    5  38478.588 ±  1541.057  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat128_var   thrpt    5  41186.723 ±  3419.629  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat256_con   thrpt    5   7485.397 ±  1416.455  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat256_var   thrpt    5   7283.971 ±   327.163  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat512_con   thrpt    5   7649.485 ±   330.863  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat512_var   thrpt    5   6959.958 ±  2711.768  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat64_con    thrpt    5  49323.783 ±  2927.553  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat64_var    thrpt    5  48624.178 ±  1846.360  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt128_con     thrpt    5  38527.355 ±  1488.745  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt128_var     thrpt    5  41548.496 ±  1624.575  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt256_con     thrpt    5   7644.357 ±   328.948  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt256_var     thrpt    5   7162.416 ±   301.319  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt512_con     thrpt    5   7718.560 ±   303.295  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt512_var     thrpt    5   7140.243 ±   332.466  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt64_con      thrpt    5  49378.527 ±  2865.946  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt64_var      thrpt    5  48516.702 ±  2172.615  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong128_con    thrpt    5  49598.942 ±  1895.195  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong128_var    thrpt    5  46705.616 ± 15421.800  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong256_con    thrpt    5  14140.650 ±   558.014  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong256_var    thrpt    5  13625.685 ±   642.149  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong512_con    thrpt    5   7653.109 ±   312.389  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong512_var    thrpt    5   7277.743 ±   305.047  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong64_con     thrpt    5  43006.885 ±  1670.854  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong64_var     thrpt    5  40315.518 ±  1677.991  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort128_con   thrpt    5  25817.990 ±  1081.830  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort128_var   thrpt    5  25956.156 ±  1097.803  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort256_con   thrpt    5   7654.815 ±   325.747  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort256_var   thrpt    5   7278.425 ±   305.481  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort512_con   thrpt    5   7665.816 ±   323.819  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort512_var   thrpt    5   7186.201 ±   300.562  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort64_con    thrpt    5  38470.998 ±  1575.303  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort64_var    thrpt    5  41396.755 ±  1972.867  ops/ms
```
#### SG2044 (vlen=128bit) after
```
Benchmark                                                Mode  Cnt      Score      Error   Units
VectorExtractBenchmark.microMaskLaneIsSetByte128_con    thrpt    5  42523.871 ± 1940.177  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte128_var    thrpt    5  40544.292 ± 2081.099  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte256_con    thrpt    5   7658.172 ±  252.304  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte256_var    thrpt    5   7287.017 ±  203.857  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte512_con    thrpt    5   7649.011 ±  348.445  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte512_var    thrpt    5   7303.085 ±  260.066  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte64_con     thrpt    5  30287.809 ±  868.463  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte64_var     thrpt    5  27860.730 ± 1117.329  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble128_con  thrpt    5  57353.196 ± 1826.231  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble128_var  thrpt    5  56106.891 ± 2156.363  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble256_con  thrpt    5  14154.895 ±  391.992  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble256_var  thrpt    5  13666.685 ±  500.522  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble512_con  thrpt    5   7604.957 ±  328.344  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble512_var  thrpt    5   7278.919 ±  383.439  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble64_con   thrpt    5  42941.644 ± 1618.714  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble64_var   thrpt    5  40329.641 ± 1367.149  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat128_con   thrpt    5  43744.485 ± 1420.895  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat128_var   thrpt    5  43016.885 ± 1472.147  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat256_con   thrpt    5   7508.484 ± 1113.047  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat256_var   thrpt    5   7288.256 ±  264.668  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat512_con   thrpt    5   7661.599 ±  211.685  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat512_var   thrpt    5   7295.130 ±  245.349  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat64_con    thrpt    5  57148.824 ± 2073.315  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat64_var    thrpt    5  56102.395 ± 2009.933  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt128_con     thrpt    5  43682.288 ± 1456.652  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt128_var     thrpt    5  42802.504 ± 1888.765  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt256_con     thrpt    5   7653.029 ±  283.022  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt256_var     thrpt    5   7173.100 ±  226.734  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt512_con     thrpt    5   7719.175 ±  251.547  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt512_var     thrpt    5   7168.217 ±  242.462  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt64_con      thrpt    5  57356.020 ± 1883.216  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt64_var      thrpt    5  55879.028 ± 2444.737  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong128_con    thrpt    5  57363.854 ± 1788.891  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong128_var    thrpt    5  56139.883 ± 1961.607  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong256_con    thrpt    5  14140.155 ±  449.406  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong256_var    thrpt    5  13426.919 ±  441.366  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong512_con    thrpt    5   7663.713 ±  251.944  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong512_var    thrpt    5   7295.611 ±  227.155  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong64_con     thrpt    5  43043.568 ± 1104.758  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong64_var     thrpt    5  40359.603 ± 1350.149  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort128_con   thrpt    5  30037.620 ±  961.610  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort128_var   thrpt    5  28874.621 ± 1303.006  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort256_con   thrpt    5   7655.910 ±  241.388  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort256_var   thrpt    5   7289.008 ±  234.073  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort512_con   thrpt    5   7678.474 ±  253.619  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort512_var   thrpt    5   7176.144 ±  270.567  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort64_con    thrpt    5  43755.172 ± 1443.171  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort64_var    thrpt    5  42986.162 ± 1454.976  ops/ms
```
#### K3 (vlen=256bit) before
```
Benchmark                                                Mode  Cnt      Score     Error   Units
VectorExtractBenchmark.microMaskLaneIsSetByte128_con    thrpt    5  14318.394 ±  11.383  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte128_var    thrpt    5  13984.880 ±  32.727  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte256_con    thrpt    5  14314.539 ±  17.342  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte256_var    thrpt    5  13906.216 ±  86.028  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte512_con    thrpt    5   5929.585 ±  44.498  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte512_var    thrpt    5   5817.978 ±   2.409  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte64_con     thrpt    5  13911.596 ±  18.795  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte64_var     thrpt    5  14006.471 ±  21.226  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble128_con  thrpt    5  39950.734 ±  21.468  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble128_var  thrpt    5  38850.506 ±  37.827  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble256_con  thrpt    5  25347.916 ±  29.731  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble256_var  thrpt    5  24710.687 ±   9.613  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble512_con  thrpt    5   5960.936 ±  10.542  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble512_var  thrpt    5   5817.517 ±   4.205  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble64_con   thrpt    5  34739.517 ±  20.802  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble64_var   thrpt    5  33760.127 ±  15.560  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat128_con   thrpt    5  25311.165 ±  13.556  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat128_var   thrpt    5  24710.372 ±  11.715  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat256_con   thrpt    5  14305.864 ±  16.568  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat256_var   thrpt    5  13795.575 ±  36.224  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat512_con   thrpt    5   5976.068 ±   3.108  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat512_var   thrpt    5   5808.960 ±  79.581  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat64_con    thrpt    5  39951.324 ±  17.201  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat64_var    thrpt    5  38888.383 ± 114.235  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt128_con     thrpt    5  25358.754 ±  17.520  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt128_var     thrpt    5  24932.117 ±  41.718  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt256_con     thrpt    5  14317.827 ±   4.413  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt256_var     thrpt    5  13766.256 ±  63.836  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt512_con     thrpt    5   5977.604 ±   2.680  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt512_var     thrpt    5   5817.700 ±   3.480  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt64_con      thrpt    5  39952.386 ±  17.546  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt64_var      thrpt    5  38897.509 ±  12.880  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong128_con    thrpt    5  39918.963 ± 270.226  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong128_var    thrpt    5  38904.689 ±  13.442  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong256_con    thrpt    5  25312.856 ±  28.576  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong256_var    thrpt    5  24951.731 ±  29.280  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong512_con    thrpt    5   5977.877 ±   2.369  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong512_var    thrpt    5   5817.789 ±   2.966  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong64_con     thrpt    5  34740.765 ±  31.679  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong64_var     thrpt    5  34739.083 ±  16.777  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort128_con   thrpt    5  14308.880 ±  22.768  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort128_var   thrpt    5  13847.889 ±  35.214  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort256_con   thrpt    5  14324.517 ±  17.544  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort256_var   thrpt    5  13870.108 ± 190.251  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort512_con   thrpt    5   5846.452 ±   2.521  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort512_var   thrpt    5   5818.044 ±   2.933  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort64_con    thrpt    5  25319.563 ±  37.762  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort64_var    thrpt    5  25098.315 ±  30.513  ops/ms
```
#### K3 (vlen=256bit) after
```
Benchmark                                                Mode  Cnt      Score     Error   Units
VectorExtractBenchmark.microMaskLaneIsSetByte128_con    thrpt    5  18779.207 ±   7.296  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte128_var    thrpt    5  17933.731 ±  18.601  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte256_con    thrpt    5  18158.906 ±   7.974  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte256_var    thrpt    5  17407.495 ±  23.251  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte512_con    thrpt    5   5932.601 ±   2.524  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte512_var    thrpt    5   5830.068 ±   2.705  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte64_con     thrpt    5  19567.178 ±  11.513  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetByte64_var     thrpt    5  17715.115 ±  36.903  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble128_con  thrpt    5  50998.632 ±  25.149  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble128_var  thrpt    5  45332.921 ± 119.380  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble256_con  thrpt    5  33859.854 ±  28.613  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble256_var  thrpt    5  32096.326 ±  42.976  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble512_con  thrpt    5   5975.262 ±   9.764  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble512_var  thrpt    5   5837.474 ±  82.771  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble64_con   thrpt    5  34740.026 ±  15.413  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetDouble64_var   thrpt    5  34740.012 ±  17.930  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat128_con   thrpt    5  34000.479 ±  13.681  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat128_var   thrpt    5  32047.762 ±  59.487  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat256_con   thrpt    5  19422.161 ±   5.479  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat256_var   thrpt    5  18245.968 ±   9.461  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat512_con   thrpt    5   5977.735 ±   2.563  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat512_var   thrpt    5   5846.160 ±   3.093  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat64_con    thrpt    5  51000.967 ±  24.780  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetFloat64_var    thrpt    5  45278.053 ± 161.778  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt128_con     thrpt    5  33984.755 ± 237.285  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt128_var     thrpt    5  32016.715 ±  48.509  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt256_con     thrpt    5  19580.580 ±  10.192  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt256_var     thrpt    5  17967.654 ±  31.719  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt512_con     thrpt    5   5978.393 ±   9.269  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt512_var     thrpt    5   5832.613 ±   6.806  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt64_con      thrpt    5  51000.152 ±  19.392  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetInt64_var      thrpt    5  45376.238 ± 188.023  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong128_con    thrpt    5  50999.249 ±  23.673  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong128_var    thrpt    5  45733.101 ±  68.446  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong256_con    thrpt    5  33997.758 ±  13.962  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong256_var    thrpt    5  31808.543 ± 150.517  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong512_con    thrpt    5   5977.532 ±   2.639  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong512_var    thrpt    5   5846.436 ±   1.978  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong64_con     thrpt    5  34741.745 ±  33.132  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetLong64_var     thrpt    5  34741.890 ±  11.532  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort128_con   thrpt    5  19387.505 ±  13.050  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort128_var   thrpt    5  18196.560 ±  43.082  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort256_con   thrpt    5  19567.997 ±   6.532  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort256_var   thrpt    5  18175.436 ±  39.601  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort512_con   thrpt    5   5860.740 ±   2.823  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort512_var   thrpt    5   5846.155 ±   2.713  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort64_con    thrpt    5  34148.606 ±  21.806  ops/ms
VectorExtractBenchmark.microMaskLaneIsSetShort64_var    thrpt    5  32086.258 ±  28.929  ops/ms
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8321012](https://bugs.openjdk.org/browse/JDK-8321012): RISC-V: C2 ExtractUB (**Sub-task** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31880/head:pull/31880` \
`$ git checkout pull/31880`

Update a local copy of the PR: \
`$ git checkout pull/31880` \
`$ git pull https://git.openjdk.org/jdk.git pull/31880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31880`

View PR using the GUI difftool: \
`$ git pr show -t 31880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31880.diff">https://git.openjdk.org/jdk/pull/31880.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31880#issuecomment-5059474800)
</details>
