### PR TITLE
8387328: C2: A Phi must not have a narrower Type than its inputs

### DIFF
--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -480,6 +480,7 @@ class Parse : public GraphKit {
   // Helper: Merge the current mapping into the given basic block
   void merge_common(Block* target, int pnum);
   // Helper functions for merging individual cells.
+  Node* maybe_narrow_phi_input(Node* ctrl, Node* n, const Type* phi_type);
   PhiNode *ensure_phi(       int idx, bool nocreate = false);
   PhiNode *ensure_memory_phi(int idx, bool nocreate = false);
   // Helper to merge the current memory state into the given basic block

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1883,7 +1883,8 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
       if (phi != nullptr) {
         assert(n != top() || r->in(pnum) == top(), "live value must not be garbage");
         assert(phi->region() == r, "");
-        phi->set_req(pnum, n);  // Then add 'n' to the merge
+        phi->set_req(pnum, maybe_narrow_phi_input(r->in(pnum), n, _gvn.type(phi)));
+
         if (pnum == PhiNode::Input) {
           // Last merge for this Phi.
           // So far, Phis have had a reasonable type from ciTypeFlow.
@@ -2060,6 +2061,21 @@ int Parse::Block::add_new_path() {
   return pnum;
 }
 
+// The verifier ensures that the ciType of phi is not narrower than its inputs. However, since
+// TypeOopPtr::make_from_klass may be aggressive if it finds that the ciType has only a single
+// concrete subtype, and concurrent class loading/unloading may change this property during the
+// compilation process, it may be the case that the Type of phi is narrower than its inputs. In
+// those cases, we need to insert a CheckCastPP, otherwise several PhiNode idealization may be
+// unsound, as we may replace a Phi which has a narrower Type with one of its input which has a
+// wider Type.
+Node* Parse::maybe_narrow_phi_input(Node* ctrl, Node* n, const Type* phi_type) {
+  if (phi_type->isa_oopptr() != nullptr && !_gvn.type(n)->higher_equal(phi_type)) {
+    n = new CheckCastPPNode(ctrl, n, phi_type, ConstraintCastNode::DependencyType::NonFloatingNarrowing);
+    n = _gvn.transform(n);
+  }
+  return n;
+}
+
 //------------------------------ensure_phi-------------------------------------
 // Turn the idx'th entry of the current map into a Phi
 PhiNode *Parse::ensure_phi(int idx, bool nocreate) {
@@ -2108,9 +2124,18 @@ PhiNode *Parse::ensure_phi(int idx, bool nocreate) {
     return nullptr;
   }
 
-  PhiNode* phi = PhiNode::make(region, o, t);
+  PhiNode* phi = new PhiNode(region, t);
   gvn().set_type(phi, t);
-  if (C->do_escape_analysis()) record_for_igvn(phi);
+  for (uint i = 1; i < phi->req(); i++) {
+    Node* ctrl = region->in(i);
+    if (ctrl != nullptr) {
+      phi->init_req(i, maybe_narrow_phi_input(ctrl, o, t));
+    }
+  }
+
+  if (C->do_escape_analysis()) {
+    record_for_igvn(phi);
+  }
   map->set_req(idx, phi);
   return phi;
 }

--- a/test/hotspot/jtreg/compiler/parsing/TestNarrowPhi.java
+++ b/test/hotspot/jtreg/compiler/parsing/TestNarrowPhi.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.parsing;
+
+import java.io.IOException;
+import java.util.Objects;
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+import jdk.test.lib.process.ProcessTools;
+
+/*
+ * @test
+ * @bug 8387328
+ * @summary A Phi having a narrower Type than its inputs may result in incorrect scheduling
+ * @library /test/lib
+ * @requires vm.compiler2.enabled
+ * @modules java.base/jdk.internal.misc
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   ${test.main.class}
+ */
+public class TestNarrowPhi {
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+    private static volatile Throwable failure;
+
+    private static abstract class P {
+        int u;
+
+        private static P allocate() {
+            return new C();
+        }
+    }
+
+    private static class C extends P {
+        int v;
+    }
+
+    public static void main(String[] args) throws IOException, InterruptedException, NoSuchMethodException {
+        if (args.length == 0) {
+            spawnTestProcesses();
+        } else {
+            int idx = Integer.parseInt(args[0]);
+            runTest(idx);
+        }
+    }
+
+    private static void spawnTestProcesses() throws IOException, InterruptedException {
+        String testClassName = TestNarrowPhi.class.getName();
+        // Since we cannot reliably coordinate the compiler thread and the thread that load the
+        // child class, randomly delaying one of them
+        for (int i = 0; i <= 10; i++) {
+            var builder = ProcessTools.createTestJavaProcessBuilder(
+                    "-Xbootclasspath/a:.",
+                    "-Xbatch",
+                    "-XX:-TieredCompilation",
+                    "-XX:+UnlockDiagnosticVMOptions",
+                    "-XX:+WhiteBoxAPI",
+                    "-XX:CompileOnly=" + testClassName + "::test*",
+                    "-XX:CompileCommand=inline," + testClassName + "::inline*",
+                    "-XX:CompileCommand=dontinline," + testClassName + "::nonInline",
+                    "-XX:CompileCommand=delayinline," + testClassName + "::inlineTestHelper",
+                    testClassName,
+                    Integer.toString(i));
+            builder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+            builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+            var process = builder.start();
+            process.waitFor();
+            Asserts.assertEQ(0, process.exitValue());
+        }
+    }
+
+    private static void runTest(int idx) throws InterruptedException, NoSuchMethodException {
+        var testMethod = TestNarrowPhi.class.getDeclaredMethod("testMethod", boolean.class, P.class, P.class, P.class);
+        var _ = Objects.class;
+        Thread loader = new Thread(() -> {
+            try {
+                if (idx < 5) {
+                    Thread.sleep((5 - idx) * 10L);
+                }
+                var _ = C.class;
+            } catch (Exception e) {
+                failure = e;
+            }
+        });
+        loader.start();
+
+        if (idx > 5) {
+            Thread.sleep((idx - 5) * 10L);
+        }
+        if (!WHITE_BOX.enqueueMethodForCompilation(testMethod, 4)) {
+            throw new RuntimeException("Could not enqueue the test method for C2 compilation");
+        }
+        while (WHITE_BOX.isMethodQueuedForCompilation(testMethod)) {
+            Thread.yield();
+        }
+        P p = P.allocate();
+        Asserts.assertEQ(0, testMethod(true, p, p, p));
+        loader.join();
+        if (failure != null) {
+            throw new RuntimeException(failure);
+        }
+    }
+
+    private static int testMethod(boolean b, P p1, P p2, P p3) {
+        // Arbitrarily delay the parser between generating the Type for P1 and for the loop Phi
+        // below
+        inline0();
+        // This method is late-inlined, which increases the chance that C has been loaded then
+        return inlineTestHelper(b, p1, p2, p3);
+    }
+
+    private static int inlineTestHelper(boolean b, P p1, P p2, P p3) {
+        // Random access that can be used as an implicit null-check, so that the load below can
+        // float freely
+        p1.u = 0;
+        P p = p1;
+        for (int i = 0; i < 1; i++) {
+            if (i % 2 != 0) {
+                p = p2;
+            }
+        }
+
+        C cp = (C) Objects.requireNonNull(p);
+        C cp3 = (C) Objects.requireNonNull(p3);
+        int res = cp.v;
+        cp3.v = 1;
+        if (b) {
+            cp3.v = 2;
+            return res;
+        } else {
+            return nonInline();
+        }
+    }
+
+    private static int nonInline() {
+        return 0;
+    }
+
+    private static void inline0() {
+        inline1();
+        inline1();
+        inline1();
+        inline1();
+    }
+
+    private static void inline1() {
+        inline2();
+        inline2();
+        inline2();
+        inline2();
+    }
+
+    private static void inline2() {
+        inline3();
+        inline3();
+        inline3();
+        inline3();
+    }
+
+    private static void inline3() {
+        inline4();
+        inline4();
+        inline4();
+        inline4();
+    }
+
+    private static void inline4() {
+        inline5();
+        inline5();
+        inline5();
+        inline5();
+    }
+
+    private static void inline5() {}
+}


### PR DESCRIPTION
Hi,

This pull request contains a backport of commit [2b05a136](https://github.com/openjdk/jdk/commit/2b05a136cb80221a4252719510f817e268da5d5a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Quan Anh Mai on 15 Jul 2026 and was reviewed by Tobias Hartmann and Vladimir Ivanov.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387328](https://bugs.openjdk.org/browse/JDK-8387328): C2: A Phi must not have a narrower Type than its inputs (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31905/head:pull/31905` \
`$ git checkout pull/31905`

Update a local copy of the PR: \
`$ git checkout pull/31905` \
`$ git pull https://git.openjdk.org/jdk.git pull/31905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31905`

View PR using the GUI difftool: \
`$ git pr show -t 31905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31905.diff">https://git.openjdk.org/jdk/pull/31905.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31905#issuecomment-4977972678)
</details>
