### PR TITLE
8373487: Out-of-bounds access in AlignmentGapAccess test

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -72,8 +72,6 @@ compiler/intrinsics/TestReturnOopSetForJFRWriteCheckpoint.java 8286300 linux-s39
 
 compiler/c2/aarch64/TestStaticCallStub.java 8359963 generic-aarch64
 
-compiler/unsafe/AlignmentGapAccess.java 8373487 generic-all
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/unsafe/AlignmentGapAccess.java
+++ b/test/hotspot/jtreg/compiler/unsafe/AlignmentGapAccess.java
@@ -38,17 +38,22 @@ public class AlignmentGapAccess {
 
     static class A           { int  fa; }
     static class B extends A { byte fb; }
+    static class C extends B { int  fc; }
 
     static final long FA_OFFSET = UNSAFE.objectFieldOffset(A.class, "fa");
     static final long FB_OFFSET = UNSAFE.objectFieldOffset(B.class, "fb");
+    static final long FC_OFFSET = UNSAFE.objectFieldOffset(C.class, "fc");
 
     static int test(B obj) {
         return UNSAFE.getInt(obj, FB_OFFSET + 1);
     }
 
     public static void main(String[] args) {
+        System.out.printf("Layout: +%d: fa; +%d: fb; +%d: fc\n",
+                          FA_OFFSET, FB_OFFSET, FC_OFFSET);
+
         for (int i = 0; i < 20_000; i++) {
-            test(new B());
+            test(new C());
         }
         System.out.println("TEST PASSED");
     }


### PR DESCRIPTION
This pull request contains a backport of commit 30abe0b3 from the openjdk/jdk repository.

The commit being backported was authored by Vladimir Ivanov on 13 Jul 2026 and was reviewed by Dean Long and Albert Mingkun Yang.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8373487](https://bugs.openjdk.org/browse/JDK-8373487): Out-of-bounds access in AlignmentGapAccess test (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31886/head:pull/31886` \
`$ git checkout pull/31886`

Update a local copy of the PR: \
`$ git checkout pull/31886` \
`$ git pull https://git.openjdk.org/jdk.git pull/31886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31886`

View PR using the GUI difftool: \
`$ git pr show -t 31886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31886.diff">https://git.openjdk.org/jdk/pull/31886.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31886#issuecomment-4962971228)
</details>
