### PR TITLE
8388173: Shenandoah: Overly strict assertion failure in CAS barrier

### DIFF
--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -679,8 +679,7 @@ void ShenandoahBarrierSetAssembler::compare_and_set_c2(const MachNode* node, Mac
 
   assert(oldval == rax, "must be in rax for implicit use in cmpxchg");
 
-  // Oldval and newval cannot be clobbered by aliasing with tmp. The stub's constructor already asserts
-  // that tmp (_obj) is not the same register as addr.base() and addr.index().
+  // Oldval and newval cannot be clobbered by aliasing with tmp.
   assert_different_registers(oldval, tmp);
   assert_different_registers(newval, tmp);
 

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -679,10 +679,10 @@ void ShenandoahBarrierSetAssembler::compare_and_set_c2(const MachNode* node, Mac
 
   assert(oldval == rax, "must be in rax for implicit use in cmpxchg");
 
-  // Oldval and newval can be in the same register, but all other registers should be
-  // distinct for extra safety, as we shuffle register values around.
-  assert_different_registers(oldval, tmp, addr.base(), addr.index());
-  assert_different_registers(newval, tmp, addr.base(), addr.index());
+  // Oldval and newval cannot be in the same register as tmp. The stub's constructor already asserts
+  // that tmp (_obj) is not the same register as addr.base() and addr.index().
+  assert_different_registers(oldval, tmp);
+  assert_different_registers(newval, tmp);
 
   ShenandoahBarrierStubC2::load_store_pre(masm, node, addr, tmp, noreg, noreg, narrow);
 

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -679,7 +679,7 @@ void ShenandoahBarrierSetAssembler::compare_and_set_c2(const MachNode* node, Mac
 
   assert(oldval == rax, "must be in rax for implicit use in cmpxchg");
 
-  // Oldval and newval cannot be in the same register as tmp. The stub's constructor already asserts
+  // Oldval and newval cannot be clobbered by aliasing with tmp. The stub's constructor already asserts
   // that tmp (_obj) is not the same register as addr.base() and addr.index().
   assert_different_registers(oldval, tmp);
   assert_different_registers(newval, tmp);
@@ -703,7 +703,7 @@ void ShenandoahBarrierSetAssembler::compare_and_set_c2(const MachNode* node, Mac
 }
 
 void ShenandoahBarrierSetAssembler::get_and_set_c2(const MachNode* node, MacroAssembler* masm, Register newval, Address addr, Register tmp, bool narrow) {
-  assert_different_registers(newval, tmp, addr.base(), addr.index());
+  assert_different_registers(newval, tmp);
 
   ShenandoahBarrierStubC2::load_store_pre(masm, node, addr, tmp, noreg, noreg, narrow);
 


### PR DESCRIPTION
The stub's constructor already `assert_different_registers(_obj, _addr.base(), _addr.index());` where `_obj` is `tmp` for all x86 callers.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388173](https://bugs.openjdk.org/browse/JDK-8388173): Shenandoah: Overly strict assertion failure in CAS barrier (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31889/head:pull/31889` \
`$ git checkout pull/31889`

Update a local copy of the PR: \
`$ git checkout pull/31889` \
`$ git pull https://git.openjdk.org/jdk.git pull/31889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31889`

View PR using the GUI difftool: \
`$ git pr show -t 31889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31889.diff">https://git.openjdk.org/jdk/pull/31889.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31889#issuecomment-4963843708)
</details>
