### PR TITLE
8388284: [s390] resolve_jobject uses wrong branch condition after tmll

### DIFF
--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -124,7 +124,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, 
 
   __ bind(tagged);
   __ testbit(value, exact_log2(JNIHandles::TypeTag::weak_global)); // test for weak tag
-  __ z_btrue(weak_tag);
+  __ branch_optimized(Assembler::bcondNotAllZero, weak_tag);
 
   // resolve global handle
   __ access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::TypeTag::global), value, tmp1, tmp2);

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -116,7 +116,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, 
   __ z_bre(done);          // Use null result as-is.
 
   __ z_tmll(value, JNIHandles::tag_mask);
-  __ z_btrue(tagged); // not zero
+  __ branch_optimized(Assembler::bcondNotAllZero, tagged); // not zero
 
   // Resolve Local handle
   __ access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, Address(value, 0), value, tmp1, tmp2);


### PR DESCRIPTION
In generic Implementation of resolve_jobject on s390 we are testing the last 2 bits of the JNI handle when we are trying to check if it is tagged or not, these bits can be as follows
`enum TypeTag {`
`  local = 0b00,`
`  weak_global = 0b01,`
`  global = 0b10,`
`};`
After that we want to jump in the case of weak_global or global but the branch condition used there is z_btrue which resolves to z_brc(bcondAllOne, ...) This is wrong as we want to jump on the condition NotAllZero.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388284](https://bugs.openjdk.org/browse/JDK-8388284): [s390] resolve_jobject uses wrong branch condition after tmll (**Bug** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31908/head:pull/31908` \
`$ git checkout pull/31908`

Update a local copy of the PR: \
`$ git checkout pull/31908` \
`$ git pull https://git.openjdk.org/jdk.git pull/31908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31908`

View PR using the GUI difftool: \
`$ git pr show -t 31908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31908.diff">https://git.openjdk.org/jdk/pull/31908.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31908#issuecomment-4978381160)
</details>
