### PR TITLE
8387802: Add TLS Unique Channel Binding APIs to ExtendedSSLSession

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/ExtendedSSLSession.java
+++ b/src/java.base/share/classes/javax/net/ssl/ExtendedSSLSession.java
@@ -273,4 +273,23 @@ public abstract class ExtendedSSLSession implements SSLSession {
         throw new UnsupportedOperationException(
                 "Underlying provider does not implement the method");
     }
+
+    /**
+     * Returns the tls-unique channel binding value for this session, as defined in
+     * RFC 5929.
+     * <P>
+     * Returns null if: Feature not enabled via
+     * sun.security.ssl.enableTlsUniqueChannelBinding, Session uses TLS 1.3+ (use
+     * exportKeyingMaterialData instead), Extended Master Secret (RFC 7627) not
+     * active, Handshake not yet completed.
+     * 
+     * @implSpec The default implementation returns null.
+     * 
+     * @return channel binding bytes (typically 12 bytes for TLS 1.2), or null if
+     *         unavailable
+     * @since 27
+     */
+    public byte[] getTlsUniqueChannelBinding() {
+        return null;
+    }
 }

--- a/src/java.base/share/classes/javax/net/ssl/ExtendedSSLSession.java
+++ b/src/java.base/share/classes/javax/net/ssl/ExtendedSSLSession.java
@@ -275,21 +275,26 @@ public abstract class ExtendedSSLSession implements SSLSession {
     }
 
     /**
-     * Returns the tls-unique channel binding value for this session, as defined in
-     * RFC 5929.
-     * <P>
-     * Returns null if: Feature not enabled via
-     * sun.security.ssl.enableTlsUniqueChannelBinding, Session uses TLS 1.3+ (use
-     * exportKeyingMaterialData instead), Extended Master Secret (RFC 7627) not
-     * active, Handshake not yet completed.
-     * 
+     * Returns the Client Finished verify_data for this session.
+     *
      * @implSpec The default implementation returns null.
-     * 
-     * @return channel binding bytes (typically 12 bytes for TLS 1.2), or null if
-     *         unavailable
+     *
+     * @return Client Finished verify_data bytes, or null if unavailable
      * @since 27
      */
-    public byte[] getTlsUniqueChannelBinding() {
+    public byte[] getTlsUniqueClientFirstFinishedVerifyData() {
+        return null;
+    }
+
+    /**
+     * Returns the first Finished verify_data sent for this session.
+     *
+     * @implSpec The default implementation returns null.
+     *
+     * @return first Finished verify_data bytes, or null if unavailable
+     * @since 27
+     */
+    public byte[] getTlsUniqueFirstFinishedVerifyData() {
         return null;
     }
 }

--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -474,6 +474,11 @@ final class Finished {
                 shc.conContext.serverVerifyData = fm.verifyData;
             }
 
