### PR TITLE
8388183: Wrong example in documentation for String.toLowerCase()

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4062,7 +4062,7 @@ public final class String
      *   <td>(all)</td>
      *   <th scope="row" style="font-weight:normal; text-align:left">
      *       &Iota;&Chi;&Theta;&Upsilon;&Sigma;</th>
-     *   <td>&iota;&chi;&theta;&upsilon;&sigma;</td>
+     *   <td>&iota;&chi;&theta;&upsilon;&sigmaf;</td>
      *   <td>lowercased all chars in String</td>
      * </tr>
      * </tbody>


### PR DESCRIPTION
Backport to JDK27

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388183](https://bugs.openjdk.org/browse/JDK-8388183): Wrong example in documentation for String.toLowerCase() (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31953/head:pull/31953` \
`$ git checkout pull/31953`

Update a local copy of the PR: \
`$ git checkout pull/31953` \
`$ git pull https://git.openjdk.org/jdk.git pull/31953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31953`

View PR using the GUI difftool: \
`$ git pr show -t 31953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31953.diff">https://git.openjdk.org/jdk/pull/31953.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31953#issuecomment-5008586824)
</details>
