### PR TITLE
8388459: RISC-V: Add specialized CMove patterns with zero operand

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10405,7 +10405,7 @@ instruct cmovI_cmpN_zero(iRegINoSp dst, immI0 src, iRegN op1, iRegN op2, cmpOpU 
   match(Set dst (CMoveI (Binary cop (CmpN op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
 
-  format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr #@cmovI_cmpN_zero" %}
+  format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr\t#@cmovI_cmpN_zero" %}
 
   ins_encode %{
     __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
@@ -10420,7 +10420,7 @@ instruct cmovI_cmpP_zero(iRegINoSp dst, immI0 src, iRegP op1, iRegP op2, cmpOpU 
   match(Set dst (CMoveI (Binary cop (CmpP op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
 
-  format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr #@cmovI_cmpP_zero" %}
+  format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr\t#@cmovI_cmpP_zero" %}
 
   ins_encode %{
     __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10401,6 +10401,36 @@ instruct cmovI_cmpU_zero(iRegINoSp dst, immI0 src, iRegI op1, iRegI op2, cmpOpU 
   ins_pipe(pipe_class_compare);
 %}
 
+instruct cmovI_cmpN_zero(iRegINoSp dst, immI0 src, iRegN op1, iRegN op2, cmpOpU cop) %{
+  match(Set dst (CMoveI (Binary cop (CmpN op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST * 2);
+
+  format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr #@cmovI_cmpN_zero" %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), zr);
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
+instruct cmovI_cmpP_zero(iRegINoSp dst, immI0 src, iRegP op1, iRegP op2, cmpOpU cop) %{
+  match(Set dst (CMoveI (Binary cop (CmpP op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST * 2);
+
+  format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr #@cmovI_cmpP_zero" %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), zr);
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
 // --------- CMoveL ---------
 
 instruct cmovL_cmpL(iRegLNoSp dst, iRegL src, iRegL op1, iRegL op2, cmpOp cop) %{

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10403,7 +10403,7 @@ instruct cmovI_cmpU_zero(iRegINoSp dst, immI0 src, iRegI op1, iRegI op2, cmpOpU 
 
 instruct cmovI_cmpN_zero(iRegINoSp dst, immI0 src, iRegN op1, iRegN op2, cmpOpU cop) %{
   match(Set dst (CMoveI (Binary cop (CmpN op1 op2)) (Binary dst src)));
-  ins_cost(ALU_COST * 2);
+  ins_cost(ALU_COST + BRANCH_COST);
 
   format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr #@cmovI_cmpN_zero" %}
 
@@ -10418,7 +10418,7 @@ instruct cmovI_cmpN_zero(iRegINoSp dst, immI0 src, iRegN op1, iRegN op2, cmpOpU 
 
 instruct cmovI_cmpP_zero(iRegINoSp dst, immI0 src, iRegP op1, iRegP op2, cmpOpU cop) %{
   match(Set dst (CMoveI (Binary cop (CmpP op1 op2)) (Binary dst src)));
-  ins_cost(ALU_COST * 2);
+  ins_cost(ALU_COST + BRANCH_COST);
 
   format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr #@cmovI_cmpP_zero" %}
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10364,6 +10364,43 @@ instruct cmovI_cmpP(iRegINoSp dst, iRegI src, iRegP op1, iRegP op2, cmpOpU cop) 
   ins_pipe(pipe_class_compare);
 %}
 
+// Special cases where one arg is zero
+// These are selected in preference to the rules above because they
+// avoid loading constant 0 into a source register
+
+// CMoveI (signed compare) with zero as second operand
+// Pattern: dst = cond ? dst : 0 (conditional clear)
+instruct cmovI_cmpI_zero(iRegINoSp dst, immI0 src, iRegI op1, iRegI op2, cmpOp cop) %{
+  match(Set dst (CMoveI (Binary cop (CmpI op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST + BRANCH_COST);
+
+  format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr\t#@cmovI_cmpI_zero" %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), zr);
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
+// CMoveI (unsigned compare) with zero as second operand
+instruct cmovI_cmpU_zero(iRegINoSp dst, immI0 src, iRegI op1, iRegI op2, cmpOpU cop) %{
+  match(Set dst (CMoveI (Binary cop (CmpU op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST + BRANCH_COST);
+
+  format %{ "CMoveI $dst, ($op1 $cop $op2), $dst, zr\t#@cmovI_cmpU_zero" %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), zr);
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
 // --------- CMoveL ---------
 
 instruct cmovL_cmpL(iRegLNoSp dst, iRegL src, iRegL op1, iRegL op2, cmpOp cop) %{
@@ -10497,6 +10534,38 @@ instruct cmovL_cmpP(iRegLNoSp dst, iRegL src, iRegP op1, iRegP op2, cmpOpU cop) 
     __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
                  as_Register($op1$$reg), as_Register($op2$$reg),
                  as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
+// CMoveL (signed compare) with zero as second operand
+instruct cmovL_cmpL_zero(iRegLNoSp dst, immL0 src, iRegL op1, iRegL op2, cmpOp cop) %{
+  match(Set dst (CMoveL (Binary cop (CmpL op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST + BRANCH_COST);
+
+  format %{ "CMoveL $dst, ($op1 $cop $op2), $dst, zr\t#@cmovL_cmpL_zero" %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), zr);
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
+// CMoveL (unsigned compare) with zero as second operand
+instruct cmovL_cmpUL_zero(iRegLNoSp dst, immL0 src, iRegL op1, iRegL op2, cmpOpU cop) %{
+  match(Set dst (CMoveL (Binary cop (CmpUL op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST + BRANCH_COST);
+
+  format %{ "CMoveL $dst, ($op1 $cop $op2), $dst, zr\t#@cmovL_cmpUL_zero" %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), zr);
   %}
 
   ins_pipe(pipe_class_compare);


### PR DESCRIPTION
Hi, this patch adds six specialized CMoveI/CMoveL C2 instruct for the zero-operand case:
cmovI_cmpI_zero, cmovI_cmpU_zero, cmovL_cmpL_zero, cmovL_cmpUL_zero, cmovL_cmpL_zero, cmovL_cmpUL_zero.
These rules pass the hardware zero register (x0/zr) directly to enc_cmove(), avoiding the need to load constant 0 into a register.

### Testing
- [x] Run tier1-tier3 test with release on SpacemiT Key Stone K3
- [x] C2 instruct Opto log:

```
$ qemu-riscv64 -L /home/zifeihan/riscv_toolchain/sysroot \
      build/riscv64-fastdebug/jdk/bin/java \
      -XX:+UnlockDiagnosticVMOptions \
      -XX:+PrintOptoAssembly \
      -version 2>&1 | grep -oP "cmov[ILNP]_cmp\w*_zero\w*" | sort | uniq -c

    103 cmovI_cmpI_zero
```

We can see from the java -version Opto log that the newly added `cmovI_cmpI_zero` is a hot c2 instruct with a relatively high call count.

Without this patch, the C2 Opto log excerpt is as follows:

```
048 +   addw  R28, R28, zr	#@convL2I_reg
04a +   mv R30, #0	# int, #@loadConI
04c +   mv R16, #1	# int, #@loadConI
04e +   addw  R31, R7, zr	#@convI2L_reg_reg
052 +   addi  R10, R29, #-1	#@addL_reg_imm
...
0ba     B19: #	out( B20 ) <- in( B18 B21 ) Loop( B19-B21 ) Freq: 4.99992
0ba     subw  R18, R28, R16	#@subI_reg_reg
0be     CMoveI R18, (R28 lt R16), R18, R30	#@cmovI_cmpI
```

With this patch, the C2 Opto log excerpt is as follows: (Replaced the original `mv R30, #0	# int, #@loadConI` and `cmovI_cmpI` with `cmovI_cmpI_zero`):

```
0b2     subw  R30, R15, R31	#@subI_reg_reg
0b6     CMoveI R30, (R15 lt R31), R30, zr	#@cmovI_cmpI_zero
```

For easier verification, I constructed the following test to validate the other newly added c2 instruct.

```java
import java.util.Random;

public class CMoveZeroTest {

    public static void main(String[] args) {
        Random r = new Random(42);
        int N = 100;
        int[] ia = new int[N], ib = new int[N];
        long[] la = new long[N], lb = new long[N];
        for (int i = 0; i < N; i++) {
            ia[i] = r.nextInt();
            ib[i] = r.nextInt();
            la[i] = r.nextLong();
            lb[i] = r.nextLong();
        }

        long sum = 0;
        for (int iter = 0; iter < 50000; iter++) {
            sum += testIntSignedClamp(ia, ib, N);
            sum += testIntUnsignedClamp(ia, ib, N);
            sum += testLongSignedClamp(la, lb, N);
            sum += testLongUnsignedClamp(la, lb, N);
        }
        System.out.println("sum=" + sum);
    }

    static int testIntSignedClamp(int[] a, int[] b, int n) {
        int sum = 0;
        for (int i = 0; i < n; i++) {
            int diff = a[i] - b[i];
            if (diff < 0) diff = 0;
            sum += diff;
        }
        return sum;
    }

    static int testIntUnsignedClamp(int[] a, int[] b, int n) {
        int sum = 0;
        for (int i = 0; i < n; i++) {
            int x = a[i];
            int y = b[i];
            int diff = x - y;
            if (Integer.compareUnsigned(x, y) < 0) diff = 0;
            sum += diff;
        }
        return sum;
    }

    static long testLongSignedClamp(long[] a, long[] b, int n) {
        long sum = 0;
        for (int i = 0; i < n; i++) {
            long diff = a[i] - b[i];
            if (diff < 0L) diff = 0L;
            sum += diff;
        }
        return sum;
    }

    static long testLongUnsignedClamp(long[] a, long[] b, int n) {
        long sum = 0;
        for (int i = 0; i < n; i++) {
            long x = a[i];
            long y = b[i];
            long diff = x - y;
            if (Long.compareUnsigned(x, y) < 0) diff = 0L;
            sum += diff;
        }
        return sum;
    }
}
```

Opto log result:

```
$ qemu-riscv64 -L /home/zifeihan/riscv_toolchain/sysroot \
    build/riscv64-fastdebug/jdk/bin/java \
    -XX:+UnlockDiagnosticVMOptions \
    -XX:+PrintOptoAssembly \
    '-XX:CompileCommand=dontinline,CMoveZeroTest::test*' \
    CMoveZeroTest 2>&1 | grep -oP "cmov[IL]_cmp\w*_zero\b" | sort | uniq -c

    127 cmovI_cmpI_zero
     10 cmovI_cmpU_zero
     20 cmovL_cmpL_zero
     10 cmovL_cmpUL_zero
```

```
import java.util.Random;

public class CMoveZeroCmpObjTest {

    public static void main(String[] args) {
        int N = 100;
        Random r = new Random(42);
        Object[] a = new Object[N], b = new Object[N];
        int[] c = new int[N];
        for (int i = 0; i < N; i++) {
            a[i] = new Object();
            b[i] = (i % 3 == 0) ? a[i] : new Object();
            c[i] = r.nextInt() | 1;
        }

        long sum = 0;
        for (int iter = 0; iter < 50000; iter++) {
            sum += testCmpObjEQ(a, b, c, N);
            sum += testCmpObjNE(a, b, c, N);
        }
        System.out.println("sum=" + sum);
    }

    public static int testCmpObjEQ(Object[] a, Object[] b, int[] c, int n) {
        int sum = 0;
        for (int i = 0; i < n; i++) {
            int x = c[i];
            if (a[i] == b[i]) x = 0;
            sum += x;
        }
        return sum;
    }

    public static int testCmpObjNE(Object[] a, Object[] b, int[] c, int n) {
        int sum = 0;
        for (int i = 0; i < n; i++) {
            int x = c[i];
            if (a[i] != b[i]) x = 0;
            sum += x;
        }
        return sum;
    }
}

```
Opto log result:
```
[zifeihan@localhost bin]$ ./java -XX:+UseCompressedOops -XX:+UnlockDiagnosticVMOptions -XX:+PrintOptoAssembly CMoveZeroCmpObjTest | grep cmovI_cmpN_zero
15a     CMoveI R31, (R14 eq R10), R31, zr #@cmovI_cmpN_zero
23e     CMoveI R21, (R31 eq R11), R21, zr #@cmovI_cmpN_zero
25a     CMoveI R31, (R29 eq R11), R31, zr #@cmovI_cmpN_zero


[zifeihan@localhost bin]$ ./java -XX:-UseCompressedOops -XX:+UnlockDiagnosticVMOptions -XX:+PrintOptoAssembly CMoveZeroCmpObjTest | grep cmovI_cmpP_zero
15a     CMoveI R16, (R8 eq R30), R16, zr #@cmovI_cmpP_zero
240     CMoveI R11, (R12 eq R10), R11, zr #@cmovI_cmpP_zero
25c     CMoveI R10, (R13 eq R12), R10, zr #@cmovI_cmpP_zero
```



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388459](https://bugs.openjdk.org/browse/JDK-8388459): RISC-V: Add specialized CMove patterns with zero operand (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Anjian Wen](https://openjdk.org/census#wenanjian) (@Anjian-Wen - Committer)

### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31958/head:pull/31958` \
`$ git checkout pull/31958`

Update a local copy of the PR: \
`$ git checkout pull/31958` \
`$ git pull https://git.openjdk.org/jdk.git pull/31958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31958`

View PR using the GUI difftool: \
`$ git pr show -t 31958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31958.diff">https://git.openjdk.org/jdk/pull/31958.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31958#issuecomment-5010038650)
</details>
