### PR TITLE
8388016: [s390x] Remove the alignment from stubGenerator

### DIFF
--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -3306,10 +3306,12 @@ class StubGenerator: public StubCodeGenerator {
     // Make room for the thawed frames and align the stack.
     __ add64(Z_RET, frame::z_abi_160_size);
 
-    { // stack alignment
-      __ z_lcgr(Z_RET, Z_RET); // negate Z_RET value
-      __ z_nill(Z_RET, -frame::alignment_in_bytes);
-    }
+#ifdef ASSERT
+    __ z_tmll(Z_RET, frame::alignment_in_bytes - 1);
+    __ asm_assert(Assembler::bcondAllZero, FILE_AND_LINE ": size is not aligned properly", 71);
+#endif // ASSERT
+
+    __ z_lcgr(Z_RET, Z_RET); // negate Z_RET value
     __ resize_frame( /* offset = */ Z_RET,/* fp = */ Z_R1, /* load_fp = */ true);
 
     __ z_lghi(Z_ARG2, kind);


### PR DESCRIPTION
In generate_cont_thaw on s390, after Continuation::prepare_thaw returns the size of the frames to thaw, the stub was aligning the size to the multiple of frame::alignment_in_bytes (8 bytes). This alignment is redundant as the size should already be 8 bytes aligned.

See comment: https://github.com/openjdk/jdk/pull/31441#discussion_r3550081682

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388016](https://bugs.openjdk.org/browse/JDK-8388016): [s390x] Remove the alignment from stubGenerator (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31893/head:pull/31893` \
`$ git checkout pull/31893`

Update a local copy of the PR: \
`$ git checkout pull/31893` \
`$ git pull https://git.openjdk.org/jdk.git pull/31893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31893`

View PR using the GUI difftool: \
`$ git pr show -t 31893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31893.diff">https://git.openjdk.org/jdk/pull/31893.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31893#issuecomment-4965366087)
</details>
