### PR TITLE
8380928: C2 SuperWord: PopulateIndex for NEON/aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_vector.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_vector.ad
@@ -168,6 +168,11 @@ source %{
     // Check whether specific Op is supported.
     // Fail fast, otherwise fall through to common vector_size_supported() check.
     switch (opcode) {
+      case Op_PopulateIndex:
+        if (UseSVE == 0 && (is_unsigned_subword_type(bt) || is_reference_type(bt))) {
+          return false;
+        }
+        break;
       case Op_AndVMask:
       case Op_OrVMask:
       case Op_XorVMask:
@@ -177,7 +182,6 @@ source %{
       case Op_StoreVectorMasked:
       case Op_StoreVectorScatter:
       case Op_StoreVectorScatterMasked:
-      case Op_PopulateIndex:
       case Op_CompressM:
       case Op_CompressV:
         if (UseSVE == 0) {
@@ -7714,7 +7718,22 @@ instruct vreverseBytes_masked(vReg dst, vReg src, pRegGov pg) %{
 
 // ------------------------------ Populate Index to a Vector -------------------
 
-instruct populateindex(vReg dst, iRegIorL2I src1, immI src2) %{
+instruct populateindex_neon_stride1(vReg dst, iRegIorL2I src1, immI_1 src2, vReg tmp) %{
+  predicate(UseSVE == 0);
+  match(Set dst (PopulateIndex src1 src2));
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "populateindex $dst, $src1, $src2\t # populate index, KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    assert($src2$$constant == 1, "required");
+    __ neon_load_iota_indices($dst$$FloatRegister, bt);
+    __ dup($tmp$$FloatRegister, get_arrangement(this), $src1$$Register);
+    __ addv($dst$$FloatRegister, get_arrangement(this), $dst$$FloatRegister, $tmp$$FloatRegister);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct populateindex_sve(vReg dst, iRegIorL2I src1, immI src2) %{
   predicate(UseSVE > 0);
   match(Set dst (PopulateIndex src1 src2));
   format %{ "populateindex $dst, $src1, $src2\t # populate index (sve)" %}

--- a/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_vector_ad.m4
@@ -158,6 +158,11 @@ source %{
     // Check whether specific Op is supported.
     // Fail fast, otherwise fall through to common vector_size_supported() check.
     switch (opcode) {
+      case Op_PopulateIndex:
+        if (UseSVE == 0 && (is_unsigned_subword_type(bt) || is_reference_type(bt))) {
+          return false;
+        }
+        break;
       case Op_AndVMask:
       case Op_OrVMask:
       case Op_XorVMask:
@@ -167,7 +172,6 @@ source %{
       case Op_StoreVectorMasked:
       case Op_StoreVectorScatter:
       case Op_StoreVectorScatterMasked:
-      case Op_PopulateIndex:
       case Op_CompressM:
       case Op_CompressV:
         if (UseSVE == 0) {
@@ -5344,7 +5348,22 @@ instruct vreverseBytes_masked(vReg dst, vReg src, pRegGov pg) %{
 
 // ------------------------------ Populate Index to a Vector -------------------
 
-instruct populateindex(vReg dst, iRegIorL2I src1, immI src2) %{
+instruct populateindex_neon_stride1(vReg dst, iRegIorL2I src1, immI_1 src2, vReg tmp) %{
+  predicate(UseSVE == 0);
+  match(Set dst (PopulateIndex src1 src2));
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "populateindex $dst, $src1, $src2\t # populate index, KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    assert($src2$$constant == 1, "required");
+    __ neon_load_iota_indices($dst$$FloatRegister, bt);
+    __ dup($tmp$$FloatRegister, get_arrangement(this), $src1$$Register);
+    __ addv($dst$$FloatRegister, get_arrangement(this), $dst$$FloatRegister, $tmp$$FloatRegister);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct populateindex_sve(vReg dst, iRegIorL2I src1, immI src2) %{
   predicate(UseSVE > 0);
   match(Set dst (PopulateIndex src1 src2));
   format %{ "populateindex $dst, $src1, $src2\t # populate index (sve)" %}

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -2970,3 +2970,10 @@ int C2_MacroAssembler::vector_iota_entry_index(BasicType bt) {
     ShouldNotReachHere();
   }
 }
+
+void C2_MacroAssembler::neon_load_iota_indices(FloatRegister dst, BasicType bt) {
+  int type_index = vector_iota_entry_index(bt);
+  lea(rscratch1,
+      ExternalAddress(StubRoutines::aarch64::vector_iota_indices(type_index)));
+  ldrq(dst, rscratch1);
+}

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -253,4 +253,5 @@
   void sve_cpy(FloatRegister dst, SIMD_RegVariant T, PRegister pg, int imm8,
                bool isMerge);
   int vector_iota_entry_index(BasicType bt);
+  void neon_load_iota_indices(FloatRegister dst, BasicType bt);
 #endif // CPU_AARCH64_C2_MACROASSEMBLER_AARCH64_HPP

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
@@ -1164,7 +1164,7 @@ public class TestSplitPacks {
                   IRNode.MUL_VI,         "> 0",
                   IRNode.POPULATE_INDEX, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "sve", "true", "rvv", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     // Index Populate:
     // There can be an issue when all the (iv + 1), (iv + 2), ...
     // get packed, but not (iv). Then we have a pack that is one element

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -27,15 +27,18 @@
 * @summary Test vectorization of loop induction variable usage in the loop
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*") |
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*asimd.*") |
 *           (os.simpleArch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
 * @library /test/lib /
-* @run driver compiler.vectorization.TestPopulateIndex
+* @build jdk.test.whitebox.WhiteBox
+* @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+* @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.vectorization.TestPopulateIndex
 */
 
 package compiler.vectorization;
 import compiler.lib.ir_framework.*;
 import java.util.Random;
+import jdk.test.whitebox.cpuinfo.CPUInfo;
 
 public class TestPopulateIndex {
     private static final int count = 10000;
@@ -46,6 +49,10 @@ public class TestPopulateIndex {
     private float[] f;
 
     public static void main(String args[]) {
+        if (CPUInfo.hasFeature("sve")) {
+            // If AArch64 SVE is available, we want to force a run with it disabled, using NEON as a fallback
+            TestFramework.runWithFlags("-XX:UseSVE=0");
+        }
         TestFramework.run(TestPopulateIndex.class);
     }
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorAlgorithms.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorAlgorithms.java
@@ -304,7 +304,7 @@ public class TestVectorAlgorithms {
     @Test
     @IR(counts = {IRNode.POPULATE_INDEX, "> 0",
                   IRNode.STORE_VECTOR,   "> 0"},
-        applyIfCPUFeatureOr = {"avx2", "true", "sve", "true", "rvv", "true"},
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"},
         applyIf = {"UseSuperWord", "true"})
     // Note: the Vector API example below can also vectorize for AVX,
     //       because it does not use a PopulateIndex.

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
@@ -52,7 +52,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public byte[] fillByteArray() {
         byte[] res = new byte[SIZE];
@@ -63,7 +63,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public short[] fillShortArray() {
         short[] res = new short[SIZE];
@@ -74,7 +74,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public char[] fillCharArray() {
         char[] res = new char[SIZE];
@@ -85,7 +85,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public int[] fillIntArray() {
         int[] res = new int[SIZE];
@@ -96,7 +96,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, "=0"})
     // The ConvI2L can be pushed through the AddI, creating a mix of
     // ConvI2L(AddI) and AddL(ConvI2L) cases, which do not vectorize.
@@ -110,7 +110,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     // The variable init/limit has the consequence that we do not split
     // the ConvI2L through the AddI.
@@ -123,7 +123,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public float[] fillFloatArray() {
         float[] res = new float[SIZE];
@@ -134,7 +134,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public float[] fillFloatArray2() {
         float[] res = new float[SIZE];
@@ -145,7 +145,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public double[] fillDoubleArray() {
         double[] res = new double[SIZE];
@@ -156,7 +156,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public double[] fillDoubleArray2() {
         double[] res = new double[SIZE];
@@ -167,7 +167,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public short[] fillShortArrayWithShortIndex() {
         short[] res = new short[SIZE];
@@ -178,7 +178,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public int[] fillMultipleArraysDifferentTypes1() {
         int[] res1 = new int[SIZE];
@@ -191,7 +191,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public char[] fillMultipleArraysDifferentTypes2() {
         int[] res1 = new int[SIZE];


### PR DESCRIPTION
By supporting the PopulateIndex operation node in C2, the benchmarks in org.openjdk.bench.vm.compiler.IndexVector see the following performance improvements on an Arm Neoverse N1 CPU:

exprWithIndex1: 55.53%
exprWithIndex2: 58.11%
indexArrayFull: 26.56%

The C2 IR node of `populateindex V17, R17, #1   # populate index with
temp register V16` expands to the following assembly:
```
dup     v16.4s, w17
movz    x8, #0x8e0          ;   {external_word}
movk    x8, #0xfb42, lsl #16
movk    x8, #0xf1f2, lsl #32
ldr     q17, [x8], #0
add     v17.4s, v17.4s, v16.4s
```




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-BoldOblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans-Oblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSans.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-BoldOblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono-Oblique.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSansMono.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-Bold.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-BoldItalic.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif-Italic.woff)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/fonts/DejaVuLGCSerif.woff)

### Issue
 * [JDK-8380928](https://bugs.openjdk.org/browse/JDK-8380928): C2 SuperWord: PopulateIndex for NEON/aarch64 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31935/head:pull/31935` \
`$ git checkout pull/31935`

Update a local copy of the PR: \
`$ git checkout pull/31935` \
`$ git pull https://git.openjdk.org/jdk.git pull/31935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31935`

View PR using the GUI difftool: \
`$ git pr show -t 31935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31935.diff">https://git.openjdk.org/jdk/pull/31935.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31935#issuecomment-4993367150)
</details>
