### PR TITLE
8387409: JFR chunk writer aborts with guarantee(successful_write) failed

### DIFF
--- a/src/hotspot/share/jfr/recorder/storage/jfrStorageUtils.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorageUtils.inline.hpp
@@ -54,25 +54,22 @@ inline size_t get_unflushed_size(const u1* top, Type* t) {
 
 template <typename Operation>
 inline bool ConcurrentWriteOp<Operation>::process(typename Operation::Type* t) {
-  const bool is_retired = t->retired();
-  // acquire_critical_section_top() must be read before pos() for stable access
-  const u1* const top = is_retired ? t->top() : t->acquire_critical_section_top();
+  // A buffer can be accessed concurrently (e.g. JfrBuffer::move() during promotion,
+  // or a buffer being recycled through the free list), so top is read through the
+  // critical-section protocol. acquire_critical_section_top() reads top via
+  // stable_top(), so it never observes the TOP_CRITICAL_SECTION sentinel, and its
+  // CAS grants exclusive access to top for the duration of the operation, keeping
+  // the pos - top delta parsable. acquire_critical_section_top() must be read
+  // before pos() for stable access.
+  const u1* const top = t->acquire_critical_section_top();
   const size_t unflushed_size = get_unflushed_size(top, t);
   assert((intptr_t)unflushed_size >= 0, "invariant");
   if (unflushed_size == 0) {
-    if (is_retired) {
-      t->set_top(top);
-    } else {
-      t->release_critical_section_top(top);
-    }
+    t->release_critical_section_top(top);
     return true;
   }
   const bool result = _operation.write(t, top, unflushed_size);
-  if (is_retired) {
-    t->set_top(top + unflushed_size);
-  } else {
-    t->release_critical_section_top(top + unflushed_size);
-  }
+  t->release_critical_section_top(top + unflushed_size);
   return result;
 }
 


### PR DESCRIPTION
See [JDK-8387409](https://bugs.openjdk.org/browse/JDK-8387409) for description and analysis of the failure. This fixes the known mechanism that leads to the failure in the chunk-writer. We still don't know what exactly triggered this (could be very high event churn leading to very frequent buffer recycling), and we haven't managed to make a standalone reproducer.

ConcurrentWriteOp::process read a retired buffer's top with a plain t->top(), bypassing the stable_top() critical-section protocol that every other concurrent top-reader (and DiscardOp in concurrent mode) uses. A retired buffer can still be accessed concurrently -- e.g. JfrBuffer::move() during promotion, or a buffer recycled through the free list -- so top could be observed as the TOP_CRITICAL_SECTION (nullptr) sentinel or as a stale value greater than pos. get_unflushed_size() (pos - top) then underflowed to a multi-gigabyte size_t, which was passed to os::write and tripped guarantee(successful_write) in StreamWriterHost::write_bytes.

Read top through acquire_critical_section_top() unconditionally, so the sentinel is never observed as a value and top cannot change under the operation, keeping the pos - top delta parsable.

Testing:
 - [x] jdk/jfr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387409](https://bugs.openjdk.org/browse/JDK-8387409): JFR chunk writer aborts with guarantee(successful_write) failed (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31931/head:pull/31931` \
`$ git checkout pull/31931`

Update a local copy of the PR: \
`$ git checkout pull/31931` \
`$ git pull https://git.openjdk.org/jdk.git pull/31931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31931`

View PR using the GUI difftool: \
`$ git pr show -t 31931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31931.diff">https://git.openjdk.org/jdk/pull/31931.diff</a>

</details>
