### PR TITLE
8388456: RISC-V: Add UseZvbb to RVA23U64Profile

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -445,6 +445,7 @@ private:
     RV_ENABLE_EXTENSION(UseZicond)                  \
     RV_ENABLE_EXTENSION(UseZihintpause)             \
     RV_ENABLE_EXTENSION(UseZvfhmin)                 \
+    RV_ENABLE_EXTENSION(UseZvbb)                    \
 
   static void useRVA23U64Profile();
 


### PR DESCRIPTION
Hi, please consider,

Zvbb (Vector basic bit-manipulation) is a mandatory extension of the RVA23U64 profile (see rva23-profile.adoc[1]), but it is currently missing from the RV_USE_RVA23U64 macro. As a result, even on hardware that supports Zvbb, and even when the user explicitly enables -XX:+UseRVA23U64, the UseZvbb flag is not turned on.
This change adds RV_ENABLE_EXTENSION(UseZvbb) to the RV_USE_RVA23U64 macro so that useRVA23U64Profile() enables Zvbb in line with the RVA23U64 specification.
[1] https://github.com/riscv/riscv-profiles/blob/main/src/rva23-profile.adoc#rva23u64-mandatory-extensions

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388456](https://bugs.openjdk.org/browse/JDK-8388456): RISC-V: Add UseZvbb to RVA23U64Profile (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Anjian Wen](https://openjdk.org/census#wenanjian) (@Anjian-Wen - Committer)

### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31954/head:pull/31954` \
`$ git checkout pull/31954`

Update a local copy of the PR: \
`$ git checkout pull/31954` \
`$ git pull https://git.openjdk.org/jdk.git pull/31954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31954`

View PR using the GUI difftool: \
`$ git pr show -t 31954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31954.diff">https://git.openjdk.org/jdk/pull/31954.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31954#issuecomment-5009742404)
</details>
