### PR TITLE
8388442: C2: LoadNKlassNode::Identity() may return a new node

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1960,7 +1960,7 @@ Node* LoadNode::Ideal_load_common(PhaseGVN* phase, bool can_reshape) {
   Node* address = in(MemNode::Address);
 
   bool addr_mark = ((phase->type(address)->isa_oopptr() || phase->type(address)->isa_narrowoop()) &&
-                    phase->type(address)->is_ptr()->offset() == oopDesc::mark_offset_in_bytes());
+         phase->type(address)->is_ptr()->offset() == oopDesc::mark_offset_in_bytes());
 
   // Skip up past a SafePoint control.  Cannot do this for Stores because
   // pointer stores & cardmarks must stay on the same side of a SafePoint.
@@ -1978,10 +1978,10 @@ Node* LoadNode::Ideal_load_common(PhaseGVN* phase, bool can_reshape) {
   if (base != nullptr &&
       phase->C->get_alias_index(phase->type(address)->is_ptr()) != Compile::AliasIdxRaw) {
     // Check for useless control edge in some common special cases
-    if (in(MemNode::Control) != nullptr &&
-        can_remove_control() &&
-        phase->type(base)->higher_equal(TypePtr::NOTNULL) &&
-        all_controls_dominate(base, phase->C->start(), phase)) {
+    if (in(MemNode::Control) != nullptr
+        && can_remove_control()
+        && phase->type(base)->higher_equal(TypePtr::NOTNULL)
+        && all_controls_dominate(base, phase->C->start(), phase)) {
       // A method-invariant, non-null address (constant or 'this' argument).
       set_req(MemNode::Control, nullptr);
       return this;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1952,6 +1952,22 @@ AllocateNode* LoadNode::is_new_object_mark_load() const {
   return nullptr;
 }
 
+// If the load is from Field memory and the pointer is non-null, it might be possible to
+// zero out the control input.
+// If the offset is constant and the base is an object allocation,
+// try to hook me up to the exact initializing store.
+Node* LoadNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  if (has_pinned_control_dependency()) { return nullptr; }
+  Node* p = Ideal_load_common(phase, can_reshape);
+  if (p == NodeSentinel) { return nullptr; }
+
+  if (p == nullptr && !can_reshape) {
+    phase->record_for_igvn(this);
+  }
+
+  return p;
+}
+
 Node* LoadNode::Ideal_load_common(PhaseGVN* phase, bool can_reshape) {
   Node* p = MemNode::Ideal_common(phase, can_reshape);
   if (p != nullptr) { return p; }
@@ -2080,22 +2096,6 @@ Node* LoadNode::Ideal_load_common(PhaseGVN* phase, bool can_reshape) {
   }
 
   return nullptr;
-}
-
-// If the load is from Field memory and the pointer is non-null, it might be possible to
-// zero out the control input.
-// If the offset is constant and the base is an object allocation,
-// try to hook me up to the exact initializing store.
-Node* LoadNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  if (has_pinned_control_dependency()) { return nullptr; }
-  Node* p = Ideal_load_common(phase, can_reshape);
-  if (p == NodeSentinel) { return nullptr; }
-
-  if (p == nullptr && !can_reshape) {
-    phase->record_for_igvn(this);
-  }
-
-  return p;
 }
 
 // Helper to recognize certain Klass fields which are invariant across
@@ -2638,9 +2638,17 @@ Node* LoadKlassNode::Identity(PhaseGVN* phase) {
   return klass_identity_common(phase);
 }
 
+Node* LoadNode::klass_identity_common(PhaseGVN* phase) {
+  Node* x = LoadNode::Identity(phase);
+  if (x != this) { return x; }
+
+  Node* k = find_known_klass(phase);
+  return k == nullptr ? this : k;
+}
+
 // Find an existing Klass node from a recognized allocation or
 // class-mirror pattern.
-Node* LoadNode::find_known_klass(PhaseGVN* phase) {
+Node* LoadNode::find_known_klass(PhaseGVN* phase) const {
   // Take apart the address into an oop and offset.
   // Return 'nullptr' if we cannot.
   Node* adr = in(MemNode::Address);
@@ -2703,14 +2711,6 @@ Node* LoadNode::find_known_klass(PhaseGVN* phase) {
   return nullptr;
 }
 
-Node* LoadNode::klass_identity_common(PhaseGVN* phase) {
-  Node* x = LoadNode::Identity(phase);
-  if (x != this)  { return x; }
-
-  Node* k = find_known_klass(phase);
-  return k == nullptr ? this : k;
-}
-
 LoadNode* LoadNode::clone_pinned() const {
   LoadNode* ld = clone()->as_Load();
   ld->_control_dependency = UnknownControl;
@@ -2733,7 +2733,6 @@ LoadNode* LoadNode::pin_node_under_control_impl() const {
   return nullptr;
 }
 
-//------------------------------Ideal---------------------------------------
 Node* LoadNKlassNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   bool pinned = has_pinned_control_dependency();
   if (!pinned) {
@@ -2760,7 +2759,6 @@ Node* LoadNKlassNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   return nullptr;
 }
 
-//------------------------------Value------------------------------------------
 const Type* LoadNKlassNode::Value(PhaseGVN* phase) const {
   const Type *t = klass_value_common(phase);
   if (t == Type::TOP)
@@ -2769,7 +2767,6 @@ const Type* LoadNKlassNode::Value(PhaseGVN* phase) const {
   return t->make_narrowklass();
 }
 
-//------------------------------Identity---------------------------------------
 Node* LoadNKlassNode::Identity(PhaseGVN* phase) {
   Node* x = klass_identity_common(phase);
   const Type* t = phase->type(x);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2082,7 +2082,6 @@ Node* LoadNode::Ideal_load_common(PhaseGVN* phase, bool can_reshape) {
   return nullptr;
 }
 
-//------------------------------Ideal------------------------------------------
 // If the load is from Field memory and the pointer is non-null, it might be possible to
 // zero out the control input.
 // If the offset is constant and the base is an object allocation,
@@ -2706,7 +2705,7 @@ Node* LoadNode::find_known_klass(PhaseGVN* phase) {
 
 Node* LoadNode::klass_identity_common(PhaseGVN* phase) {
   Node* x = LoadNode::Identity(phase);
-  if (x != this)  return x;
+  if (x != this)  { return x; }
 
   Node* k = find_known_klass(phase);
   return k == nullptr ? this : k;
@@ -2743,6 +2742,8 @@ Node* LoadNKlassNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     if (p != nullptr) { return p; }
   }
 
+  // To clean up reflective code, simplify k.java_mirror.as_klass to narrow k.
+  // Also feed through the klass in Allocate(...klass...)._klass.
   Node* k = find_known_klass(phase);
   if (k != nullptr) {
     const Type* t = phase->type(k);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1952,24 +1952,15 @@ AllocateNode* LoadNode::is_new_object_mark_load() const {
   return nullptr;
 }
 
-
-//------------------------------Ideal------------------------------------------
-// If the load is from Field memory and the pointer is non-null, it might be possible to
-// zero out the control input.
-// If the offset is constant and the base is an object allocation,
-// try to hook me up to the exact initializing store.
-Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  if (has_pinned_control_dependency()) {
-    return nullptr;
-  }
+Node* LoadNode::Ideal_load_common(PhaseGVN* phase, bool can_reshape) {
   Node* p = MemNode::Ideal_common(phase, can_reshape);
-  if (p)  return (p == NodeSentinel) ? nullptr : p;
+  if (p != nullptr) { return p; }
 
-  Node* ctrl    = in(MemNode::Control);
+  Node* ctrl = in(MemNode::Control);
   Node* address = in(MemNode::Address);
 
   bool addr_mark = ((phase->type(address)->isa_oopptr() || phase->type(address)->isa_narrowoop()) &&
-         phase->type(address)->is_ptr()->offset() == oopDesc::mark_offset_in_bytes());
+                    phase->type(address)->is_ptr()->offset() == oopDesc::mark_offset_in_bytes());
 
   // Skip up past a SafePoint control.  Cannot do this for Stores because
   // pointer stores & cardmarks must stay on the same side of a SafePoint.
@@ -1983,14 +1974,14 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   intptr_t ignore = 0;
-  Node*    base   = AddPNode::Ideal_base_and_offset(address, phase, ignore);
-  if (base != nullptr
-      && phase->C->get_alias_index(phase->type(address)->is_ptr()) != Compile::AliasIdxRaw) {
+  Node* base = AddPNode::Ideal_base_and_offset(address, phase, ignore);
+  if (base != nullptr &&
+      phase->C->get_alias_index(phase->type(address)->is_ptr()) != Compile::AliasIdxRaw) {
     // Check for useless control edge in some common special cases
-    if (in(MemNode::Control) != nullptr
-        && can_remove_control()
-        && phase->type(base)->higher_equal(TypePtr::NOTNULL)
-        && all_controls_dominate(base, phase->C->start(), phase)) {
+    if (in(MemNode::Control) != nullptr &&
+        can_remove_control() &&
+        phase->type(base)->higher_equal(TypePtr::NOTNULL) &&
+        all_controls_dominate(base, phase->C->start(), phase)) {
       // A method-invariant, non-null address (constant or 'this' argument).
       set_req(MemNode::Control, nullptr);
       return this;
@@ -1998,26 +1989,26 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   Node* mem = in(MemNode::Memory);
-  const TypePtr *addr_t = phase->type(address)->isa_ptr();
+  const TypePtr* addr_t = phase->type(address)->isa_ptr();
 
   if (can_reshape && (addr_t != nullptr)) {
     // try to optimize our memory input
     Node* opt_mem = MemNode::optimize_memory_chain(mem, addr_t, this, phase);
     if (opt_mem != mem) {
       set_req_X(MemNode::Memory, opt_mem, phase);
-      if (phase->type( opt_mem ) == Type::TOP) return nullptr;
+      if (phase->type(opt_mem) == Type::TOP) { return NodeSentinel; }
       return this;
     }
-    const TypeOopPtr *t_oop = addr_t->isa_oopptr();
+    const TypeOopPtr* t_oop = addr_t->isa_oopptr();
     if ((t_oop != nullptr) &&
         (t_oop->is_known_instance_field() ||
          t_oop->is_ptr_to_boxed_value())) {
-      PhaseIterGVN *igvn = phase->is_IterGVN();
+      PhaseIterGVN* igvn = phase->is_IterGVN();
       assert(igvn != nullptr, "must be PhaseIterGVN when can_reshape is true");
       if (igvn->_worklist.member(opt_mem)) {
         // Delay this transformation until memory Phi is processed.
         igvn->_worklist.push(this);
-        return nullptr;
+        return NodeSentinel;
       }
       // Split instance field load through Phi.
       Node* result = split_through_phi(phase);
@@ -2035,7 +2026,7 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // barriers etc.) alone
   if (in(0) != nullptr && !adr_type()->isa_rawptr() && can_reshape) {
     for (DUIterator_Fast imax, i = mem->fast_outs(imax); i < imax; i++) {
-      Node *use = mem->fast_out(i);
+      Node* use = mem->fast_out(i);
       if (use != this &&
           use->Opcode() == Opcode() &&
           use->in(0) != nullptr &&
@@ -2088,11 +2079,24 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  if (!can_reshape) {
+  return nullptr;
+}
+
+//------------------------------Ideal------------------------------------------
+// If the load is from Field memory and the pointer is non-null, it might be possible to
+// zero out the control input.
+// If the offset is constant and the base is an object allocation,
+// try to hook me up to the exact initializing store.
+Node* LoadNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  if (has_pinned_control_dependency()) { return nullptr; }
+  Node* p = Ideal_load_common(phase, can_reshape);
+  if (p == NodeSentinel) { return nullptr; }
+
+  if (p == nullptr && !can_reshape) {
     phase->record_for_igvn(this);
   }
 
-  return nullptr;
+  return p;
 }
 
 // Helper to recognize certain Klass fields which are invariant across
@@ -2635,18 +2639,17 @@ Node* LoadKlassNode::Identity(PhaseGVN* phase) {
   return klass_identity_common(phase);
 }
 
-Node* LoadNode::klass_identity_common(PhaseGVN* phase) {
-  Node* x = LoadNode::Identity(phase);
-  if (x != this)  return x;
-
+// Find an existing Klass node from a recognized allocation or
+// class-mirror pattern.
+Node* LoadNode::find_known_klass(PhaseGVN* phase) {
   // Take apart the address into an oop and offset.
-  // Return 'this' if we cannot.
-  Node*    adr    = in(MemNode::Address);
+  // Return 'nullptr' if we cannot.
+  Node* adr = in(MemNode::Address);
   intptr_t offset = 0;
-  Node*    base   = AddPNode::Ideal_base_and_offset(adr, phase, offset);
-  if (base == nullptr)     return this;
+  Node* base = AddPNode::Ideal_base_and_offset(adr, phase, offset);
+  if (base == nullptr) { return nullptr; }
   const TypeOopPtr* toop = phase->type(adr)->isa_oopptr();
-  if (toop == nullptr)     return this;
+  if (toop == nullptr) { return nullptr; }
 
   // Step over potential GC barrier for OopHandle resolve
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
@@ -2698,7 +2701,15 @@ Node* LoadNode::klass_identity_common(PhaseGVN* phase) {
     }
   }
 
-  return this;
+  return nullptr;
+}
+
+Node* LoadNode::klass_identity_common(PhaseGVN* phase) {
+  Node* x = LoadNode::Identity(phase);
+  if (x != this)  return x;
+
+  Node* k = find_known_klass(phase);
+  return k == nullptr ? this : k;
 }
 
 LoadNode* LoadNode::clone_pinned() const {
@@ -2723,6 +2734,31 @@ LoadNode* LoadNode::pin_node_under_control_impl() const {
   return nullptr;
 }
 
+//------------------------------Ideal---------------------------------------
+Node* LoadNKlassNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  bool pinned = has_pinned_control_dependency();
+  if (!pinned) {
+    Node* p = Ideal_load_common(phase, can_reshape);
+    if (p == NodeSentinel) { return nullptr; }
+    if (p != nullptr) { return p; }
+  }
+
+  Node* k = find_known_klass(phase);
+  if (k != nullptr) {
+    const Type* t = phase->type(k);
+    if (t != Type::TOP) {
+      assert(t->isa_klassptr(), "must be a klass pointer");
+      return new EncodePKlassNode(k, t->make_narrowklass());
+    }
+  }
+
+  if (!pinned && !can_reshape) {
+    phase->record_for_igvn(this);
+  }
+
+  return nullptr;
+}
+
 //------------------------------Value------------------------------------------
 const Type* LoadNKlassNode::Value(PhaseGVN* phase) const {
   const Type *t = klass_value_common(phase);
@@ -2733,17 +2769,11 @@ const Type* LoadNKlassNode::Value(PhaseGVN* phase) const {
 }
 
 //------------------------------Identity---------------------------------------
-// To clean up reflective code, simplify k.java_mirror.as_klass to narrow k.
-// Also feed through the klass in Allocate(...klass...)._klass.
 Node* LoadNKlassNode::Identity(PhaseGVN* phase) {
-  Node *x = klass_identity_common(phase);
-
-  const Type *t = phase->type( x );
-  if( t == Type::TOP ) return x;
-  if( t->isa_narrowklass()) return x;
-  assert (!t->isa_narrowoop(), "no narrow oop here");
-
-  return phase->transform(new EncodePKlassNode(x, t->make_narrowklass()));
+  Node* x = klass_identity_common(phase);
+  const Type* t = phase->type(x);
+  if (t == Type::TOP || t->isa_narrowklass()) { return x; }
+  return this;
 }
 
 //------------------------------Value-----------------------------------------

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -267,6 +267,7 @@ protected:
 
   virtual Node* find_previous_arraycopy(PhaseValues* phase, Node* ld_alloc, Node*& mem, bool can_see_stored_value) const;
   Node* can_see_stored_value_through_membars(Node* st, PhaseValues* phase) const;
+  Node* Ideal_load_common(PhaseGVN* phase, bool can_reshape);
 public:
 
   LoadNode(Node *c, Node *mem, Node *adr, const TypePtr* at, const Type *rt, MemOrd mo, ControlDependency control_dependency)
@@ -318,6 +319,7 @@ public:
   // Common methods for LoadKlass and LoadNKlass nodes.
   const Type* klass_value_common(PhaseGVN* phase) const;
   Node* klass_identity_common(PhaseGVN* phase);
+  Node* find_known_klass(PhaseGVN* phase);
 
   virtual uint ideal_reg() const;
   virtual const Type *bottom_type() const;
@@ -613,6 +615,7 @@ public:
 
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -319,7 +319,7 @@ public:
   // Common methods for LoadKlass and LoadNKlass nodes.
   const Type* klass_value_common(PhaseGVN* phase) const;
   Node* klass_identity_common(PhaseGVN* phase);
-  Node* find_known_klass(PhaseGVN* phase);
+  Node* find_known_klass(PhaseGVN* phase) const;
 
   virtual uint ideal_reg() const;
   virtual const Type *bottom_type() const;


### PR DESCRIPTION
Please review this change, thanks!

**Description:**

`LoadNKlassNode::Identity()` may create a new `EncodePKlassNode` when recognizing an allocation or class-mirror pattern. This violates the Identity() contract. 
This issue was spotted while testing my patch for JDK-8347266, and it is currently blocking that patch.

**Solution:**

Move the `EncodePKlassNode` creation from `LoadNKlassNode::Identity()` to a new `LoadNKlassNode::Ideal()` implementation. Since a `nullptr` result from the existing `LoadNode::Ideal()` does not distinguish between stopping the current optimization and continuing with subsequent optimizations, add `LoadNode::Ideal_load_common()` to provide more information to its caller. Also extract the allocation and class-mirror pattern matching into LoadNode::find_known_klass() so that it can be shared by the klass load optimizations.

**Test:**

GHA, hotspot_compiler


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388442](https://bugs.openjdk.org/browse/JDK-8388442): C2: LoadNKlassNode::Identity() may return a new node (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer) Review applies to [78acd364](https://git.openjdk.org/jdk/pull/31963/files/78acd364ddce27220c2f699e177f37244b5b1db6)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31963/head:pull/31963` \
`$ git checkout pull/31963`

Update a local copy of the PR: \
`$ git checkout pull/31963` \
`$ git pull https://git.openjdk.org/jdk.git pull/31963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31963`

View PR using the GUI difftool: \
`$ git pr show -t 31963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31963.diff">https://git.openjdk.org/jdk/pull/31963.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31963#issuecomment-5015683354)
</details>
