### PR TITLE
8387855: G1: Separate G1ParScanThreadStateSet and shared state

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -62,13 +62,13 @@ static uint initial_nmethod_table_size(G1CollectedHeap* g1h) {
 }
 
 G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
-                                           G1ParScanThreadStateSet* per_thread_states,
+                                           G1ParScanSharedState* shared_state,
                                            uint worker_id,
                                            uint num_workers,
                                            G1CollectionSet* collection_set,
                                            G1EvacFailureRegions* evac_failure_regions)
   : _g1h(g1h),
-    _per_thread_states(per_thread_states),
+    _shared_state(shared_state),
     _task_queue(g1h->task_queue(worker_id)),
     _ct(g1h->refinement_table()),
     _closures(nullptr),
@@ -588,12 +588,56 @@ oop G1ParScanThreadState::copy_to_survivor_space(G1HeapRegionAttr region_attr,
   return do_copy_to_survivor_space(region_attr, old, old_mark);
 }
 
+G1ParScanSharedState::G1ParScanSharedState(G1CollectedHeap* g1h) :
+    _g1h(g1h),
+    _has_nmethods_to_add(g1h->max_num_regions(), mtGC),
+    _num_nmethod_regions_to_add(0),
+    _nmethod_regions_to_add(NEW_C_HEAP_ARRAY(uint, g1h->max_num_regions(), mtGC)) // Conservative length estimation.
+{ }
+
+G1ParScanSharedState::~G1ParScanSharedState() {
+  FREE_C_HEAP_ARRAY(_nmethod_regions_to_add);
+}
+
+void G1ParScanSharedState::update_nmethod_regions_to_add(G1NmethodsToAdd* nmethods) {
+  if (nmethods->number_of_entries() == 0) {
+    return;
+  }
+
+  // Take the key set, look which are not yet in the global set, and update the necessary ones.
+  ResourceMark rm;
+  GrowableArray<uint> regions_to_add = GrowableArray<uint>(nmethods->table_size());
+
+  nmethods->iterate_all([&] (uint& region, void*) {
+    if (_has_nmethods_to_add.par_set_bit(region, memory_order_relaxed)) {
+      regions_to_add.push(region);
+    }
+  });
+
+  uint num_regions_to_add = (uint)regions_to_add.length();
+
+  if (num_regions_to_add == 0) {
+    return;
+  }
+
+  uint first_index = _num_nmethod_regions_to_add.fetch_then_add(num_regions_to_add, memory_order_relaxed);
+  guarantee(first_index + num_regions_to_add <= _g1h->max_num_regions(), "must be");
+
+  memcpy(&_nmethod_regions_to_add[first_index], regions_to_add.adr_at(0), num_regions_to_add * sizeof(uint));
+}
+
+void G1ParScanSharedState::par_iterate_nmethod_regions_to_add(G1HeapRegionClosure* cl,
+                                                              G1HeapRegionClaimer* claimer,
+                                                              uint worker_id) {
+  _g1h->par_iterate_regions_array(cl, claimer, _nmethod_regions_to_add, num_nmethod_regions_to_add(), worker_id);
+}
+
 G1ParScanThreadState* G1ParScanThreadStateSet::state_for_worker(uint worker_id) {
   assert(worker_id < _num_workers, "out of bounds access");
   if (_states[worker_id] == nullptr) {
     _states[worker_id] =
       new G1ParScanThreadState(_g1h,
-                               this,
+                               &_shared_state,
                                worker_id,
                                _num_workers,
                                _collection_set,
@@ -643,39 +687,6 @@ void G1ParScanThreadStateSet::destroy_worker_states() {
     delete _states[worker_id];
     _states[worker_id] = nullptr;
   }
-}
-
-void G1ParScanThreadStateSet::update_nmethod_regions_to_add(G1NmethodsToAdd* nmethods) {
-  if (nmethods->number_of_entries() == 0) {
-    return;
-  }
-
-  // Take the key set, look which are not yet in the global set, and update the necessary ones.
-  ResourceMark rm;
-  GrowableArray<uint> regions_to_add = GrowableArray<uint>(nmethods->table_size());
-
-  nmethods->iterate_all([&] (uint& region, void*) {
-    if (_has_nmethods_to_add.par_set_bit(region, memory_order_relaxed)) {
-      regions_to_add.push(region);
-    }
-  });
-
-  uint num_regions_to_add = (uint)regions_to_add.length();
-
-  if (num_regions_to_add == 0) {
-    return;
-  }
-
-  uint first_index = _num_nmethod_regions_to_add.fetch_then_add(num_regions_to_add, memory_order_relaxed);
-  guarantee(first_index + num_regions_to_add <= _g1h->max_num_regions(), "must be");
-
-  memcpy(&_nmethod_regions_to_add[first_index], regions_to_add.adr_at(0), num_regions_to_add * sizeof(uint));
-}
-
-void G1ParScanThreadStateSet::par_iterate_nmethod_regions_to_add(G1HeapRegionClosure* cl,
-                                                                 G1HeapRegionClaimer* claimer,
-                                                                 uint worker_id) {
-  _g1h->par_iterate_regions_array(cl, claimer, _nmethod_regions_to_add, num_nmethod_regions_to_add(), worker_id);
 }
 
 void G1ParScanThreadStateSet::record_unused_optional_region(G1HeapRegion* hr) {
@@ -734,7 +745,7 @@ oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m, Kla
 }
 
 void G1ParScanThreadState::update_nmethod_regions_to_add() {
-  _per_thread_states->update_nmethod_regions_to_add(&_nmethods_to_add);
+  _shared_state->update_nmethod_regions_to_add(&_nmethods_to_add);
 }
 
 void G1ParScanThreadState::initialize_numa_stats() {
@@ -776,15 +787,13 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
                                                  G1CollectionSet* collection_set,
                                                  G1EvacFailureRegions* evac_failure_regions) :
     _g1h(g1h),
+    _shared_state(g1h),
     _collection_set(collection_set),
     _states(NEW_C_HEAP_ARRAY(G1ParScanThreadState*, num_workers, mtGC)),
     _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->num_young_regions() + 1, mtGC)),
     _num_workers(num_workers),
     _flushed(false),
