### PR TITLE
8388358: HotCodeHeap should throw warning when enabled without C2

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -272,7 +272,11 @@ void CompilerConfig::set_compilation_policy_flags() {
   }
 
 #ifdef COMPILER2
-  if (HotCodeHeap) {
+  if (HotCodeHeap && !is_c2_enabled()) {
+    warning("HotCodeHeap disabled because C2 is disabled.");
+    FLAG_SET_ERGO(HotCodeHeap, false);
+    FLAG_SET_ERGO(HotCodeHeapSize, 0);
+  } else if (HotCodeHeap) {
     if (FLAG_IS_DEFAULT(SegmentedCodeCache)) {
       FLAG_SET_ERGO(SegmentedCodeCache, true);
     } else if (!SegmentedCodeCache) {
@@ -283,10 +287,6 @@ void CompilerConfig::set_compilation_policy_flags() {
       FLAG_SET_ERGO(NMethodRelocation, true);
     } else if (!NMethodRelocation) {
       vm_exit_during_initialization("HotCodeHeap requires NMethodRelocation enabled");
-    }
-
-    if (!is_c2_enabled()) {
-      vm_exit_during_initialization("HotCodeHeap requires C2 enabled");
     }
 
     if (HotCodeMinSamplingMs > HotCodeMaxSamplingMs) {


### PR DESCRIPTION
Instead of causing the jvm to exit when `HotCodeHeap` is enabled without C2, print a warning and disable `HotCodeHeap`. This change is very low risk since `HotCodeHeap` is currently experimental and disabled by default.

Testing:
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   jtreg:test/hotspot/jtreg/compiler                  2304  2081     0     0   223   
==============================
TEST SUCCESS
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388358](https://bugs.openjdk.org/browse/JDK-8388358): HotCodeHeap should throw warning when enabled without C2 (**Enhancement** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31920/head:pull/31920` \
`$ git checkout pull/31920`

Update a local copy of the PR: \
`$ git checkout pull/31920` \
`$ git pull https://git.openjdk.org/jdk.git pull/31920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31920`

View PR using the GUI difftool: \
`$ git pr show -t 31920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31920.diff">https://git.openjdk.org/jdk/pull/31920.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31920#issuecomment-4985020376)
</details>
