### PR TITLE
8387967: RISC-V: Optimize compare-to-int with branch-free implementation

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -6555,34 +6555,21 @@ void MacroAssembler::cmp_x2i(Register dst, Register src1, Register src2,
     mv(dst, zr);
     return;
   }
-  Label done;
-  Register left = src1;
-  Register right = src2;
-  if (dst == src1) {
-    assert_different_registers(dst, src2, tmp);
-    mv(tmp, src1);
-    left = tmp;
-  } else if (dst == src2) {
-    assert_different_registers(dst, src1, tmp);
-    mv(tmp, src2);
-    right = tmp;
-  }
 
-  // installs 1 if gt else 0
+  // dst = (src1 > src2) - (src1 < src2)
+  assert(tmp != dst, "tmp must be different from dst");
+  assert(tmp != src1, "tmp must be different from src1");
+  assert(tmp != src2, "tmp must be different from src2");
+
   if (is_signed) {
-    slt(dst, right, left);
+    slt(tmp, src2, src1);
+    slt(dst, src1, src2);
   } else {
-    sltu(dst, right, left);
+    sltu(tmp, src2, src1);
+    sltu(dst, src1, src2);
   }
-  bnez(dst, done);
-  if (is_signed) {
-    slt(dst, left, right);
-  } else {
-    sltu(dst, left, right);
-  }
-  // dst = -1 if lt; else if eq , dst = 0
   neg(dst, dst);
-  bind(done);
+  add(dst, tmp, dst);
 }
 
 void MacroAssembler::cmp_l2i(Register dst, Register src1, Register src2, Register tmp)

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -6557,9 +6557,8 @@ void MacroAssembler::cmp_x2i(Register dst, Register src1, Register src2,
   }
 
   // dst = (src1 > src2) - (src1 < src2)
