### PR TITLE
8387802: Add TLS Unique Channel Binding APIs to ExtendedSSLSession

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/ExtendedSSLSession.java
+++ b/src/java.base/share/classes/javax/net/ssl/ExtendedSSLSession.java
@@ -273,4 +273,28 @@ public abstract class ExtendedSSLSession implements SSLSession {
         throw new UnsupportedOperationException(
                 "Underlying provider does not implement the method");
     }
+
+    /**
+     * Returns the Client Finished verify_data for this session.
+     *
+     * @implSpec The default implementation returns null.
+     *
+     * @return Client Finished verify_data bytes, or null if unavailable
+     * @since 27
+     */
+    public byte[] getTlsUniqueClientFirstFinishedVerifyData() {
+        return null;
+    }
+
+    /**
+     * Returns the first Finished verify_data sent for this session.
+     *
+     * @implSpec The default implementation returns null.
+     *
+     * @return first Finished verify_data bytes, or null if unavailable
+     * @since 27
+     */
+    public byte[] getTlsUniqueFirstFinishedVerifyData() {
+        return null;
+    }
 }

--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -406,6 +406,11 @@ final class Finished {
                 chc.conContext.clientVerifyData = fm.verifyData;
             }
 
+            // Store client's Finished verify_data for tls-unique (RFC 5929)
+            if (chc.handshakeSession != null) {
+                chc.handshakeSession.setClientFinishedVerifyData(fm.verifyData);
+            }
+
             if (chc.statelessResumption) {
                 chc.handshakeConsumers.put(
                         SSLHandshake.NEW_SESSION_TICKET.id, SSLHandshake.NEW_SESSION_TICKET);
@@ -467,6 +472,11 @@ final class Finished {
              */
             if (shc.conContext.secureRenegotiation) {
                 shc.conContext.serverVerifyData = fm.verifyData;
+            }
+
+            // Store server's Finished verify_data for tls-unique (RFC 5929)
+            if (shc.handshakeSession != null) {
+                shc.handshakeSession.setServerFinishedVerifyData(fm.verifyData);
             }
 
             // update the consumers and producers
@@ -551,6 +561,11 @@ final class Finished {
                 chc.conContext.serverVerifyData = fm.verifyData;
             }
 
+            // Store server's Finished verify_data for tls-unique (RFC 5929)
+            if (chc.handshakeSession != null) {
+                chc.handshakeSession.setServerFinishedVerifyData(fm.verifyData);
+            }
+
             if (!chc.isResumption) {
                 if (chc.handshakeSession.isRejoinable()) {
                     ((SSLSessionContextImpl)chc.sslContext.
@@ -609,6 +624,11 @@ final class Finished {
 
             if (shc.conContext.secureRenegotiation) {
                 shc.conContext.clientVerifyData = fm.verifyData;
+            }
+
+            // Store client's Finished verify_data for tls-unique (RFC 5929)
+            if (shc.handshakeSession != null) {
+                shc.handshakeSession.setClientFinishedVerifyData(fm.verifyData);
             }
 
             if (shc.isResumption) {

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -115,6 +115,11 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     private int                 negotiatedMaxFragLen = -1;
     private int                 maximumPacketSize;
 
+    private static final boolean tlsUniqueChannelBindingEnabled = Utilities.getBooleanProperty(
+            "sun.security.ssl.enableTlsUniqueChannelBinding", false);
+    private volatile byte[] clientFinishedVerifyData;
+    private volatile byte[] serverFinishedVerifyData;
+
     private final Queue<SSLSessionImpl> childSessions =
                                         new ConcurrentLinkedQueue<>();
 
@@ -1685,9 +1690,59 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         return (byte[])exportKeyingMaterial(null, label, context, length);
     }
 
-    /** Returns a string representation of this SSL session */
+    void setClientFinishedVerifyData(byte[] verifyData) {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return;
+        }
+        this.clientFinishedVerifyData = (verifyData != null)
+                ? verifyData.clone()
+                : null;
+    }
+
+    void setServerFinishedVerifyData(byte[] verifyData) {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return;
+        }
+        this.serverFinishedVerifyData = (verifyData != null)
+                ? verifyData.clone()
+                : null;
+    }
+
     @Override
-    public String toString() {
-        return "Session(" + creationTime + "|" + getCipherSuite() + ")";
+    public byte[] getTlsUniqueClientFirstFinishedVerifyData() {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return null;
+        }
+
+        if (protocolVersion.useTLS13PlusSpec()) {
+            return null;
+        }
+        if (!useExtendedMasterSecret) {
+            return null;
+        }
+
+        return (clientFinishedVerifyData != null)
+                ? clientFinishedVerifyData.clone()
+                : null;
+    }
+
+    @Override
+    public byte[] getTlsUniqueFirstFinishedVerifyData() {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return null;
+        }
+
+        if (protocolVersion.useTLS13PlusSpec()) {
+            return null;
+        }
+        if (!useExtendedMasterSecret) {
+            return null;
+        }
+
+        byte[] result = (serverFinishedVerifyData != null
+                && clientFinishedVerifyData == null)
+                        ? serverFinishedVerifyData
+                        : clientFinishedVerifyData;
+        return (result != null) ? result.clone() : null;
     }
 }

--- a/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
+++ b/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.Security;
+import java.util.Arrays;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
+/*
+ * @test
+ * @bug 8387802
+ * @summary Verify tls-unique channel binding (RFC 5929) via ExtendedSSLSession
+ * @library /javax/net/ssl/templates /test/lib
+ * @build SSLEngineTemplate
+ * @run main/othervm -Dsun.security.ssl.enableTlsUniqueChannelBinding=true TlsUniqueChannelBindingTest TLS12_ENABLED
+ * @run main/othervm TlsUniqueChannelBindingTest DISABLED
+ * @run main/othervm -Dsun.security.ssl.enableTlsUniqueChannelBinding=true TlsUniqueChannelBindingTest TLS13_NULL
+ */
+
+public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
+
+    private final String protocol;
+    private final String ciphersuite;
+
+    TlsUniqueChannelBindingTest(String protocol, String ciphersuite)
+            throws Exception {
+        super();
+        this.protocol = protocol;
+        this.ciphersuite = ciphersuite;
+    }
+
+    private void configureEngines(SSLEngine clientEngine,
+            SSLEngine serverEngine) {
+        clientEngine.setUseClientMode(true);
+        SSLParameters clientParams = clientEngine.getSSLParameters();
+        clientParams.setProtocols(new String[] { protocol });
+        clientParams.setCipherSuites(new String[] { ciphersuite });
+        clientEngine.setSSLParameters(clientParams);
+
+        serverEngine.setUseClientMode(false);
+        serverEngine.setNeedClientAuth(true);
+        SSLParameters serverParams = serverEngine.getSSLParameters();
+        serverParams.setProtocols(new String[]{
+                "TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1"});
+        serverEngine.setSSLParameters(serverParams);
+    }
+
+    public static void main(String[] args) throws Exception {
+        String testCase = args.length > 0 ? args[0] : "TLS12_ENABLED";
+        Security.setProperty("jdk.tls.disabledAlgorithms", "");
+
+        switch (testCase) {
+            case "TLS12_ENABLED":
+                testTls12Enabled();
+                break;
+            case "DISABLED":
+                testDisabled();
+                break;
+            case "TLS13_NULL":
+                testTls13Null();
+                break;
+            default:
+                throw new RuntimeException("Unknown test case: " + testCase);
+        }
+    }
+
+    private static void testTls12Enabled() throws Exception {
+        new TlsUniqueChannelBindingTest(
+                "TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+                .runTest(true);
+    }
+
+    private static void testDisabled() throws Exception {
+        new TlsUniqueChannelBindingTest(
+                "TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+                .runTest(false);
+    }
+
+    private static void testTls13Null() throws Exception {
+        new TlsUniqueChannelBindingTest(
+                "TLSv1.3", "TLS_AES_128_GCM_SHA256")
+                .runTest(false);
+    }
+
+    private void runTest(boolean expectNonNull) throws Exception {
+        configureEngines(clientEngine, serverEngine);
+
+        boolean dataDone = false;
+        while (isOpen(clientEngine) || isOpen(serverEngine)) {
+            clientEngine.wrap(clientOut, cTOs);
+            runDelegatedTasks(clientEngine);
+
+            serverEngine.wrap(serverOut, sTOc);
+            runDelegatedTasks(serverEngine);
+
+            cTOs.flip();
+            sTOc.flip();
+
+            clientEngine.unwrap(sTOc, clientIn);
+            runDelegatedTasks(clientEngine);
+
+            serverEngine.unwrap(cTOs, serverIn);
+            runDelegatedTasks(serverEngine);
+
+            cTOs.compact();
+            sTOc.compact();
+
+            if (!dataDone
+                    && (clientOut.limit() == serverIn.position())
+                    && (serverOut.limit() == clientIn.position())) {
+
+                ExtendedSSLSession clientSession =
+                        (ExtendedSSLSession) clientEngine.getSession();
+                ExtendedSSLSession serverSession =
+                        (ExtendedSSLSession) serverEngine.getSession();
+
+                verifyChannelBinding(clientSession, serverSession,
+                        expectNonNull);
+
+                clientEngine.closeOutbound();
+                serverEngine.closeOutbound();
+                dataDone = true;
+            }
+        }
+    }
+
+    private static void verifyChannelBinding(
+            ExtendedSSLSession clientSession,
+            ExtendedSSLSession serverSession,
+            boolean expectNonNull) throws Exception {
+
+        byte[] clientClientFirst =
+                clientSession.getTlsUniqueClientFirstFinishedVerifyData();
+        byte[] serverClientFirst =
+                serverSession.getTlsUniqueClientFirstFinishedVerifyData();
+        byte[] clientFirstFinished =
+                clientSession.getTlsUniqueFirstFinishedVerifyData();
+        byte[] serverFirstFinished =
+                serverSession.getTlsUniqueFirstFinishedVerifyData();
+
+        if (!expectNonNull) {
+            assertAllNull(clientClientFirst, serverClientFirst,
+                    clientFirstFinished, serverFirstFinished);
+            return;
+        }
+
+        assertPair("Client-first", clientClientFirst, serverClientFirst);
+        assertPair("First-finished", clientFirstFinished, serverFirstFinished);
+
+        byte[] second = clientSession.getTlsUniqueFirstFinishedVerifyData();
+        if (clientFirstFinished == second) {
+            throw new Exception("Same array instance returned (no clone)");
+        }
+        if (!Arrays.equals(clientFirstFinished, second)) {
+            throw new Exception("Subsequent calls return different values");
+        }
+    }
+
+    private static void assertAllNull(byte[]... values) throws Exception {
+        for (byte[] value : values) {
+            if (value != null) {
+                throw new Exception("Expected null channel binding");
+            }
+        }
+    }
+
+    private static void assertPair(String label, byte[] clientValue,
+            byte[] serverValue) throws Exception {
+        if (clientValue == null || serverValue == null) {
+            throw new Exception(label + " verify_data is null");
+        }
+        if (clientValue.length != 12 || serverValue.length != 12) {
+            throw new Exception(label + " verify_data length is not 12");
+        }
+        if (!Arrays.equals(clientValue, serverValue)) {
+            throw new Exception(label + " verify_data does not match");
+        }
+    }
+}


### PR DESCRIPTION
Added two new public API methods to ExtendedSSLSession to support TLS unique channel binding as defined in RFC 5929. The updated API exposes two explicit Finished verify_data values:
- getTlsUniqueClientFirstFinishedVerifyData() returns the Client Finished verify_data for the session.
- getTlsUniqueFirstFinishedVerifyData() returns the first Finished verify_data sent for the session.
 
Tier1 tests pass on Ubuntu




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387802](https://bugs.openjdk.org/browse/JDK-8387802): Add TLS Unique Channel Binding APIs to ExtendedSSLSession (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31943/head:pull/31943` \
`$ git checkout pull/31943`

Update a local copy of the PR: \
`$ git checkout pull/31943` \
`$ git pull https://git.openjdk.org/jdk.git pull/31943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31943`

View PR using the GUI difftool: \
`$ git pr show -t 31943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31943.diff">https://git.openjdk.org/jdk/pull/31943.diff</a>

</details>
