### PR TITLE
8387048: NMTCommittedVirtualMemoryTracker.test_committed_virtualmemory_region_vm fails due to found_stack_top

### DIFF
--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -58,16 +58,14 @@ public:
     address i_addr = (address)&i;
     bool found_i_addr = false;
 
-    // stack grows downward
+    // Stack grows downward.
     address stack_top = stack_end + stack_size;
-    bool found_stack_top = false;
     {
       MemTracker::NmtVirtualMemoryLocker vml;
+      // For thread stacks, this historically named API visits resident ranges.
       VirtualMemoryTracker::Instance::tree()->visit_committed_regions(rgn_found, [&](const VirtualMemoryRegion& rgn) {
-        if (rgn.base() + rgn.size() == stack_top) {
-          EXPECT_TRUE(rgn.size() <= stack_size);
-          found_stack_top = true;
-        }
+        EXPECT_GE(rgn.base(), stack_end);
+        EXPECT_LE(rgn.end(), stack_top);
         if (i_addr < stack_top && i_addr >= rgn.base()) {
           found_i_addr = true;
         }
@@ -76,10 +74,9 @@ public:
       });
     }
 
-    // stack and guard pages may be contiguous as one region
+    // Stack and guard pages may be contiguous as one region.
     ASSERT_TRUE(i >= 1);
     ASSERT_TRUE(found_i_addr);
-    ASSERT_TRUE(found_stack_top);
   }
 
   static const int PAGE_CONTAINED_IN_RANGE_TAG = -1;

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -63,6 +63,7 @@ public:
     {
       MemTracker::NmtVirtualMemoryLocker vml;
       // For thread stacks, this historically named API visits resident ranges.
+      // Not all committed pages have to be resident.
       VirtualMemoryTracker::Instance::tree()->visit_committed_regions(rgn_found, [&](const VirtualMemoryRegion& rgn) {
         EXPECT_GE(rgn.base(), stack_end);
         EXPECT_LE(rgn.end(), stack_top);


### PR DESCRIPTION
The `found_stack_top` assertion in the `NMTCommittedVirtualMemoryTracker` gtest is incorrect. It assumes that a thread stack has a resident range ending at `stack_top`. For thread stacks, NMT stores resident ranges in its historically named committed-region tree. A stack page may be nonresident while the stack remains valid, so a resident range does not have to reach the top of the reservation.

The failure has only been observed on Windows/AArch64, mainly on resource-constrained machines where stack pages are more likely to leave the working set. I attached a standalone Linux reproducer to the JBS issue. It demonstrates the underlying residency behavior by creating a deep live stack under a small memory limit and observing one of its own high-address frames as nonresident before unwinding successfully.

This change removes the `found_stack_top` assertion. It keeps the checks that NMT finds the active stack frame and at least one stack range, and verifies that every reported range stays within the stack reservation. A comment next to `visit_committed_regions()` documents that the API visits resident ranges for thread stacks.

This is a test-side workaround for the existing API mismatch. The long-term solution is to expose and use a resident-range API for thread-stack snapshots instead of storing and visiting resident pages through APIs named for committed memory.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387048](https://bugs.openjdk.org/browse/JDK-8387048): NMTCommittedVirtualMemoryTracker.test_committed_virtualmemory_region_vm fails due to found_stack_top (**Bug** - P4)


### Reviewers
 * [Robert Toyonaga](https://openjdk.org/census#rtoyonaga) (@roberttoyonaga - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31883/head:pull/31883` \
`$ git checkout pull/31883`

Update a local copy of the PR: \
`$ git checkout pull/31883` \
`$ git pull https://git.openjdk.org/jdk.git pull/31883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31883`

View PR using the GUI difftool: \
`$ git pr show -t 31883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31883.diff">https://git.openjdk.org/jdk/pull/31883.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31883#issuecomment-4958132625)
</details>
