### PR TITLE
8388399: RISC-V: Enable vector FP16 conversions with Zvfhmin

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -120,6 +120,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZvbb, false, DIAGNOSTIC, "Use Zvbb instructions")             \
   product(bool, UseZvbc, false, EXPERIMENTAL, "Use Zvbc instructions")           \
   product(bool, UseZvfh, false, DIAGNOSTIC, "Use Zvfh instructions")             \
+  product(bool, UseZvfhmin, false, DIAGNOSTIC, "Use Zvfhmin instructions")       \
   product(bool, UseZvkg, false, DIAGNOSTIC, "Use Zvkg instructions")             \
   product(bool, UseZvkn, false, DIAGNOSTIC,                                      \
           "Use Zvkn group extension, Zvkned, Zvknhb, Zvkb, Zvkt")                \

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -113,6 +113,7 @@ source %{
         break;
       case Op_VectorCastHF2F:
       case Op_VectorCastF2HF:
+        return UseZvfh || UseZvfhmin;
       case Op_AddVHF:
       case Op_SubVHF:
       case Op_MulVHF:

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -287,6 +287,8 @@ class VM_Version : public Abstract_VM_Version {
   decl(Zvbc        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvbc, &ext_v, nullptr))           \
   /* Vector Extension for Half-Precision Floating-Point */                                             \
   decl(Zvfh        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvfh, &ext_v, &ext_Zfh, nullptr)) \
+  /* Vector Extension for Minimal Half-Precision Floating-Point */                                     \
+  decl(Zvfhmin     ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvfhmin, &ext_v, nullptr))        \
   /* Shorthand for Zvkned + Zvknhb + Zvkb + Zvkt */                                                    \
   decl(Zvkn        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvkn, &ext_v, nullptr))           \
   /* Zvkg crypto extension for ghash and gcm */                                                        \
@@ -442,6 +444,7 @@ private:
     RV_ENABLE_EXTENSION(UseZicboz)                  \
     RV_ENABLE_EXTENSION(UseZicond)                  \
     RV_ENABLE_EXTENSION(UseZihintpause)             \
