### PR TITLE
8388347: Remove enablePreview from TestEnableNativeAccessJarManifest

### DIFF
--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  * @requires jdk.foreign.linker != "UNSUPPORTED"
  * @requires !vm.musl
  *
- * @enablePreview
  * @build TestEnableNativeAccessJarManifest
  *        panama_module/*
  *        org.openjdk.foreigntest.unnamed.PanamaMainUnnamedModule


### PR DESCRIPTION
TestEnableNativeAccessJarManifest has a `@enablePreview` jtreg directive. This test was added in the commit where FFM became a permanent feature, so its omission was likely an oversight.

Now, this test declares a record, which makes all its class files preview with JEP 401. As a consequence, the command line arguments are no longer sufficient to run the test. We can simply remove `@enablePreview` to clear this butterfly effect.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388347](https://bugs.openjdk.org/browse/JDK-8388347): Remove enablePreview from TestEnableNativeAccessJarManifest (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31916/head:pull/31916` \
`$ git checkout pull/31916`

Update a local copy of the PR: \
`$ git checkout pull/31916` \
`$ git pull https://git.openjdk.org/jdk.git pull/31916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31916`

View PR using the GUI difftool: \
`$ git pr show -t 31916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31916.diff">https://git.openjdk.org/jdk/pull/31916.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31916#issuecomment-4983461816)
</details>
