### PR TITLE
8387698: C2 VectorAPI: Float16Vector::indexInRange hits: fatal error: Not monotonic

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -468,6 +468,11 @@ const Type* CheckCastPPNode::Value(PhaseGVN* phase) const {
   if (in_type != nullptr && my_type != nullptr) {
     TypePtr::PTR in_ptr = in_type->ptr();
     if (in_ptr == TypePtr::Null) {
+      // A null input cast to a type that cannot be null (e.g. NotNull) describes
+      // an impossible value: the join is empty, so the result must be TOP.
+      if (my_type->join_ptr(TypePtr::Null) == TypePtr::TopPTR) {
+        return Type::TOP;
+      }
       result = in_type;
     } else if (in_ptr != TypePtr::Constant) {
       result =  my_type->cast_to_ptr_type(my_type->join_ptr(in_ptr));

--- a/test/hotspot/jtreg/compiler/vectorapi/TestFloat16VectorConvergence.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestFloat16VectorConvergence.java
@@ -33,9 +33,10 @@ import java.util.Random;
  * @summary C2 VectorAPI: Float16Vector::indexInRange hits fatal error: Not monotonic.
  * @modules jdk.incubator.vector
  * @requires vm.debug == true
- * @run main/othervm -XX:-UncommonNullCast -XX:-MonomorphicArrayCheck -Xbatch
- *                   -XX:CompileCommand=compileonly,compiler.vectorapi.TestFloat16VectorConvergence::test
- *                   compiler.vectorapi.TestFloat16VectorConvergence
+ * @run main ${test.main.class}
+ * @run main/othervm -XX:-UncommonNullCast -Xbatch
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
  */
 public class TestFloat16VectorConvergence {
 
@@ -47,12 +48,13 @@ public class TestFloat16VectorConvergence {
 
     public static void main(String[] args) {
         Random random = new Random(0);
-        Object last = null;
         for (int i = 0; i < 10_000; i++) {
             // A negative offset drives indexInRange into indexPartiallyInRange,
             // which is where the un-foldable Float16 mask unbox is produced.
-            last = test(-70368744177664L, random.nextLong());
+            Object mask = test(-70368744177664L, random.nextLong());
+            if (mask == null) {
+                throw new AssertionError("Unexpected null result from indexInRange");
+            }
         }
-        System.out.println("Test passed: " + (last != null));
     }
 }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestFloat16VectorConvergence.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestFloat16VectorConvergence.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.vectorapi;
+
+import jdk.incubator.vector.Float16Vector;
+import jdk.incubator.vector.VectorMask;
+
+import java.util.Random;
+
+/*
+ * @test
+ * @bug 8387698
+ * @summary C2 VectorAPI: Float16Vector::indexInRange hits fatal error: Not monotonic.
+ * @modules jdk.incubator.vector
+ * @requires vm.debug == true
+ * @run main/othervm -XX:-UncommonNullCast -XX:-MonomorphicArrayCheck -Xbatch
+ *                   -XX:CompileCommand=compileonly,compiler.vectorapi.TestFloat16VectorConvergence::test
+ *                   compiler.vectorapi.TestFloat16VectorConvergence
+ */
+public class TestFloat16VectorConvergence {
+
+    static Object test(long offset, long limit) {
+        boolean[] array = new boolean[16];
+        var v = VectorMask.fromArray(Float16Vector.SPECIES_256, array, 0);
+        return v.indexInRange(offset, limit);
+    }
+
+    public static void main(String[] args) {
+        Random random = new Random(0);
+        Object last = null;
+        for (int i = 0; i < 10_000; i++) {
+            // A negative offset drives indexInRange into indexPartiallyInRange,
+            // which is where the un-foldable Float16 mask unbox is produced.
+            last = test(-70368744177664L, random.nextLong());
+        }
+        System.out.println("Test passed: " + (last != null));
+    }
+}


### PR DESCRIPTION
This PR fixes a fatal error: Not monotonic in` PhaseCCP::verify_type`, hit while compiling an unbox of a partially-intrinsified Float16Vector type.

CCP is an optimistic data flow analysis pass where initially all the lattice points are initialized with TOP value, with each iteration Value routines are called on graph nodes, and it's expected that the type information of a lattice value monotonically widens with each iteration. In this case a CheckCastPP is tied to a Phi node with one of its inputs being null and the other being non-null, and the cast's own type is a NotNull oop array (the vector payload).

During the fixed-point iteration the Phi (and hence the cast input) is first seen as null before it widens to a nullable oop. `CheckCastPPNode::Value() `handles the null input through the branch `if (in_ptr == TypePtr::Null) result = in_type;, `returning the null input as the cast's type. On a later iteration the input widens to a nullable oop, and the cast then joins it with its NotNull type and returns NotNull. So the cast's computed type moves` null -> NotNull `across iterations, which is not a monotonic (downward) step — null and NotNull are incomparable in the pointer lattice` (meet(NotNull, Null) == BotPTR != NotNull) `— and `PhaseCCP::verify_type` aborts with `told = null, tnew = NotNull.`

A null value cast to a type that cannot be null describes an impossible value, so the correct result is TOP — not the null input. With TOP the sequence becomes`TOP -> NotNull`, a valid downward step in the lattice, and the type monotonically widens as expected.

Kindly review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387698](https://bugs.openjdk.org/browse/JDK-8387698): C2 VectorAPI: Float16Vector::indexInRange hits: fatal error: Not monotonic (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31896/head:pull/31896` \
`$ git checkout pull/31896`

Update a local copy of the PR: \
`$ git checkout pull/31896` \
`$ git pull https://git.openjdk.org/jdk.git pull/31896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31896`

View PR using the GUI difftool: \
`$ git pr show -t 31896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31896.diff">https://git.openjdk.org/jdk/pull/31896.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31896#issuecomment-4966798643)
</details>
