### PR TITLE
8388457: parse_integer: typo in hex prefix detection causes out-of-bounds read and wrong base for negative hex

### DIFF
--- a/src/hotspot/share/utilities/parseInteger.hpp
+++ b/src/hotspot/share/utilities/parseInteger.hpp
@@ -124,7 +124,7 @@ static bool parse_integer(const char *s, char **endptr, T* result) {
 
   T n = 0;
   bool is_hex = (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) ||
-                (s[0] == '-' && s[1] == '0' && (s[2] == 'x' || s[3] == 'X'));
+                (s[0] == '-' && s[1] == '0' && (s[2] == 'x' || s[2] == 'X'));
   char* remainder;
 
   if (!parse_integer_impl<T>(s, &remainder, (is_hex ? 16 : 10), &n)) {

--- a/test/hotspot/gtest/utilities/test_parse_memory_size.cpp
+++ b/test/hotspot/gtest/utilities/test_parse_memory_size.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -23,6 +23,7 @@
  */
 
 #include "jvm_io.h"
+#include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
@@ -155,4 +156,70 @@ TEST(ParseMemorySize, negatives_both) {
 
   do_test_invalid_for_parse_arguments("100 M"); // parse_memory_size would see "100", parse_argument_memory_size would reject it
   do_test_invalid_for_parse_arguments("100X");  // parse_memory_size would see "100", parse_argument_memory_size would reject it
+}
+
+// Hex prefix handling for negative numbers. Only signed types are covered here:
+// parse_integer_impl() refuses a leading '-' for unsigned types before the base
+// is ever used.
+
+template <typename T>
+static void test_negative_hex_prefix() {
+  T value = 17;
+  char* end = nullptr;
+
+  // Both spellings of the prefix must be recognized, just as "0x"/"0X" are for
+  // positive numbers.
+  ASSERT_TRUE(parse_integer("-0x10", &end, &value));
+  ASSERT_EQ(value, (T)-16);
+  EXPECT_STREQ(end, "");
+
+  ASSERT_TRUE(parse_integer("-0X10", &end, &value));
+  ASSERT_EQ(value, (T)-16);
+  EXPECT_STREQ(end, "");
+
+  ASSERT_TRUE(parse_integer("-0xff", &end, &value));
+  ASSERT_EQ(value, (T)-255);
+
+  ASSERT_TRUE(parse_integer("-0XFF", &end, &value));
+  ASSERT_EQ(value, (T)-255);
+
+  // A unit suffix still applies after a negative hex number.
+  ASSERT_TRUE(parse_integer("-0X10k", &end, &value));
+  ASSERT_EQ(value, (T)(-16 * K));
+  EXPECT_STREQ(end, "");
+
+  // "-0" is decimal; the character after the '0' decides, and here there is
+  // none. The value is zero either way, but see minus_zero_no_overread below.
+  ASSERT_TRUE(parse_integer("-0", &end, &value));
+  ASSERT_EQ(value, (T)0);
+  EXPECT_STREQ(end, "");
+
+  // Not a hex prefix: 'f' is not 'x'/'X', so this is decimal "-0" with "fX"
+  // left over, not hex "-0f".
+  value = 17;
+  ASSERT_TRUE(parse_integer("-0fX", &end, &value));
+  ASSERT_EQ(value, (T)0);
+  EXPECT_STREQ(end, "fX");
+  ASSERT_FALSE(parse_integer("-0fX", &value));
+}
+
+TEST(ParseMemorySize, negative_hex_prefix) {
+  test_negative_hex_prefix<int64_t>();
+  test_negative_hex_prefix<int32_t>();
+}
+
+// "-0" holds just two characters plus the terminating NUL, so hex prefix
+// detection must stop at the NUL rather than read the character beyond it.
+// The string is copied into a tightly sized allocation so that an over-read
+// is caught when running under a memory checker such as ASan.
+TEST(ParseMemorySize, minus_zero_no_overread) {
+  char* s = os::strdup("-0", mtTest);
+  int64_t value = 17;
+  char* end = nullptr;
+
+  ASSERT_TRUE(parse_integer(s, &end, &value));
+  ASSERT_EQ(value, (int64_t)0);
+  EXPECT_STREQ(end, "");
+
+  os::free(s);
 }


### PR DESCRIPTION
Found while auditing the -XX size-argument parsing helpers.

parse_integer misdetects a hexadecimal prefix on negative numbers because of a single-character index typo: the check inspects the character one position too far along the string. This has two consequences. First, for the input "-0" it reads one byte past the end of the string, an out-of-bounds read confirmed under AddressSanitizer. Second, a negative upper-case hex value such as -0X10 is not recognised as hexadecimal, so it is parsed as decimal and yields the wrong result.

The fix inspects the correct character. The typo dates back to JDK-8293711, which factored these helpers out of arguments.cpp.

Added negative-hex coverage to the parse_memory_size gtest, which previously had none.

Additional testing:
- [x] gtest passes with the fix on linux-x86_64 fastdebug, and fails without it
- [ ] Regular tier1 pipelines

-------------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388457](https://bugs.openjdk.org/browse/JDK-8388457): parse_integer: typo in hex prefix detection causes out-of-bounds read and wrong base for negative hex (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31957/head:pull/31957` \
`$ git checkout pull/31957`

Update a local copy of the PR: \
`$ git checkout pull/31957` \
`$ git pull https://git.openjdk.org/jdk.git pull/31957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31957`

View PR using the GUI difftool: \
`$ git pr show -t 31957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31957.diff">https://git.openjdk.org/jdk/pull/31957.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31957#issuecomment-5010013645)
</details>
