### PR TITLE
8387753: Improve SimpleDateFormat.set2DigitYearStart() documentation

### DIFF
--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -922,10 +922,11 @@ public class SimpleDateFormat extends DateFormat {
     /**
      * Sets the start date of the 100-year period used to interpret 2-digit years.
      * <p>
-     * For example, if the start date is set to January 1, 1950, 2-digit years
-     * are interpreted as falling within the 100-year range from 1950 through
-     * 2049. In that case, 50 is interpreted as 1950, 99 as 1999, 00 as 2000,
-     * and 49 as 2049.
+     * For example, given a {@code SimpleDateFormat} with a {@code GregorianCalendar},
+     * if the start date is set to January 1, 1950, 2-digit years are
+     * interpreted as falling within the 100-year range from 1950 through 2049.
+     * In that case, 50 is interpreted as 1950, 99 as 1999, 00 as 2000, and 49
+     * as 2049.
      *
      * @param startDate During parsing, 2-digit years will be placed in the range
      * {@code startDate} to {@code startDate + 100 years}.

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -920,10 +920,14 @@ public class SimpleDateFormat extends DateFormat {
     }
 
     /**
-     * Sets the 100-year period 2-digit years will be interpreted as being in
-     * to begin on the date the user specifies.
+     * Sets the start date of the 100-year period used to interpret 2-digit years.
+     * <p>
+     * For example, if the start date is set to January 1, 1950, 2-digit years
+     * are interpreted as falling within the 100-year range from 1950 through
+     * 2049. In that case, 50 is interpreted as 1950, 99 as 1999, 00 as 2000,
+     * and 49 as 2049.
      *
-     * @param startDate During parsing, two digit years will be placed in the range
+     * @param startDate During parsing, 2-digit years will be placed in the range
      * {@code startDate} to {@code startDate + 100 years}.
      * @see #get2DigitYearStart
      * @throws NullPointerException if {@code startDate} is {@code null}.
@@ -934,11 +938,8 @@ public class SimpleDateFormat extends DateFormat {
     }
 
     /**
-     * Returns the beginning date of the 100-year period 2-digit years are interpreted
-     * as being within.
+     * {@return the start date of the 100-year period used to interpret 2-digit years}
      *
-     * @return the start of the 100-year period into which two digit years are
-     * parsed
      * @see #set2DigitYearStart
      * @since 1.2
      */


### PR DESCRIPTION
Improve `SimpleDateFormat::{get,set}2DigitYearStart()` documentation.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387753](https://bugs.openjdk.org/browse/JDK-8387753): Improve SimpleDateFormat.set2DigitYearStart() documentation (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31909/head:pull/31909` \
`$ git checkout pull/31909`

Update a local copy of the PR: \
`$ git checkout pull/31909` \
`$ git pull https://git.openjdk.org/jdk.git pull/31909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31909`

View PR using the GUI difftool: \
`$ git pr show -t 31909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31909.diff">https://git.openjdk.org/jdk/pull/31909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31909#issuecomment-4979033693)
</details>
