### PR TITLE
8288618: Permissions are different in container as platform execution affecting some tests

### DIFF
--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -24,6 +24,7 @@
 /* @test
  * @bug 4842706 8024695 8361587 8362429
  * @summary Test some file operations with empty path
+ * @library /test/lib
  * @run junit EmptyPath
  */
 
@@ -46,9 +47,12 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+
+import jdk.test.lib.Platform;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -322,6 +326,7 @@ public class EmptyPath {
 
     @Test
     @DisabledOnOs({OS.WINDOWS})
+    @DisabledIf("jdk.test.lib.Platform#isRoot")
     public void setReadable() {
         assertTrue(f.canRead());
         try {
@@ -336,6 +341,7 @@ public class EmptyPath {
 
     @Test
     @DisabledOnOs({OS.WINDOWS})
+    @DisabledIf("jdk.test.lib.Platform#isRoot")
     public void setReadOnly() {
         assertTrue(f.canExecute());
         assertTrue(f.canRead());
@@ -353,6 +359,7 @@ public class EmptyPath {
 
     @Test
     @DisabledOnOs({OS.WINDOWS})
+    @DisabledIf("jdk.test.lib.Platform#isRoot")
     public void setWritable() {
         assertTrue(f.canWrite());
         try {

--- a/test/jdk/java/nio/file/Files/CopyAndMove.java
+++ b/test/jdk/java/nio/file/Files/CopyAndMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -846,7 +846,8 @@ public class CopyAndMove {
             createFile(target);
             try {
                 Files.copy(source, target, REPLACE_EXISTING);
-                throw new RuntimeException("AccessDeniedException not thrown");
+                if (!Platform.isRoot())
+                    throw new RuntimeException("AccessDeniedException not thrown");
             } catch (AccessDeniedException expected) {
             }
             if (!Files.exists(target))

--- a/test/jdk/javax/management/security/HashedPasswordFileTest.java
+++ b/test/jdk/javax/management/security/HashedPasswordFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,11 @@
  */
 
 import jdk.internal.agent.ConnectorAddressLink;
+import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -233,6 +235,9 @@ public class HashedPasswordFileTest {
 
     @Test
     public void testReadOnlyPasswordFile() throws IOException {
+        if (Platform.isRoot()) {
+            throw new SkipException("Test skipped when executed by root user.");
+        }
         Boolean[] bvals = new Boolean[]{true, false};
         for (boolean bval : bvals) {
             try {


### PR DESCRIPTION
Adds Platform.isRoot() guards to the permission check methods in these tests so they skip when running as root. In container-as-platform / root execution, root bypasses permission bits, so tests asserting permission-denial fail (the expected exception isn't thrown).

- EmptyPath: @DisabledIf isRoot on setReadable/setReadOnly/setWritable
- CopyAndMove: skip the AccessDeniedException assertion when root
- HashedPasswordFileTest: SkipException on testReadOnlyPasswordFile when root

Follows the existing pattern (TargetDirectory.java, JCmdTestFileSafety.java already do this, per JDK-8311952)
Verified on OL9 x64 and aarch64, both root (methods skip, no false failures) and non-root (all methods run and pass)


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8288618`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8288618`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31895/head:pull/31895` \
`$ git checkout pull/31895`

Update a local copy of the PR: \
`$ git checkout pull/31895` \
`$ git pull https://git.openjdk.org/jdk.git pull/31895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31895`

View PR using the GUI difftool: \
`$ git pr show -t 31895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31895.diff">https://git.openjdk.org/jdk/pull/31895.diff</a>

</details>