+    RV_ENABLE_EXTENSION(UseZvfhmin)                 \
 
   static void useRVA23U64Profile();
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -219,80 +219,80 @@ class VM_Version : public Abstract_VM_Version {
   //
   // Fields description in `decl`:
   //    declaration name, extension name, bit value from linux, feature string?, mapped flag)
-  #define RV_EXT_FEATURE_FLAGS(decl)                                                                   \
-  /* A Atomic Instructions */                                                                          \
-  decl(a           ,     ('A' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* C Compressed Instructions */                                                                      \
-  decl(c           ,     ('C' - 'A'),  true ,  UPDATE_DEFAULT(UseRVC))                                 \
-  /* D Single-Precision Floating-Point */                                                              \
-  decl(d           ,     ('D' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* F Single-Precision Floating-Point */                                                              \
-  decl(f           ,     ('F' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* H Hypervisor */                                                                                   \
-  decl(h           ,     ('H' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* I RV64I */                                                                                        \
-  decl(i           ,     ('I' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* M Integer Multiplication and Division */                                                          \
-  decl(m           ,     ('M' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* Q Quad-Precision Floating-Point */                                                                \
-  decl(q           ,     ('Q' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* V Vector */                                                                                       \
-  decl(v           ,     ('V' - 'A'),  true ,  UPDATE_DEFAULT(UseRVV))                                 \
-                                                                                                       \
-  /* ----------------------- Other extensions ----------------------- */                               \
-                                                                                                       \
-  /* Atomic compare-and-swap (CAS) instructions */                                                     \
-  decl(Zacas       ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZacas))                               \
-  /* Zba Address generation instructions */                                                            \
-  decl(Zba         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZba))                                 \
-  /* Zbb Basic bit-manipulation */                                                                     \
-  decl(Zbb         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZbb))                                 \
-  /* Zbc Carry-less multiplication */                                                                  \
-  decl(Zbc         ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* Bitmanip instructions for Cryptography */                                                         \
-  decl(Zbkb        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZbkb))                                \
-  /* Zbs Single-bit instructions */                                                                    \
-  decl(Zbs         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZbs))                                 \
-  /* Zcb Simple code-size saving instructions */                                                       \
-  decl(Zcb         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZcb))                                 \
-  /* Additional Floating-Point instructions */                                                         \
-  decl(Zfa         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZfa))                                 \
-  /* Zfh Half-Precision Floating-Point instructions */                                                 \
-  decl(Zfh         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZfh))                                 \
-  /* Zfhmin Minimal Half-Precision Floating-Point instructions */                                      \
-  decl(Zfhmin      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZfhmin))                              \
-  /* Zicbom Cache Block Management Operations */                                                       \
-  decl(Zicbom      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicbom))                              \
-  /* Zicbop Cache Block Prefetch Operations */                                                         \
-  decl(Zicbop      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicbop))                              \
-  /* Zicboz Cache Block Zero Operations */                                                             \
-  decl(Zicboz      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicboz))                              \
-  /* Base Counters and Timers */                                                                       \
-  decl(Zicntr      ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* Zicond Conditional operations */                                                                  \
-  decl(Zicond      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicond))                              \
-  /* Zicsr Control and Status Register (CSR) Instructions */                                           \
-  decl(Zicsr       ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* Zic64b Cache blocks must be 64 bytes in size, naturally aligned in the address space. */          \
-  decl(Zic64b      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZic64b))                              \
-  /* Zifencei Instruction-Fetch Fence */                                                               \
-  decl(Zifencei    ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                      \
-  /* Zihintpause Pause instruction HINT */                                                             \
-  decl(Zihintpause ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZihintpause))                         \
-  /* Total Store Ordering */                                                                           \
-  decl(Ztso        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZtso))                                \
-  /* Vector Basic Bit-manipulation */                                                                  \
-  decl(Zvbb        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvbb, &ext_v, nullptr))           \
-  /* Vector Carryless Multiplication */                                                                \
-  decl(Zvbc        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvbc, &ext_v, nullptr))           \
-  /* Vector Extension for Half-Precision Floating-Point */                                             \
-  decl(Zvfh        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvfh, &ext_v, &ext_Zfh, nullptr)) \
-  /* Vector Extension for Minimal Half-Precision Floating-Point */                                     \
-  decl(Zvfhmin     ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvfhmin, &ext_v, nullptr))        \
-  /* Shorthand for Zvkned + Zvknhb + Zvkb + Zvkt */                                                    \
-  decl(Zvkn        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvkn, &ext_v, nullptr))           \
-  /* Zvkg crypto extension for ghash and gcm */                                                        \
-  decl(Zvkg        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvkg, &ext_v, nullptr))           \
+  #define RV_EXT_FEATURE_FLAGS(decl)                                                                      \
+  /* A Atomic Instructions */                                                                             \
+  decl(a           ,     ('A' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* C Compressed Instructions */                                                                         \
+  decl(c           ,     ('C' - 'A'),  true ,  UPDATE_DEFAULT(UseRVC))                                    \
+  /* D Single-Precision Floating-Point */                                                                 \
+  decl(d           ,     ('D' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* F Single-Precision Floating-Point */                                                                 \
+  decl(f           ,     ('F' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* H Hypervisor */                                                                                      \
+  decl(h           ,     ('H' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* I RV64I */                                                                                           \
+  decl(i           ,     ('I' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* M Integer Multiplication and Division */                                                             \
+  decl(m           ,     ('M' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* Q Quad-Precision Floating-Point */                                                                   \
+  decl(q           ,     ('Q' - 'A'),  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* V Vector */                                                                                          \
+  decl(v           ,     ('V' - 'A'),  true ,  UPDATE_DEFAULT(UseRVV))                                    \
+                                                                                                          \
+  /* ----------------------- Other extensions ----------------------- */                                  \
+                                                                                                          \
+  /* Atomic compare-and-swap (CAS) instructions */                                                        \
+  decl(Zacas       ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZacas))                                  \
+  /* Zba Address generation instructions */                                                               \
+  decl(Zba         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZba))                                    \
+  /* Zbb Basic bit-manipulation */                                                                        \
+  decl(Zbb         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZbb))                                    \
+  /* Zbc Carry-less multiplication */                                                                     \
+  decl(Zbc         ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* Bitmanip instructions for Cryptography */                                                            \
+  decl(Zbkb        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZbkb))                                   \
+  /* Zbs Single-bit instructions */                                                                       \
+  decl(Zbs         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZbs))                                    \
+  /* Zcb Simple code-size saving instructions */                                                          \
+  decl(Zcb         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZcb))                                    \
+  /* Additional Floating-Point instructions */                                                            \
+  decl(Zfa         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZfa))                                    \
+  /* Zfh Half-Precision Floating-Point instructions */                                                    \
+  decl(Zfh         ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZfh))                                    \
+  /* Zfhmin Minimal Half-Precision Floating-Point instructions */                                         \
+  decl(Zfhmin      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZfhmin))                                 \
+  /* Zicbom Cache Block Management Operations */                                                          \
+  decl(Zicbom      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicbom))                                 \
+  /* Zicbop Cache Block Prefetch Operations */                                                            \
+  decl(Zicbop      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicbop))                                 \
+  /* Zicboz Cache Block Zero Operations */                                                                \
+  decl(Zicboz      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicboz))                                 \
+  /* Base Counters and Timers */                                                                          \
+  decl(Zicntr      ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* Zicond Conditional operations */                                                                     \
+  decl(Zicond      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicond))                                 \
+  /* Zicsr Control and Status Register (CSR) Instructions */                                              \
+  decl(Zicsr       ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* Zic64b Cache blocks must be 64 bytes in size, naturally aligned in the address space. */             \
+  decl(Zic64b      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZic64b))                                 \
+  /* Zifencei Instruction-Fetch Fence */                                                                  \
+  decl(Zifencei    ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                         \
+  /* Zihintpause Pause instruction HINT */                                                                \
+  decl(Zihintpause ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZihintpause))                            \
+  /* Total Store Ordering */                                                                              \
+  decl(Ztso        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZtso))                                   \
+  /* Vector Basic Bit-manipulation */                                                                     \
+  decl(Zvbb        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvbb, &ext_v, nullptr))              \
+  /* Vector Carryless Multiplication */                                                                   \
+  decl(Zvbc        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvbc, &ext_v, nullptr))              \
+  /* Vector Extension for Half-Precision Floating-Point */                                                \
+  decl(Zvfh        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvfh, &ext_v, &ext_Zfhmin, nullptr)) \
+  /* Vector Extension for Minimal Half-Precision Floating-Point */                                        \
+  decl(Zvfhmin     ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvfhmin, &ext_v, nullptr))           \
+  /* Shorthand for Zvkned + Zvknhb + Zvkb + Zvkt */                                                       \
+  decl(Zvkn        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvkn, &ext_v, nullptr))              \
+  /* Zvkg crypto extension for ghash and gcm */                                                           \
+  decl(Zvkg        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZvkg, &ext_v, nullptr))              \
 
   #define DECLARE_RV_EXT_FEATURE(PRETTY, LINUX_BIT, FSTRING, FLAGF)                             \
   struct ext_##PRETTY##RVExtFeatureValue : public RVExtFeatureValue {                           \

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -247,6 +247,9 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVFH)) {
     VM_Version::ext_Zvfh.enable_feature();
   }
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVFHMIN)) {
+    VM_Version::ext_Zvfhmin.enable_feature();
+  }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKNED) &&
       is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKNHB) &&
       is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKB)   &&


