### PR TITLE
8388312: ZGC: Diagnostic VM option `ZIndexDistributorStrategy` is not validated

### DIFF
--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,6 +100,7 @@
           "Strategy used to distribute indices to parallel workers "        \
           "0: Claim tree "                                                  \
           "1: Simple Striped ")                                             \
+          range(0, 1)                                                       \
                                                                             \
   product(bool, ZVerifyRemembered, trueInDebug, DIAGNOSTIC,                 \
           "Verify remembered sets")                                         \

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -96,7 +96,7 @@
   product(uint, ZOldGCThreads, 0, DIAGNOSTIC,                               \
           "Number of GC threads for the old generation")                    \
                                                                             \
-  product(uintx, ZIndexDistributorStrategy, 0, DIAGNOSTIC,                  \
+  product(uint, ZIndexDistributorStrategy, 0, DIAGNOSTIC,                   \
           "Strategy used to distribute indices to parallel workers "        \
           "0: Claim tree "                                                  \
           "1: Simple Striped ")                                             \


### PR DESCRIPTION
Please review this change , thanks!

A small PR that adds range validation for the command-line flag `ZIndexDistributorStrategy` to prevent JVM crashes caused by out-of-range values.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388312](https://bugs.openjdk.org/browse/JDK-8388312): ZGC: Diagnostic VM option `ZIndexDistributorStrategy` is not validated (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31936/head:pull/31936` \
`$ git checkout pull/31936`

Update a local copy of the PR: \
`$ git checkout pull/31936` \
`$ git pull https://git.openjdk.org/jdk.git pull/31936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31936`

View PR using the GUI difftool: \
`$ git pr show -t 31936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31936.diff">https://git.openjdk.org/jdk/pull/31936.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31936#issuecomment-4993969078)
</details>
