### PR TITLE
8388385: CDS dumping fails with circular JAR manifest Class-Path

### DIFF
--- a/src/hotspot/share/cds/aotClassLocation.cpp
+++ b/src/hotspot/share/cds/aotClassLocation.cpp
@@ -629,11 +629,11 @@ void AOTClassLocationConfig::add_class_location(JavaThread* current, GrowableCla
         int n = os::snprintf(libname, libname_len + 1, "%.*s%s", dir_len, dir_name, file_start);
         assert((size_t)n == libname_len, "Unexpected number of characters in string");
 
-        // Avoid infinite recursion when two JAR files refer to each
-        // other via cpattr.
+        // Avoid infinite recursion when JAR files refer to each other through
+        // equivalent path names in their Class-Path attributes.
         bool found_duplicate = false;
         for (int i = boot_cp_start_index(); i < tmp_array.length(); i++) {
-          if (strcmp(tmp_array.at(i)->path(), libname) == 0) {
+          if (os::same_files(tmp_array.at(i)->path(), libname)) {
             found_duplicate = true;
             break;
           }

--- a/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttrCircularReference.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttrCircularReference.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary CDS dumping should not loop when JAR manifest Class-Path entries form a circular reference through equivalent paths
+ * @bug 8388385
+ * @requires vm.cds
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run driver/timeout=60 ClassPathAttrCircularReference
+ */
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class ClassPathAttrCircularReference {
+    public static void main(String[] args) throws Exception {
+        Path jarDir = Paths.get(CDSTestUtils.getOutputDir(), "cpattr-circular");
+        Files.createDirectories(jarDir);
+
+        Path jarA = jarDir.resolve("A.jar");
+        Path jarB = jarDir.resolve("B.jar");
+        createJar(jarA, "./B.jar");
+        createJar(jarB, "A.jar");
+
+        Path jarADot = jarDir.resolve(".").resolve("A.jar");
+        Path jarBDot = jarDir.resolve(".").resolve("B.jar");
+        if (!Files.isSameFile(jarA, jarADot)) {
+            throw new RuntimeException(jarA + " and " + jarADot + " should refer to the same file");
+        }
+        if (!Files.isSameFile(jarB, jarBDot)) {
+            throw new RuntimeException(jarB + " and " + jarBDot + " should refer to the same file");
+        }
+
+        String java = JDKToolFinder.getJDKTool("java");
+        String archive = TestCommon.getNewArchiveName("cpattr-circular");
+        ProcessBuilder pb = CDSTestUtils.makeBuilder(java,
+                                                     "-Xshare:dump",
+                                                     "-XX:SharedArchiveFile=" + archive,
+                                                     "-Xlog:class+path=info",
+                                                     "-cp", jarA.toString());
+        OutputAnalyzer output = TestCommon.executeAndLog(pb, "dump");
+
+        output.shouldHaveExitValue(0);
+        output.shouldContain("path [2] =");
+        output.shouldNotContain("path [3] =");
+    }
+
+    private static void createJar(Path jar, String classPath) throws Exception {
+        Manifest manifest = new Manifest();
+        Attributes attrs = manifest.getMainAttributes();
+        attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attrs.put(Attributes.Name.CLASS_PATH, classPath);
+
+        try (OutputStream out = Files.newOutputStream(jar);
+             JarOutputStream jos = new JarOutputStream(out, manifest)) {
+            // No class entries are needed. CDS only needs the manifest Class-Path.
+        }
+    }
+}


### PR DESCRIPTION
CDS dumping does not detect circular JAR manifest Class-Path references when the same file is written with different path strings.

The fix compares file identity instead of raw path strings, preventing recursive manifest Class-Path processing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8388385](https://bugs.openjdk.org/browse/JDK-8388385): CDS dumping fails with circular JAR manifest Class-Path (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31926/head:pull/31926` \
`$ git checkout pull/31926`

Update a local copy of the PR: \
`$ git checkout pull/31926` \
`$ git pull https://git.openjdk.org/jdk.git pull/31926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31926`

View PR using the GUI difftool: \
`$ git pr show -t 31926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31926.diff">https://git.openjdk.org/jdk/pull/31926.diff</a>

</details>
