### PR TITLE
8388432: [IR Framework] Various clean-ups in preparation for skipping IR tests and IR rules

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/LeafMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/LeafMatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,31 +21,18 @@
  * questions.
  */
 
-package compiler.lib.ir_framework.driver.irmatching.visitor;
-
-import compiler.lib.ir_framework.driver.irmatching.MatchResult;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Consumer;
+package compiler.lib.ir_framework.driver.irmatching;
 
 /**
- * This class invokes {@link MatchResult#accept(MatchResultVisitor)} on all failed match results (i.e. children) inside
- * a {@link MatchResult} object to visit them.
+ * This interface represents a special leaf match result that does not have any further sub results.
  */
-public class AcceptChildren implements Consumer<MatchResultVisitor> {
-    private final Collection<? extends MatchResult> matchResults;
+public interface LeafMatchResult extends MatchResult {
 
-    public AcceptChildren(List<MatchResult> matchResults) {
-        this.matchResults = matchResults;
-    }
-
+    /**
+     * A leaf result does not have sub results and thus returns an empty {@link SubResults} object.
+     */
     @Override
-    public void accept(MatchResultVisitor visitor) {
-        for (MatchResult result : matchResults) {
-            if (result.fail()) {
-                result.accept(visitor);
-            }
-        }
+    default SubResults subResults() {
+        return SubResults.createEmpty();
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/MatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/MatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,14 +23,12 @@
 
 package compiler.lib.ir_framework.driver.irmatching;
 
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 
 /**
  * This interface is implemented by all classes which represent an IR match result of a {@link Matchable} class.
  * A match result class accepts a {@link MatchResultVisitor} to visit the result (i.e. for reporting etc.).
- * The visitor is responsible to call {@link #accept(MatchResultVisitor)} of the children match results by using
- * {@link AcceptChildren#accept(MatchResultVisitor)}.
+ * The visitor is responsible to call {@link #accept(MatchResultVisitor)} on the sub results.
  */
 public interface MatchResult {
     /**
@@ -43,4 +41,9 @@ public interface MatchResult {
      * visitor.
      */
     void accept(MatchResultVisitor visitor);
+
+    /**
+     * Returns the sub results of this {@link MatchResult}.
+     */
+    SubResults subResults();
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/SubResults.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/SubResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,41 @@
 
 package compiler.lib.ir_framework.driver.irmatching;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 /**
- * This class performs matching on a collection of {@link Matchable} objects. It returns a list of {@link MatchResult}
- * objects which failed or an empty list of there was not failure.
+ * Class to represent sub results as part of a {@link MatchResult}. A {@link LeafMatchResult} use an empty sub results
+ * object.
  */
-public class MatchableMatcher {
-    private final Collection<? extends Matchable> matchables;
+public class SubResults implements Iterable<MatchResult> {
+    private final List<MatchResult> subResults;
+    private final int failCount;
 
-    public MatchableMatcher(Collection<? extends Matchable> matchables) {
-        this.matchables = matchables;
+    public SubResults(List<MatchResult> subResults) {
+        this.failCount = (int)subResults.stream().filter(MatchResult::fail).count();
+        this.subResults = subResults;
     }
 
-    public SubResults match() {
-        List<MatchResult> results = new ArrayList<>();
-        for (Matchable matchable : matchables) {
-            results.add(matchable.match());
-        }
-        return new SubResults(results);
+    /**
+     * Used for {@link LeafMatchResult} objects with no sub results.
+     */
+    public static SubResults createEmpty() {
+        return new SubResults(List.of());
+    }
+
+    /**
+     * Is there a sub result with a failure?
+     */
+    public boolean hasFailure() {
+        return failCount > 0;
+    }
+
+    public int failCount() {
+        return failCount;
+    }
+
+    public Iterator<MatchResult> iterator() {
+        return subResults.iterator();
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/TestClassMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/TestClassMatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,7 @@
 
 package compiler.lib.ir_framework.driver.irmatching;
 
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
-
-import java.util.List;
 
 /**
  * This class represents a matching result of a {@link TestClass}. It contains all IR method results, sorted by
@@ -34,22 +31,14 @@ import java.util.List;
  *
  * @see TestClass
  */
-public class TestClassMatchResult implements MatchResult {
-    private final AcceptChildren acceptChildren;
-    private final boolean failed;
-
-    public TestClassMatchResult(List<MatchResult> matchResults) {
-        this.acceptChildren = new AcceptChildren(matchResults);
-        this.failed = !matchResults.isEmpty();
-    }
-
+public record TestClassMatchResult(SubResults subResults) implements MatchResult {
     @Override
     public boolean fail() {
-        return failed;
+        return subResults.hasFailure();
     }
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitTestClass(acceptChildren);
+        visitor.visit(this);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
@@ -26,10 +26,7 @@ package compiler.lib.ir_framework.driver.irmatching.irmethod;
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IR;
 import compiler.lib.ir_framework.Test;
-import compiler.lib.ir_framework.driver.irmatching.Compilation;
-import compiler.lib.ir_framework.driver.irmatching.MatchResult;
-import compiler.lib.ir_framework.driver.irmatching.Matchable;
-import compiler.lib.ir_framework.driver.irmatching.MatchableMatcher;
+import compiler.lib.ir_framework.driver.irmatching.*;
 import compiler.lib.ir_framework.driver.irmatching.irrule.IRRule;
 import compiler.lib.ir_framework.driver.network.testvm.java.IRRuleIds;
 import compiler.lib.ir_framework.driver.network.testvm.java.VMInfo;
@@ -95,10 +92,10 @@ public class IRMethod implements IRMethodMatchable {
         }
 
         long startTime = System.nanoTime();
-        List<MatchResult> match = matcher.match();
+        SubResults subResults = matcher.match();
         long endTime = System.nanoTime();
         long duration = (endTime - startTime);
         System.out.println("Verifying IR rules for " + name() + ": " + duration + " ns = " + (duration / 1_000_000) + " ms");
-        return new IRMethodMatchResult(method, match);
+        return new IRMethodMatchResult(method, subResults);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethodMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethodMatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,10 @@
 package compiler.lib.ir_framework.driver.irmatching.irmethod;
 
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
+import compiler.lib.ir_framework.driver.irmatching.SubResults;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 
 import java.lang.reflect.Method;
-import java.util.List;
 
 /**
  * This class represents a matching result of an {@link IRMethod}. It contains a list of all IR rule match results
@@ -36,26 +35,14 @@ import java.util.List;
  *
  * @see IRMethod
  */
-public class IRMethodMatchResult implements MatchResult {
-    private final AcceptChildren acceptChildren;
-    private final boolean failed;
-    private final Method method;
-    private final int failedIRRules;
-
-    public IRMethodMatchResult(Method method, List<MatchResult> matchResults) {
-        this.acceptChildren = new AcceptChildren(matchResults);
-        this.failed = !matchResults.isEmpty();
-        this.method = method;
-        this.failedIRRules = matchResults.size();
-    }
-
+public record IRMethodMatchResult(Method method, SubResults subResults) implements MatchResult {
     @Override
     public boolean fail() {
-        return failed;
+        return subResults.hasFailure();
     }
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitIRMethod(acceptChildren, method, failedIRRules);
+        visitor.visit(this);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/NotCompilableIRMethod.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/NotCompilableIRMethod.java
@@ -38,11 +38,11 @@ import java.lang.reflect.Method;
  */
 public class NotCompilableIRMethod implements IRMethodMatchable {
     private final Method method;
-    private final int ruleCount;
+    private final int irRuleCount;
 
-    public NotCompilableIRMethod(Method method, int ruleCount) {
+    public NotCompilableIRMethod(Method method, int irRuleCount) {
         this.method = method;
-        this.ruleCount = ruleCount;
+        this.irRuleCount = irRuleCount;
     }
 
     @Override
@@ -55,6 +55,6 @@ public class NotCompilableIRMethod implements IRMethodMatchable {
      */
     @Override
     public NotCompilableIRMethodMatchResult match() {
-        return new NotCompilableIRMethodMatchResult(method, ruleCount);
+        return new NotCompilableIRMethodMatchResult(method, irRuleCount);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/NotCompilableIRMethodMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/NotCompilableIRMethodMatchResult.java
@@ -24,7 +24,7 @@
 package compiler.lib.ir_framework.driver.irmatching.irmethod;
 
 import compiler.lib.ir_framework.Test;
-import compiler.lib.ir_framework.driver.irmatching.MatchResult;
+import compiler.lib.ir_framework.driver.irmatching.LeafMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 
 import java.lang.reflect.Method;
@@ -37,14 +37,7 @@ import java.lang.reflect.Method;
  * @see NotCompilableIRMethod
  * @see Test
  */
-public class NotCompilableIRMethodMatchResult implements MatchResult {
-    private final Method method;
-    private final int failedIRRules;
-
-    public NotCompilableIRMethodMatchResult(Method method, int failedIRRules) {
-        this.method = method;
-        this.failedIRRules = failedIRRules;
-    }
+public record NotCompilableIRMethodMatchResult(Method method, int irRuleCount) implements LeafMatchResult {
 
     @Override
     public boolean fail() {
@@ -53,7 +46,7 @@ public class NotCompilableIRMethodMatchResult implements MatchResult {
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitMethodNotCompilable(method, failedIRRules);
+        visitor.visitLeaf(this);
     }
 }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/NotCompiledIRMethod.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/NotCompiledIRMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,11 @@ import java.lang.reflect.Method;
  */
 public class NotCompiledIRMethod implements IRMethodMatchable {
     private final Method method;
-    private final int ruleCount;
+    private final int irRuleCount;
 
-    public NotCompiledIRMethod(Method method, int ruleCount) {
+    public NotCompiledIRMethod(Method method, int irRuleCount) {
         this.method = method;
-        this.ruleCount = ruleCount;
+        this.irRuleCount = irRuleCount;
     }
 
     @Override
@@ -55,6 +55,6 @@ public class NotCompiledIRMethod implements IRMethodMatchable {
      */
     @Override
     public NotCompiledIRMethodMatchResult match() {
-        return new NotCompiledIRMethodMatchResult(method, ruleCount);
+        return new NotCompiledIRMethodMatchResult(method, irRuleCount);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/NotCompiledIRMethodMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/NotCompiledIRMethodMatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ package compiler.lib.ir_framework.driver.irmatching.irmethod;
 
 import compiler.lib.ir_framework.Run;
 import compiler.lib.ir_framework.RunMode;
-import compiler.lib.ir_framework.driver.irmatching.MatchResult;
+import compiler.lib.ir_framework.driver.irmatching.LeafMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 
 import java.lang.reflect.Method;
@@ -37,14 +37,7 @@ import java.lang.reflect.Method;
  * @see NotCompiledIRMethod
  * @see Run
  */
-public class NotCompiledIRMethodMatchResult implements MatchResult {
-    private final Method method;
-    private final int failedIRRules;
-
-    public NotCompiledIRMethodMatchResult(Method method, int failedIRRules) {
-        this.method = method;
-        this.failedIRRules = failedIRRules;
-    }
+public record NotCompiledIRMethodMatchResult(Method method, int irRuleCount) implements LeafMatchResult {
 
     @Override
     public boolean fail() {
@@ -53,7 +46,7 @@ public class NotCompiledIRMethodMatchResult implements MatchResult {
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitMethodNotCompiled(method, failedIRRules);
+        visitor.visitLeaf(this);
     }
 }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/IRRuleMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/IRRuleMatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,9 @@ package compiler.lib.ir_framework.driver.irmatching.irrule;
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IR;
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
+import compiler.lib.ir_framework.driver.irmatching.SubResults;
 import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseIRRuleMatchResult;
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
-
-import java.util.List;
 
 /**
  * This class represents a match result of an {@link IRRule} (applied to all compile phases specified in
@@ -39,26 +37,14 @@ import java.util.List;
  *
  * @see IRRule
  */
-public class IRRuleMatchResult implements MatchResult {
-    private final AcceptChildren acceptChildren;
-    private final boolean failed;
-    private final int irRuleId;
-    private final IR irAnno;
-
-    public IRRuleMatchResult(int irRuleId, IR irAnno, List<MatchResult> matchResults) {
-        this.acceptChildren = new AcceptChildren(matchResults);
-        this.failed = !matchResults.isEmpty();
-        this.irRuleId = irRuleId;
-        this.irAnno = irAnno;
-    }
-
+public record IRRuleMatchResult(int irRuleId, IR irAnno, SubResults subResults) implements MatchResult {
     @Override
     public boolean fail() {
-        return failed;
+        return subResults.hasFailure();
     }
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitIRRule(acceptChildren, irRuleId, irAnno);
+        visitor.visit(this);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/checkattribute/CheckAttributeMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/checkattribute/CheckAttributeMatchResult.java
@@ -25,10 +25,8 @@ package compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute;
 
 import compiler.lib.ir_framework.IR;
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
+import compiler.lib.ir_framework.driver.irmatching.SubResults;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
-
-import java.util.List;
 
 /**
  * This class represents a match result of a {@link CheckAttribute} (i.e. either from {@link IR#failOn} or
@@ -37,24 +35,15 @@ import java.util.List;
  * @see CheckAttribute
  * @see CheckAttributeType
  */
-public class CheckAttributeMatchResult implements MatchResult {
-    private final AcceptChildren acceptChildren;
-    private final boolean failed;
-    private final CheckAttributeType checkAttributeType;
-
-    CheckAttributeMatchResult(CheckAttributeType checkAttributeType, List<MatchResult> matchResults) {
-        this.acceptChildren = new AcceptChildren(matchResults);
-        this.failed = !matchResults.isEmpty();
-        this.checkAttributeType = checkAttributeType;
-    }
-
+public record CheckAttributeMatchResult(CheckAttributeType checkAttributeType,
+                                        SubResults subResults) implements MatchResult {
     @Override
     public boolean fail() {
-        return failed;
+        return subResults.hasFailure();
     }
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitCheckAttribute(acceptChildren, checkAttributeType);
+        visitor.visit(this);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/ConstraintFailure.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/ConstraintFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package compiler.lib.ir_framework.driver.irmatching.irrule.constraint;
 
-import compiler.lib.ir_framework.driver.irmatching.MatchResult;
+import compiler.lib.ir_framework.driver.irmatching.LeafMatchResult;
 
 import java.util.List;
 
@@ -32,7 +32,7 @@ import java.util.List;
  *
  * @see Constraint
  */
-public interface ConstraintFailure extends MatchResult {
+public interface ConstraintFailure extends LeafMatchResult {
     @Override
     default boolean fail() {
         return true;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/CountsConstraintFailure.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/CountsConstraintFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,6 @@ public record CountsConstraintFailure(String nodeRegex, int constraintId, List<S
                                       Comparison<Integer> comparison) implements ConstraintFailure {
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitCountsConstraint(this);
+        visitor.visitLeaf(this);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/FailOnConstraintFailure.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/FailOnConstraintFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,6 @@ public record FailOnConstraintFailure(String nodeRegex, int constraintId, List<S
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitFailOnConstraint(this);
+        visitor.visitLeaf(this);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/SuccessResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/SuccessResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,14 +23,14 @@
 
 package compiler.lib.ir_framework.driver.irmatching.irrule.constraint;
 
-import compiler.lib.ir_framework.driver.irmatching.MatchResult;
+import compiler.lib.ir_framework.driver.irmatching.LeafMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.Matchable;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 
 /**
  * This class represents a successful match result of any {@link Matchable} object.
  */
-public class SuccessResult implements MatchResult {
+public class SuccessResult implements LeafMatchResult {
     private static final SuccessResult INSTANCE = new SuccessResult();
 
     private SuccessResult() {}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/phase/CompilePhaseIRRuleMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/phase/CompilePhaseIRRuleMatchResult.java
@@ -25,37 +25,23 @@ package compiler.lib.ir_framework.driver.irmatching.irrule.phase;
 
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
+import compiler.lib.ir_framework.driver.irmatching.SubResults;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
-
-import java.util.List;
 
 /**
  * This class represents a match result of a {@link CompilePhaseIRRule} (i.e. an IR rule applied on a compile phase).
  *
  * @see CompilePhaseIRRule
  */
-public class CompilePhaseIRRuleMatchResult implements MatchResult {
-    private final AcceptChildren acceptChildren;
-    private final boolean failed;
-    private final CompilePhase compilePhase;
-    private final String compilationOutput;
-
-    public CompilePhaseIRRuleMatchResult(CompilePhase compilePhase, String compilationOutput,
-                                         List<MatchResult> matchResults) {
-        this.acceptChildren = new AcceptChildren(matchResults);
-        this.failed = !matchResults.isEmpty();
-        this.compilePhase = compilePhase;
-        this.compilationOutput = compilationOutput;
-    }
-
+public record CompilePhaseIRRuleMatchResult(CompilePhase compilePhase, String compilationOutput,
+                                            SubResults subResults) implements MatchResult {
     @Override
     public boolean fail() {
-        return failed;
+        return subResults.hasFailure();
     }
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitCompilePhaseIRRule(acceptChildren, compilePhase, compilationOutput);
+        visitor.visit(this);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/phase/CompilePhaseNoCompilationIRRuleMatchResult.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/phase/CompilePhaseNoCompilationIRRuleMatchResult.java
@@ -24,7 +24,7 @@
 package compiler.lib.ir_framework.driver.irmatching.irrule.phase;
 
 import compiler.lib.ir_framework.CompilePhase;
-import compiler.lib.ir_framework.driver.irmatching.MatchResult;
+import compiler.lib.ir_framework.driver.irmatching.LeafMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 
 /**
@@ -33,7 +33,7 @@ import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
  *
  * @see CompilePhaseNoCompilationIRRule
  */
-public record CompilePhaseNoCompilationIRRuleMatchResult(CompilePhase compilePhase) implements MatchResult {
+public record CompilePhaseNoCompilationIRRuleMatchResult(CompilePhase compilePhase) implements LeafMatchResult {
 
     @Override
     public boolean fail() {
@@ -42,6 +42,6 @@ public record CompilePhaseNoCompilationIRRuleMatchResult(CompilePhase compilePha
 
     @Override
     public void accept(MatchResultVisitor visitor) {
-        visitor.visitNoCompilePhaseCompilation(compilePhase);
+        visitor.visitLeaf(this);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/report/CompilationOutputBuilder.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/report/CompilationOutputBuilder.java
@@ -24,13 +24,14 @@
 package compiler.lib.ir_framework.driver.irmatching.report;
 
 import compiler.lib.ir_framework.CompilePhase;
-import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.driver.irmatching.TestClassMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.IRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompilableIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompiledIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseIRRuleMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseNoCompilationIRRuleMatchResult;
 import compiler.lib.ir_framework.shared.TestFrameworkException;
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
-import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.CheckAttributeType;
-import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.CountsConstraintFailure;
-import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.FailOnConstraintFailure;
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 
 import java.lang.reflect.Method;
@@ -59,8 +60,7 @@ public class CompilationOutputBuilder implements MatchResultVisitor {
     }
 
     @Override
-    public void visitTestClass(AcceptChildren acceptChildren) {
-        acceptChildren.accept(this);
+    public void leave(TestClassMatchResult matchResult) {
         StringBuilder builder = new StringBuilder();
         builder.append("Compilation");
         if (compilePhaseCount > 1) {
@@ -77,16 +77,15 @@ public class CompilationOutputBuilder implements MatchResultVisitor {
         output.insert(0, builder);
     }
 
-    private String getTitleSeparator(int failedIRMethods) {
-        int failedMethodDashes = failedIRMethods > 1 ? digitCount(failedIRMethods) + 4 : 0;
+    private String getTitleSeparator(int failedIrMethodCount) {
+        int failedMethodDashes = failedIrMethodCount > 1 ? digitCount(failedIrMethodCount) + 4 : 0;
         int compilePhaseDashes = compilePhaseCount > 1 ? digitCount(compilePhaseCount) + 4 : 0;
         return "-".repeat(28 + compilePhaseDashes + failedMethodDashes);
     }
 
     @Override
-    public void visitIRMethod(AcceptChildren acceptChildren, Method method, int failedIRRules) {
-        acceptChildren.accept(this);
-        appendIRMethodHeader(method);
+    public void leave(IRMethodMatchResult result) {
+        appendIRMethodHeader(result.method());
         appendMatchedCompilationOutputOfPhases();
         failedCompilePhases.clear();
     }
@@ -116,33 +115,32 @@ public class CompilationOutputBuilder implements MatchResultVisitor {
     }
 
     @Override
-    public void visitMethodNotCompiled(Method method, int failedIRRules) {
-        appendIRMethodHeader(method);
+    public void visitLeaf(NotCompiledIRMethodMatchResult result) {
+        appendIRMethodHeader(result.method());
         compilePhaseCount++; // Count this as one phase
         output.append("<empty>").append(System.lineSeparator());
     }
 
     @Override
-    public void visitMethodNotCompilable(Method method, int failedIRRules) {
-        throw new TestFrameworkException("Sould not reach here");
+    public void visitLeaf(NotCompilableIRMethodMatchResult result) {
+        throw new TestFrameworkException("Should not reach here");
     }
 
+    /**
+     * We directly override this method to stop visiting check attribute sub results.
+     */
     @Override
-    public void visitIRRule(AcceptChildren acceptChildren, int irRuleId, IR irAnno) {
-        acceptChildren.accept(this);
-    }
-
-    @Override
-    public void visitCompilePhaseIRRule(AcceptChildren acceptChildren, CompilePhase compilePhase, String compilationOutput) {
+    public void visit(CompilePhaseIRRuleMatchResult result) {
+        CompilePhase compilePhase = result.compilePhase();
         if (!failedCompilePhases.containsKey(compilePhase)) {
-            failedCompilePhases.put(compilePhase, compilationOutput);
+            failedCompilePhases.put(compilePhase, result.compilationOutput());
             compilePhaseCount++;
         }
-        // No need to visit check attributes
     }
 
     @Override
-    public void visitNoCompilePhaseCompilation(CompilePhase compilePhase) {
+    public void visitLeaf(CompilePhaseNoCompilationIRRuleMatchResult result) {
+        CompilePhase compilePhase = result.compilePhase();
         if (!failedCompilePhases.containsKey(compilePhase)) {
             failedCompilePhases.put(compilePhase,
                                     "> Phase \"" + compilePhase.getName() + "\":" + System.lineSeparator() + "<empty>" +
@@ -150,15 +148,6 @@ public class CompilationOutputBuilder implements MatchResultVisitor {
             compilePhaseCount++;
         }
     }
-
-    @Override
-    public void visitCheckAttribute(AcceptChildren acceptChildren, CheckAttributeType checkAttributeType) {}
-
-    @Override
-    public void visitFailOnConstraint(FailOnConstraintFailure failOnConstraintFailure) {}
-
-    @Override
-    public void visitCountsConstraint(CountsConstraintFailure countsConstraintFailure) {}
 
     public String build() {
         testClassMatchResult.accept(this);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/report/FailCountVisitor.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/report/FailCountVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,11 @@
 
 package compiler.lib.ir_framework.driver.irmatching.report;
 
-import compiler.lib.ir_framework.CompilePhase;
-import compiler.lib.ir_framework.IR;
-import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.CheckAttributeType;
-import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.CountsConstraintFailure;
-import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.FailOnConstraintFailure;
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.IRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompilableIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompiledIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.IRRuleMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
-
-import java.lang.reflect.Method;
 
 /**
  * Visitor to collect the number of IR method and IR rule failures.
@@ -40,54 +36,36 @@ class FailCountVisitor implements MatchResultVisitor {
     private int irMethodCount;
     private int irRuleCount;
 
-    @Override
-    public void visitTestClass(AcceptChildren acceptChildren) {
-        acceptChildren.accept(this);
-    }
 
     @Override
-    public void visitIRMethod(AcceptChildren acceptChildren, Method method, int failedIRRules) {
+    public void enter(IRMethodMatchResult result) {
         irMethodCount++;
-        acceptChildren.accept(this);
     }
 
+    /**
+     * We directly override this method to stop visiting compile phase IR rule sub results.
+     */
     @Override
-    public void visitIRRule(AcceptChildren acceptChildren, int irRuleId, IR irAnno) {
+    public void visit(IRRuleMatchResult result) {
         irRuleCount++;
-        // Do not need to visit compile phase IR rules
     }
 
     @Override
-    public void visitMethodNotCompiled(Method method, int failedIRRules) {
+    public void visitLeaf(NotCompiledIRMethodMatchResult result) {
         irMethodCount++;
-        irRuleCount += failedIRRules;
+        irRuleCount += result.irRuleCount();
     }
 
     @Override
-    public void visitMethodNotCompilable(Method method, int failedIRRules) {
+    public void visitLeaf(NotCompilableIRMethodMatchResult result) {
         irMethodCount++;
     }
 
-    public int getIrRuleCount() {
+    public int irRuleCount() {
         return irRuleCount;
     }
 
-    public int getIrMethodCount() {
+    public int irMethodCount() {
         return irMethodCount;
     }
-
-    @Override
-    public void visitCompilePhaseIRRule(AcceptChildren acceptChildren, CompilePhase compilePhase, String compilationOutput) {}
-
-    @Override
-    public void visitNoCompilePhaseCompilation(CompilePhase compilePhase) {}
-
-    @Override
-    public void visitCheckAttribute(AcceptChildren acceptChildren, CheckAttributeType checkAttributeType) {}
-
-    @Override
-    public void visitFailOnConstraint(FailOnConstraintFailure failOnConstraintFailure) {}
-
-    @Override
-    public void visitCountsConstraint(CountsConstraintFailure countsConstraintFailure) {}
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/report/FailureMessageBuilder.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/report/FailureMessageBuilder.java
@@ -24,13 +24,19 @@
 package compiler.lib.ir_framework.driver.irmatching.report;
 
 import compiler.lib.ir_framework.CompilePhase;
-import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.driver.irmatching.TestClassMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.IRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompilableIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompiledIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.IRRuleMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.CheckAttributeMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseIRRuleMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseNoCompilationIRRuleMatchResult;
 import compiler.lib.ir_framework.shared.TestFrameworkException;
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
 import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.CheckAttributeType;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.CountsConstraintFailure;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.FailOnConstraintFailure;
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 
 import java.lang.reflect.Method;
@@ -50,11 +56,11 @@ public class FailureMessageBuilder implements MatchResultVisitor {
     }
 
     @Override
-    public void visitTestClass(AcceptChildren acceptChildren) {
+    public void enter(TestClassMatchResult result) {
         FailCountVisitor failCountVisitor = new FailCountVisitor();
         testClassMatchResult.accept(failCountVisitor);
-        int failedMethodCount = failCountVisitor.getIrMethodCount();
-        int failedIRRulesCount = failCountVisitor.getIrRuleCount();
+        int failedMethodCount = failCountVisitor.irMethodCount();
+        int failedIRRulesCount = failCountVisitor.irRuleCount();
         msg.append("One or more @IR rules failed:")
            .append(System.lineSeparator())
            .append(System.lineSeparator())
@@ -62,7 +68,6 @@ public class FailureMessageBuilder implements MatchResultVisitor {
            .append(")").append(System.lineSeparator())
            .append(getTitleSeparator(failedMethodCount, failedIRRulesCount))
            .append(System.lineSeparator());
-        acceptChildren.accept(this);
     }
 
     private static String getTitleSeparator(int failedMethodCount, int failedIRRulesCount) {
@@ -70,27 +75,13 @@ public class FailureMessageBuilder implements MatchResultVisitor {
     }
 
     @Override
-    public void visitIRMethod(AcceptChildren acceptChildren, Method method, int failedIRRules) {
-        appendIRMethodHeader(method, failedIRRules);
-        acceptChildren.accept(this);
-    }
-
-    private void appendIRMethodHeader(Method method, int failedIRRules) {
-        methodIndex++;
-        indentation = new Indentation(digitCount(methodIndex));
-        if (methodIndex > 1) {
-            msg.append(System.lineSeparator());
-        }
-        msg.append(methodIndex).append(") ");
-        msg.append("Method \"")
-           .append(method.getDeclaringClass().getTypeName()).append("::").append(method.getName())
-           .append("\" - [Failed IR rules: ").append(failedIRRules).append("]:")
-           .append(System.lineSeparator());
+    public void enter(IRMethodMatchResult result) {
+        appendIRMethodHeader(result.method(), result.subResults().failCount());
     }
 
     @Override
-    public void visitMethodNotCompiled(Method method, int failedIRRules) {
-        appendIRMethodHeader(method, failedIRRules);
+    public void visitLeaf(NotCompiledIRMethodMatchResult result) {
+        appendIRMethodHeader(result.method(), result.irRuleCount());
         indentation.add();
         msg.append(indentation)
            .append("* Method was not compiled. Did you specify a @Run method in STANDALONE mode? In this case, make " +
@@ -99,24 +90,57 @@ public class FailureMessageBuilder implements MatchResultVisitor {
         indentation.sub();
     }
 
-    public void visitMethodNotCompilable(Method method, int failedIRRules) {
-        throw new TestFrameworkException("Sould not reach here");
+    private void appendIRMethodHeader(Method method, int failedIrRuleCount) {
+        methodIndex++;
+        indentation = new Indentation(digitCount(methodIndex));
+        if (methodIndex > 1) {
+            msg.append(System.lineSeparator());
+        }
+        msg.append(methodIndex).append(") ");
+        msg.append("Method \"")
+           .append(method.getDeclaringClass().getTypeName()).append("::").append(method.getName())
+           .append("\" - [Failed IR rules: ").append(failedIrRuleCount).append("]:")
+           .append(System.lineSeparator());
     }
 
     @Override
-    public void visitIRRule(AcceptChildren acceptChildren, int irRuleId, IR irAnno) {
+    public void visitLeaf(NotCompilableIRMethodMatchResult result) {
+        throw new TestFrameworkException("Should not reach here");
+    }
+
+    @Override
+    public void enter(IRRuleMatchResult result) {
         indentation.add();
-        msg.append(indentation).append("* @IR rule ").append(irRuleId).append(": \"")
-           .append(irAnno).append("\"").append(System.lineSeparator());
-        acceptChildren.accept(this);
+        msg.append(indentation).append("* @IR rule ").append(result.irRuleId()).append(": \"")
+           .append(result.irAnno()).append("\"").append(System.lineSeparator());
+    }
+
+    @Override
+    public void leave(IRRuleMatchResult result) {
         indentation.sub();
     }
 
     @Override
-    public void visitCompilePhaseIRRule(AcceptChildren acceptChildren, CompilePhase compilePhase, String compilationOutput) {
+    public void enter(CompilePhaseIRRuleMatchResult result) {
         indentation.add();
-        appendCompilePhaseIRRule(compilePhase);
-        acceptChildren.accept(this);
+        appendCompilePhaseIRRule(result.compilePhase());
+    }
+
+    @Override
+    public void leave(CompilePhaseIRRuleMatchResult result) {
+        indentation.sub();
+    }
+
+    @Override
+    public void visitLeaf(CompilePhaseNoCompilationIRRuleMatchResult result) {
+        indentation.add();
+        appendCompilePhaseIRRule(result.compilePhase());
+        indentation.add();
+        msg.append(indentation)
+           .append("- NO compilation output found for this phase! Make sure this phase is emitted or remove it from ")
+           .append("the list of compile phases in the @IR rule to match on.")
+           .append(System.lineSeparator());
+        indentation.sub();
         indentation.sub();
     }
 
@@ -127,20 +151,8 @@ public class FailureMessageBuilder implements MatchResultVisitor {
     }
 
     @Override
-    public void visitNoCompilePhaseCompilation(CompilePhase compilePhase) {
-        indentation.add();
-        appendCompilePhaseIRRule(compilePhase);
-        indentation.add();
-        msg.append(indentation)
-           .append("- NO compilation output found for this phase! Make sure this phase is emitted or remove it from ")
-           .append("the list of compile phases in the @IR rule to match on.")
-           .append(System.lineSeparator());
-        indentation.sub();
-        indentation.sub();
-    }
-
-    @Override
-    public void visitCheckAttribute(AcceptChildren acceptChildren, CheckAttributeType checkAttributeType) {
+    public void enter(CheckAttributeMatchResult result) {
+        CheckAttributeType checkAttributeType = result.checkAttributeType();
         indentation.add();
         String checkAttributeFailureMsg;
         switch (checkAttributeType) {
@@ -151,15 +163,18 @@ public class FailureMessageBuilder implements MatchResultVisitor {
         }
         msg.append(indentation).append("- ").append(checkAttributeFailureMsg)
            .append(":").append(System.lineSeparator());
-        acceptChildren.accept(this);
+    }
+
+    @Override
+    public void leave(CheckAttributeMatchResult result) {
         indentation.sub();
     }
 
     @Override
-    public void visitFailOnConstraint(FailOnConstraintFailure matchResult) {
+    public void visitLeaf(FailOnConstraintFailure result) {
         indentation.add();
         ConstraintFailureMessageBuilder constrainFailureMessageBuilder =
-                new ConstraintFailureMessageBuilder(matchResult, indentation);
+                new ConstraintFailureMessageBuilder(result, indentation);
         String failureMessage = constrainFailureMessageBuilder.buildConstraintHeader() +
                                 constrainFailureMessageBuilder.buildMatchedNodesMessage("Matched forbidden");
         msg.append(failureMessage);
@@ -167,9 +182,9 @@ public class FailureMessageBuilder implements MatchResultVisitor {
     }
 
     @Override
-    public void visitCountsConstraint(CountsConstraintFailure matchResult) {
+    public void visitLeaf(CountsConstraintFailure result) {
         indentation.add();
-        msg.append(new CountsConstraintFailureMessageBuilder(matchResult, indentation).build());
+        msg.append(new CountsConstraintFailureMessageBuilder(result, indentation).build());
         indentation.sub();
     }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/visitor/MatchResultVisitor.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/visitor/MatchResultVisitor.java
@@ -66,7 +66,7 @@ import java.util.function.Consumer;
  *   </li>
  *   <li>
  *     {@link #visitLeaf} on {@link LeafMatchResult}s that do not have any sub results. This interface provides
- *     an empty default implementation. Override {link #visitLeaf} to specify a different behavior.
+ *     an empty default implementation. Override {@link #visitLeaf} to specify a different behavior.
  *   </li>
  * </ol>
  */

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/visitor/MatchResultVisitor.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/visitor/MatchResultVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,28 +23,133 @@
 
 package compiler.lib.ir_framework.driver.irmatching.visitor;
 
-import compiler.lib.ir_framework.CompilePhase;
-import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.driver.irmatching.LeafMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
-import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.CheckAttributeType;
+import compiler.lib.ir_framework.driver.irmatching.TestClassMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.IRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompilableIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompiledIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.IRRuleMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.CheckAttributeMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.CountsConstraintFailure;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.FailOnConstraintFailure;
+import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseIRRuleMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseNoCompilationIRRuleMatchResult;
 
-import java.lang.reflect.Method;
+import java.util.function.Consumer;
 
 /**
  * This interface specifies visit methods for each {@link MatchResult} class must be implemented a by a concrete visitor.
+ *
+ * <p>
+ * There are two kinds of visits:
+ *
+ * <ol>
+ *   <li>
+ *     {@link #visit} on {@link MatchResult}s that can have one or more sub results. This interface provides the following
+ *     default implementation for them (directly override this method when you do not want to visit sub results later):
+ *     <ol>
+ *       <li>
+ *         {@link #enter}: First called to visit the current {@link MatchResult} before visiting sub results. Override
+ *                         this method to specify behavior at this stage. Afterward, the sub results will be visited.
+ *                         By default, this method does nothing.
+ *       </li>
+ *       <li>
+ *         {@link #visitSubResults}: Called after {@link #enter} to visit the sub results. This should not be overridden.
+ *       </li>
+ *       <li>
+ *         {@link #leave}: After visiting the sub results, this method is called to visit the current {@link MatchResult}
+ *                         again to do some post work. Override this method to specify behavior at this stage.
+ *                         By default, this method does nothing.
+ *       </li>
+ *     </ol>
+ *   </li>
+ *   <li>
+ *     {@link #visitLeaf} on {@link LeafMatchResult}s that do not have any sub results. This interface provides
+ *     an empty default implementation. Override {link #visitLeaf} to specify a different behavior.
+ *   </li>
+ * </ol>
  */
 public interface MatchResultVisitor {
-    void visitTestClass(AcceptChildren acceptChildren);
-    void visitIRMethod(AcceptChildren acceptChildren, Method method, int failedIRRules);
-    void visitMethodNotCompiled(Method method, int failedIRRules);
-    void visitMethodNotCompilable(Method method, int failedIRRules);
-    void visitIRRule(AcceptChildren acceptChildren, int irRuleId, IR irAnno);
-    void visitCompilePhaseIRRule(AcceptChildren acceptChildren, CompilePhase compilePhase, String compilationOutput);
-    void visitNoCompilePhaseCompilation(CompilePhase compilePhase);
-    void visitCheckAttribute(AcceptChildren acceptChildren, CheckAttributeType checkAttributeType);
-    void visitFailOnConstraint(FailOnConstraintFailure failOnConstraintFailure);
-    void visitCountsConstraint(CountsConstraintFailure countsConstraintFailure);
-}
 
+    /**
+     * Should a result be visited? By default, we only visit failing results. Override this method to change this behavior.
+     */
+    default boolean shouldVisit(MatchResult result) {
+        return result.fail();
+    }
+
+    default void visit(TestClassMatchResult result) {
+        doVisit(result, this::enter, this::leave);
+    }
+
+    default void enter(TestClassMatchResult result) {}
+    default void leave(TestClassMatchResult result) {}
+
+    default void visit(IRMethodMatchResult result) {
+        doVisit(result, this::enter, this::leave);
+    }
+
+    default void enter(IRMethodMatchResult result) {}
+    default void leave(IRMethodMatchResult result) {}
+
+    default void visit(IRRuleMatchResult result) {
+        doVisit(result, this::enter, this::leave);
+    }
+
+    default void enter(IRRuleMatchResult result) {}
+    default void leave(IRRuleMatchResult result) {}
+
+    default void visit(CompilePhaseIRRuleMatchResult result) {
+        doVisit(result, this::enter, this::leave);
+    }
+
+    default void enter(CompilePhaseIRRuleMatchResult result) {}
+    default void leave(CompilePhaseIRRuleMatchResult result) {}
+
+    default void visit(CheckAttributeMatchResult result) {
+        doVisit(result, this::enter, this::leave);
+    }
+
+    default void enter(CheckAttributeMatchResult result) {}
+    default void leave(CheckAttributeMatchResult result) {}
+
+    /**
+     * Default visit when {@link #visit} is not overridden.
+     *
+     * <p>
+     * Note: Do not override this method.
+     */
+    default <R extends MatchResult> void doVisit(R result, Consumer<R> enter, Consumer<R> leave) {
+        if (!shouldVisit(result)) {
+            return;
+        }
+        enter.accept(result);
+        visitSubResults(result);
+        leave.accept(result);
+    }
+
+    /**
+     * Visit children of {@code result}. This is called when {@link #visit} is not overridden.
+     *
+     * <p>
+     * Note: Do not override this method.
+     */
+    default void visitSubResults(MatchResult result) {
+        for (MatchResult subResult : result.subResults()) {
+            if (shouldVisit(subResult)) {
+                subResult.accept(this);
+            }
+        }
+    }
+
+    /*
+     * Visit methods for LeafMatchResults without sub results.
+     */
+
+    default void visitLeaf(CompilePhaseNoCompilationIRRuleMatchResult result) {}
+    default void visitLeaf(NotCompiledIRMethodMatchResult result) {}
+    default void visitLeaf(NotCompilableIRMethodMatchResult result) {}
+    default void visitLeaf(FailOnConstraintFailure result) {}
+    default void visitLeaf(CountsConstraintFailure result) {}
+}

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -28,11 +28,16 @@ import compiler.lib.ir_framework.driver.FlagVMProcess;
 import compiler.lib.ir_framework.driver.TestVMProcess;
 import compiler.lib.ir_framework.driver.irmatching.MatchResult;
 import compiler.lib.ir_framework.driver.irmatching.Matchable;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.IRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompilableIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irmethod.NotCompiledIRMethodMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.IRRuleMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.CheckAttributeType;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.CountsConstraintFailure;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.FailOnConstraintFailure;
+import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseIRRuleMatchResult;
+import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseNoCompilationIRRuleMatchResult;
 import compiler.lib.ir_framework.driver.irmatching.parser.TestClassParser;
-import compiler.lib.ir_framework.driver.irmatching.visitor.AcceptChildren;
 import compiler.lib.ir_framework.driver.irmatching.visitor.MatchResultVisitor;
 import jdk.test.lib.Asserts;
 
@@ -406,59 +411,46 @@ class FailureBuilder implements MatchResultVisitor {
     }
 
     @Override
-    public void visitTestClass(AcceptChildren acceptChildren) {
-        acceptChildren.accept(this);
+    public void enter(IRMethodMatchResult result) {
+        methodName = result.method().getName();
     }
 
     @Override
-    public void visitIRMethod(AcceptChildren acceptChildren, Method method, int failedIRRules) {
-        methodName = method.getName();
-        acceptChildren.accept(this);
-    }
-
-    @Override
-    public void visitMethodNotCompiled(Method method, int failedIRRules) {
-        methodName = method.getName();
+    public void visitLeaf(NotCompiledIRMethodMatchResult result) {
+        methodName = result.method().getName();
         failures.add(new Failure(methodName, -1, CompilePhase.DEFAULT, CheckAttributeType.FAIL_ON, -1));
     }
 
     @Override
-    public void visitMethodNotCompilable(Method method, int failedIRRules) {
+    public void visitLeaf(NotCompilableIRMethodMatchResult result) {
         throw new RuntimeException("No test should bailout from compilation");
     }
 
     @Override
-    public void visitIRRule(AcceptChildren acceptChildren, int irRuleId, IR irAnno) {
-        ruleId = irRuleId;
-        acceptChildren.accept(this);
+    public void enter(IRRuleMatchResult result) {
+        ruleId = result.irRuleId();
     }
 
     @Override
-    public void visitCompilePhaseIRRule(AcceptChildren acceptChildren, CompilePhase compilePhase, String compilationOutput) {
-        this.compilePhase = compilePhase;
-        acceptChildren.accept(this);
+    public void enter(CompilePhaseIRRuleMatchResult result) {
+        this.compilePhase = result.compilePhase();
     }
 
     @Override
-    public void visitNoCompilePhaseCompilation(CompilePhase compilePhase) {
-        failures.add(new Failure(methodName, ruleId, compilePhase, CheckAttributeType.FAIL_ON, -1));
+    public void visitLeaf(CompilePhaseNoCompilationIRRuleMatchResult result) {
+        failures.add(new Failure(methodName, ruleId, result.compilePhase(), CheckAttributeType.FAIL_ON, -1));
     }
 
     @Override
-    public void visitCheckAttribute(AcceptChildren acceptChildren, CheckAttributeType checkAttributeType) {
-        acceptChildren.accept(this);
-    }
-
-    @Override
-    public void visitFailOnConstraint(FailOnConstraintFailure matchResult) {
+    public void visitLeaf(FailOnConstraintFailure result) {
         failures.add(new Failure(methodName, ruleId, compilePhase, CheckAttributeType.FAIL_ON,
-                                 matchResult.constraintId()));
+                                 result.constraintId()));
     }
 
     @Override
-    public void visitCountsConstraint(CountsConstraintFailure matchResult) {
+    public void visitLeaf(CountsConstraintFailure result) {
         failures.add(new Failure(methodName, ruleId, compilePhase, CheckAttributeType.COUNTS,
-                                 matchResult.constraintId()));
+                                 result.constraintId()));
     }
 }
 


### PR DESCRIPTION
This patch applies various clean-ups split of from a new approach to tackle [JDK-8343659](https://bugs.openjdk.org/browse/JDK-8343659). In the initial review (https://github.com/openjdk/jdk/pull/30982), some improvements were suggested which I try to incorporate now. This required quite some more changes which is why I now split the work into three sub tasks, this being the first one, to ease the review.

The main clean-ups are:
- Removing `AcceptChildren` to simplify the `MatchResultVisitor`: 
  - We now provide `enter()`, `leave()` to do some pre and post work for visiting sub results.
  - Directly operate on `MatchResult` instead of passing in its field directly into the visit methods. This allows us to simplify the `MatchResult` classes to simple records. 
- Turn `List<MatchResult>` into an own `SubResults` class.
- Introduce `LeafMatchResult` for `MatchResult` classes without further sub results.

There are no semantic changes. More PR comments can be found at the changes.

Thanks,
Christian
 
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388432](https://bugs.openjdk.org/browse/JDK-8388432): [IR Framework] Various clean-ups in preparation for skipping IR tests and IR rules (**Sub-task** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31949/head:pull/31949` \
`$ git checkout pull/31949`

Update a local copy of the PR: \
`$ git checkout pull/31949` \
`$ git pull https://git.openjdk.org/jdk.git pull/31949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31949`

View PR using the GUI difftool: \
`$ git pr show -t 31949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31949.diff">https://git.openjdk.org/jdk/pull/31949.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31949#issuecomment-5003122319)
</details>
