### PR TITLE
8388437: [IR Framework] Remove unused applyIfNot attribute in @IR

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
@@ -108,6 +108,35 @@ public @interface IR {
      */
     String[] applyIf() default {};
 
+
+    /**
+     * Define a list of at least two VM flag precondition which <i><b>all</b> must hold</i> when applying the IR rule.
+     * If the one of the VM flag preconditions does not hold, then the IR rule is not applied. This is useful if
+     * commonly used flags alter the IR in such a way that an IR rule would fail. This can also be defined as conjunction
+     * of preconditions.
+     * <p>
+     * A precondition is a (flag, value) string pair where the flag must be a valid VM flag and the value must conform
+     * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
+     * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
+     * <p>
+     * Use  {@link #applyIfOr()} for disjunction and for single precondition constraints use {@link #applyIf()}.
+     */
+    String[] applyIfAnd() default {};
+
+    /**
+     * Define a list of at least two VM flag precondition from which <i><b>at least one</b> must hold</i> when applying
+     * the IR rule. If none of the VM flag preconditions holds, then the IR rule is not applied. This is useful if
+     * commonly used flags alter the IR in such a way that an IR rule would fail. This can also be defined as disjunction
+     * of preconditions.
+     * <p>
+     * A precondition is a (flag, value) string pair where the flag must be a valid VM flag and the value must conform
+     * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
+     * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
+     * <p>
+     * Use  {@link #applyIfAnd()} for conjunction and for single precondition constraints use {@link #applyIf()}.
+     */
+    String[] applyIfOr() default {};
+
     /**
      * Accepts a single pair composed of a platform string followed by a true/false
      * value where a true value necessitates that we are currently testing on that platform and vice versa.
@@ -149,32 +178,4 @@ public @interface IR {
      * IR verifications checks are enforced if any of the specified feature constraint is met.
      */
     String[] applyIfCPUFeatureOr() default {};
-
-    /**
-     * Define a list of at least two VM flag precondition which <i><b>all</b> must hold</i> when applying the IR rule.
-     * If the one of the VM flag preconditions does not hold, then the IR rule is not applied. This is useful if
-     * commonly used flags alter the IR in such a way that an IR rule would fail. This can also be defined as conjunction
-     * of preconditions.
-     * <p>
-     * A precondition is a (flag, value) string pair where the flag must be a valid VM flag and the value must conform
-     * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
-     * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
-     * <p>
-     * Use  {@link #applyIfOr()} for disjunction and for single precondition constraints use {@link #applyIf()}.
-     */
-    String[] applyIfAnd() default {};
-
-    /**
-     * Define a list of at least two VM flag precondition from which <i><b>at least one</b> must hold</i> when applying
-     * the IR rule. If none of the VM flag preconditions holds, then the IR rule is not applied. This is useful if
-     * commonly used flags alter the IR in such a way that an IR rule would fail. This can also be defined as disjunction
-     * of preconditions.
-     * <p>
-     * A precondition is a (flag, value) string pair where the flag must be a valid VM flag and the value must conform
-     * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
-     * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
-     * <p>
-     * Use  {@link #applyIfAnd()} for conjunction and for single precondition constraints use {@link #applyIf()}.
-     */
-    String[] applyIfOr() default {};
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
@@ -103,8 +103,7 @@ public @interface IR {
      * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
      * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
      * <p>
-     * For multiple preconditions, use {@link #applyIfAnd()} or
-     * {@link #applyIfOr()} depending on the use case.
+     * For multiple preconditions, use {@link #applyIfAnd()} or {@link #applyIfOr()} depending on the use case.
      */
     String[] applyIf() default {};
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
@@ -57,7 +57,7 @@ import java.lang.annotation.RetentionPolicy;
  * To restrict the application of IR rules when certain flags are present that could change the IR, each {@code @IR}
  * annotation can specify additional preconditions on the allowed Test VM flags that must hold when an IR rule is applied.
  * If the specified preconditions fail, then the framework does not apply the IR rule. These preconditions can be
- * set with {@link #applyIf()}, {@link #applyIfNot()}, {@link #applyIfAnd()}, or {@link #applyIfOr()}.
+ * set with {@link #applyIf()}, {@link #applyIfAnd()}, or {@link #applyIfOr()}.
  * <p>
  * Examples on how to write tests with IR rules can be found in {@link ir_framework.examples.IRExample}
  * and also as part of the internal testing in {@link ir_framework.tests.TestIRMatching}.
@@ -103,66 +103,52 @@ public @interface IR {
      * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
      * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
      * <p>
-     * This is the inverse of {@link #applyIfNot()}. For multiple preconditions, use {@link #applyIfAnd()} or
+     * For multiple preconditions, use {@link #applyIfAnd()} or
      * {@link #applyIfOr()} depending on the use case.
      */
     String[] applyIf() default {};
 
     /**
      * Accepts a single pair composed of a platform string followed by a true/false
-     * value where a true value necessitates that we are currently testing on that platform and vice-versa.
+     * value where a true value necessitates that we are currently testing on that platform and vice versa.
      * IR checks are enforced only if the specified platform constraint is met.
      */
     String[] applyIfPlatform() default {};
 
     /**
      * Accepts a list of pairs where each pair is composed of a platform string followed by a true/false
-     * value where a true value necessitates that we are currently testing on that platform and vice-versa.
+     * value where a true value necessitates that we are currently testing on that platform and vice versa.
      * IR checks are enforced only if all the specified platform constraints are met.
      */
     String[] applyIfPlatformAnd() default {};
 
     /**
      * Accepts a list of pairs where each pair is composed of a platform string followed by a true/false
-     * value where a true value necessitates that we are currently testing on that platform and vice-versa.
+     * value where a true value necessitates that we are currently testing on that platform and vice versa.
      * IR checks are enforced if any of the specified platform constraints are met.
      */
     String[] applyIfPlatformOr() default {};
 
     /**
      * Accepts a single feature pair which is composed of CPU feature string followed by a true/false
-     * value where a true value necessitates existence of CPU feature and vice-versa.
+     * value where a true value necessitates existence of CPU feature and vice versa.
      * IR verifications checks are enforced only if the specified feature constraint is met.
      */
     String[] applyIfCPUFeature() default {};
 
     /**
      * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
-     * value where a true value necessitates existence of target feature and vice-versa.
+     * value where a true value necessitates existence of target feature and vice versa.
      * IR verifications checks are enforced only if all the specified feature constraints are met.
      */
     String[] applyIfCPUFeatureAnd() default {};
 
      /**
      * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
-     * value where a true value necessitates existence of target feature and vice-versa.
+     * value where a true value necessitates existence of target feature and vice versa.
      * IR verifications checks are enforced if any of the specified feature constraint is met.
      */
     String[] applyIfCPUFeatureOr() default {};
-
-    /**
-     * Define a single VM flag precondition which <i>must <b>not</b> hold</i> when applying the IR rule. If, however,
-     * the VM flag precondition holds, then the IR rule is not applied. This could also be defined as <i>negative</i>
-     * precondition. This is useful if a commonly used flag alters the IR in such a way that an IR rule would fail.
-     * <p>
-     * The precondition is a (flag, value) string pair where the flag must be a valid VM flag and the value must conform
-     * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
-     * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
-     * <p>
-     * This is the inverse of {@link #applyIf()}. For multiple preconditions, use {@link #applyIfAnd()} or
-     * {@link #applyIfOr()} depending on the use case.
-     */
-    String[] applyIfNot() default {};
 
     /**
      * Define a list of at least two VM flag precondition which <i><b>all</b> must hold</i> when applying the IR rule.
@@ -174,8 +160,7 @@ public @interface IR {
      * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
      * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
      * <p>
-     * Use  {@link #applyIfOr()} for disjunction and for single precondition constraints use {@link #applyIf()} or
-     * {@link #applyIfNot()} depending on the use case.
+     * Use  {@link #applyIfOr()} for disjunction and for single precondition constraints use {@link #applyIf()}.
      */
     String[] applyIfAnd() default {};
 
@@ -189,8 +174,7 @@ public @interface IR {
      * with the type of the VM flag. A number based flag value can be proceeded with an additional comparator
      * ({@code =, !=, <, <=, =>, >}) where the equality operator is optional (default if no comparator is specified).
      * <p>
-     * Use  {@link #applyIfAnd()} for conjunction and for single precondition constraints use {@link #applyIf()} or
-     * {@link #applyIfNot()} depending on the use case.
+     * Use  {@link #applyIfAnd()} for conjunction and for single precondition constraints use {@link #applyIf()}.
      */
     String[] applyIfOr() default {};
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -118,8 +118,6 @@ The [@IR](./IR.java) annotation provides two kinds of checks:
 One might also want to restrict the application of certain `@IR` rules depending on the used flags in the Test VM. These could be flags defined by the user or by JTreg. In the latter case, the flags must be whitelisted in `JTREG_WHITELIST_FLAGS` in [TestFramework](./TestFramework.java) (i.e. have no unexpected impact on the IR except if the flag simulates a specific machine setup like `UseAVX={1,2,3}` etc.) to enable an IR verification by the framework. The `@IR` rules thus have an option to restrict their application:
 
 - `applyIf`: Only apply a rule if a flag has the specified value/range of values.
-- `applyIfNot`: Only apply a rule if a flag has **not** a specified value/range of values
-               (inverse of `applyIf`).
 - `applyIfAnd`: Only apply a rule if **all** flags have the specified value/range of values.
 - `applyIfOr`:  Only apply a rule if **at least one** flag has the specified value/range of values.
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/ApplicableIRRulesPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/ApplicableIRRulesPrinter.java
@@ -196,9 +196,6 @@ public class ApplicableIRRulesPrinter {
         } else if (irAnno.applyIf().length != 0 && !hasAllRequiredFlags(irAnno.applyIf(), "applyIf")) {
             printDisableReason(m, "Flag constraint not met (applyIf)", irAnno.applyIf(), ruleIndex, ruleMax);
             return false;
-        } else if (irAnno.applyIfNot().length != 0 && !hasNoRequiredFlags(irAnno.applyIfNot(), "applyIfNot")) {
-            printDisableReason(m, "Flag constraint not met (applyIfNot)", irAnno.applyIfNot(), ruleIndex, ruleMax);
-            return false;
         } else if (irAnno.applyIfAnd().length != 0 && !hasAllRequiredFlags(irAnno.applyIfAnd(), "applyIfAnd")) {
             printDisableReason(m, "Not all flag constraints are met (applyIfAnd)", irAnno.applyIfAnd(), ruleIndex, ruleMax);
             return false;
@@ -220,12 +217,12 @@ public class ApplicableIRRulesPrinter {
         if (irAnno.applyIfAnd().length != 0) {
             flagConstraints++;
             TestFormat.checkNoThrow(irAnno.applyIfAnd().length > 2,
-                                    "Use applyIf or applyIfNot or at least 2 conditions for applyIfAnd" + failAt());
+                                    "Use applyIf or at least 2 conditions for applyIfAnd" + failAt());
         }
         if (irAnno.applyIfOr().length != 0) {
             flagConstraints++;
             TestFormat.checkNoThrow(irAnno.applyIfOr().length > 2,
-                                    "Use applyIf or applyIfNot or at least 2 conditions for applyIfOr" + failAt());
+                                    "Use applyIf or at least 2 conditions for applyIfOr" + failAt());
         }
         if (irAnno.applyIf().length != 0) {
             flagConstraints++;
@@ -261,11 +258,6 @@ public class ApplicableIRRulesPrinter {
             cpuFeatureConstraints++;
             TestFormat.checkNoThrow(irAnno.applyIfCPUFeatureOr().length % 2 == 0,
                                     "applyIfCPUFeatureOr expects more than one CPU feature pair" + failAt());
-        }
-        if (irAnno.applyIfNot().length != 0) {
-            flagConstraints++;
-            TestFormat.checkNoThrow(irAnno.applyIfNot().length <= 2,
-                                    "Use applyIfAnd or applyIfOr or only 1 condition for applyIfNot" + failAt());
         }
         TestFormat.checkNoThrow(flagConstraints <= 1, "Can only specify one flag constraint" + failAt());
         TestFormat.checkNoThrow(platformConstraints <= 1, "Can only specify one platform constraint" + failAt());

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -844,12 +844,11 @@ class BadIRAnnotations {
     public void mustSpecifyAtLeastOneConstraint3() {
     }
 
-    @FailCount(3)
+    @FailCount(2)
     @Test
-    @IR(failOn = IRNode.CALL, applyIf = {"TLABRefillWasteFraction", "50"}, applyIfNot = {"UseTLAB", "true"})
     @IR(failOn = IRNode.CALL, applyIfAnd = {"TLABRefillWasteFraction", "50", "UseTLAB", "true"},
         applyIfOr = {"TLABRefillWasteFraction", "50", "UseTLAB", "true"})
-    @IR(failOn = IRNode.CALL, applyIf = {"TLABRefillWasteFraction", "50"}, applyIfNot = {"TLABRefillWasteFraction", "50"},
+    @IR(failOn = IRNode.CALL, applyIf = {"TLABRefillWasteFraction", "50"},
         applyIfAnd = {"TLABRefillWasteFraction", "50", "UseTLAB", "true"},
         applyIfOr = {"TLABRefillWasteFraction", "50", "UseTLAB", "true"})
     public void onlyOneApply() {}
@@ -889,43 +888,6 @@ class BadIRAnnotations {
     @IR(failOn = IRNode.CALL, applyIf = {"TLABRefillWasteFraction", "=<34"})
     @IR(failOn = IRNode.CALL, applyIf = {"TLABRefillWasteFraction", "<"})
     public void applyIfFaultyComparator() {}
-
-    @FailCount(3)
-    @Test
-    @IR(failOn = IRNode.CALL, applyIfNot = {"TLABRefillWasteFraction", "50", "UseTLAB", "true"})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"TLABRefillWasteFraction", "50", "UseTLAB"})
-    public void applyIfNotTooManyFlags() {}
-
-    @FailCount(2)
-    @Test
-    @IR(failOn = IRNode.CALL, applyIfNot = {"TLABRefillWasteFraction"})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"Bla"})
-    public void applyIfNotMissingValue() {}
-
-    @FailCount(2)
-    @Test
-    @IR(failOn = IRNode.CALL, applyIfNot = {"PrintIdealGraphFilee", "true"})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"Bla", "foo"})
-    public void applyIfNotUnknownFlag() {}
-
-    @FailCount(5)
-    @Test
-    @IR(failOn = IRNode.CALL, applyIfNot = {"PrintIdealGraphFile", ""})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"UseTLAB", ""})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"", "true"})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"", ""})
-    @IR(failOn = IRNode.CALL, applyIfNot = {" ", " "})
-    public void applyIfNotEmptyValue() {}
-
-    @FailCount(5)
-    @Test
-    @IR(failOn = IRNode.CALL, applyIfNot = {"TLABRefillWasteFraction", "! 34"})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"TLABRefillWasteFraction", "!== 34"})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"TLABRefillWasteFraction", "<<= 34"})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"TLABRefillWasteFraction", "=<34"})
-    @IR(failOn = IRNode.CALL, applyIfNot = {"TLABRefillWasteFraction", "<"})
-    public void applyIfNotFaultyComparator() {}
-
 
     @FailCount(2)
     @Test

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -467,16 +467,16 @@ class MultipleFailOnGood {
 
     @Test
     @IR(failOn = {IRNode.STORE, IRNode.CALL})
-    @IR(applyIfNot = {"TLABRefillWasteFraction", "20"}, failOn = {IRNode.ALLOC})
-    @IR(applyIfNot = {"TLABRefillWasteFraction", "< 100"}, failOn = {IRNode.ALLOC_OF, "Test"})
+    @IR(applyIf = {"TLABRefillWasteFraction", "!= 20"}, failOn = {IRNode.ALLOC})
+    @IR(applyIf = {"TLABRefillWasteFraction", ">= 100"}, failOn = {IRNode.ALLOC_OF, "Test"})
     public void good2() {
         forceInline();
     }
 
     @Test
     @IR(failOn = {IRNode.STORE_OF_CLASS, "Test", IRNode.CALL})
-    @IR(applyIfNot = {"TLABRefillWasteFraction", "20"}, failOn = {IRNode.ALLOC})
-    @IR(applyIfNot = {"TLABRefillWasteFraction", "< 100"}, failOn = {IRNode.ALLOC_OF, "Test"})
+    @IR(applyIf = {"TLABRefillWasteFraction", "!= 20"}, failOn = {IRNode.ALLOC})
+    @IR(applyIf = {"TLABRefillWasteFraction", ">= 100"}, failOn = {IRNode.ALLOC_OF, "Test"})
     public void good3() {
         forceInline();
     }


### PR DESCRIPTION
Since the initial introduction of the IR Framework, `applyIfNot` was never used outside internal IR Framework tests. We can use `applyIf` instead with equal expersiveness. I therefore propose to remove this attribute.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388437](https://bugs.openjdk.org/browse/JDK-8388437): [IR Framework] Remove unused applyIfNot attribute in @<!---->IR (**Enhancement** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31948/head:pull/31948` \
`$ git checkout pull/31948`

Update a local copy of the PR: \
`$ git checkout pull/31948` \
`$ git pull https://git.openjdk.org/jdk.git pull/31948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31948`

View PR using the GUI difftool: \
`$ git pr show -t 31948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31948.diff">https://git.openjdk.org/jdk/pull/31948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31948#issuecomment-5002991136)
</details>
