### PR TITLE
8388158: Change CPU detection code beyond hardcoded CPU list

### DIFF
--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -145,6 +145,19 @@ void VM_Version::get_os_cpu_info() {
   }
 
   {
+    DWORD key_type = 0;
+    uint64_t value = 0;
+    DWORD value_size = sizeof(value);
+    if ((RegGetValueA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", "CP 4000",
+      RRF_RT_REG_QWORD, &key_type, &value, &value_size) == ERROR_SUCCESS) && (value_size == sizeof(value))) {
+      _cpu = value >> 24 & 0xFF;
+      _variant = value >> 20 & 0x0F;
+      _model = value >> 4 & 0x0FFF;
+      _revision = value & 0x0F;
+    }
+  }
+
+  if (_cpu == 0) {
     char* buf = ::getenv("PROCESSOR_IDENTIFIER");
     if (buf && strstr(buf, "Ampere(TM)") != nullptr) {
       _cpu = CPU_AMCC;

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -148,6 +148,7 @@ void VM_Version::get_os_cpu_info() {
     DWORD key_type = 0;
     uint64_t value = 0;
     DWORD value_size = sizeof(value);
+    // Read registry value "CP 4000" which maps to MIDR_EL1.
     if ((RegGetValueA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", "CP 4000",
                       RRF_RT_REG_QWORD, &key_type, &value, &value_size) == ERROR_SUCCESS) && (value_size == sizeof(value))) {
       _cpu = value >> 24 & 0xFF;

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -149,7 +149,7 @@ void VM_Version::get_os_cpu_info() {
     uint64_t value = 0;
     DWORD value_size = sizeof(value);
     if ((RegGetValueA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", "CP 4000",
-      RRF_RT_REG_QWORD, &key_type, &value, &value_size) == ERROR_SUCCESS) && (value_size == sizeof(value))) {
+                      RRF_RT_REG_QWORD, &key_type, &value, &value_size) == ERROR_SUCCESS) && (value_size == sizeof(value))) {
       _cpu = value >> 24 & 0xFF;
       _variant = value >> 20 & 0x0F;
       _model = value >> 4 & 0x0FFF;


### PR DESCRIPTION
The previous method for identifying the cpu was narrow and fragile as it was based on string representations of the vendor.

The current method for getting the information is to read the MIDR_EL1 register, but this is not always available. Fortunately Windows exposes the register value in the registry.

This patch reads the registry value "CP 4000" which maps to MIDR_EL1 to determine CPU implementer, variant, model (part) and revision. If there's an error (e.g. missing registry entry) then the code path falls through into the previous implementation that handled a few specific vendors.

Tier1 tests pass on Windows+arm64

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388158](https://bugs.openjdk.org/browse/JDK-8388158): Change CPU detection code beyond hardcoded CPU list (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31887/head:pull/31887` \
`$ git checkout pull/31887`

Update a local copy of the PR: \
`$ git checkout pull/31887` \
`$ git pull https://git.openjdk.org/jdk.git pull/31887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31887`

View PR using the GUI difftool: \
`$ git pr show -t 31887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31887.diff">https://git.openjdk.org/jdk/pull/31887.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31887#issuecomment-4963241397)
</details>
