### PR TITLE
8388428: Log level of jfr+startup might be changed implicitly

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -144,7 +144,7 @@ static void log(oop content, TRAPS) {
 }
 
 // RAII object to ensure log level.
-// handle_dcmd_start() need to print info level jfr+startup message to stdout,
+// handle_dcmd_result() need to print info level jfr+startup message to stdout,
 // so this RAII would log level of jfr+startup to Info if needs, and would restore
 // it to Warning.
 class LogLevelForJfrStartupMark : StackObj {

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -148,23 +148,20 @@ static void log(oop content, TRAPS) {
 // so this RAII would log level of jfr+startup to Info if needs, and would restore
 // it to Warning.
 class LogLevelForJfrStartupMark : StackObj {
-  private:
-    // true if original log level is warning - it is the case which this RAII
-    // should update log level.
-    bool _needs_update;
+    const bool _active;
 
   public:
     // Info or lower is enabled if the log level is Warning, thus we need to
     // check it is not Info (or lower).
     LogLevelForJfrStartupMark()
-      : _needs_update(log_is_enabled(Warning, jfr, startup) && !log_is_enabled(Info, jfr, startup)) {
-      if (_needs_update) {
+      : _active(log_is_enabled(Warning, jfr, startup) && !log_is_enabled(Info, jfr, startup)) {
+      if (_active) {
         LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(jfr, startup));
       }
     }
 
     ~LogLevelForJfrStartupMark() {
-      if (_needs_update) {
+      if (_active) {
         LogConfiguration::configure_stdout(LogLevel::Warning, true, LOG_TAGS(jfr, startup));
       }
     }

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -143,6 +143,33 @@ static void log(oop content, TRAPS) {
   }
 }
 
+// RAII object to ensure log level.
+// handle_dcmd_start() need to print info level jfr+startup message to stdout,
+// so this RAII would log level of jfr+startup to Info if needs, and would restore
+// it to Warning.
+class LogLevelForJfrStartupMark : StackObj {
+  private:
+    // true if original log level is warning - it is the case which this RAII
+    // should update log level.
+    bool _needs_update;
+
+  public:
+    // Info or lower is enabled if the log level is Warning, thus we need to
+    // check it is not Info (or lower).
+    LogLevelForJfrStartupMark()
+      : _needs_update(log_is_enabled(Warning, jfr, startup) && !log_is_enabled(Info, jfr, startup)) {
+      if (_needs_update) {
+        LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(jfr, startup));
+      }
+    }
+
+    ~LogLevelForJfrStartupMark() {
+      if (_needs_update) {
+        LogConfiguration::configure_stdout(LogLevel::Warning, true, LOG_TAGS(jfr, startup));
+      }
+    }
+};
+
 static void handle_dcmd_result(outputStream* output,
                                const oop result,
                                const DCmdSource source,
@@ -163,16 +190,8 @@ static void handle_dcmd_result(outputStream* output,
   assert(!HAS_PENDING_EXCEPTION, "invariant");
 
   if (startup) {
-    if (log_is_enabled(Warning, jfr, startup))  {
-      // if warning is set, assume user hasn't configured log level
-      // Log to Info and reset to Warning. This way user can disable
-      // default output by setting -Xlog:jfr+startup=error/off
-      LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(jfr, startup));
-      log(result, THREAD);
-      LogConfiguration::configure_stdout(LogLevel::Warning, true, LOG_TAGS(jfr, startup));
-    } else {
-      log(result, THREAD);
-    }
+    LogLevelForJfrStartupMark mark;
+    log(result, THREAD);
   } else {
       // Print output for jcmd or MXBean
       print_message(output, result, THREAD);


### PR DESCRIPTION
We can see info level jfr+startup log even if it is set to warn level (by default).

```
$ ./build/linux-x86_64-server-fastdebug/images/jdk/bin/java -XX:StartFlightRecording --version
[0.803s][info][jfr,startup] Started recording 1. No limit specified, using maxsize=250MB as default.
[0.803s][info][jfr,startup]
[0.803s][info][jfr,startup] Use jcmd 1360 JFR.dump name=1 filename=FILEPATH to copy recording data to file.
openjdk 28-internal 2027-03-23
OpenJDK Runtime Environment (fastdebug build 28-internal-adhoc.yasuenag.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 28-internal-adhoc.yasuenag.jdk, mixed mode, sharing)
```

They come from following code in jfrDcmds.cpp:

```cpp
    if (log_is_enabled(Warning, jfr, startup)) {
      // if warning is set, assume user hasn't configured log level
      // Log to Info and reset to Warning. This way user can disable
      // default output by setting -Xlog:jfr+startup=error/off
      LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(jfr, startup));
      log(result, THREAD);
      LogConfiguration::configure_stdout(LogLevel::Warning, true, LOG_TAGS(jfr, startup));
    } else {
      log(result, THREAD);
    }
```

Log level of jfr+startup would be changed to Info temporally, and it would be reset to Warning implicitly. `log_is_enabled(Warning, jfr, startup)` returns `true` if log level of jfr+startup is Warning or "lower" - for example, it is `true` if `-Xlog:jfr+startup=debug`. It should be back to Debug, not Warning in that case.

This PR introduces RAII class to keep original log level of jfr+startup. It affects Warning level only. We don't need to care for other levels - if the level is Info or lower, we can see the log without any changes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388428](https://bugs.openjdk.org/browse/JDK-8388428): Log level of jfr+startup might be changed implicitly (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [119cfc83](https://git.openjdk.org/jdk/pull/31944/files/119cfc832eef8af81ad0136f19010de9543ba69c)
 * [Robert Toyonaga](https://openjdk.org/census#rtoyonaga) (@roberttoyonaga - Committer) Review applies to [f7e43eeb](https://git.openjdk.org/jdk/pull/31944/files/f7e43eeb07186ae38944aea3f3f59131aa6a9a80)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31944/head:pull/31944` \
`$ git checkout pull/31944`

Update a local copy of the PR: \
`$ git checkout pull/31944` \
`$ git pull https://git.openjdk.org/jdk.git pull/31944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31944`

View PR using the GUI difftool: \
`$ git pr show -t 31944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31944.diff">https://git.openjdk.org/jdk/pull/31944.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31944#issuecomment-5000675410)
</details>
