### PR TITLE
8387949: Implementation of PEM Encodings of Cryptographic Objects 

### DIFF
--- a/src/java.base/share/classes/java/security/BinaryEncodable.java
+++ b/src/java.base/share/classes/java/security/BinaryEncodable.java
@@ -31,27 +31,27 @@ import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
-import jdk.internal.javac.PreviewFeature;
 import sun.security.internal.InternalBinaryEncodable;
 
-
 /**
- * This interface identifies the cryptographic objects that can be converted
- * to and from binary data, and thereby encoded and decoded as PEM text.
+ * This interface identifies cryptographic objects that can be converted to
+ * and from standardized binary representations.
  *
  * <p> The APIs for cryptographic objects such as public keys, private keys,
  * certificates, and certificate revocation lists all provide the means to
  * convert their instances to and from standardized binary representations.
  * Other kinds of cryptographic objects, such as certificate requests, have
  * no corresponding API but can still be expressed as standardized binary
- * representations. The {@code BinaryEncodable} interface allows the
- * {@link PEMEncoder} and {@link PEMDecoder} classes to operate uniformly on
- * binary representations of key or certificate material.
+ * representations.  The {@code BinaryEncodable} interface allows APIs that
+ * operate on standardized binary representations, such as {@link PEMEncoder}
+ * and {@link PEMDecoder}, to process all kinds of cryptographic objects
+ * uniformly.
  *
  * <p> The permitted subtype {@code PEM} is notable for supporting the encoding
  * and decoding of PEM text that represents cryptographic objects for which no
  * API exists. In future releases, other permitted subtypes may be added to
- * support the encoding and decoding of such cryptographic objects.
+ * support the encoding and decoding of additional kinds of cryptographic
+ * objects as standardized binary representations.
  *
  * <p> The list of permitted subtypes shown after {@code permits} is not
  * exhaustive. This means if application code switches over a
@@ -71,10 +71,9 @@ import sun.security.internal.InternalBinaryEncodable;
  * @see X509CRL
  * @see PEM
  *
- * @since 27
+ * @since 28
  */
 
