### PR TITLE
8388339: Replacing non-ascii characters in HttpServerAdapters.java

### DIFF
--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -692,7 +692,7 @@ public interface HttpServerAdapters {
     public static class HttpHeadOrGetHandler implements HttpTestHandler {
         final String responseBody;
         public HttpHeadOrGetHandler() {
-            this("pâté de tête persillé");
+            this("pate de tete persille");
         }
         public HttpHeadOrGetHandler(String responseBody) {
             this.responseBody = Objects.requireNonNull(responseBody);


### PR DESCRIPTION
On some Linux distros like Ubunto and Sles, the default environment variables can lead to the non-ascii characters in this string causing any tests using this class to fail due to the unmappable characters.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8388339](https://bugs.openjdk.org/browse/JDK-8388339)

### Issue
 * [JDK-8388339](https://bugs.openjdk.org/browse/JDK-8388339): HttpServersAdapter.java uses non ascii characters causing error (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31932/head:pull/31932` \
`$ git checkout pull/31932`

Update a local copy of the PR: \
`$ git checkout pull/31932` \
`$ git pull https://git.openjdk.org/jdk.git pull/31932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31932`

View PR using the GUI difftool: \
`$ git pr show -t 31932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31932.diff">https://git.openjdk.org/jdk/pull/31932.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31932#issuecomment-4992430749)
</details>
