### PR TITLE
8388285: [s390] compP_reg_mem is missing the barrier_data() == 0 predicate

### DIFF
--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -8783,6 +8783,7 @@ instruct compP_decode_reg_imm0(flagsReg cr, iRegN op1, immP0 op2) %{
 
 instruct compP_reg_mem(iRegP dst, memory src, flagsReg cr)%{
   match(Set cr (CmpP dst (LoadP src)));
+  predicate(n->in(2)->as_Load()->barrier_data() == 0);
   ins_cost(MEMORY_REF_COST);
   size(Z_DISP3_SIZE);
   format %{ "CLG     $dst, $src\t # ptr" %}


### PR DESCRIPTION
[JDK-8334060](https://bugs.openjdk.org/browse/JDK-8334060) introduced ADL predicates to force C2 to implement memory accesses tagged with barrier information to use G1-specific, barrier-aware instruction versions. But they missed compP_reg_mem instruction which also requires this predicate.
The x86 counterpart of this instruction(compP_rReg_mem) also does have this predicate.
I discovered this bug while working on the zgc port for s390.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388285](https://bugs.openjdk.org/browse/JDK-8388285): [s390] compP_reg_mem is missing the barrier_data() == 0 predicate (**Bug** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31907/head:pull/31907` \
`$ git checkout pull/31907`

Update a local copy of the PR: \
`$ git checkout pull/31907` \
`$ git pull https://git.openjdk.org/jdk.git pull/31907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31907`

View PR using the GUI difftool: \
`$ git pr show -t 31907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31907.diff">https://git.openjdk.org/jdk/pull/31907.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31907#issuecomment-4978340678)
</details>
