### PR TITLE
8388360: Dead sharedRuntime.cpp stub name code

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -108,14 +108,6 @@
 
 nmethod*            SharedRuntime::_cont_doYield_stub;
 
-#if 0
-// TODO tweak global stub name generation to match this
-#define SHARED_STUB_NAME_DECLARE(name, type) "Shared Runtime " # name "_blob",
-const char *SharedRuntime::_stub_names[] = {
-  SHARED_STUBS_DO(SHARED_STUB_NAME_DECLARE)
-};
-#endif
-
 //----------------------------generate_stubs-----------------------------------
 void SharedRuntime::generate_initial_stubs() {
   // Build this early so it's available for the interpreter.


### PR DESCRIPTION
JDK-8360707 removed all references to `SharedRuntime::_stub_names` except for dead `#if 0`ed block that this change now removes too.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388360](https://bugs.openjdk.org/browse/JDK-8388360): Dead sharedRuntime.cpp stub name code (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31919/head:pull/31919` \
`$ git checkout pull/31919`

Update a local copy of the PR: \
`$ git checkout pull/31919` \
`$ git pull https://git.openjdk.org/jdk.git pull/31919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31919`

View PR using the GUI difftool: \
`$ git pr show -t 31919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31919.diff">https://git.openjdk.org/jdk/pull/31919.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31919#issuecomment-4984697899)
</details>