### PR DESCRIPTION
Hi,
Can you help to review this patch? Thanks!

We currently require UseZvfh for C2's `VectorCastHF2F` and `VectorCastF2HF` nodes. However, the underlying instructions, `vfwcvt.f.f.v` and `vfncvt.f.f.w`, only require Zvfhmin.

`Zvfhmin` is mandatory in RVA23U64[1], while `Zvfh` is optional. Requiring `UseZvfh` therefore unnecessarily disables these conversions on RVA23U64 systems without `Zvfh`.

I also updated the dependency of `Zvfh` from `Zfh` to `Zfhmin`. According to the specification[2], `Zvfh` depends on `Zve32f` and `Zfhmin`, so requiring the full `Zfh` extension here was unnecessarily restrictive.

[1] https://github.com/riscv/riscv-profiles/blob/main/src/rva23-profile.adoc#rva23u64-mandatory-extensions
[2] https://github.com/riscv/riscv-isa-manual/blob/main/src/unpriv/zvfh.adoc

Tested with QEMU 11.0.0 using the `ubuntu-26.04-preinstalled-server-riscv64.img` image and with:
`-cpu rva23s64,sv48=on,v=true,vext_spec=v1.0,vlen=256,elen=64,rvv_ma_all_1s=true,rvv_ta_all_1s=true`