-    _evac_failure_regions(evac_failure_regions),
-    _has_nmethods_to_add(g1h->max_num_regions(), mtGC),
-    _num_nmethod_regions_to_add(0),
-    _nmethod_regions_to_add(NEW_C_HEAP_ARRAY(uint, g1h->max_num_regions(), mtGC)) // Conservative length estimation.
+    _evac_failure_regions(evac_failure_regions)
 {
   for (uint i = 0; i < num_workers; ++i) {
     _states[i] = nullptr;
@@ -796,7 +805,6 @@ G1ParScanThreadStateSet::~G1ParScanThreadStateSet() {
   for (uint i = 0; i < _num_workers; i++) {
     assert(_states[i] == nullptr, "must be");
   }
-  FREE_C_HEAP_ARRAY(_nmethod_regions_to_add);
   FREE_C_HEAP_ARRAY(_states);
   FREE_C_HEAP_ARRAY(_surviving_young_words_total);
 }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -47,16 +47,35 @@ class G1CollectionSet;
 class G1EvacFailureRegions;
 class G1EvacuationRootClosures;
 class G1OopStarChunkedList;
-class G1ParScanThreadStateSet;
 class G1PLABAllocator;
 class G1HeapRegion;
 class outputStream;
 
 typedef GrowableArrayCHeap<nmethod*, mtGC> G1NmethodSet;
 typedef ResizeableHashTable<uint, G1NmethodSet*, AnyObj::C_HEAP, mtGC> G1NmethodsToAdd;
+
+class G1ParScanSharedState : public StackObj {
+  G1CollectedHeap* _g1h;
+
+  CHeapBitMap _has_nmethods_to_add;
+  Atomic<uint> _num_nmethod_regions_to_add;
+  uint* _nmethod_regions_to_add;
+
+public:
+  G1ParScanSharedState(G1CollectedHeap* g1h);
+  ~G1ParScanSharedState();
+
+  // Updates the region set that has code root updates with the regions in the given set.
+  void update_nmethod_regions_to_add(G1NmethodsToAdd* nmethods);
+  void par_iterate_nmethod_regions_to_add(G1HeapRegionClosure* cl,
+                                          G1HeapRegionClaimer* claimer,
+                                          uint worker_id);
+  uint num_nmethod_regions_to_add() const { return _num_nmethod_regions_to_add.load_relaxed(); }
+};
+
 class G1ParScanThreadState : public CHeapObj<mtGC> {
   G1CollectedHeap* _g1h;
-  G1ParScanThreadStateSet* _per_thread_states;
+  G1ParScanSharedState* _shared_state;
   G1ScannerTasksQueue* _task_queue;
   G1CardTable* _ct;
   G1EvacuationRootClosures* _closures;
@@ -124,7 +143,7 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
 
 public:
   G1ParScanThreadState(G1CollectedHeap* g1h,
-                       G1ParScanThreadStateSet* per_thread_states,
+                       G1ParScanSharedState* shared_state,
                        uint worker_id,
                        uint num_workers,
                        G1CollectionSet* collection_set,
@@ -274,16 +293,13 @@ public:
 
 class G1ParScanThreadStateSet : public StackObj {
   G1CollectedHeap* _g1h;
+  G1ParScanSharedState _shared_state;
   G1CollectionSet* _collection_set;
   G1ParScanThreadState** _states;
   size_t* _surviving_young_words_total;
   uint _num_workers;
   bool _flushed;
   G1EvacFailureRegions* _evac_failure_regions;
-
-  CHeapBitMap _has_nmethods_to_add;
-  Atomic<uint> _num_nmethod_regions_to_add;
-  uint* _nmethod_regions_to_add;
 
  public:
   G1ParScanThreadStateSet(G1CollectedHeap* g1h,
@@ -295,19 +311,13 @@ class G1ParScanThreadStateSet : public StackObj {
   void flush_stats();
   void destroy_worker_states();
 
-  // Updates the region set that has code root updates with the regions in the given set.
-  void update_nmethod_regions_to_add(G1NmethodsToAdd* nmethods);
-  void par_iterate_nmethod_regions_to_add(G1HeapRegionClosure* cl,
-                                          G1HeapRegionClaimer* claimer,
-                                          uint worker_id);
-  uint num_nmethod_regions_to_add() const { return _num_nmethod_regions_to_add.load_relaxed(); }
-
   void record_unused_optional_region(G1HeapRegion* hr);
 #if TASKQUEUE_STATS
   void print_partial_array_task_stats();
 #endif // TASKQUEUE_STATS
 
   G1ParScanThreadState* state_for_worker(uint worker_id);
+  G1ParScanSharedState* shared_state() { return &_shared_state; }
   uint num_workers() const { return _num_workers; }
 
   const size_t* surviving_young_words() const;

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -151,14 +151,18 @@ class G1PostEvacuateCollectionSetCleanupTask1::UpdateCodeRootsTask
   };
 
   G1ParScanThreadStateSet* _psss;
+  G1ParScanSharedState* _shared_state;
   G1HeapRegionClaimer _claimer;
 
 public:
   UpdateCodeRootsTask(G1ParScanThreadStateSet* per_thread_states)
-    : G1AbstractSubTask(G1GCPhaseTimes::UpdateCodeRoots), _psss(per_thread_states), _claimer(0) { }
+    : G1AbstractSubTask(G1GCPhaseTimes::UpdateCodeRoots),
+      _psss(per_thread_states),
+      _shared_state(per_thread_states->shared_state()),
+      _claimer(0) { }
 
   double worker_cost() const override {
-    return _psss->num_nmethod_regions_to_add();
+    return _shared_state->num_nmethod_regions_to_add();
   }
 
   void set_max_workers(uint max_workers) override {
@@ -167,7 +171,7 @@ public:
 
   void do_work(uint worker_id) override {
     ProcessRegionClosure cl(_psss);
-    _psss->par_iterate_nmethod_regions_to_add(&cl, &_claimer, worker_id);
+    _shared_state->par_iterate_nmethod_regions_to_add(&cl, &_claimer, worker_id);
   }
 };
 


### PR DESCRIPTION
`G1ParScanThreadState` currently keeps a reference to its containing
`G1ParScanThreadStateSet` solely to access the shared nmethod-region
bookkeeping.

This change introduces `G1ParScanSharedState` to own that shared state.
`G1ParScanThreadStateSet` remains responsible for managing the per-worker
states and their aggregated statistics, while each `G1ParScanThreadState`
now references the shared state directly.

Testing:
- `make CONF=windows-x86_64-server-fastdebug hotspot`
- `make CONF=windows-x86_64-server-fastdebug test TEST="test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java test/hotspot/jtreg/gc/g1/TestGCLogMessages.java test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java"`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387855](https://bugs.openjdk.org/browse/JDK-8387855): G1: Separate G1ParScanThreadStateSet and shared state (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31929/head:pull/31929` \
`$ git checkout pull/31929`

Update a local copy of the PR: \
`$ git checkout pull/31929` \
`$ git pull https://git.openjdk.org/jdk.git pull/31929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31929`

View PR using the GUI difftool: \
`$ git pr show -t 31929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31929.diff">https://git.openjdk.org/jdk/pull/31929.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31929#issuecomment-4990811042)
</details>
