### PR TITLE
8388363: testlibrary_tests/template_framework/examples/TestVectorTypes.java failed with C1

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestVectorTypes.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestVectorTypes.java
@@ -23,8 +23,9 @@
 
 /*
  * @test
- * @bug 8358772
+ * @bug 8358772 8388363
  * @summary Demonstrate the use of VectorTypes (Vector API) form the Template Library.
+ * @requires vm.compiler2.enabled
  * @modules java.base/jdk.internal.misc
  * @modules jdk.incubator.vector
  * @library /test/lib /


### PR DESCRIPTION
The test fails in Valhalla CI (build jdk-28-valhalla+1-96, hotspot_misc task) with 24 TestRunExceptions because that task sets -XX:TieredStopAtLevel=3, and hotspot_misc includes testlibrary_tests, so the test inherits the flag. The failure is in the IR test framework, not a miscompile: AbstractTest.compileMethod() force-compiles each generated @Test method at the requested level and asserts it is compilable. With TieredStopAtLevel=3 the only available level is C1_FULL_PROFILE, the generated Vector API methods are reported not-compilable at that level, and the framework throws at TestRun.check (AbstractTest.java:122). All 24 failures are identical, differing only in the generated method.

This test is an IR-framework test that exercises C2 compilation of Vector API code, so it genuinely depends on C2... the same as the incubator Vector API tests that already carry @requires vm.compiler2.enabled. Most tests under test/jdk/jdk/incubator/vector/ run fine on C1 because they only execute the code; they don’t force compilation, so they don’t hit this. I added @requires vm.compiler2.enabled because it expresses that real dependency; vm.flagless would over-skip on unrelated flags like GC selection. With TieredStopAtLevel=3 the test is no longer selected, and with no flags it still runs and passes, so coverage is retained.

The "IR verification disabled … non-whitelisted JTreg VM or Javaoptions flag(s): TieredStopAtLevel=3" line is expected and unrelated to any non-whitelisted flag disables the @IR checks, and this test carries no @IR annotations regardless. I could not reproduce locally: it passes on mainline jdk-27 (x64 release/fastdebug) and on lworld (macosx-aarch64 release/fastdebug), with the flags confirmed applied in the .jtr. Deferring to hotspot-compiler to confirm the C1 behavior before integrating.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8388363](https://bugs.openjdk.org/browse/JDK-8388363)

### Issue
 * [JDK-8388363](https://bugs.openjdk.org/browse/JDK-8388363): [lworld] C1: Constant fold substitutability check with non-value objects (**Enhancement** - P4)(⚠️ The fixVersion in this issue is [repo-valhalla] but the fixVersion in .jcheck/conf is 28, a new backport will be created when this pr is integrated.) ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Ekaterina Pavlova](https://openjdk.org/census#epavlova) (@katyapav - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31938/head:pull/31938` \
`$ git checkout pull/31938`

Update a local copy of the PR: \
`$ git checkout pull/31938` \
`$ git pull https://git.openjdk.org/jdk.git pull/31938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31938`

View PR using the GUI difftool: \
`$ git pr show -t 31938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31938.diff">https://git.openjdk.org/jdk/pull/31938.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31938#issuecomment-5012858535)
</details>
