### PR TITLE
8387701: TestAVXRegisterDump: guarantee(how == 0) failed: test guarantee

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestAVXRegisterDump.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestAVXRegisterDump.java
@@ -26,6 +26,7 @@
  * @summary Test that YMM and ZMM registers are correctly dumped in hs_err for different UseAVX settings
  * @library /test/lib
  * @requires os.family == "linux" & os.arch == "amd64"
+ * @requires vm.cpu.features ~= ".*avx.*"
  * @requires vm.debug == true
  * @modules java.base/jdk.internal.misc
  * @build jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
The test uses AVX 1, 2 and 3 but doesn't check if they are actually available in any way.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387701](https://bugs.openjdk.org/browse/JDK-8387701): TestAVXRegisterDump: guarantee(how == 0) failed: test guarantee (**Bug** - P4)


### Reviewers
 * [Mohamed Issa](https://openjdk.org/census#missa) (@missa-prime - Author)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31911/head:pull/31911` \
`$ git checkout pull/31911`

Update a local copy of the PR: \
`$ git checkout pull/31911` \
`$ git pull https://git.openjdk.org/jdk.git pull/31911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31911`

View PR using the GUI difftool: \
`$ git pr show -t 31911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31911.diff">https://git.openjdk.org/jdk/pull/31911.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31911#issuecomment-4980130835)
</details>
