### PR TITLE
8387597: AwtTrayIcon::InitNID remove handling of ancient Windows versions

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,35 +185,7 @@ AwtTrayIcon* AwtTrayIcon::Create(jobject self, jobject parent)
 
 void AwtTrayIcon::InitNID(UINT uID)
 {
-    // fix for 6271589: we MUST set the size of the structure to match
-    // the shell version, otherwise some errors may occur (like missing
-    // balloon messages on win2k)
-    DLLVERSIONINFO dllVersionInfo;
-    dllVersionInfo.cbSize = sizeof(DLLVERSIONINFO);
-    int shellVersion = 5; // WIN_2000
-    // MSDN: DllGetVersion should not be implicitly called, but rather
-    // loaded using GetProcAddress
-    HMODULE hShell = JDK_LoadSystemLibrary("Shell32.dll");
-    if (hShell != NULL) {
-        DLLGETVERSIONPROC proc = (DLLGETVERSIONPROC)GetProcAddress(hShell, "DllGetVersion");
-        if (proc != NULL) {
-            if (proc(&dllVersionInfo) == NOERROR) {
-                shellVersion = dllVersionInfo.dwMajorVersion;
-            }
-        }
-    }
-    FreeLibrary(hShell);
-    switch (shellVersion) {
-        case 5: // WIN_2000
-            m_nid.cbSize = (BYTE *)(&m_nid.guidItem) - (BYTE *)(&m_nid.cbSize);
-            break;
-        case 6: // WIN_XP
-            m_nid.cbSize = (BYTE *)(&m_nid.hBalloonIcon) - (BYTE *)(&m_nid.cbSize);
-            break;
-        default: // WIN_VISTA
-            m_nid.cbSize = sizeof(m_nid);
-            break;
-    }
+    m_nid.cbSize = sizeof(m_nid);
     m_nid.hWnd = AwtTrayIcon::sm_msgWindow;
     m_nid.uID = uID;
     m_nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;


### PR DESCRIPTION
There is some handling for ancient Windows versions in AwtTrayIcon::InitNID which most likely can be removed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387597](https://bugs.openjdk.org/browse/JDK-8387597): AwtTrayIcon::InitNID remove handling of ancient Windows versions (**Enhancement** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31930/head:pull/31930` \
`$ git checkout pull/31930`

Update a local copy of the PR: \
`$ git checkout pull/31930` \
`$ git pull https://git.openjdk.org/jdk.git pull/31930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31930`

View PR using the GUI difftool: \
`$ git pr show -t 31930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31930.diff">https://git.openjdk.org/jdk/pull/31930.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31930#issuecomment-4991717955)
</details>
