### PR TITLE
8387674: Remove isXP() function from jabswitch.cpp

### DIFF
--- a/src/jdk.accessibility/windows/native/jabswitch/jabswitch.cpp
+++ b/src/jdk.accessibility/windows/native/jabswitch/jabswitch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,23 +52,6 @@ static LPCTSTR STR_ACCESSBRIDGE =
 
 FILE* origFile;
 FILE* tempFile;
-
-bool isXP()
-{
-    static bool isXPFlag = false;
-    OSVERSIONINFO  osvi;
-
-    // Initialize the OSVERSIONINFO structure.
-    ZeroMemory( &osvi, sizeof( osvi ) );
-    osvi.dwOSVersionInfoSize = sizeof( osvi );
-
-    GetVersionEx( &osvi );
-
-    if ( osvi.dwMajorVersion == 5 ) // For Windows XP and Windows 2000
-        isXPFlag = true;
-
-    return isXPFlag ;
-}
 
 void enableJAB() {
     // Copy lines from orig to temp modifying the line containing
@@ -458,16 +441,14 @@ int main(int argc, char* argv[]) {
                 enableWasRequested = true;
                 error = modify(true);
                 if (error == 0) {
-                   if( !isXP() )
-                      regEnable();
+                    regEnable();
                 }
             } else if (_stricmp(argv[1], "-disable") == 0 || _stricmp(argv[1], "/disable") == 0) {
                 badParams = false;
                 disableWasRequested = true;
                 error = modify(false);
                 if (error == 0) {
-                   if( !isXP() )
-                      regDisable();
+                    regDisable();
                 }
             }
         }


### PR DESCRIPTION
We can remove the isXP() function from jabswitch.cpp because it deals with very ancient Windows versions we do not support any more.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387674](https://bugs.openjdk.org/browse/JDK-8387674): Remove isXP() function from jabswitch.cpp (**Enhancement** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31881/head:pull/31881` \
`$ git checkout pull/31881`

Update a local copy of the PR: \
`$ git checkout pull/31881` \
`$ git pull https://git.openjdk.org/jdk.git pull/31881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31881`

View PR using the GUI difftool: \
`$ git pr show -t 31881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31881.diff">https://git.openjdk.org/jdk/pull/31881.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31881#issuecomment-4957379557)
</details>
