### PR TITLE
8387750: 'java -XshowSettings' alone should not be an error

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -911,10 +911,12 @@ the Java HotSpot Virtual Machine.
     :   Do not attempt to use shared class data.
 
 [`-XshowSettings`]{#-XshowSettings}
-:   Shows all settings and then continues.
+:   Shows all settings and continues. It exits normally if there is no Java
+    application to launch.
 
 [`-XshowSettings:`]{#-XshowSettings_}*category*
-:   Shows settings and continues. Possible *category* arguments for this option
+:   Shows settings and continues. It exits normally if there is no Java
+    application to launch. Possible *category* arguments for this option
     include the following:
 
     `all`

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -911,13 +911,11 @@ the Java HotSpot Virtual Machine.
     :   Do not attempt to use shared class data.
 
 [`-XshowSettings`]{#-XshowSettings}
-:   Shows all settings and continues if further action is specified;
-    otherwise, exits normally.
+:   Shows all settings and then continues.
 
 [`-XshowSettings:`]{#-XshowSettings_}*category*
-:   Shows settings and continues if further action is specified; otherwise,
-    exits normally. Possible *category* arguments for this option include
-    the following:
+:   Shows settings and continues. Possible *category* arguments for this option
+    include the following:
 
     `all`
     :   Shows all categories of settings in **verbose** detail.
@@ -942,7 +940,7 @@ the Java HotSpot Virtual Machine.
     :   Shows the settings of the JVM.
 
     `system`
-    :   **Linux only:** Shows host system or container configuration.
+    :   **Linux only:** Shows host system or container configuration and continues.
 
 [`-Xss`]{#-Xss} *size*
 :   Sets the thread stack size (in bytes). Append the letter `k` or `K` to

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -911,11 +911,13 @@ the Java HotSpot Virtual Machine.
     :   Do not attempt to use shared class data.
 
 [`-XshowSettings`]{#-XshowSettings}
-:   Shows all settings and then continues.
+:   Shows all settings and continues if further action is specified;
+    otherwise, exits normally.
 
 [`-XshowSettings:`]{#-XshowSettings_}*category*
-:   Shows settings and continues. Possible *category* arguments for this option
-    include the following:
+:   Shows settings and continues if further action is specified; otherwise,
+    exits normally. Possible *category* arguments for this option include
+    the following:
 
     `all`
     :   Shows all categories of settings in **verbose** detail.
@@ -940,7 +942,7 @@ the Java HotSpot Virtual Machine.
     :   Shows the settings of the JVM.
 
     `system`
-    :   **Linux only:** Shows host system or container configuration and continues.
+    :   **Linux only:** Shows host system or container configuration.
 
 [`-Xss`]{#-Xss} *size*
 :   Sets the thread stack size (in bytes). Append the letter `k` or `K` to

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1360,7 +1360,7 @@ ParseArguments(int *pargc, char ***pargv,
             !describeModule &&
             !validateModules &&
             !dumpSharedSpaces &&
-            showSettings == NULL) {
+            !showSettings) {
             *pret = 1;
             printUsageKind = HELP_CONCISE;
         }

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1356,7 +1356,10 @@ ParseArguments(int *pargc, char ***pargv,
 
     if (*pwhat == NULL) {
         /* LM_UNKNOWN okay for options that exit */
-        if (!listModules && !describeModule && !validateModules && !dumpSharedSpaces &&
+        if (!listModules &&
+            !describeModule &&
+            !validateModules &&
+            !dumpSharedSpaces &&
             showSettings == NULL) {
             *pret = 1;
             printUsageKind = HELP_CONCISE;

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -549,6 +549,11 @@ JavaMain(void* _args)
         LEAVE();
     }
 
+    /* Exit normally after showing the settings if no application was specified. */
+    if (showSettings != NULL && what == NULL) {
+        LEAVE();
+    }
+
     FreeKnownVMs(); /* after last possible PrintUsage */
 
     if (JLI_IsTraceLauncher()) {
@@ -1351,7 +1356,8 @@ ParseArguments(int *pargc, char ***pargv,
 
     if (*pwhat == NULL) {
         /* LM_UNKNOWN okay for options that exit */
-        if (!listModules && !describeModule && !validateModules && !dumpSharedSpaces) {
+        if (!listModules && !describeModule && !validateModules && !dumpSharedSpaces &&
+            showSettings == NULL) {
             *pret = 1;
             printUsageKind = HELP_CONCISE;
         }

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -86,6 +86,7 @@ public class Settings extends TestHelper {
     private static final String ENABLED_GROUPS_SETTINGS = "Enabled Named Groups:";
     private static final String ENABLED_SIG_SCHEMES_SETTINGS =
             "Enabled Signature Schemes:";
+    private static final String USAGE_HEADER = "Usage: java";
 
     /*
      * "all" should print verbose settings
@@ -176,6 +177,7 @@ public class Settings extends TestHelper {
         TestResult tr = doExec(javaCmd, "-XshowSettings:all");
         tr.checkPositive();
         containsAllOptions(tr);
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionVM() throws IOException {
@@ -184,6 +186,7 @@ public class Settings extends TestHelper {
         checkContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
         checkNotContains(tr, LOCALE_SETTINGS);
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionProperty() throws IOException {
@@ -192,6 +195,7 @@ public class Settings extends TestHelper {
         checkNotContains(tr, VM_SETTINGS);
         checkContains(tr, PROP_SETTINGS);
         checkNotContains(tr, LOCALE_SETTINGS);
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionLocale() throws IOException {
@@ -204,6 +208,7 @@ public class Settings extends TestHelper {
         checkNotContains(tr, LOCALE_SUMMARY_SETTINGS);
         checkContains(tr, TIMEZONE_SETTINGS);
         checkContains(tr, TZDATA_SETTINGS);
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionSecurity() throws IOException {
@@ -214,6 +219,7 @@ public class Settings extends TestHelper {
         checkContains(tr, SEC_PROPS_SETTINGS);
         checkContains(tr, SEC_PROVIDER_SETTINGS);
         checkContains(tr, SEC_TLS_SETTINGS);
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionSecurityProps() throws IOException {
@@ -224,6 +230,7 @@ public class Settings extends TestHelper {
         checkNotContains(tr, SEC_TLS_SETTINGS);
         // test a well known property for sanity
         checkContains(tr, "keystore.type=pkcs12");
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionSecurityProv() throws IOException {
@@ -237,6 +244,7 @@ public class Settings extends TestHelper {
         // test for a well known alias (SunJCE: AlgorithmParameterGenerator.DiffieHellman)
         checkContains(tr, "aliases: [1.2.840.113549.1.3.1, " +
                 "DH, OID.1.2.840.113549.1.3.1]");
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionSecurityTLS() throws IOException {
@@ -249,6 +257,7 @@ public class Settings extends TestHelper {
         checkContains(tr, "TLSv1.2");
         checkContains(tr, ENABLED_GROUPS_SETTINGS);
         checkContains(tr, ENABLED_SIG_SCHEMES_SETTINGS);
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     // ensure error message is printed when unrecognized option used
@@ -275,6 +284,7 @@ public class Settings extends TestHelper {
             checkNotContains(tr, VM_SETTINGS);
             checkContains(tr, METRICS_NOT_AVAILABLE_MSG);
         }
+        checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestBadOptions() throws IOException {
@@ -323,15 +333,6 @@ public class Settings extends TestHelper {
             throw new RuntimeException("test fails");
         }
         containsDefaultOptions(tr);
-    }
-
-    static void runTestStandaloneDoesNotPrintUsage() throws IOException {
-        TestResult tr = doExec(javaCmd,
-                               "-Duser.language=en",
-                               "-Duser.country=US",
-                               "-XshowSettings:vm");
-        tr.checkPositive();
-        checkNotContains(tr, "Usage: java");
     }
 
     public static void main(String... args) throws IOException {

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 /*
  * @test
- * @bug 6994753 7123582 8305950 8281658 8310201 8311653 8343804 8351354 8366364
+ * @bug 6994753 7123582 8305950 8281658 8310201 8311653 8343804 8351354 8366364 8387750
  * @summary tests -XshowSettings options
  * @modules jdk.compiler
  *          jdk.zipfs
@@ -174,11 +174,13 @@ public class Settings extends TestHelper {
     static void runTestOptionAll() throws IOException {
         init();
         TestResult tr = doExec(javaCmd, "-XshowSettings:all");
+        tr.checkPositive();
         containsAllOptions(tr);
     }
 
     static void runTestOptionVM() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:vm");
+        tr.checkPositive();
         checkContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
         checkNotContains(tr, LOCALE_SETTINGS);
@@ -186,6 +188,7 @@ public class Settings extends TestHelper {
 
     static void runTestOptionProperty() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:properties");
+        tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkContains(tr, PROP_SETTINGS);
         checkNotContains(tr, LOCALE_SETTINGS);
@@ -193,6 +196,7 @@ public class Settings extends TestHelper {
 
     static void runTestOptionLocale() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:locale");
+        tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
         checkContains(tr, LOCALE_SETTINGS);
@@ -204,6 +208,7 @@ public class Settings extends TestHelper {
 
     static void runTestOptionSecurity() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:security");
+        tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
         checkContains(tr, SEC_PROPS_SETTINGS);
@@ -213,6 +218,7 @@ public class Settings extends TestHelper {
 
     static void runTestOptionSecurityProps() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:security:properties");
+        tr.checkPositive();
         checkContains(tr, SEC_PROPS_SETTINGS);
         checkNotContains(tr, SEC_PROVIDER_SETTINGS);
         checkNotContains(tr, SEC_TLS_SETTINGS);
@@ -222,6 +228,7 @@ public class Settings extends TestHelper {
 
     static void runTestOptionSecurityProv() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:security:providers");
+        tr.checkPositive();
         checkNotContains(tr, SEC_PROPS_SETTINGS);
         checkContains(tr, SEC_PROVIDER_SETTINGS);
         checkNotContains(tr, SEC_TLS_SETTINGS);
@@ -234,6 +241,7 @@ public class Settings extends TestHelper {
 
     static void runTestOptionSecurityTLS() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:security:tls");
+        tr.checkPositive();
         checkNotContains(tr, SEC_PROPS_SETTINGS);
         checkNotContains(tr, SEC_PROVIDER_SETTINGS);
         checkContains(tr, SEC_TLS_SETTINGS);
@@ -255,6 +263,7 @@ public class Settings extends TestHelper {
     }
     static void runTestOptionSystem() throws IOException {
         TestResult tr = doExec(javaCmd, "-XshowSettings:system");
+        tr.checkPositive();
         if (System.getProperty("os.name").contains("Linux")) {
             checkNotContains(tr, VM_SETTINGS);
             checkNotContains(tr, PROP_SETTINGS);
@@ -314,6 +323,15 @@ public class Settings extends TestHelper {
             throw new RuntimeException("test fails");
         }
         containsDefaultOptions(tr);
+    }
+
+    static void runTestStandaloneDoesNotPrintUsage() throws IOException {
+        TestResult tr = doExec(javaCmd,
+                               "-Duser.language=en",
+                               "-Duser.country=US",
+                               "-XshowSettings:vm");
+        tr.checkPositive();
+        checkNotContains(tr, "Usage: java");
     }
 
     public static void main(String... args) throws IOException {


### PR DESCRIPTION
Please review this change, thanks!

**Description:**

`java -XshowSettings` without an application currently prints the requested settings, then prints usage information and exits with code 1.

**Solution:**

Treat `-XshowSettings` as an option that can be used without an application target. During argument parsing, do not mark the absence of a main class or JAR file as an error when `-XshowSettings` is specified. After the settings and any explicitly requested launcher output have been processed, exit normally if no application was provided.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8388185](https://bugs.openjdk.org/browse/JDK-8388185) to be approved
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8387750](https://bugs.openjdk.org/browse/JDK-8387750): 'java -XshowSettings' alone should not be an error (**Enhancement** - P4)
 * [JDK-8388185](https://bugs.openjdk.org/browse/JDK-8388185): 'java -XshowSettings' alone should not be an error (**CSR**)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31891/head:pull/31891` \
`$ git checkout pull/31891`

Update a local copy of the PR: \
`$ git checkout pull/31891` \
`$ git pull https://git.openjdk.org/jdk.git pull/31891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31891`

View PR using the GUI difftool: \
`$ git pr show -t 31891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31891.diff">https://git.openjdk.org/jdk/pull/31891.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31891#issuecomment-4965282511)
</details>
