### PR TITLE
8388307: SSLEngineService-based tests misuse non-blocking sockets

### DIFF
--- a/test/jdk/javax/net/ssl/SSLEngine/LargePacket.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/LargePacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,11 +88,6 @@ public class LargePacket extends SSLEngineService {
         // Accept a socket channel.
         SocketChannel sc = ssc.accept();
 
-        // Complete connection.
-        while (!sc.finishConnect()) {
-            // waiting for the connection completed.
-        }
-
         // handshaking
         ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
@@ -124,17 +119,11 @@ public class LargePacket extends SSLEngineService {
             Thread.sleep(50);
         }
 
-        // Create a non-blocking socket channel.
+        // Create a socket channel.
         SocketChannel sc = SocketChannel.open();
-        sc.configureBlocking(false);
         InetSocketAddress isa =
                 new InetSocketAddress(InetAddress.getLocalHost(), serverPort);
         sc.connect(isa);
-
-        // Complete connection.
-        while (!sc.finishConnect() ) {
-            // waiting for the connection completed.
-        }
 
         // handshaking
         ByteBuffer peerNetData = handshaking(ssle, sc, null);

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorer.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,13 +95,6 @@ public class SSLEngineExplorer extends SSLEngineService {
 
         // Accept a socket channel.
         SocketChannel sc = ssc.accept();
-        sc.configureBlocking(false);
-
-        // Complete connection.
-        while (!sc.finishConnect()) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
 
         ByteBuffer buffer = ByteBuffer.allocate(0xFF);
         int position = 0;
@@ -178,18 +171,11 @@ public class SSLEngineExplorer extends SSLEngineService {
             Thread.sleep(50);
         }
 
-        // Create a non-blocking socket channel.
+        // Create a socket channel.
         SocketChannel sc = SocketChannel.open();
-        sc.configureBlocking(false);
         InetSocketAddress isa =
                 new InetSocketAddress(InetAddress.getLocalHost(), serverPort);
         sc.connect(isa);
-
-        // Complete connection.
-        while (!sc.finishConnect() ) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
 
         // enable the specified TLS protocol
         ssle.setEnabledProtocols(supportedProtocols);

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,12 +97,6 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
         // Accept a socket channel.
         SocketChannel sc = ssc.accept();
 
-        // Complete connection.
-        while (!sc.finishConnect()) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
-
         ByteBuffer buffer = ByteBuffer.allocate(0xFF);
         int position = 0;
         SSLCapabilities capabilities = null;
@@ -188,18 +182,11 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
             Thread.sleep(50);
         }
 
-        // Create a non-blocking socket channel.
+        // Create a socket channel.
         SocketChannel sc = SocketChannel.open();
-        sc.configureBlocking(false);
         InetSocketAddress isa =
                 new InetSocketAddress(InetAddress.getLocalHost(), serverPort);
         sc.connect(isa);
-
-        // Complete connection.
-        while (!sc.finishConnect() ) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
 
         SNIHostName serverName = new SNIHostName(clientRequestedHostname);
         List<SNIServerName> serverNames = new ArrayList<>(1);

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,12 +89,6 @@ public class SSLEngineExplorerUnmatchedSNI extends SSLEngineService {
 
         // Accept a socket channel.
         SocketChannel sc = ssc.accept();
-
-        // Complete connection.
-        while (!sc.finishConnect()) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
 
         ByteBuffer buffer = ByteBuffer.allocate(0xFF);
         int position = 0;
@@ -191,18 +185,11 @@ public class SSLEngineExplorerUnmatchedSNI extends SSLEngineService {
             Thread.sleep(50);
         }
 
-        // Create a non-blocking socket channel.
+        // Create a socket channel.
         SocketChannel sc = SocketChannel.open();
-        sc.configureBlocking(false);
         InetSocketAddress isa =
                 new InetSocketAddress(InetAddress.getLocalHost(), serverPort);
         sc.connect(isa);
-
-        // Complete connection.
-        while (!sc.finishConnect() ) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
 
         SNIHostName serverName = new SNIHostName(clientRequestedHostname);
         List<SNIServerName> serverNames = new ArrayList<>(1);

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,12 +88,6 @@ public class SSLEngineExplorerWithCli extends SSLEngineService {
         // Accept a socket channel.
         SocketChannel sc = ssc.accept();
 
-        // Complete connection.
-        while (!sc.finishConnect()) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
-
         ByteBuffer buffer = ByteBuffer.allocate(0xFF);
         int position = 0;
         SSLCapabilities capabilities = null;
@@ -169,18 +163,11 @@ public class SSLEngineExplorerWithCli extends SSLEngineService {
             Thread.sleep(50);
         }
 
-        // Create a non-blocking socket channel.
+        // Create a socket channel.
         SocketChannel sc = SocketChannel.open();
-        sc.configureBlocking(false);
         InetSocketAddress isa =
                 new InetSocketAddress(InetAddress.getLocalHost(), serverPort);
         sc.connect(isa);
-
-        // Complete connection.
-        while (!sc.finishConnect() ) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
 
         SNIHostName serverName = new SNIHostName(clientRequestedHostname);
         List<SNIServerName> serverNames = new ArrayList<>(1);

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,12 +88,6 @@ public class SSLEngineExplorerWithSrv extends SSLEngineService {
         // Accept a socket channel.
         SocketChannel sc = ssc.accept();
 
-        // Complete connection.
-        while (!sc.finishConnect()) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
-
         ByteBuffer buffer = ByteBuffer.allocate(0xFF);
         int position = 0;
         SSLCapabilities capabilities = null;
@@ -179,18 +173,11 @@ public class SSLEngineExplorerWithSrv extends SSLEngineService {
             Thread.sleep(50);
         }
 
-        // Create a non-blocking socket channel.
+        // Create a socket channel.
         SocketChannel sc = SocketChannel.open();
-        sc.configureBlocking(false);
         InetSocketAddress isa =
                 new InetSocketAddress(InetAddress.getLocalHost(), serverPort);
         sc.connect(isa);
-
-        // Complete connection.
-        while (!sc.finishConnect() ) {
-            Thread.sleep(50);
-            // waiting for the connection completed.
-        }
 
         // handshaking
         ByteBuffer peerNetData = handshaking(ssle, sc, null);


### PR DESCRIPTION
Change the tests to use blocking sockets instead.

This change removes the busy-looping on finishConnect, read, and write. The change is safe because:
- finishConnect is no longer necessary,
- all uses of write() loop until wither all data is written or an error occurs
- read() is only used when additional data is expected.

Tier2 still green.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388307](https://bugs.openjdk.org/browse/JDK-8388307): SSLEngineService-based tests misuse non-blocking sockets (**Bug** - P4)


### Reviewers
 * [Mikhail Yankelevich](https://openjdk.org/census#myankelevich) (@myankelev - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31912/head:pull/31912` \
`$ git checkout pull/31912`

Update a local copy of the PR: \
`$ git checkout pull/31912` \
`$ git pull https://git.openjdk.org/jdk.git pull/31912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31912`

View PR using the GUI difftool: \
`$ git pr show -t 31912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31912.diff">https://git.openjdk.org/jdk/pull/31912.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31912#issuecomment-4980232600)
</details>
