### PR TITLE
8388460: RISC-V: Auto-enable Zcb extension features

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -108,7 +108,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZfhmin, false, DIAGNOSTIC, "Use Zfhmin instructions")         \
   product(bool, UseZacas, false, EXPERIMENTAL, "Use Zacas instructions")         \
   product(bool, UseZabha, false, EXPERIMENTAL, "Use UseZabha instructions")      \
-  product(bool, UseZcb, false, EXPERIMENTAL, "Use Zcb instructions")             \
+  product(bool, UseZcb, false, DIAGNOSTIC, "Use Zcb instructions")               \
   product(bool, UseZic64b, false, EXPERIMENTAL, "Use Zic64b instructions")       \
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -80,6 +80,7 @@
 #define   RISCV_HWPROBE_EXT_ZTSO                (1ULL << 33)
 #define   RISCV_HWPROBE_EXT_ZACAS               (1ULL << 34)
 #define   RISCV_HWPROBE_EXT_ZICOND              (1ULL << 35)
+#define   RISCV_HWPROBE_EXT_ZCB                 (1ULL << 44)
 
 #define RISCV_HWPROBE_KEY_CPUPERF_0     5
 #define   RISCV_HWPROBE_MISALIGNED_UNKNOWN      (0 << 0)
@@ -223,6 +224,9 @@ void RiscvHwprobe::add_features_from_query_result() {
   }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZFHMIN)) {
     VM_Version::ext_Zfhmin.enable_feature();
+  }
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZCB)) {
+    VM_Version::ext_Zcb.enable_feature();
   }
 #ifndef PRODUCT
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZICBOZ)) {


### PR DESCRIPTION
Hi, I ran some tests on the SpacemiT Key Stone K3 (which features physical Zcb hardware extensions). After enabling Zcb, the size of the related CodeCache decreased. So I propose to auto-enable this feature through hwprobe.

### Correctness testing
- [x] Run tier1-tier3 test with release on SpacemiT Key Stone K3

### Assembly variation

We can print the assembly logs using the following command:
```
./java -XX:+UnlockDiagnosticVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+PrintStubCode -XX:+PrintInterpreter -XX:-TieredCompilation -XX:+PrintAssembly -version
```

```
before this patch:
  0x0000003f810051ea:   li	a1,24
  0x0000003f810051ec:   mul	a2,a2,a1
  0x0000003f810051f0:   ld	a1,56(s10)
  0x0000003f810051f4:   addi	a1,a1,8
  0x0000003f810051f6:   add	a1,a1,a2

with this patch:

  0x0000003f98a051e2:   li	a1,24
  0x0000003f98a051e4:   .insn	2, 0x9e4d
  0x0000003f98a051e6:   ld	a1,56(s10)
  0x0000003f98a051ea:   addi	a1,a1,8
  0x0000003f98a051ec:   add	a1,a1,a2
```

```
before this patch:
  0x0000003f8100b2c2:   addi	a3,a1,4
  0x0000003f8100b2c6:   add	a3,a3,a0
  0x0000003f8100b2c8:   lbu	a3,0(a3)
  0x0000003f8100b2cc:   fence	r,rw

with this patch:
  0x0000003f98a0b282:   addi	a3,a1,4
  0x0000003f98a0b286:   add	a3,a3,a0
  0x0000003f98a0b288:   .insn	2, 0x8294
  0x0000003f98a0b28a:   fence	r,rw
```

```
before this patch:
  0x0000003f8101384a:   add	s1,s1,a2
  0x0000003f8101384c:   sb	a0,0(s1)


with this patch:

  0x0000003f98a137c4:   add	s1,s1,a2
  0x0000003f98a137c6:   .insn	2, 0x8888
```

As above, after decoding the Zcb instruction, it is:
```
zifeihan@riscv-spacemitk3picoitx:~$ cat opcode.s
.insn 0x9e4d
.insn 0x8294
.insn 0x8888
zifeihan@riscv-spacemitk3picoitx:~$ bash b2i.sh opcode.s

opcode.o:     file format elf64-littleriscv


Disassembly of section .text:

0000000000000000 <.text>:
   0:	9e4d                	c.mul	a2,a1
   2:	8294                	c.lbu	a3,0(a3)
   4:	8888                	c.sb	a0,0(s1)
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388460](https://bugs.openjdk.org/browse/JDK-8388460): RISC-V: Auto-enable Zcb extension features (**Enhancement** - P4)


### Reviewers
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31961/head:pull/31961` \
`$ git checkout pull/31961`

Update a local copy of the PR: \
`$ git checkout pull/31961` \
`$ git pull https://git.openjdk.org/jdk.git pull/31961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31961`

View PR using the GUI difftool: \
`$ git pr show -t 31961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31961.diff">https://git.openjdk.org/jdk/pull/31961.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31961#issuecomment-5078358268)
</details>
