### PR TITLE
8388461: G1: Missing G1FromCardCache footprint

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
@@ -168,7 +168,7 @@ public:
   // Returns the memory occupancy of all static data structures associated
   // with remembered sets.
   static size_t static_mem_size() {
-    return G1CardSet::static_mem_size();
+    return G1CardSet::static_mem_size() + G1FromCardCache::static_mem_size();
   }
 
   static void print_static_mem_size(outputStream* out);


### PR DESCRIPTION
Trivial change restoring the missing `G1FromCardCache` data in the `G1CardSet` footprint.

Test: manually verified the increase in `gc+remset*=trace` 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388461](https://bugs.openjdk.org/browse/JDK-8388461): G1: Missing G1FromCardCache footprint (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31962/head:pull/31962` \
`$ git checkout pull/31962`

Update a local copy of the PR: \
`$ git checkout pull/31962` \
`$ git pull https://git.openjdk.org/jdk.git pull/31962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31962`

View PR using the GUI difftool: \
`$ git pr show -t 31962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31962.diff">https://git.openjdk.org/jdk/pull/31962.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31962#issuecomment-5010477428)
</details>