+            // Store server's Finished verify_data for tls-unique (RFC 5929)
+            if (shc.handshakeSession != null) {
+                shc.handshakeSession.setServerFinishedVerifyData(fm.verifyData);
+            }
+
             // update the consumers and producers
             if (shc.isResumption) {
                 shc.conContext.consumers.put(ContentType.CHANGE_CIPHER_SPEC.id,
@@ -554,6 +559,11 @@ final class Finished {
 
             if (chc.conContext.secureRenegotiation) {
                 chc.conContext.serverVerifyData = fm.verifyData;
+            }
+
+            // Store server's Finished verify_data for tls-unique (RFC 5929)
+            if (chc.handshakeSession != null) {
+                chc.handshakeSession.setServerFinishedVerifyData(fm.verifyData);
             }
 
             if (!chc.isResumption) {

--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -406,6 +406,11 @@ final class Finished {
                 chc.conContext.clientVerifyData = fm.verifyData;
             }
 
+            // Store client's Finished verify_data for tls-unique (RFC 5929)
+            if (chc.handshakeSession != null) {
+                chc.handshakeSession.setClientFinishedVerifyData(fm.verifyData);
+            }
+
             if (chc.statelessResumption) {
                 chc.handshakeConsumers.put(
                         SSLHandshake.NEW_SESSION_TICKET.id, SSLHandshake.NEW_SESSION_TICKET);
@@ -609,6 +614,11 @@ final class Finished {
 
             if (shc.conContext.secureRenegotiation) {
                 shc.conContext.clientVerifyData = fm.verifyData;
+            }
+
+            // Store client's Finished verify_data for tls-unique (RFC 5929)
+            if (shc.handshakeSession != null) {
+                shc.handshakeSession.setClientFinishedVerifyData(fm.verifyData);
             }
 
             if (shc.isResumption) {

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -115,11 +115,8 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     private int                 negotiatedMaxFragLen = -1;
     private int                 maximumPacketSize;
 
-    // tls-unique channel binding (RFC 5929) - verify_data from Finished messages
     private static final boolean tlsUniqueChannelBindingEnabled = Utilities.getBooleanProperty(
             "sun.security.ssl.enableTlsUniqueChannelBinding", false);
-    private static final String tlsUniqueChannelBindingMode = System.getProperty(
-            "sun.security.ssl.tlsUniqueChannelBindingMode", "rfc5929");
     private volatile byte[] clientFinishedVerifyData;
     private volatile byte[] serverFinishedVerifyData;
 
@@ -1693,7 +1690,6 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         return (byte[])exportKeyingMaterial(null, label, context, length);
     }
 
-    // tls-unique channel binding (RFC 5929)
     void setClientFinishedVerifyData(byte[] verifyData) {
         if (!tlsUniqueChannelBindingEnabled) {
             return;
@@ -1713,7 +1709,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     }
 
     @Override
-    public byte[] getTlsUniqueChannelBinding() {
+    public byte[] getTlsUniqueClientFirstFinishedVerifyData() {
         if (!tlsUniqueChannelBindingEnabled) {
             return null;
         }
@@ -1725,30 +1721,28 @@ final class SSLSessionImpl extends ExtendedSSLSession {
             return null;
         }
 
-        byte[] result;
-        if ("client".equalsIgnoreCase(tlsUniqueChannelBindingMode)) {
-            result = getClientFinishedData();
-        } else {
-            result = getFirstFinishedData();
+        return (clientFinishedVerifyData != null)
+                ? clientFinishedVerifyData.clone()
+                : null;
+    }
+
+    @Override
+    public byte[] getTlsUniqueFirstFinishedVerifyData() {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return null;
         }
 
-        return (result != null) ? result.clone() : null;
-    }
+        if (protocolVersion.useTLS13PlusSpec()) {
+            return null;
+        }
+        if (!useExtendedMasterSecret) {
+            return null;
+        }
 
-    // Returns the client's Finished verify_data.
-    private byte[] getClientFinishedData() {
-        return clientFinishedVerifyData;
-    }
-
-    /**
-     * Returns the first Finished verify_data sent per RFC 5929.
-     * In a full handshake the client sends Finished first.
-     * In a resumed session the server sends Finished first.
-     */
-    private byte[] getFirstFinishedData() {
-        return (serverFinishedVerifyData != null
+        byte[] result = (serverFinishedVerifyData != null
                 && clientFinishedVerifyData == null)
                         ? serverFinishedVerifyData
                         : clientFinishedVerifyData;
+        return (result != null) ? result.clone() : null;
     }
 }

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -115,6 +115,8 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     private int                 negotiatedMaxFragLen = -1;
     private int                 maximumPacketSize;
 
+    private volatile byte[] clientFinishedVerifyData;
+
     private final Queue<SSLSessionImpl> childSessions =
                                         new ConcurrentLinkedQueue<>();
 
@@ -1683,6 +1685,25 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     public byte[] exportKeyingMaterialData(
             String label, byte[] context, int length) throws SSLKeyException {
         return (byte[])exportKeyingMaterial(null, label, context, length);
+    }
+
+    void setClientFinishedVerifyData(byte[] verifyData) {
+        this.clientFinishedVerifyData = (verifyData != null)
+                ? verifyData.clone()
+                : null;
+    }
+
+    @Override
+    public byte[] getTlsUniqueChannelBinding() {
+        if (protocolVersion.useTLS13PlusSpec()) {
+            return null;
+        }
+        if (!useExtendedMasterSecret) {
+            return null;
+        }
+        return (clientFinishedVerifyData != null)
+                ? clientFinishedVerifyData.clone()
+                : null;
     }
 
     /** Returns a string representation of this SSL session */

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -115,7 +115,13 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     private int                 negotiatedMaxFragLen = -1;
     private int                 maximumPacketSize;
 
+    // tls-unique channel binding (RFC 5929) - verify_data from Finished messages
+    private static final boolean tlsUniqueChannelBindingEnabled = Utilities.getBooleanProperty(
+            "sun.security.ssl.enableTlsUniqueChannelBinding", false);
+    private static final String tlsUniqueChannelBindingMode = System.getProperty(
+            "sun.security.ssl.tlsUniqueChannelBindingMode", "rfc5929");
     private volatile byte[] clientFinishedVerifyData;
+    private volatile byte[] serverFinishedVerifyData;
 
     private final Queue<SSLSessionImpl> childSessions =
                                         new ConcurrentLinkedQueue<>();
@@ -1687,28 +1693,62 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         return (byte[])exportKeyingMaterial(null, label, context, length);
     }
 
+    // tls-unique channel binding (RFC 5929)
     void setClientFinishedVerifyData(byte[] verifyData) {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return;
+        }
         this.clientFinishedVerifyData = (verifyData != null)
+                ? verifyData.clone()
+                : null;
+    }
+
+    void setServerFinishedVerifyData(byte[] verifyData) {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return;
+        }
+        this.serverFinishedVerifyData = (verifyData != null)
                 ? verifyData.clone()
                 : null;
     }
 
     @Override
     public byte[] getTlsUniqueChannelBinding() {
+        if (!tlsUniqueChannelBindingEnabled) {
+            return null;
+        }
+
         if (protocolVersion.useTLS13PlusSpec()) {
             return null;
         }
         if (!useExtendedMasterSecret) {
             return null;
         }
-        return (clientFinishedVerifyData != null)
-                ? clientFinishedVerifyData.clone()
-                : null;
+
+        byte[] result;
+        if ("client".equalsIgnoreCase(tlsUniqueChannelBindingMode)) {
+            result = getClientFinishedData();
+        } else {
+            result = getFirstFinishedData();
+        }
+
+        return (result != null) ? result.clone() : null;
     }
 
-    /** Returns a string representation of this SSL session */
-    @Override
-    public String toString() {
-        return "Session(" + creationTime + "|" + getCipherSuite() + ")";
+    // Returns the client's Finished verify_data.
+    private byte[] getClientFinishedData() {
+        return clientFinishedVerifyData;
+    }
+
+    /**
+     * Returns the first Finished verify_data sent per RFC 5929.
+     * In a full handshake the client sends Finished first.
+     * In a resumed session the server sends Finished first.
+     */
+    private byte[] getFirstFinishedData() {
+        return (serverFinishedVerifyData != null
+                && clientFinishedVerifyData == null)
+                        ? serverFinishedVerifyData
+                        : clientFinishedVerifyData;
     }
 }

--- a/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
+++ b/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.ByteBuffer;
+import java.security.Security;
+import java.util.Arrays;
+import javax.net.ssl.*;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+
+/*
+ * @test
+ * @bug <TBD>
+ * @summary Verify tls-unique channel binding (RFC 5929) via ExtendedSSLSession
+ * @library /javax/net/ssl/templates /test/lib
+ * @build SSLEngineTemplate
+ * @run main/othervm TlsUniqueChannelBindingTest
+ */
+
+public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
+
+    private final String protocol;
+    private final String ciphersuite;
+
+    TlsUniqueChannelBindingTest(String protocol, String ciphersuite)
+            throws Exception {
+        super();
+        this.protocol = protocol;
+        this.ciphersuite = ciphersuite;
+    }
+
+    private void configureEngines(SSLEngine clientEngine,
+            SSLEngine serverEngine) {
+        clientEngine.setUseClientMode(true);
+        SSLParameters clientParams = clientEngine.getSSLParameters();
+        clientParams.setProtocols(new String[] { protocol });
+        clientParams.setCipherSuites(new String[] { ciphersuite });
+        clientEngine.setSSLParameters(clientParams);
+
+        serverEngine.setUseClientMode(false);
+        serverEngine.setNeedClientAuth(true);
+        SSLParameters serverParams = serverEngine.getSSLParameters();
+        serverParams.setProtocols(new String[]{
+                "TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1"});
+        serverEngine.setSSLParameters(serverParams);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Security.setProperty("jdk.tls.disabledAlgorithms", "");
+
+        // TLS 1.2 full handshake should produce non-null channel binding
+        new TlsUniqueChannelBindingTest(
+                "TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+                .runTest(true);
+
+        new TlsUniqueChannelBindingTest(
+                "TLSv1.2", "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")
+                .runTest(true);
+
+        // TLS 1.3 should return null (use tls-exporter instead)
+        new TlsUniqueChannelBindingTest(
+                "TLSv1.3", "TLS_AES_128_GCM_SHA256")
+                .runTest(false);
+
+        System.out.println("All tests PASSED");
+    }
+
+    private void runTest(boolean expectNonNull) throws Exception {
+        configureEngines(clientEngine, serverEngine);
+
+        boolean dataDone = false;
+        while (isOpen(clientEngine) || isOpen(serverEngine)) {
+            clientEngine.wrap(clientOut, cTOs);
+            runDelegatedTasks(clientEngine);
+
+            serverEngine.wrap(serverOut, sTOc);
+            runDelegatedTasks(serverEngine);
+
+            cTOs.flip();
+            sTOc.flip();
+
+            clientEngine.unwrap(sTOc, clientIn);
+            runDelegatedTasks(clientEngine);
+
+            serverEngine.unwrap(cTOs, serverIn);
+            runDelegatedTasks(serverEngine);
+
+            cTOs.compact();
+            sTOc.compact();
+
+            if (!dataDone && (clientOut.limit() == serverIn.position()) &&
+                    (serverOut.limit() == clientIn.position())) {
+
+                ExtendedSSLSession clientSession =
+                        (ExtendedSSLSession) clientEngine.getSession();
+                ExtendedSSLSession serverSession =
+                        (ExtendedSSLSession) serverEngine.getSession();
+
+                verifyChannelBinding(clientSession, serverSession,
+                        expectNonNull);
+
+                clientEngine.closeOutbound();
+                serverEngine.closeOutbound();
+                dataDone = true;
+            }
+        }
+    }
+
+    private static void verifyChannelBinding(
+            ExtendedSSLSession clientSession,
+            ExtendedSSLSession serverSession,
+            boolean expectNonNull) throws Exception {
+
+        byte[] clientBinding = clientSession.getTlsUniqueChannelBinding();
+        byte[] serverBinding = serverSession.getTlsUniqueChannelBinding();
+
+        if (!expectNonNull) {
+            if (clientBinding != null || serverBinding != null) {
+                throw new Exception(
+                        "Expected null channel binding for TLS 1.3");
+            }
+            System.out.println("TLS 1.3: null binding as expected");
+            return;
+        }
+
+        if (clientBinding == null) {
+            throw new Exception("Client channel binding is null");
+        }
+        if (serverBinding == null) {
+            throw new Exception("Server channel binding is null");
+        }
+        if (clientBinding.length != 12) {
+            throw new Exception(
+                    "Expected 12 bytes, got " + clientBinding.length);
+        }
+        if (!Arrays.equals(clientBinding, serverBinding)) {
+            throw new Exception(
+                    "Client and server channel bindings do not match");
+        }
+
+        // Verify defensive copy
+        byte[] second = clientSession.getTlsUniqueChannelBinding();
+        if (clientBinding == second) {
+            throw new Exception("Same array instance returned (no clone)");
+        }
+        if (!Arrays.equals(clientBinding, second)) {
+            throw new Exception("Subsequent calls return different values");
+        }
+
+        System.out.println("PASSED: " + clientSession.getProtocol() +
+                " binding=" + clientBinding.length + " bytes, both sides match");
+    }
+}

--- a/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
+++ b/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
@@ -150,40 +150,51 @@ public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
             ExtendedSSLSession serverSession,
             boolean expectNonNull) throws Exception {
 
-        byte[] clientBinding = clientSession.getTlsUniqueChannelBinding();
-        byte[] serverBinding = serverSession.getTlsUniqueChannelBinding();
+        byte[] clientClientFirst =
+                clientSession.getTlsUniqueClientFirstFinishedVerifyData();
+        byte[] serverClientFirst =
+                serverSession.getTlsUniqueClientFirstFinishedVerifyData();
+        byte[] clientFirstFinished =
+                clientSession.getTlsUniqueFirstFinishedVerifyData();
+        byte[] serverFirstFinished =
+                serverSession.getTlsUniqueFirstFinishedVerifyData();
 
         if (!expectNonNull) {
-            if (clientBinding != null || serverBinding != null) {
-                throw new Exception(
-                        "Expected null channel binding");
-            }
+            assertAllNull(clientClientFirst, serverClientFirst,
+                    clientFirstFinished, serverFirstFinished);
             return;
         }
 
-        if (clientBinding == null) {
-            throw new Exception("Client channel binding is null");
-        }
-        if (serverBinding == null) {
-            throw new Exception("Server channel binding is null");
-        }
-        if (clientBinding.length != 12) {
-            throw new Exception(
-                    "Expected 12 bytes, got " + clientBinding.length);
-        }
-        if (!Arrays.equals(clientBinding, serverBinding)) {
-            throw new Exception(
-                    "Client and server channel bindings do not match");
-        }
+        assertPair("Client-first", clientClientFirst, serverClientFirst);
+        assertPair("First-finished", clientFirstFinished, serverFirstFinished);
 
-        // Verify that each call returns a defensive copy.
-        byte[] second = clientSession.getTlsUniqueChannelBinding();
-        if (clientBinding == second) {
+        byte[] second = clientSession.getTlsUniqueFirstFinishedVerifyData();
+        if (clientFirstFinished == second) {
             throw new Exception("Same array instance returned (no clone)");
         }
-        if (!Arrays.equals(clientBinding, second)) {
+        if (!Arrays.equals(clientFirstFinished, second)) {
             throw new Exception("Subsequent calls return different values");
         }
+    }
 
+    private static void assertAllNull(byte[]... values) throws Exception {
+        for (byte[] value : values) {
+            if (value != null) {
+                throw new Exception("Expected null channel binding");
+            }
+        }
+    }
+
+    private static void assertPair(String label, byte[] clientValue,
+            byte[] serverValue) throws Exception {
+        if (clientValue == null || serverValue == null) {
+            throw new Exception(label + " verify_data is null");
+        }
+        if (clientValue.length != 12 || serverValue.length != 12) {
+            throw new Exception(label + " verify_data length is not 12");
+        }
+        if (!Arrays.equals(clientValue, serverValue)) {
+            throw new Exception(label + " verify_data does not match");
+        }
     }
 }

--- a/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
+++ b/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
@@ -29,7 +29,7 @@ import javax.net.ssl.SSLParameters;
 
 /*
  * @test
- * @bug <TBD>
+ * @bug 8387802
  * @summary Verify tls-unique channel binding (RFC 5929) via ExtendedSSLSession
  * @library /javax/net/ssl/templates /test/lib
  * @build SSLEngineTemplate

--- a/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
+++ b/test/jdk/javax/net/ssl/ExtendedSSLSession/TlsUniqueChannelBindingTest.java
@@ -21,11 +21,11 @@
  * questions.
  */
 
-import java.nio.ByteBuffer;
 import java.security.Security;
 import java.util.Arrays;
-import javax.net.ssl.*;
-import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 
 /*
  * @test
@@ -33,7 +33,9 @@ import javax.net.ssl.SSLEngineResult.HandshakeStatus;
  * @summary Verify tls-unique channel binding (RFC 5929) via ExtendedSSLSession
  * @library /javax/net/ssl/templates /test/lib
  * @build SSLEngineTemplate
- * @run main/othervm TlsUniqueChannelBindingTest
+ * @run main/othervm -Dsun.security.ssl.enableTlsUniqueChannelBinding=true TlsUniqueChannelBindingTest TLS12_ENABLED
+ * @run main/othervm TlsUniqueChannelBindingTest DISABLED
+ * @run main/othervm -Dsun.security.ssl.enableTlsUniqueChannelBinding=true TlsUniqueChannelBindingTest TLS13_NULL
  */
 
 public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
@@ -65,23 +67,40 @@ public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
     }
 
     public static void main(String[] args) throws Exception {
+        String testCase = args.length > 0 ? args[0] : "TLS12_ENABLED";
         Security.setProperty("jdk.tls.disabledAlgorithms", "");
 
-        // TLS 1.2 full handshake should produce non-null channel binding
+        switch (testCase) {
+            case "TLS12_ENABLED":
+                testTls12Enabled();
+                break;
+            case "DISABLED":
+                testDisabled();
+                break;
+            case "TLS13_NULL":
+                testTls13Null();
+                break;
+            default:
+                throw new RuntimeException("Unknown test case: " + testCase);
+        }
+    }
+
+    private static void testTls12Enabled() throws Exception {
         new TlsUniqueChannelBindingTest(
                 "TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
                 .runTest(true);
+    }
 
+    private static void testDisabled() throws Exception {
         new TlsUniqueChannelBindingTest(
-                "TLSv1.2", "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")
-                .runTest(true);
+                "TLSv1.2", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+                .runTest(false);
+    }
 
-        // TLS 1.3 should return null (use tls-exporter instead)
+    private static void testTls13Null() throws Exception {
         new TlsUniqueChannelBindingTest(
                 "TLSv1.3", "TLS_AES_128_GCM_SHA256")
                 .runTest(false);
-
-        System.out.println("All tests PASSED");
     }
 
     private void runTest(boolean expectNonNull) throws Exception {
@@ -107,8 +126,9 @@ public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
             cTOs.compact();
             sTOc.compact();
 
-            if (!dataDone && (clientOut.limit() == serverIn.position()) &&
-                    (serverOut.limit() == clientIn.position())) {
+            if (!dataDone
+                    && (clientOut.limit() == serverIn.position())
+                    && (serverOut.limit() == clientIn.position())) {
 
                 ExtendedSSLSession clientSession =
                         (ExtendedSSLSession) clientEngine.getSession();
@@ -136,9 +156,8 @@ public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
         if (!expectNonNull) {
             if (clientBinding != null || serverBinding != null) {
                 throw new Exception(
-                        "Expected null channel binding for TLS 1.3");
+                        "Expected null channel binding");
             }
-            System.out.println("TLS 1.3: null binding as expected");
             return;
         }
 
@@ -157,7 +176,7 @@ public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
                     "Client and server channel bindings do not match");
         }
 
-        // Verify defensive copy
+        // Verify that each call returns a defensive copy.
         byte[] second = clientSession.getTlsUniqueChannelBinding();
         if (clientBinding == second) {
             throw new Exception("Same array instance returned (no clone)");
@@ -166,7 +185,5 @@ public class TlsUniqueChannelBindingTest extends SSLEngineTemplate {
             throw new Exception("Subsequent calls return different values");
         }
 
-        System.out.println("PASSED: " + clientSession.getProtocol() +
-                " binding=" + clientBinding.length + " bytes, both sides match");
     }
 }


### PR DESCRIPTION
Added two new public API methods to ExtendedSSLSession to support TLS unique channel binding as defined in RFC 5929.
The updated API exposes two explicit Finished verify_data values:
- getTlsUniqueClientFirstFinishedVerifyData() returns the Client Finished verify_data for the session.
- getTlsUniqueFirstFinishedVerifyData() returns the first Finished verify_data sent for the session.
 
Tier1 tests pass on Ubuntu

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387802](https://bugs.openjdk.org/browse/JDK-8387802): Add TLS Unique Channel Binding APIs to ExtendedSSLSession (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31946/head:pull/31946` \
`$ git checkout pull/31946`

Update a local copy of the PR: \
`$ git checkout pull/31946` \
`$ git pull https://git.openjdk.org/jdk.git pull/31946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31946`

View PR using the GUI difftool: \
`$ git pr show -t 31946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31946.diff">https://git.openjdk.org/jdk/pull/31946.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31946#issuecomment-5001872884)
</details>
