### PR TITLE
8388188: NMT: Remove unused local variable in RegionIterator::next_committed

### DIFF
--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -281,7 +281,6 @@ private:
 bool RegionIterator::next_committed(address& committed_start, size_t& committed_size) {
   if (end() <= _current_start) return false;
 
-  const size_t page_sz = os::vm_page_size();
   const size_t current_size = end() - _current_start;
   if (os::first_resident_in_range(_current_start, current_size, committed_start, committed_size)) {
     assert(committed_start != nullptr, "Must be");


### PR DESCRIPTION
Trivial removing dead code.

Test: build

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388188](https://bugs.openjdk.org/browse/JDK-8388188): NMT: Remove unused local variable in RegionIterator::next_committed (**Enhancement** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31894/head:pull/31894` \
`$ git checkout pull/31894`

Update a local copy of the PR: \
`$ git checkout pull/31894` \
`$ git pull https://git.openjdk.org/jdk.git pull/31894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31894`

View PR using the GUI difftool: \
`$ git pr show -t 31894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31894.diff">https://git.openjdk.org/jdk/pull/31894.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31894#issuecomment-4966562371)
</details>
