### PR TITLE
8334329: [s390x] Refactor & adjust the code which is using runtime_call_w_cp_type

### DIFF
--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -2536,35 +2536,31 @@ bool MacroAssembler::is_call_far_patchable_variant2_at(address instruction_addr)
 //                      to the constant pool and a runtime_call relocation is added
 //                      to the code buffer.
 // If toc_offset != -2, target must already be in the constant pool at
-//                      _ctableStart+toc_offset (a caller can retrieve toc_offset
-//                      from the runtime_call relocation).
+//                      _ctableStart+toc_offset.  Note: callers no longer retrieve
+//                      toc_offset from the runtime_call relocation; the patcher
+//                      reads it directly from the LGRL instruction.
 // Special handling of emitting to scratch buffer when there is no constant pool.
-// Slightly changed code pattern. We emit an additional nop if we would
-// not end emitting at a word aligned address. This is to ensure
-// an atomically patchable displacement in brasl instructions.
 //
-// A call_far_patchable comes in different flavors:
-//  - LARL(CP) / LG(CP) / BR (address in constant pool, access via CP register)
-//  - LGRL(CP) / BR          (address in constant pool, pc-relative access)
-//  - BRASL                  (relative address of call target coded in instruction)
-// All flavors occupy the same amount of space. Length differences are compensated
-// by leading nops, such that the instruction sequence always ends at the same
-// byte offset. This is required to keep the return offset constant.
-// Furthermore, the return address (the end of the instruction sequence) is forced
-// to be on a 4-byte boundary. This is required for atomic patching, should we ever
-// need to patch the call target of the BRASL flavor.
+// As of now, only one flavor is emitted for new compilations:
+//  - LGRL(CP) / BASR  (address in constant pool, pc-relative access)
+// The BRASL flavor (relative address of call target coded in instruction) is no
+// longer emitted because the global ExternalsRecorder table must be able to
+// enumerate all runtime call sites.  BRASL instructions from already-compiled
+// nmethods in the code cache are still recognised and handled for compatibility.
+// All flavors occupy the same amount of space; length differences are compensated
+// by leading nops so that the return-address offset is always constant and the
+// last byte is 4-byte aligned.
 // RETURN value: false, if no constant pool entry could be allocated, true otherwise.
 bool MacroAssembler::call_far_patchable(address target, int64_t tocOffset) {
   // Get current pc and ensure word alignment for end of instr sequence.
   const address start_pc = pc();
   const intptr_t       start_off = offset();
   assert(!call_far_patchable_requires_alignment_nop(start_pc), "call_far_patchable requires aligned address");
-  const ptrdiff_t      dist      = (ptrdiff_t)(target - (start_pc + 2)); // Prepend each BRASL with a nop.
   const bool emit_target_to_pool = (tocOffset == -2) && !code_section()->scratch_emit();
-  const bool emit_relative_call  = !emit_target_to_pool &&
-                                   RelAddr::is_in_range_of_RelAddr32(dist) &&
-                                   ReoptimizeCallSequences &&
-                                   !code_section()->scratch_emit();
+  // Disable pc-relative BRASL calls: all runtime call targets must go through
+  // the constant pool (TOC) so that the global ExternalsRecorder table can
+  // track and patch them uniformly.
+  const bool emit_relative_call  = false;
 
   if (emit_relative_call) {
     // Add padding to get the same size as below.
@@ -2653,10 +2649,10 @@ void MacroAssembler::set_dest_of_call_far_patchable_at(address instruction_addr,
 
 // Get dest address of a call_far_patchable instruction.
 address MacroAssembler::get_dest_of_call_far_patchable_at(address instruction_addr, address ctable) {
-  // Dynamic TOC: absolute address in constant pool.
-  // Check variant2 first, it is more frequent.
+  // New code always emits Variant 0 (LGRL+BASR).  Variant 2 (BRASL) is checked
+  // first only for compatibility with already-compiled nmethods in the code cache.
 
-  // Relative address encoded in call instruction.
+  // Relative address encoded in call instruction (BRASL, legacy).
   if (is_call_far_patchable_variant2_at(instruction_addr)) {
     return MacroAssembler::get_target_addr_pcrel(instruction_addr + nop_size()); // Prepend each BRASL with a nop.
 
@@ -4968,9 +4964,16 @@ int MacroAssembler::store_oop_in_toc(AddressLiteral& oop) {
     RelocationHolder rsp = oop.rspec();
     Relocation      *rel = rsp.reloc();
 
-    // Store toc_offset in relocation, used by call_far_patchable.
+    // Store toc_offset and the call target in the relocation.
+    // toc_offset is retained so the relocation is self-describing for
+    // diagnostic purposes.  _target is used by pack_data_to() to register
+    // the address in the global ExternalsRecorder table.
+    // NativeFarCall::set_destination() no longer uses toc_offset; it derives
+    // the TOC slot address directly from the LGRL instruction.
     if ((relocInfo::relocType)rel->type() == relocInfo::runtime_call_w_cp_type) {
-      ((runtime_call_w_cp_Relocation *)(rel))->set_constant_pool_offset(tocOffset);
+      runtime_call_w_cp_Relocation* rcwcp = (runtime_call_w_cp_Relocation*)(rel);
+      rcwcp->set_constant_pool_offset(tocOffset);
+      rcwcp->set_call_target((address)oop.value());
     }
     // Relocate at the load's pc.
     relocate(rsp);

--- a/src/hotspot/cpu/s390/nativeInst_s390.cpp
+++ b/src/hotspot/cpu/s390/nativeInst_s390.cpp
@@ -239,18 +239,21 @@ address NativeFarCall::destination() {
 
 
 // Handles both patterns of patchable far calls.
-void NativeFarCall::set_destination(address dest, int toc_offset) {
+void NativeFarCall::set_destination(address dest) {
   address inst_addr = (address)this;
 
   // Set new destination (implementation of call may change here).
   assert(MacroAssembler::is_call_far_patchable_at(inst_addr), "unexpected call type");
 
   if (!MacroAssembler::is_call_far_patchable_pcrelative_at(inst_addr)) {
-    address ctable = CodeCache::find_blob(inst_addr)->ctable_begin();
-    // Need distance of TOC entry from current instruction.
-    toc_offset = (ctable + toc_offset) - inst_addr;
-    // Call is via constant table entry.
-    MacroAssembler::set_dest_of_call_far_patchable_at(inst_addr, dest, toc_offset);
+    // Derive the pc-relative displacement to the TOC slot directly from the
+    // LGRL instruction.  The toc_offset parameter (byte offset from
+    // ctable_begin) is no longer needed now that the global ExternalsRecorder
+    // table owns the target address.
+    long inst_toc_offset = MacroAssembler::get_load_const_from_toc_offset(inst_addr);
+    // Write the new destination into the TOC slot and re-emit the instruction
+    // sequence pointing at that same slot.
+    MacroAssembler::set_dest_of_call_far_patchable_at(inst_addr, dest, inst_toc_offset);
   } else {
     // Here, we have a pc-relative call (brasl).
     // Be aware: dest may have moved in this case, so really patch the displacement,

--- a/src/hotspot/cpu/s390/nativeInst_s390.hpp
+++ b/src/hotspot/cpu/s390/nativeInst_s390.hpp
@@ -420,7 +420,7 @@ class NativeFarCall: public NativeInstruction {
 
   // Sets the NativeCall's destination, not necessarily mt-safe.
   // Used when relocating code.
-  void set_destination(address dest, int toc_offset);
+  void set_destination(address dest);
 
   // Checks whether instr points at a NativeFarCall instruction.
   static bool is_far_call_at(address instr) {

--- a/src/hotspot/cpu/s390/relocInfo_s390.cpp
+++ b/src/hotspot/cpu/s390/relocInfo_s390.cpp
@@ -131,19 +131,16 @@ void Relocation::pd_set_call_destination(address x) {
           assert(false, "pc-relative call w/o ShortenBranches?");
         }
 #endif
-        nativeFarCall_at(inst_addr)->set_destination(x, 0);
+        nativeFarCall_at(inst_addr)->set_destination(x);
         return;
       }
       assert(x == (address)-1, "consistency check");
       return;
     }
-    int toc_offset = -1;
+    // The TOC slot address is self-described by the LGRL instruction; we no
+    // longer need the per-relocation toc_offset to find it.
     if (type() == relocInfo::runtime_call_w_cp_type) {
-      toc_offset = ((runtime_call_w_cp_Relocation *)this)->get_constant_pool_offset();
-    }
-    if (toc_offset>=0) {
-      NativeFarCall* call = nativeFarCall_at(inst_addr);
-      call->set_destination(x, toc_offset);
+      nativeFarCall_at(inst_addr)->set_destination(x);
       return;
     }
   }

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -458,13 +458,29 @@ void virtual_call_Relocation::unpack_data() {
   _cached_value = x0==0? nullptr: address_from_scaled_offset(x0, point);
 }
 
-void runtime_call_w_cp_Relocation::pack_data_to(CodeSection * dest) {
-  short* p = pack_1_int_to((short *)dest->locs_end(), (jint)(_offset >> 2));
+void runtime_call_w_cp_Relocation::pack_data_to(CodeSection* dest) {
+  // Pack two values into the locs stream:
+  //   [0..3]  4-byte ExternalsRecorder index for the call target address.
+  //   [4..5]  variable-width toc_offset >> 2 (byte offset into the nmethod
+  //           constant pool where the target address is stored, divided by 4).
+  // The fixed-width jint for the index matches the format used by
+  // external_word_Relocation so that AOT relocation patching works uniformly.
+  assert(_target != nullptr, "call target must be set via set_call_target() before packing");
+  short* p = (short*) dest->locs_end();
+  int index = ExternalsRecorder::find_index(_target);
+  p = add_jint(p, index);
+  p = add_var_int(p, (jint)(_offset >> 2));
   dest->set_locs_end((relocInfo*) p);
 }
 
 void runtime_call_w_cp_Relocation::unpack_data() {
-  _offset = unpack_1_int() << 2;
+  // Mirror of pack_data_to(): read the ExternalsRecorder index first (fixed
+  // 4 bytes / 2 shorts), then the toc_offset.
+  short* dp   = data();
+  int    dlen = datalen();
+  int    index = relocInfo::jint_data_at(0, dp, dlen);
+  _target  = ExternalsRecorder::at(index);
+  _offset  = relocInfo::jint_data_at(2, dp, dlen) << 2;
 }
 
 void static_stub_Relocation::pack_data_to(CodeSection* dest) {

--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -1229,25 +1229,29 @@ class runtime_call_w_cp_Relocation : public CallRelocation {
   void copy_into(RelocationHolder& holder) const override;
 
  private:
-  friend class RelocationHolder;
-  runtime_call_w_cp_Relocation()
-    : CallRelocation(relocInfo::runtime_call_w_cp_type),
-      _offset(-4) /* <0 = invalid */ { }
+   friend class RelocationHolder;
+   runtime_call_w_cp_Relocation()
+     : CallRelocation(relocInfo::runtime_call_w_cp_type),
+       _offset(-4) /* <0 = invalid */,
+       _target(nullptr) { }
 
-  // On z/Architecture, runtime calls are either a sequence
-  // of two instructions (load destination of call from constant pool + do call)
-  // or a pc-relative call. The pc-relative call is faster, but it can only
-  // be used if the destination of the call is not too far away.
-  // In order to be able to patch a pc-relative call back into one using
-  // the constant pool, we have to remember the location of the call's destination
-  // in the constant pool.
-  int _offset;
+   // On z/Architecture, runtime calls go through the nmethod constant pool
+   // (TOC): the target address is stored there and loaded via LGRL + BASR.
+   // _offset records the byte offset of the TOC slot from ctable_begin() for
+   // diagnostic and self-description purposes; the patcher (set_destination)
+   // derives the slot address directly from the LGRL instruction instead.
+   // _target holds the actual call destination so that pack_data_to() can
+   // register it in the global ExternalsRecorder table.
+   int     _offset;
+   address _target;
 
  public:
-  void set_constant_pool_offset(int offset) { _offset = offset; }
-  int get_constant_pool_offset() { return _offset; }
-  void pack_data_to(CodeSection * dest) override;
-  void unpack_data() override;
+   void set_constant_pool_offset(int offset) { _offset = offset; }
+   int  get_constant_pool_offset()            { return _offset; }
+   void set_call_target(address target)       { _target = target; }
+   address get_call_target()                  { return _target; }
+   void pack_data_to(CodeSection * dest) override;
+   void unpack_data() override;
 };
 
 // Trampoline Relocations.


### PR DESCRIPTION
Hi, this PR adds `runtime_call_w_cp_Relocation` entries to the ExternalRecorder global table and disables the use of the `BRASL` instruction for nmethod calls. Setting `emit_relative_call = false` achieves this.

Reason: Vladimir [mentioned](https://github.com/openjdk/jdk/pull/19703#issuecomment-2173723804) that, with Project Leyden, [ForceUnreachable](https://github.com/openjdk/leyden/blob/d1c87e5b4f3f17c473e2425983b3eb8c7ac15fa8/src/hotspot/share/runtime/globals.hpp#L274 ) will be set to true by default, which makes BRASL effectively unusable for these calls.

I have intentionally kept the existing BRASL-related code for now instead of removing it. I'd like to run a few more experiments to determine whether we can still make use of it in some cases.

Thoughts:
I want to investigate whether there are runtime calls that are still emitted within the 32-bit displacement range. If such cases exist, it would be worth preserving the implementation and re-enabling it where applicable. Otherwise, I'll follow up with a cleanup PR to remove the dead code entirely.

I ran renaissance / dotty benchmark with PrintNMethodStatistics and: 

Validation: `84 entries and 481k accesses` in the ExternalsRecorder. Before the patch it was `0/0`.

Cost: relocation section grew by `~12.7%` (C1) and `~27.9%` (C2):
This is expected and explained by the locs stream format change. The old pack_data_to wrote:
```
1 × var_int  (offset >> 2)      ← ~2 bytes typically
```

The new pack_data_to writes:
```
1 × fixed jint  (ExternalsRecorder index)  ← always 4 bytes
1 × var_int     (offset >> 2)              ← ~2 bytes
```
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8334329](https://bugs.openjdk.org/browse/JDK-8334329): [s390x] Refactor &amp; adjust the code which is using runtime_call_w_cp_type (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31915/head:pull/31915` \
`$ git checkout pull/31915`

Update a local copy of the PR: \
`$ git checkout pull/31915` \
`$ git pull https://git.openjdk.org/jdk.git pull/31915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31915`

View PR using the GUI difftool: \
`$ git pr show -t 31915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31915.diff">https://git.openjdk.org/jdk/pull/31915.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31915#issuecomment-4982804202)
</details>
