### PR TITLE
8387745: [aot] Several tests fail because a SoftReferenceKey cannot be archived

### DIFF
--- a/src/hotspot/share/cds/aotReferenceObjSupport.cpp
+++ b/src/hotspot/share/cds/aotReferenceObjSupport.cpp
@@ -142,6 +142,16 @@ void AOTReferenceObjSupport::stabilize_cached_reference_objects(TRAPS) {
                            vmSymbols::void_method_signature(),
                            CHECK);
     }
+    {
+      TempNewSymbol method_name = SymbolTable::new_symbol("assemblySetup");
+      JavaValue result(T_VOID);
+      Symbol* baseLocale_name = vmSymbols::sun_util_locale_BaseLocale();
+      Klass* baseLocale_klass = SystemDictionary::resolve_or_fail(baseLocale_name, true, CHECK);
+      JavaCalls::call_static(&result, baseLocale_klass,
+                             method_name,
+                             vmSymbols::void_method_signature(),
+                             CHECK);
+    }
 
     {
       Symbol* cds_name  = vmSymbols::jdk_internal_misc_CDS();

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -731,6 +731,7 @@ class SerializeClosure;
   template(runtimeSetup,                                    "runtimeSetup")                                       \
   template(toFileURL_name,                                  "toFileURL")                                          \
   template(toFileURL_signature,                             "(Ljava/lang/String;)Ljava/net/URL;")                 \
+  template(sun_util_locale_BaseLocale,                      "sun/util/locale/BaseLocale")                         \
                                                                                                                   \
   /* jcmd Thread.dump_to_file */                                                                                  \
   template(jdk_internal_vm_ThreadDumper,           "jdk/internal/vm/ThreadDumper")                                \

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -275,4 +275,10 @@ public final class BaseLocale {
         }
         return h;
     }
+
+    // This is called from C code, at the very end of Java code execution
+    // during the AOT cache assembly phase.
+    private static void assemblySetup() {
+        CACHE.get().prepareForAOTCache();
+    }
 }


### PR DESCRIPTION
This PR fixes an issue when archiving `sun.util.locale.BaseLocale.CACHE` in AOTCache or cds archive. `CACHE` is a `LazyConstant` holder for a `ReferenceKeySet`. If the CACHE has any element added during the assembly phase, then the `ReferenceKeySet` needs to be prepared for archiving, just like it is done for `MethodType.internTable` [0].

An element is added to the CACHE in `BaseLocale.getInstance` if `BaseLocale.script` is not empty. Depending on the locale settings, it may or may not be empty. For example, on my Linux system with locale `en_US`, `script` is empty. To force script to be non-empty set these system properties:
`-Duser.language=en -Duser.script=Latn -Duser.country=US`

Testing: 
To reproduce the issue on Linux, run `runtime/cds/appcds/aotClassLinking/AOTClassLinkingVMOptions.java` with the above mentioned system properties, as:
```
make test TEST=test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AOTClassLinkingVMOptions.java CONF=base-fd TEST_OPTS_JAVA_OPTIONS="-Duser.language=en -Duser.script=Latn -Duser.country=US"
```

It results in following error:
```
 stdout: [[0.004s][info][cds] Core region alignment: 4096
[0.131s][info][cds] Loading classes to share ...
[0.131s][info][cds] Parsing /home/asmehra/data/ashu-mehra/jdk/build/base-fd/images/jdk/lib/classlist
[0.198s][info][cds] Parsing /home/asmehra/data/ashu-mehra/jdk/build/base-fd/test-support/jtreg_test_hotspot_jtreg_runtime_cds_appcds_aotClassLinking_AOTClassLinkingVMOptions_java/scratch/0/runtime.cds.appcds.aotClassLinking.AOTClassLinkingVMOptions.java-test.classlist
[0.199s][info][cds] Loading classes to share: done.
[0.461s][info][cds] Dumping shared data to file: /home/asmehra/data/ashu-mehra/jdk/build/base-fd/test-support/jtreg_test_hotspot_jtreg_runtime_cds_appcds_aotClassLinking_AOTClassLinkingVMOptions_java/scratch/0/appcds-14h41m37s070.jsa
[0.461s][info][cds] Gathering all archivable objects ... 
[0.478s][info][cds] Skipping jdk/internal/misc/CDS$UnregisteredClassLoader: used only when dumping CDS archive
[0.478s][info][cds] Skipping jdk/internal/misc/CDS$UnregisteredClassLoader$Source: used only when dumping CDS archive
[0.479s][info][cds] Heap range = [0x000000009c000000 - 0x0000000100000000]
[0.535s][error][aot,heap] Cannot archive reference object 0x000000009c012418 of class jdk.internal.util.SoftReferenceKey
[0.535s][error][aot,heap] referent = 0x000000009c012440, queue = 0x000000009c012488, next = 0x0000000000000000, discovered = 0x0000000000000000
[0.535s][error][aot,heap] This object requires special clean up as its queue is not ReferenceQueue::NULL (0x000000009c12d398)
[0.535s][error][aot,heap] referent is not registered with CDS.keepAlive()
[0.535s][error][aot,heap] Reference trace
[0.535s][error][aot,heap] [ 0] {0x000000009c012338} jdk.internal.lang.LazyConstantImpl::constant (offset = 8)
[0.535s][error][aot,heap] [ 1] {0x000000009c012348} jdk.internal.util.ReferencedKeySet::map (offset = 8)
[0.535s][error][aot,heap] [ 2] {0x000000009c012358} jdk.internal.util.ReferencedKeyMap::map (offset = 12)
[0.535s][error][aot,heap] [ 3] {0x000000009c012370} java.util.concurrent.ConcurrentHashMap::table (offset = 16)
[0.535s][error][aot,heap] [ 4] {0x000000009c0123b0} [Ljava.util.concurrent.ConcurrentHashMap$Node; @[10]
[0.535s][error][aot,heap] [ 5] {0x000000009c012400} java.util.concurrent.ConcurrentHashMap$Node
[0.535s][error][cds     ] An error has occurred while writing the shared archive file.
];
```

This problem also happens during the assembly phase of generating the AOTCache.

With this patch, the error is gone and the test passes.

[0] https://github.com/openjdk/jdk/blob/fe430ad121464d731402ef4add6d57dadffe723e/src/java.base/share/classes/java/lang/invoke/MethodType.java#L1384 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387745](https://bugs.openjdk.org/browse/JDK-8387745): [aot] Several tests fail because a SoftReferenceKey cannot be archived (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31902/head:pull/31902` \
`$ git checkout pull/31902`

Update a local copy of the PR: \
`$ git checkout pull/31902` \
`$ git pull https://git.openjdk.org/jdk.git pull/31902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31902`

View PR using the GUI difftool: \
`$ git pr show -t 31902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31902.diff">https://git.openjdk.org/jdk/pull/31902.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31902#issuecomment-4973707486)
</details>