-  assert(tmp != dst, "tmp must be different from dst");
-  assert(tmp != src1, "tmp must be different from src1");
-  assert(tmp != src2, "tmp must be different from src2");
+  assert_different_registers(tmp, dst);
+  assert_different_registers(tmp, src1, src2);
 
   if (is_signed) {
     slt(tmp, src2, src1);
@@ -6568,8 +6567,7 @@ void MacroAssembler::cmp_x2i(Register dst, Register src1, Register src2,
     sltu(tmp, src2, src1);
     sltu(dst, src1, src2);
   }
-  neg(dst, dst);
-  add(dst, tmp, dst);
+  sub(dst, tmp, dst);
 }
 
 void MacroAssembler::cmp_l2i(Register dst, Register src1, Register src2, Register tmp)

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -9272,16 +9272,14 @@ instruct cmpL3_reg_reg(iRegINoSp dst, iRegL op1, iRegL op2)
 %{
   match(Set dst (CmpL3 op1 op2));
 
-  ins_cost(ALU_COST * 3 + BRANCH_COST);
-  format %{ "slt   $dst, $op2, $op1\t#@cmpL3_reg_reg\n\t"
-            "bnez  $dst, done\n\t"
-            "slt   $dst, $op1, $op2\n\t"
+  ins_cost(ALU_COST * 4);
+  format %{ "slt   t0, $op2, $op1\t# gt\n\t"
+            "slt   $dst, $op1, $op2\t# lt\n\t"
             "neg   $dst, $dst\n\t"
-            "done:"
+            "add   $dst, t0, $dst\t#@cmpL3_reg_reg (branch-free)"
   %}
   ins_encode %{
-    __ cmp_l2i(t0, as_Register($op1$$reg), as_Register($op2$$reg));
-    __ mv(as_Register($dst$$reg), t0);
+    __ cmp_l2i(as_Register($dst$$reg), as_Register($op1$$reg), as_Register($op2$$reg));
   %}
 
   ins_pipe(pipe_class_default);
@@ -9291,16 +9289,14 @@ instruct cmpUL3_reg_reg(iRegINoSp dst, iRegL op1, iRegL op2)
 %{
   match(Set dst (CmpUL3 op1 op2));
 
-  ins_cost(ALU_COST * 3 + BRANCH_COST);
-  format %{ "sltu  $dst, $op2, $op1\t#@cmpUL3_reg_reg\n\t"
-            "bnez  $dst, done\n\t"
-            "sltu  $dst, $op1, $op2\n\t"
+  ins_cost(ALU_COST * 4);
+  format %{ "sltu  t0, $op2, $op1\t# gt\n\t"
+            "sltu  $dst, $op1, $op2\t# lt\n\t"
             "neg   $dst, $dst\n\t"
-            "done:"
+            "add   $dst, t0, $dst\t#@cmpUL3_reg_reg (branch-free)"
   %}
   ins_encode %{
-    __ cmp_ul2i(t0, as_Register($op1$$reg), as_Register($op2$$reg));
-    __ mv(as_Register($dst$$reg), t0);
+    __ cmp_ul2i(as_Register($dst$$reg), as_Register($op1$$reg), as_Register($op2$$reg));
   %}
 
   ins_pipe(pipe_class_default);
@@ -9310,16 +9306,14 @@ instruct cmpU3_reg_reg(iRegINoSp dst, iRegI op1, iRegI op2)
 %{
   match(Set dst (CmpU3 op1 op2));
 
-  ins_cost(ALU_COST * 3 + BRANCH_COST);
-  format %{ "sltu  $dst, $op2, $op1\t#@cmpU3_reg_reg\n\t"
-            "bnez  $dst, done\n\t"
-            "sltu  $dst, $op1, $op2\n\t"
+  ins_cost(ALU_COST * 4);
+  format %{ "sltu  t0, $op2, $op1\t# gt\n\t"
+            "sltu  $dst, $op1, $op2\t# lt\n\t"
             "neg   $dst, $dst\n\t"
-            "done:"
+            "add   $dst, t0, $dst\t#@cmpU3_reg_reg (branch-free)"
   %}
   ins_encode %{
-    __ cmp_uw2i(t0, as_Register($op1$$reg), as_Register($op2$$reg));
-    __ mv(as_Register($dst$$reg), t0);
+    __ cmp_uw2i(as_Register($dst$$reg), as_Register($op1$$reg), as_Register($op2$$reg));
   %}
 
   ins_pipe(pipe_class_default);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -9272,11 +9272,10 @@ instruct cmpL3_reg_reg(iRegINoSp dst, iRegL op1, iRegL op2)
 %{
   match(Set dst (CmpL3 op1 op2));
 
-  ins_cost(ALU_COST * 4);
-  format %{ "slt   t0, $op2, $op1\t# gt\n\t"
-            "slt   $dst, $op1, $op2\t# lt\n\t"
-            "neg   $dst, $dst\n\t"
-            "add   $dst, t0, $dst\t#@cmpL3_reg_reg (branch-free)"
+  ins_cost(ALU_COST * 3);
+  format %{ "slt   t0, $op2, $op1\t#@cmpL3_reg_reg\n\t"
+            "slt   $dst, $op1, $op2\n\t"
+            "sub   $dst, t0, $dst"
   %}
   ins_encode %{
     __ cmp_l2i(as_Register($dst$$reg), as_Register($op1$$reg), as_Register($op2$$reg));
@@ -9289,11 +9288,10 @@ instruct cmpUL3_reg_reg(iRegINoSp dst, iRegL op1, iRegL op2)
 %{
   match(Set dst (CmpUL3 op1 op2));
 
-  ins_cost(ALU_COST * 4);
-  format %{ "sltu  t0, $op2, $op1\t# gt\n\t"
-            "sltu  $dst, $op1, $op2\t# lt\n\t"
-            "neg   $dst, $dst\n\t"
-            "add   $dst, t0, $dst\t#@cmpUL3_reg_reg (branch-free)"
+  ins_cost(ALU_COST * 3);
+  format %{ "sltu  t0, $op2, $op1\t#@cmpUL3_reg_reg\n\t"
+            "sltu  $dst, $op1, $op2\n\t"
+            "sub   $dst, t0, $dst"
   %}
   ins_encode %{
     __ cmp_ul2i(as_Register($dst$$reg), as_Register($op1$$reg), as_Register($op2$$reg));
@@ -9306,11 +9304,10 @@ instruct cmpU3_reg_reg(iRegINoSp dst, iRegI op1, iRegI op2)
 %{
   match(Set dst (CmpU3 op1 op2));
 
-  ins_cost(ALU_COST * 4);
-  format %{ "sltu  t0, $op2, $op1\t# gt\n\t"
-            "sltu  $dst, $op1, $op2\t# lt\n\t"
-            "neg   $dst, $dst\n\t"
-            "add   $dst, t0, $dst\t#@cmpU3_reg_reg (branch-free)"
+  ins_cost(ALU_COST * 3);
+  format %{ "sltu  t0, $op2, $op1\t#@cmpU3_reg_reg\n\t"
+            "sltu  $dst, $op1, $op2\n\t"
+            "sub   $dst, t0, $dst"
   %}
   ins_encode %{
     __ cmp_uw2i(as_Register($dst$$reg), as_Register($op1$$reg), as_Register($op2$$reg));

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -1582,8 +1582,7 @@ void TemplateTable::convert() {
 void TemplateTable::lcmp() {
   transition(ltos, itos);
   __ pop_l(x11);
-  __ cmp_l2i(t0, x11, x10);
-  __ mv(x10, t0);
+  __ cmp_l2i(x10, x11, x10);
 }
 
 void TemplateTable::float_cmp(bool is_float, int unordered_result) {


### PR DESCRIPTION
Hi, this patch replaces the branching compare-to-int implementation with a branch-free version using the formula: dst = (src1 > src2) - (src1 < src2).
This eliminates branch misprediction penalties and simplifies the register handling by removing the need to save src1/src2 when they overlap with dst. The result is written directly to the destination register without an extra mv.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387967](https://bugs.openjdk.org/browse/JDK-8387967): RISC-V: Optimize compare-to-int with branch-free implementation (**Enhancement** - P4)


### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31960/head:pull/31960` \
`$ git checkout pull/31960`

Update a local copy of the PR: \
`$ git checkout pull/31960` \
`$ git pull https://git.openjdk.org/jdk.git pull/31960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31960`

View PR using the GUI difftool: \
`$ git pr show -t 31960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31960.diff">https://git.openjdk.org/jdk/pull/31960.diff</a>

</details>