-@PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
 public sealed interface BinaryEncodable permits AsymmetricKey, KeyPair,
     PKCS8EncodedKeySpec, X509EncodedKeySpec, EncryptedPrivateKeyInfo,
     X509Certificate, X509CRL, PEM, InternalBinaryEncodable {

--- a/src/java.base/share/classes/java/security/PEM.java
+++ b/src/java.base/share/classes/java/security/PEM.java
@@ -25,8 +25,6 @@
 
 package java.security;
 
-import jdk.internal.javac.PreviewFeature;
-
 import jdk.internal.ref.CleanerFactory;
 import sun.security.util.KeyUtil;
 import sun.security.util.Pem;
@@ -72,9 +70,8 @@ import java.util.Objects;
  * @see PEMDecoder
  * @see PEMEncoder
  *
- * @since 26
+ * @since 28
  */
-@PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
 public final class PEM implements BinaryEncodable {
 
     private final String type;
@@ -133,8 +130,6 @@ public final class PEM implements BinaryEncodable {
      * @throws IllegalArgumentException if {@code type} contains PEM
      *         encapsulation syntax
      * @throws NullPointerException if any parameter is {@code null}
-     *
-     * @since 27
      */
     public PEM(String type, byte[] base64Content, byte[] leadingData) {
         this(type, base64Content);
@@ -153,8 +148,6 @@ public final class PEM implements BinaryEncodable {
      * @throws IllegalArgumentException if {@code type} contains PEM
      *         encapsulation syntax
      * @throws NullPointerException if any parameter is {@code null}
-     *
-     * @since 27
      */
     public PEM(String type, byte[] base64Content) {
         Objects.requireNonNull(type, "type cannot be null");
@@ -198,8 +191,6 @@ public final class PEM implements BinaryEncodable {
      * Returns the Base64-encoded content.
      *
      * @return a newly-allocated byte array containing the Base64 content
-     *
-     * @since 27
      */
     public byte[] content() {
         try {

--- a/src/java.base/share/classes/java/security/PEMDecoder.java
+++ b/src/java.base/share/classes/java/security/PEMDecoder.java
@@ -25,8 +25,6 @@
 
 package java.security;
 
-import jdk.internal.javac.PreviewFeature;
-
 import jdk.internal.ref.CleanerFactory;
 import sun.security.pkcs.PKCS8Key;
 import sun.security.rsa.RSAPrivateCrtKeyImpl;
@@ -147,9 +145,8 @@ import java.util.Objects;
  * @spec https://www.rfc-editor.org/info/rfc7468
  *       RFC 7468: Textual Encodings of PKIX, PKCS, and CMS Structures
  *
- * @since 25
+ * @since 28
  */
-@PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
 public final class PEMDecoder {
     private final Provider factory;
     private final PBEKeySpec keySpec;
@@ -294,8 +291,6 @@ public final class PEMDecoder {
      * @throws IllegalArgumentException if decoding fails or no PEM data is found
      * @throws NullPointerException if {@code str} is {@code null}
      * @throws CryptoException if an error occurs during decryption
-     *
-     * @since 27
      */
     public BinaryEncodable decode(String str) {
         Objects.requireNonNull(str);
@@ -335,8 +330,6 @@ public final class PEMDecoder {
      * @throws IllegalArgumentException if decoding fails
      * @throws NullPointerException if {@code InputStream} is {@code null}
      * @throws CryptoException if an error occurs during decryption
-     *
-     * @since 27
      */
     public BinaryEncodable decode(InputStream is) throws IOException {
         Objects.requireNonNull(is);
@@ -379,8 +372,6 @@ public final class PEMDecoder {
      * @throws ClassCastException if {@code tClass} does not represent the PEM type
      * @throws NullPointerException if any input values are {@code null}
      * @throws CryptoException if an error occurs during decryption
-     *
-     * @since 27
      */
     public <S extends BinaryEncodable> S decode(String str, Class<S> tClass) {
         Objects.requireNonNull(str);
@@ -428,8 +419,6 @@ public final class PEMDecoder {
      *
      * @see #decode(InputStream)
      * @see #decode(String, Class)
-     *
-     * @since 27
      */
     public <S extends BinaryEncodable> S decode(InputStream is, Class<S> tClass)
         throws IOException {
@@ -543,8 +532,6 @@ public final class PEMDecoder {
      * @param provider the factory {@code Provider}
      * @return a new {@code PEMDecoder} instance configured with the {@code Provider}
      * @throws NullPointerException if {@code provider} is {@code null}
-     *
-     * @since 27
      */
     public PEMDecoder withFactoriesOf(Provider provider) {
         Objects.requireNonNull(provider);

--- a/src/java.base/share/classes/java/security/PEMEncoder.java
+++ b/src/java.base/share/classes/java/security/PEMEncoder.java
@@ -25,8 +25,6 @@
 
 package java.security;
 
-import jdk.internal.javac.PreviewFeature;
-
 import jdk.internal.ref.CleanerFactory;
 import sun.security.pkcs.PKCS8Key;
 import sun.security.util.KeyUtil;
@@ -117,9 +115,8 @@ import java.util.Objects;
  * @spec https://www.rfc-editor.org/info/rfc7468
  *       RFC 7468: Textual Encodings of PKIX, PKCS, and CMS Structures
  *
- * @since 25
+ * @since 28
  */
-@PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
 public final class PEMEncoder {
 
     // Singleton instance of PEMEncoder
@@ -169,8 +166,6 @@ public final class PEMEncoder {
      * @throws NullPointerException if {@code be} is {@code null}
      * @throws CryptoException if an error occurs during encryption
      * @see #withEncryption(char[])
-     *
-     * @since 27
      */
     public String encodeToString(BinaryEncodable be) {
         Objects.requireNonNull(be);
@@ -196,8 +191,6 @@ public final class PEMEncoder {
      * @throws NullPointerException if {@code be} is {@code null}
      * @throws CryptoException if an error occurs during encryption
      * @see #withEncryption(char[])
-     *
-     * @since 27
      */
     public byte[] encode(BinaryEncodable be) {
         return switch (be) {

--- a/src/java.base/share/classes/javax/crypto/CryptoException.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoException.java
@@ -25,8 +25,6 @@
 
 package javax.crypto;
 
-import jdk.internal.javac.PreviewFeature;
-
 /**
  * Thrown to indicate a cryptographic failure during processing.
  *
@@ -38,9 +36,8 @@ import jdk.internal.javac.PreviewFeature;
  * <p>This exception is not intended to represent internal provider errors,
  * which should be reported using {@link java.security.ProviderException}.
  *
- * @since 27
+ * @since 28
  */
-@PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
 public final class CryptoException extends RuntimeException {
 
     @java.io.Serial

--- a/src/java.base/share/classes/javax/crypto/EncryptedPrivateKeyInfo.java
+++ b/src/java.base/share/classes/javax/crypto/EncryptedPrivateKeyInfo.java
@@ -25,8 +25,6 @@
 
 package javax.crypto;
 
-import jdk.internal.javac.PreviewFeature;
-
 import sun.security.jca.JCAUtil;
 import sun.security.pkcs.PKCS8Key;
 import sun.security.util.*;
@@ -368,9 +366,8 @@ public non-sealed class EncryptedPrivateKeyInfo implements BinaryEncodable {
      *         not supported by any provider, or if an error occurs during
      *         encryption
      *
-     * @since 27
+     * @since 28
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
     public static EncryptedPrivateKeyInfo encrypt(BinaryEncodable be,
         char[] password, String algorithm, AlgorithmParameterSpec params,
         Provider provider) {
@@ -411,9 +408,8 @@ public non-sealed class EncryptedPrivateKeyInfo implements BinaryEncodable {
      * defines the default encryption algorithm. The {@code AlgorithmParameterSpec}
      * defaults are determined by the provider.
      *
-     * @since 27
+     * @since 28
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
     public static EncryptedPrivateKeyInfo encrypt(BinaryEncodable be,
         char[] password) {
         return encrypt(be, password, Pem.DEFAULT_ALGO, null,
@@ -450,9 +446,8 @@ public non-sealed class EncryptedPrivateKeyInfo implements BinaryEncodable {
      *         {@code algorithm} or {@code params} are not supported by any
      *         provider, or if an error occurs during encryption
      *
-     * @since 27
+     * @since 28
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
     public static EncryptedPrivateKeyInfo encrypt(BinaryEncodable be,
         Key encryptKey, String algorithm, AlgorithmParameterSpec params,
         Provider provider, SecureRandom random) {
@@ -520,9 +515,8 @@ public non-sealed class EncryptedPrivateKeyInfo implements BinaryEncodable {
      * @throws InvalidKeyException if an error occurs during parsing,
      *         decryption, or key generation
      *
-     * @since 25
+     * @since 28
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
     public PrivateKey getKey(char[] password)
         throws NoSuchAlgorithmException, InvalidKeyException {
         Objects.requireNonNull(password, "a password must be specified");
@@ -548,9 +542,8 @@ public non-sealed class EncryptedPrivateKeyInfo implements BinaryEncodable {
      * @throws InvalidKeyException if an error occurs during parsing,
      *         decryption, or key generation
      *
-     * @since 27
+     * @since 28
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
     public PrivateKey getKey(Key decryptKey)
         throws NoSuchAlgorithmException, InvalidKeyException {
         Objects.requireNonNull(decryptKey,"a decryptKey must be specified");
@@ -576,9 +569,8 @@ public non-sealed class EncryptedPrivateKeyInfo implements BinaryEncodable {
      * @throws InvalidKeyException if the encoded data lacks a public key, or if
      *         an error occurs during parsing, decryption, or key generation
      *
-     * @since 26
+     * @since 28
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
     public KeyPair getKeyPair(char[] password)
         throws NoSuchAlgorithmException, InvalidKeyException {
         Objects.requireNonNull(password, "a password must be specified");
@@ -614,9 +606,8 @@ public non-sealed class EncryptedPrivateKeyInfo implements BinaryEncodable {
      * @throws InvalidKeyException if the encoded data lacks a public key, or if
      *         an error occurs during parsing, decryption, or key generation
      *
-     * @since 27
+     * @since 28
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.PEM_API)
     public KeyPair getKeyPair(Key decryptKey)
         throws NoSuchAlgorithmException, InvalidKeyException {
         Objects.requireNonNull(decryptKey,"a decryptKey must be specified");

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -73,9 +73,6 @@ public @interface PreviewFeature {
         STRUCTURED_CONCURRENCY,
         @JEP(number = 531, title = "Lazy Constants", status = "Third Preview")
         LAZY_CONSTANTS,
-        @JEP(number=538, title="PEM Encodings of Cryptographic Objects",
-            status="Third Preview")
-        PEM_API,
         /**
          * Indicates a preview API exists to allow access to the environment
          * where all preview features of the current Java SE release are enabled.

--- a/test/jdk/java/security/KeyStore/PKCS12/WriteP12Test.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/WriteP12Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ import java.util.Enumeration;
  * @summary Write different types p12 key store to Check the write related
  *  APIs.
  * @run main WriteP12Test
- * @enablePreview
  */
 
 public class WriteP12Test {

--- a/test/jdk/java/security/KeyStore/TestKeyStoreBasic.java
+++ b/test/jdk/java/security/KeyStore/TestKeyStoreBasic.java
@@ -36,7 +36,6 @@ import java.time.Instant;
 /*
  * @test
  * @bug 8048621 8133090 8167371 8236671 8374808
- * @enablePreview
  * @summary Test basic operations with keystores (jks, jceks, pkcs12)
  * @author Yu-Ching Valerie PENG
  */

--- a/test/jdk/java/security/PEM/PEMDecoderTest.java
+++ b/test/jdk/java/security/PEM/PEMDecoderTest.java
@@ -30,7 +30,6 @@
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.util
  * @summary Testing basic PEM API decoding
- * @enablePreview
  */
 
 import javax.crypto.EncryptedPrivateKeyInfo;

--- a/test/jdk/java/security/PEM/PEMEncoderTest.java
+++ b/test/jdk/java/security/PEM/PEMEncoderTest.java
@@ -28,7 +28,6 @@
  * @bug 8298420
  * @library /test/lib
  * @summary Testing basic PEM API encoding
- * @enablePreview
  * @modules java.base/sun.security.util
  * @run main PEMEncoderTest PBEWithHmacSHA256AndAES_128
  * @run main/othervm -Djava.security.properties=${test.src}/java.security-anotherAlgo

--- a/test/jdk/java/security/PEM/PEMMultiThreadTest.java
+++ b/test/jdk/java/security/PEM/PEMMultiThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @bug 8298420
  * @library /test/lib
  * @summary Testing PEM API is thread safe
- * @enablePreview
  * @modules java.base/sun.security.util
  */
 

--- a/test/jdk/java/security/cert/CertPathBuilder/NoExtensions.java
+++ b/test/jdk/java/security/cert/CertPathBuilder/NoExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4519462
  * @summary Verify Sun CertPathBuilder implementation handles certificates with no extensions
- * @enablePreview
  */
 
 import java.security.PEMDecoder;

--- a/test/jdk/java/security/cert/CertPathBuilder/selfIssued/DisableRevocation.java
+++ b/test/jdk/java/security/cert/CertPathBuilder/selfIssued/DisableRevocation.java
@@ -36,7 +36,6 @@
  * @run main/othervm DisableRevocation subca
  * @run main/othervm DisableRevocation subci
  * @run main/othervm DisableRevocation alice
- * @enablePreview
  * @author Xuelei Fan
  */
 

--- a/test/jdk/java/security/cert/CertPathBuilder/selfIssued/KeyUsageMatters.java
+++ b/test/jdk/java/security/cert/CertPathBuilder/selfIssued/KeyUsageMatters.java
@@ -32,7 +32,6 @@
  * @bug 6852744 8133489
  * @summary PIT b61: PKI test suite fails because self signed certificates
  *          are being rejected
- * @enablePreview
  * @modules java.base/sun.security.util
  * @run main/othervm -Djava.security.debug=certpath KeyUsageMatters subca
  * @run main/othervm -Djava.security.debug=certpath KeyUsageMatters subci

--- a/test/jdk/java/security/cert/CertPathBuilder/selfIssued/StatusLoopDependency.java
+++ b/test/jdk/java/security/cert/CertPathBuilder/selfIssued/StatusLoopDependency.java
@@ -33,7 +33,6 @@
  * @summary PIT b61: PKI test suite fails because self signed certificates
  *          are being rejected
  * @modules java.base/sun.security.util
- * @enablePreview
  * @run main/othervm StatusLoopDependency subca
  * @run main/othervm StatusLoopDependency subci
  * @run main/othervm StatusLoopDependency alice

--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/FailoverToCRL.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/FailoverToCRL.java
@@ -32,7 +32,6 @@
  * @bug 6383095
  * @summary CRL revoked certificate failures masked by OCSP failures
  * @run main/othervm FailoverToCRL
- * @enablePreview
  * @author Xuelei Fan
  */
 

--- a/test/jdk/java/security/cert/CertPathValidator/indirectCRL/CircularCRLOneLevel.java
+++ b/test/jdk/java/security/cert/CertPathValidator/indirectCRL/CircularCRLOneLevel.java
@@ -33,7 +33,6 @@
  * @bug 6720721
  * @summary CRL check with circular depency support needed
  * @run main/othervm CircularCRLOneLevel
- * @enablePreview
  * @author Xuelei Fan
  */
 

--- a/test/jdk/java/security/cert/CertPathValidator/indirectCRL/CircularCRLOneLevelRevoked.java
+++ b/test/jdk/java/security/cert/CertPathValidator/indirectCRL/CircularCRLOneLevelRevoked.java
@@ -33,7 +33,6 @@
  * @bug 6720721
  * @summary CRL check with circular depency support needed
  * @run main/othervm CircularCRLOneLevelRevoked
- * @enablePreview
  * @author Xuelei Fan
  */
 

--- a/test/jdk/java/security/cert/CertPathValidator/indirectCRL/CircularCRLTwoLevel.java
+++ b/test/jdk/java/security/cert/CertPathValidator/indirectCRL/CircularCRLTwoLevel.java
@@ -32,7 +32,6 @@
  *
  * @bug 6720721
  * @summary CRL check with circular depency support needed
- * @enablePreview
  * @run main/othervm CircularCRLTwoLevel
  * @author Xuelei Fan
  */

--- a/test/jdk/java/security/cert/CertPathValidator/indirectCRL/CircularCRLTwoLevelRevoked.java
+++ b/test/jdk/java/security/cert/CertPathValidator/indirectCRL/CircularCRLTwoLevelRevoked.java
@@ -31,8 +31,7 @@
  * @test
  *
  * @bug 6720721
- * @summary CRL check with circular depency support needed
- * @enablePreview
+ * @summary CRL check with circular dependency support needed
  * @run main/othervm CircularCRLTwoLevelRevoked
  * @author Xuelei Fan
  */

--- a/test/jdk/java/security/cert/CertPathValidator/nameConstraints/NameConstraintsWithRID.java
+++ b/test/jdk/java/security/cert/CertPathValidator/nameConstraints/NameConstraintsWithRID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  *
  * @bug 6845286
  * @summary Add regression test for name constraints
- * @enablePreview
  * @author Xuelei Fan
  */
 

--- a/test/jdk/java/security/cert/CertPathValidator/nameConstraints/NameConstraintsWithUnexpectedRID.java
+++ b/test/jdk/java/security/cert/CertPathValidator/nameConstraints/NameConstraintsWithUnexpectedRID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  *
  * @bug 6845286
  * @summary Add regression test for name constraints
- * @enablePreview
  * @author Xuelei Fan
  */
 

--- a/test/jdk/java/security/cert/CertPathValidator/nameConstraints/NameConstraintsWithoutRID.java
+++ b/test/jdk/java/security/cert/CertPathValidator/nameConstraints/NameConstraintsWithoutRID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  *
  * @bug 6845286
  * @summary Add regression test for name constraints
- * @enablePreview
  * @author Xuelei Fan
  */
 

--- a/test/jdk/java/security/cert/CertPathValidator/trustAnchor/ValWithAnchorByName.java
+++ b/test/jdk/java/security/cert/CertPathValidator/trustAnchor/ValWithAnchorByName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  * @bug 8132926
  * @summary PKIXParameters built with public key form of TrustAnchor causes
  *          NPE during cert path building/validation
- * @enablePreview
  * @run main ValWithAnchorByName
  */
 

--- a/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/Encrypt.java
+++ b/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/Encrypt.java
@@ -29,7 +29,6 @@
  * @modules java.base/sun.security.util
  * @bug 8298420
  * @summary Testing encryptKey
- * @enablePreview
  */
 
 import sun.security.util.Pem;

--- a/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKey.java
+++ b/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKey.java
@@ -27,7 +27,6 @@
  * @test
  * @bug 8298420
  * @summary Testing getKey
- * @enablePreview
  */
 
 import javax.crypto.EncryptedPrivateKeyInfo;

--- a/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeyPair.java
+++ b/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeyPair.java
@@ -28,7 +28,6 @@
  * @bug 8360563
  * @library /test/lib
  * @summary Testing getKeyPair using ML-KEM
- * @enablePreview
  * @modules java.base/sun.security.util
  */
 

--- a/test/jdk/javax/net/ssl/ServerName/SSLSocketSNISensitive.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLSocketSNISensitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  * @test
  * @bug 7068321
  * @summary Support TLS Server Name Indication (SNI) Extension in JSSE Server
- * @enablePreview
  * @run main/othervm SSLSocketSNISensitive PKIX www.example.com
  * @run main/othervm SSLSocketSNISensitive SunX509 www.example.com
  * @run main/othervm SSLSocketSNISensitive PKIX www.example.net

--- a/test/jdk/javax/net/ssl/TLSCommon/TLSTest.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/TLSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ import javax.net.ssl.TrustManagerFactory;
 /*
  * @test
  * @bug 8205111
- * @enablePreview
  * @summary Test TLS with different types of supported keys.
  * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha1 TLS_AES_128_GCM_SHA256
  * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha256 TLS_AES_128_GCM_SHA256

--- a/test/jdk/sun/security/internal/CheckIBE.java
+++ b/test/jdk/sun/security/internal/CheckIBE.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8383608
  * @summary check that InternalBinaryEncodable exists
- * @enablePreview
  * @modules java.base/sun.security.internal
  * @run main CheckIBE
  */

--- a/test/jdk/sun/security/internal/ExhaustiveBE.java
+++ b/test/jdk/sun/security/internal/ExhaustiveBE.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8383608
  * @summary verify switches over BinaryEncodable are not exhaustive
- * @enablePreview
  * @compile/fail ExhaustiveBE.java
  */
 

--- a/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPBuilder.java
+++ b/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPBuilder.java
@@ -29,7 +29,6 @@
  *
  * @bug 6861062
  * @summary Disable MD2 support
- * @enablePreview
  *
  * @run main/othervm CPBuilder trustAnchor_SHA1withRSA_1024 0 true
  * @run main/othervm CPBuilder trustAnchor_SHA1withRSA_512  0 true

--- a/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPBuilderWithMD5.java
+++ b/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPBuilderWithMD5.java
@@ -29,7 +29,6 @@
  *
  * @bug 8030829
  * @summary Add MD5 to jdk.certpath.disabledAlgorithms security property
- * @enablePreview
  *
  * @run main/othervm CPBuilderWithMD5 trustAnchor_SHA1withRSA_1024 0 true
  * @run main/othervm CPBuilderWithMD5 trustAnchor_SHA1withRSA_512  0 true

--- a/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPValidatorEndEntity.java
+++ b/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPValidatorEndEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @summary Disable MD2 support.
  *          New CertPathValidatorException.BasicReason enum constant for
  *     constrained algorithm.
- * @enablePreview
  * @run main/othervm CPValidatorEndEntity
  * @author Xuelei Fan
  */

--- a/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPValidatorIntermediate.java
+++ b/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPValidatorIntermediate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @summary Disable MD2 support
  *          new CertPathValidatorException.BasicReason enum constant for
  *     constrained algorithm
- * @enablePreview
  * @run main/othervm CPValidatorIntermediate
  * @author Xuelei Fan
  */

--- a/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPValidatorTrustAnchor.java
+++ b/test/jdk/sun/security/provider/certpath/DisabledAlgorithms/CPValidatorTrustAnchor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @summary Disable MD2 support
  *          new CertPathValidatorException.BasicReason enum constant for
  *     constrained algorithm
- * @enablePreview
  * @run main/othervm CPValidatorTrustAnchor
  * @author Xuelei Fan
  */

--- a/test/jdk/sun/security/rsa/InvalidBitString.java
+++ b/test/jdk/sun/security/rsa/InvalidBitString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 
 /* @test
  * @summary Validation of signatures succeed when it should fail
- * @enablePreview
  * @bug 6896700
  */
 

--- a/test/jdk/sun/security/rsa/pss/PSSKeyCompatibility.java
+++ b/test/jdk/sun/security/rsa/pss/PSSKeyCompatibility.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
  * @test
  * @bug 8242335
  * @summary OpenSSL generated compatibility test with RSASSA-PSS Java.
- * @enablePreview
  * @run main PSSKeyCompatibility
  */
 

--- a/test/jdk/sun/security/ssl/ClientHandshaker/RSAExport.java
+++ b/test/jdk/sun/security/ssl/ClientHandshaker/RSAExport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
 /*
  * @test
  * @bug 6690018
- * @enablePreview
  * @summary RSAClientKeyExchange NullPointerException
  * @run main/othervm RSAExport
  */

--- a/test/jdk/sun/security/ssl/X509TrustManagerImpl/BasicConstraints.java
+++ b/test/jdk/sun/security/ssl/X509TrustManagerImpl/BasicConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @bug 7166570
  * @summary JSSE certificate validation has started to fail for
  *     certificate chains
- * @enablePreview
  * @run main/othervm BasicConstraints PKIX
  * @run main/othervm BasicConstraints SunX509
  */

--- a/test/jdk/sun/security/ssl/X509TrustManagerImpl/ComodoHacker.java
+++ b/test/jdk/sun/security/ssl/X509TrustManagerImpl/ComodoHacker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 7123519
  * @summary Problem with java/classes_security
- * @enablePreview
  * @run main/othervm ComodoHacker PKIX
  * @run main/othervm ComodoHacker SunX509
  */

--- a/test/jdk/sun/security/ssl/X509TrustManagerImpl/PKIXExtendedTM.java
+++ b/test/jdk/sun/security/ssl/X509TrustManagerImpl/PKIXExtendedTM.java
@@ -30,7 +30,6 @@
  * @test
  * @bug 6916074 8170131
  * @summary Add support for TLS 1.2
- * @enablePreview
  * @run main/othervm PKIXExtendedTM 0
  * @run main/othervm PKIXExtendedTM 1
  * @run main/othervm PKIXExtendedTM 2

--- a/test/jdk/sun/security/ssl/X509TrustManagerImpl/SunX509ExtendedTM.java
+++ b/test/jdk/sun/security/ssl/X509TrustManagerImpl/SunX509ExtendedTM.java
@@ -30,7 +30,6 @@
  * @test
  * @bug 6916074
  * @summary Add support for TLS 1.2
- * @enablePreview
  * @run main/othervm SunX509ExtendedTM
  */
 

--- a/test/jdk/sun/security/validator/PKIXValAndRevCheckTests.java
+++ b/test/jdk/sun/security/validator/PKIXValAndRevCheckTests.java
@@ -27,7 +27,6 @@
  * @summary Stapled OCSPResponses should be added to PKIXRevocationChecker
  *          irrespective of revocationEnabled flag
  * @library /test/lib
- * @enablePreview
  * @modules java.base/sun.security.validator
  * @build jdk.test.lib.Convert
  * @run main PKIXValAndRevCheckTests

--- a/test/jdk/sun/security/x509/X509CRLImpl/Verify.java
+++ b/test/jdk/sun/security/x509/X509CRLImpl/Verify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 7026347
  * @summary X509CRL should have verify(PublicKey key, Provider sigProvider)
- * @enablePreview
  */
 
 import java.security.InvalidKeyException;


### PR DESCRIPTION
Hi,

Please review the finalized PEM API (https://openjdk.org/jeps/8386511). This PR updates the Javadoc and removes the preview tags from the tests. There are no API changes since the third preview, JEP 538 (https://openjdk.org/jeps/538).

Tony

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8387950](https://bugs.openjdk.org/browse/JDK-8387950) to be approved

### Issues
 * [JDK-8387949](https://bugs.openjdk.org/browse/JDK-8387949): Implementation of PEM Encodings of Cryptographic Objects (**Enhancement** - P4)
 * [JDK-8387950](https://bugs.openjdk.org/browse/JDK-8387950): Implementation of PEM Encodings of Cryptographic Objects (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31888/head:pull/31888` \
`$ git checkout pull/31888`

Update a local copy of the PR: \
`$ git checkout pull/31888` \
`$ git pull https://git.openjdk.org/jdk.git pull/31888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31888`

View PR using the GUI difftool: \
`$ git pr show -t 31888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31888.diff">https://git.openjdk.org/jdk/pull/31888.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31888#issuecomment-4964482525)
</details>
