### PR TITLE
8388030: Provide configure option to disable build of libjsound

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -95,6 +95,13 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_OPEN_OR_CUSTOM],
 
 AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
 [
+  # Should we build a JDK with/without sound ?
+  UTIL_ARG_ENABLE(NAME: jsound, DEFAULT: true,
+      RESULT: ENABLE_JSOUND,
+      DESC: [build with sound support],
+      CHECKING_MSG: [if we should build with sound support])
+  AC_SUBST(ENABLE_JSOUND)
+
   # Should we build a JDK without a graphical UI?
   UTIL_ARG_ENABLE(NAME: headless-only, DEFAULT: false,
       RESULT: ENABLE_HEADLESS_ONLY,

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -329,6 +329,8 @@ HOTSPOT_OVERRIDE_LIBPATH := @HOTSPOT_OVERRIDE_LIBPATH@
 # Control use of precompiled header in hotspot libjvm build
 USE_PRECOMPILED_HEADER := @USE_PRECOMPILED_HEADER@
 
+ENABLE_JSOUND := @ENABLE_JSOUND@
+
 # Only build headless support or not
 ENABLE_HEADLESS_ONLY := @ENABLE_HEADLESS_ONLY@
 

--- a/make/modules/java.desktop/Lib.gmk
+++ b/make/modules/java.desktop/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ $(call FillFindCache, $(wildcard $(TOPDIR)/src/java.desktop/*/native))
 include lib/AwtLibraries.gmk
 include lib/ClientLibraries.gmk
 
+ifeq ($(ENABLE_JSOUND), true)
 ifeq ($(call isTargetOs, aix), false)
   ##############################################################################
   # Build libjsound
@@ -80,6 +81,7 @@ ifeq ($(call isTargetOs, aix), false)
   ))
 
   TARGETS += $(BUILD_LIBJSOUND)
+endif
 endif
 
 ifeq ($(call isTargetOs, macosx), true)

--- a/make/modules/java.desktop/Lib.gmk
+++ b/make/modules/java.desktop/Lib.gmk
@@ -38,50 +38,50 @@ include lib/AwtLibraries.gmk
 include lib/ClientLibraries.gmk
 
 ifeq ($(ENABLE_JSOUND), true)
-ifeq ($(call isTargetOs, aix), false)
-  ##############################################################################
-  # Build libjsound
-  ##############################################################################
+  ifeq ($(call isTargetOs, aix), false)
+    ##############################################################################
+    # Build libjsound
+    ##############################################################################
 
-  LIBJSOUND_CFLAGS := \
-      $(ALSA_CFLAGS) \
-      -DX_PLATFORM=X_$(OPENJDK_TARGET_OS_UPPERCASE) \
-      -DUSE_PORTS=TRUE \
-      -DUSE_DAUDIO=TRUE \
-      -DUSE_PLATFORM_MIDI_OUT=TRUE \
-      -DUSE_PLATFORM_MIDI_IN=TRUE \
-      #
+    LIBJSOUND_CFLAGS := \
+        $(ALSA_CFLAGS) \
+        -DX_PLATFORM=X_$(OPENJDK_TARGET_OS_UPPERCASE) \
+        -DUSE_PORTS=TRUE \
+        -DUSE_DAUDIO=TRUE \
+        -DUSE_PLATFORM_MIDI_OUT=TRUE \
+        -DUSE_PLATFORM_MIDI_IN=TRUE \
+        #
 
-  LIBJSOUND_LINK_TYPE := C
-  ifeq ($(call isTargetOs, macosx), true)
-    LIBJSOUND_LINK_TYPE := C++
+    LIBJSOUND_LINK_TYPE := C
+    ifeq ($(call isTargetOs, macosx), true)
+      LIBJSOUND_LINK_TYPE := C++
+    endif
+
+    $(eval $(call SetupJdkLibrary, BUILD_LIBJSOUND, \
+        NAME := jsound, \
+        LINK_TYPE := $(LIBJSOUND_LINK_TYPE), \
+        OPTIMIZATION := LOW, \
+        EXTRA_HEADER_DIRS := java.base:libjava, \
+        CFLAGS := $(LIBJSOUND_CFLAGS), \
+        CXXFLAGS := $(LIBJSOUND_CFLAGS), \
+        DISABLED_WARNINGS_gcc := undef unused-variable, \
+        DISABLED_WARNINGS_clang := undef unused-variable, \
+        DISABLED_WARNINGS_clang_PLATFORM_API_MacOSX_MidiUtils.c := \
+            unused-but-set-variable, \
+        DISABLED_WARNINGS_clang_DirectAudioDevice.c := unused-function, \
+        LIBS_linux := $(ALSA_LIBS), \
+        LIBS_macosx := \
+            -framework AudioToolbox \
+            -framework AudioUnit \
+            -framework CoreAudio \
+            -framework CoreFoundation \
+            -framework CoreMIDI \
+            -framework CoreServices, \
+        LIBS_windows := advapi32.lib dsound.lib ole32.lib user32.lib winmm.lib, \
+    ))
+
+    TARGETS += $(BUILD_LIBJSOUND)
   endif
-
-  $(eval $(call SetupJdkLibrary, BUILD_LIBJSOUND, \
-      NAME := jsound, \
-      LINK_TYPE := $(LIBJSOUND_LINK_TYPE), \
-      OPTIMIZATION := LOW, \
-      EXTRA_HEADER_DIRS := java.base:libjava, \
-      CFLAGS := $(LIBJSOUND_CFLAGS), \
-      CXXFLAGS := $(LIBJSOUND_CFLAGS), \
-      DISABLED_WARNINGS_gcc := undef unused-variable, \
-      DISABLED_WARNINGS_clang := undef unused-variable, \
-      DISABLED_WARNINGS_clang_PLATFORM_API_MacOSX_MidiUtils.c := \
-          unused-but-set-variable, \
-      DISABLED_WARNINGS_clang_DirectAudioDevice.c := unused-function, \
-      LIBS_linux := $(ALSA_LIBS), \
-      LIBS_macosx := \
-          -framework AudioToolbox \
-          -framework AudioUnit \
-          -framework CoreAudio \
-          -framework CoreFoundation \
-          -framework CoreMIDI \
-          -framework CoreServices, \
-      LIBS_windows := advapi32.lib dsound.lib ole32.lib user32.lib winmm.lib, \
-  ))
-
-  TARGETS += $(BUILD_LIBJSOUND)
-endif
 endif
 
 ifeq ($(call isTargetOs, macosx), true)


### PR DESCRIPTION
Currently we have no configure option to disable the build of libjsound, so we always try to build it and need the related dependencies.
an exception is AIX where we have the build disabled; it might make sense to offer a configure option to disable the jsound build e.g. to build a headless jdk for container envs where we do not have sound (the JCK offers options to have a JDK without sound).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388030](https://bugs.openjdk.org/browse/JDK-8388030): Provide configure option to disable build of libjsound (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [6dc16f38](https://git.openjdk.org/jdk/pull/31951/files/6dc16f380e5cdd677d11498219771211c68d6beb)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Arno Zeller](https://openjdk.org/census#azeller) (@ArnoZeller - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31951/head:pull/31951` \
`$ git checkout pull/31951`

Update a local copy of the PR: \
`$ git checkout pull/31951` \
`$ git pull https://git.openjdk.org/jdk.git pull/31951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31951`

View PR using the GUI difftool: \
`$ git pr show -t 31951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31951.diff">https://git.openjdk.org/jdk/pull/31951.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31951#issuecomment-5022244494)
</details>
