### PR TITLE
8388286: Incorrect default value is set for maxsize at DCmdStart

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -557,7 +557,7 @@ final class DCmdStart extends AbstractDCmd {
                 "NANOTIME", false, true, "0", false),
             new Argument("maxsize",
                 "Maximum amount of bytes to keep (on disk) in (k)B, (M)B or (G)B, e.g. 500M, or 0 for no limit",
-                "MEMORY SIZE", false, true, "250M", false),
+                "MEMORY SIZE", false, true, "0", false),
             new Argument("flush-interval",
                 "Minimum time before flushing buffers, measured in (s)econds, e.g. 4 s, or 0 for flushing when a recording ends",
                 "NANOTIME", false, true, "1s", false),


### PR DESCRIPTION
According to `helpTemplate()` in `DCmdStart.java` and [the document of `java`](https://docs.oracle.com/en/java/javase/26/docs/specs/man/java.html), `maxsize` which can be specified in `-XX:StartFlightRecording` and `JFR.start` dcmd would be set to zero by default. However 250MB is set by default at `getArgumentInfos()` in `DCmdStart.java`. 250MB would be set if all of `duration`, `maxsize` and `maxage` are not specified when `disk` is `true`. It is not a default value.

All of jdk/jfr tests were passed with this change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388286](https://bugs.openjdk.org/browse/JDK-8388286): Incorrect default value is set for maxsize at DCmdStart (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31904/head:pull/31904` \
`$ git checkout pull/31904`

Update a local copy of the PR: \
`$ git checkout pull/31904` \
`$ git pull https://git.openjdk.org/jdk.git pull/31904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31904`

View PR using the GUI difftool: \
`$ git pr show -t 31904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31904.diff">https://git.openjdk.org/jdk/pull/31904.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31904#issuecomment-4977447922)
</details>
