### PR TITLE
8388316: Make jdk/jfr/event/runtime/TestResidentSetSizeEvent.java intermittent after JDK-8387697

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestResidentSetSizeEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestResidentSetSizeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import jdk.test.lib.jfr.Events;
 
 /**
  * @test
+ * @key intermittent
  * @requires vm.flagless
  * @requires vm.hasJFR
  * @library /test/lib


### PR DESCRIPTION
After [JDK-8387697](https://bugs.openjdk.org/browse/JDK-8387697), the test TestResidentSetSizeEvent fails sometimes.
Reason is that we use now an inaccurate API to get RSS values, because the accurate API was considered too costly.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388316](https://bugs.openjdk.org/browse/JDK-8388316): Make jdk/jfr/event/runtime/TestResidentSetSizeEvent.java intermittent after JDK-8387697 (**Bug** - P4)


### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31913/head:pull/31913` \
`$ git checkout pull/31913`

Update a local copy of the PR: \
`$ git checkout pull/31913` \
`$ git pull https://git.openjdk.org/jdk.git pull/31913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31913`

View PR using the GUI difftool: \
`$ git pr show -t 31913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31913.diff">https://git.openjdk.org/jdk/pull/31913.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31913#issuecomment-4981227993)
</details>