cpuinfo:
```
$ cat /proc/cpuinfo
processor       : 0
hart            : 16
isa             : rv64imafdcvh_zicbom_zicbop_zicboz_ziccrse_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalasr_zalrsc_zawrs_zfa_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zve32x_zve64d_zve64f_zve64x_zvfhmin_zvkb_zvkt_smnpm_smstateen_sscofpmf_ssnpm_sstc_svade_svinval_svnapot_svpbmt
mmu             : sv48
mvendorid       : 0x0
marchid         : 0x0
mimpid          : 0x0
hart isa        : rv64imafdcvh_zicbom_zicbop_zicboz_ziccrse_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalasr_zalrsc_zawrs_zfa_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zve32x_zve64d_zve64f_zve64x_zvfhmin_zvkb_zvkt_smnpm_smstateen_sscofpmf_ssnpm_sstc_svade_svinval_svnapot_svpbmt
```

Before:
```
./java -XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions -version | grep UseZvfh
     bool UseZvfh                                  = false                             {ARCH diagnostic} {default}
openjdk version "28-testing" 2027-03-23
OpenJDK Runtime Environment (build 28-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 28-internal-adhoc.zhangdingli.jdk, mixed mode)
```

After:
```
./java \
-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions \
-version | grep UseZvfh
     bool UseZvfh                                  = false                             {ARCH diagnostic} {default}
     bool UseZvfhmin                               = true                              {ARCH diagnostic} {default}
openjdk version "28-internal" 2027-03-23
OpenJDK Runtime Environment (build 28-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 28-internal-adhoc.zhangdingli.jdk, mixed mode)
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388399](https://bugs.openjdk.org/browse/JDK-8388399): RISC-V: Enable vector FP16 conversions with Zvfhmin (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Anjian Wen](https://openjdk.org/census#wenanjian) (@Anjian-Wen - Committer)

### Reviewers without OpenJDK IDs
 * @zifeihan (no known openjdk.org user name / role) Review applies to [baed0ebf](https://git.openjdk.org/jdk/pull/31934/files/baed0ebf6810fd22829fd1d4819d288f51ad625d)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31934/head:pull/31934` \
`$ git checkout pull/31934`

Update a local copy of the PR: \
`$ git checkout pull/31934` \
`$ git pull https://git.openjdk.org/jdk.git pull/31934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31934`

View PR using the GUI difftool: \
`$ git pr show -t 31934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31934.diff">https://git.openjdk.org/jdk/pull/31934.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31934#issuecomment-4993149386)
</details>
