### PR TITLE
8376296: ZGC: assert(can_align_up(size, alignment)) failed: precondition when setting -XX:MaxVirtMemFraction=1

### DIFF
--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -62,10 +62,8 @@ size_t GCArguments::limit_heap_by_allocatable_memory(size_t limit) {
   // Limits the given heap size by the maximum amount of virtual
   // memory this process is currently allowed to use. It also takes
   // the virtual-to-physical ratio of the current GC into account.
-  size_t fraction = MaxVirtMemFraction * heap_virtual_to_physical_ratio();
-  size_t max_allocatable = os::commit_memory_limit();
-
-  return MIN2(limit, max_allocatable / fraction);
+  size_t physical_max_allocatable = os::commit_memory_limit() / heap_virtual_to_physical_ratio();
+  return MIN2(limit, physical_max_allocatable / MaxVirtMemFraction);
 }
 
 // Use static initialization to get the default before parsing

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -62,8 +62,10 @@ size_t GCArguments::limit_heap_by_allocatable_memory(size_t limit) {
   // Limits the given heap size by the maximum amount of virtual
   // memory this process is currently allowed to use. It also takes
   // the virtual-to-physical ratio of the current GC into account.
-  size_t physical_max_allocatable = os::commit_memory_limit() / heap_virtual_to_physical_ratio();
-  return MIN2(limit, physical_max_allocatable / MaxVirtMemFraction);
+  size_t fraction = MaxVirtMemFraction * heap_virtual_to_physical_ratio();
+  size_t max_allocatable = os::commit_memory_limit();
+
+  return MIN2(limit, max_allocatable / fraction);
 }
 
 // Use static initialization to get the default before parsing

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -285,7 +285,7 @@
   develop(uintx, MaxVirtMemFraction, 2,                                     \
           "Maximum fraction (1/n) of virtual memory used for ergonomically "\
           "determining maximum heap size")                                  \
-          range(1, max_uintx)                                               \
+          range(1, max_juint)                                               \
                                                                             \
   product(bool, UseAdaptiveSizePolicy, true,                                \
           "Use adaptive generation sizing policies")                        \

--- a/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
+++ b/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
@@ -31,9 +31,13 @@
 #include "utilities/ostream.hpp"
 
 size_t ZAddressSpaceLimit::heap() {
-  // Allow the heap to occupy 50% of the address space
+  // Allow the heap to occupy [100/MaxVirtMemFraction]% of the address space
   const size_t limit = os::reserve_memory_limit() / MaxVirtMemFraction;
-  return align_up(limit, ZGranuleSize);
+  if (can_align_up(limit, ZGranuleSize)) {
+    return align_up(limit, ZGranuleSize);
+  } else {
+    return align_down(limit, ZGranuleSize);
+  }
 }
 
 void ZAddressSpaceLimit::print_limits() {

--- a/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
+++ b/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
@@ -33,11 +33,7 @@
 size_t ZAddressSpaceLimit::heap() {
   // Allow the heap to occupy [100/MaxVirtMemFraction]% of the address space
   const size_t limit = os::reserve_memory_limit() / MaxVirtMemFraction;
-  if (can_align_up(limit, ZGranuleSize)) {
-    return align_up(limit, ZGranuleSize);
-  } else {
-    return align_down(limit, ZGranuleSize);
-  }
+  return align_down(limit, ZGranuleSize);
 }
 
 void ZAddressSpaceLimit::print_limits() {

--- a/test/hotspot/jtreg/gc/arguments/TestMaxVirtMemFractionZGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxVirtMemFractionZGC.java
@@ -27,10 +27,11 @@ package gc.arguments;
  * @test
  * @bug 8376296
  * @summary Test that ZGC does not crash with boundary values for MaxVirtMemFraction
+ * @requires vm.debug
  * @library /test/lib
  * @library /
  * @requires vm.gc.Z
- * @run main/othervm ${test.main.class}
+ * @run driver ${test.main.class}
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/arguments/TestMaxVirtMemFractionZGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxVirtMemFractionZGC.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.arguments;
+
+/**
+ * @test
+ * @bug 8376296
+ * @summary Test that ZGC does not crash with boundary values for MaxVirtMemFraction
+ * @library /test/lib
+ * @library /
+ * @requires vm.gc.Z
+ * @run main/othervm ${test.main.class}
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestMaxVirtMemFractionZGC {
+    public static void main(String[] args) throws Exception {
+
+        OutputAnalyzer output = GCArguments.executeTestJava("-XX:+UseZGC", "-XX:MaxVirtMemFraction=1", "-version");
+        output.shouldHaveExitValue(0);
+
+        long val = ((long) 2) << 59;
+        output = GCArguments.executeTestJava("-XX:+UseZGC", "-XX:MaxVirtMemFraction=" + val, "-version");
+        output.shouldContain("Error occurred during initialization of VM");
+        output.shouldContain("Too small maximum heap");
+        output.shouldHaveExitValue(1);
+    }
+}

--- a/test/hotspot/jtreg/gc/arguments/TestMaxVirtMemFractionZGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxVirtMemFractionZGC.java
@@ -26,26 +26,12 @@ package gc.arguments;
 /**
  * @test
  * @bug 8376296
- * @summary Test that ZGC does not crash with boundary values for MaxVirtMemFraction
+ * @summary Test that ZGC does not crash with -XX:MaxVirtMemFraction=1
  * @requires vm.debug
- * @library /test/lib
- * @library /
  * @requires vm.gc.Z
- * @run driver ${test.main.class}
+ * @run main/othervm -XX:+UseZGC -XX:MaxVirtMemFraction=1 ${test.main.class}
  */
 
-import jdk.test.lib.process.OutputAnalyzer;
-
 public class TestMaxVirtMemFractionZGC {
-    public static void main(String[] args) throws Exception {
-
-        OutputAnalyzer output = GCArguments.executeTestJava("-XX:+UseZGC", "-XX:MaxVirtMemFraction=1", "-version");
-        output.shouldHaveExitValue(0);
-
-        long val = ((long) 2) << 59;
-        output = GCArguments.executeTestJava("-XX:+UseZGC", "-XX:MaxVirtMemFraction=" + val, "-version");
-        output.shouldContain("Error occurred during initialization of VM");
-        output.shouldContain("Too small maximum heap");
-        output.shouldHaveExitValue(1);
-    }
+    public static void main(String[] args) {}
 }


### PR DESCRIPTION
This PR addresses two crashes using boundary values for MaxVirtMemFraction on ZGC. If using MaxVirtMemFraction=1, there's an attempt to align a reservation limit (represented as SIZE_MAX in hotspot if RLIMIT_AS is unbounded) up to the nearest 2 MiB, which causes a rounding failure. If using MaxVirtMemFraction=2^60, this is later multiplied by ZVirtualToPhysicalRatio (= 16), causing a division by zero. Proposed solution: 1) round down at boundary value 2) change order of operation. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8376296](https://bugs.openjdk.org/browse/JDK-8376296): ZGC: assert(can_align_up(size, alignment)) failed: precondition when setting -XX:MaxVirtMemFraction=1 (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31882/head:pull/31882` \
`$ git checkout pull/31882`

Update a local copy of the PR: \
`$ git checkout pull/31882` \
`$ git pull https://git.openjdk.org/jdk.git pull/31882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31882`

View PR using the GUI difftool: \
`$ git pr show -t 31882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31882.diff">https://git.openjdk.org/jdk/pull/31882.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31882#issuecomment-4957590649)
</details>
