### PR TITLE
8388381: appcds/aotClassLinking/AddReads.java fails with assert(stub_id != StubId::NO_STUBID) failed: blob continuation_blob (stub gen) contains no stubs! when run with -XX:-VMContinuations

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -300,6 +300,7 @@ public:
   do_var(bool,  UseSHA3Intrinsics) \
   do_var(bool,  UseSHA512Intrinsics) \
   do_var(bool,  UseVectorizedMismatchIntrinsic) \
+  do_var(bool,  VMContinuations) \
   do_fun(int,   CompressedKlassPointers_shift,          CompressedKlassPointers::shift()) \
   do_fun(bool,  JavaAssertions_systemClassDefault,      JavaAssertions::systemClassDefault()) \
   do_fun(bool,  JavaAssertions_userClassDefault,        JavaAssertions::userClassDefault()) \

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -167,6 +167,10 @@ static BufferBlob* initialize_stubs(BlobId blob_id,
                                     const char* buffer_name,
                                     const char* assert_msg) {
   assert(StubInfo::is_stubgen(blob_id), "not a stubgen blob %s", StubInfo::name(blob_id));
+  if (blob_id == BlobId::stubgen_continuation_id && !VMContinuations) {
+      log_info(stubs)("%s\t not generated:\t VMContinuations is disabled", buffer_name);
+    return nullptr;
+  }
   ResourceMark rm;
   TraceTime timer(timer_msg, TRACETIME_LOG(Info, startuptime));
   // If we are loading stubs we need to check if we can retrieve a


### PR DESCRIPTION
StubGen blobs stored in the AOT code cache are expected to contain at least one stub and this constraint is verified when the stub is reread in a production run. When `VMContinuations` is disabled a continuations blob is created and written. However, the blob does not contain any stubs, because code generation is inhibited by the flag setting, causing the constraint to fail in production.

The best solution is not to relax the above constraint but to avoid either generating or attempting to restore a blob when VMContinuations is disabled.

Also, the AOT code cache state is (both currently and after this change) dependent on the setting for `VMContinuations` after this change. So, this flag needs to be added to the set of flags automatically checked by the AOT code, ensuring that any disparity between assembly and production runs causes the AOT code cache to be dropped.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388381](https://bugs.openjdk.org/browse/JDK-8388381): appcds/aotClassLinking/AddReads.java fails with assert(stub_id != StubId::NO_STUBID) failed: blob continuation_blob (stub gen) contains no stubs! when run with -XX:-VMContinuations (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31945/head:pull/31945` \
`$ git checkout pull/31945`

Update a local copy of the PR: \
`$ git checkout pull/31945` \
`$ git pull https://git.openjdk.org/jdk.git pull/31945/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31945`

View PR using the GUI difftool: \
`$ git pr show -t 31945`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31945.diff">https://git.openjdk.org/jdk/pull/31945.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31945#issuecomment-5001722590)
</details>
