### PR TITLE
8387598: sun.net.httpserver.maxReqTime and maxRspTime properties expect values in seconds

### DIFF
--- a/src/jdk.httpserver/share/classes/module-info.java
+++ b/src/jdk.httpserver/share/classes/module-info.java
@@ -83,7 +83,7 @@ import com.sun.net.httpserver.*;
  *  If the value is less than or equal to zero, there is no limit.
  * </li>
  * <li><p><b>{@systemProperty sun.net.httpserver.maxReqTime}</b> (default: -1)<br>
- * The maximum time in milliseconds allowed to receive a request headers and body.
+ * The maximum time in seconds allowed to receive a request headers and body.
  * In practice, the actual time is a function of request size, network speed, and handler
  * processing delays. A value less than or equal to zero means the time is not limited.
  * If the limit is exceeded then the connection is terminated and the handler will receive a
@@ -91,7 +91,7 @@ import com.sun.net.httpserver.*;
  * that may mean requests are aborted later than the specified interval.
  * </li>
  * <li><p><b>{@systemProperty sun.net.httpserver.maxRspTime}</b> (default: -1)<br>
- * The maximum time in milliseconds allowed to receive a response headers and body.
+ * The maximum time in seconds allowed to receive a response headers and body.
  * In practice, the actual time is a function of response size, network speed, and handler
  * processing delays. A value less than or equal to zero means the time is not limited.
  * If the limit is exceeded then the connection is terminated and the handler will receive a


### PR DESCRIPTION
Fix unit for the `sun.net.httpserver.max{Req,Rsp}Time` system properties.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8388314](https://bugs.openjdk.org/browse/JDK-8388314) to be approved

### Issues
 * [JDK-8387598](https://bugs.openjdk.org/browse/JDK-8387598): sun.net.httpserver.maxReqTime and maxRspTime properties expect values in seconds (**Bug** - P4)
 * [JDK-8388314](https://bugs.openjdk.org/browse/JDK-8388314): sun.net.httpserver.maxReqTime and maxRspTime properties expect values in seconds (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31910/head:pull/31910` \
`$ git checkout pull/31910`

Update a local copy of the PR: \
`$ git checkout pull/31910` \
`$ git pull https://git.openjdk.org/jdk.git pull/31910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31910`

View PR using the GUI difftool: \
`$ git pr show -t 31910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31910.diff">https://git.openjdk.org/jdk/pull/31910.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31910#issuecomment-4979134547)
</details>
