### PR TITLE
8387743: [aot] AOT tests fail intermittently with "incompatible CompressedOops::base()"

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
@@ -125,7 +125,10 @@ public class AOTCodeCompressedOopsTest {
             switch (runMode) {
             case RunMode.ASSEMBLY: {
                     List<String> args = getVMArgsForHeapConfig(zeroBaseInAsmPhase, zeroShiftInAsmPhase);
+                    // By default CDSAppTester adds -XX:+AOTCompatibleOopCompression option,
+                    // which defeats the purpose of this test. So disable this option.
                     args.addAll(List.of("-XX:+UnlockDiagnosticVMOptions",
+                                        "-XX:-AOTCompatibleOopCompression",
                                         "-Xlog:aot=info",
                                         "-Xlog:aot+codecache+init=debug",
                                         "-Xlog:aot+codecache+exit=debug"));

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
@@ -72,6 +72,8 @@ public class AOTFlags {
             "-XX:AOTConfiguration=" + aotConfigFile,
             "-XX:AOTCache=" + aotCacheFile,
             "-Xlog:aot",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+AOTCompatibleOopCompression", // avoid production run failure due to incompatible CompressedOops::base
             "-cp", appJar);
         out = CDSTestUtils.executeAndLog(pb, "asm");
         out.shouldContain("AOTCache creation is complete");
@@ -142,6 +144,8 @@ public class AOTFlags {
             "-XX:AOTConfiguration=" + aotConfigFile,
             "-XX:AOTCache=" + aotCacheFile,
             "-Xlog:aot",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+AOTCompatibleOopCompression", // avoid production run failure due to incompatible CompressedOops::base
             "-cp", appJar);
         out = CDSTestUtils.executeAndLog(pb, "asm");
         out.shouldContain("AOTCache creation is complete");

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -232,7 +232,7 @@ abstract public class CDSAppTester {
         String[] cmdLine = new String[0];
         cmdLine = addClassOrModulePath(runMode, cmdLine);
         cmdLine = addWhiteBox(cmdLine);
-        if (runMode == RunMode.TRAINING) {
+        if (runMode == RunMode.ASSEMBLY) {
             cmdLine = StringArrayUtils.concat(cmdLine, "-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTCompatibleOopCompression");
         }
         return cmdLine;

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -232,7 +232,10 @@ abstract public class CDSAppTester {
         String[] cmdLine = new String[0];
         cmdLine = addClassOrModulePath(runMode, cmdLine);
         cmdLine = addWhiteBox(cmdLine);
-        if (runMode == RunMode.ASSEMBLY || runMode == RunMode.TRAINING) {
+        // In one-step workflow ASSEMBLY phase is not executed separately.
+        // Therefore AOTCompatibleOopCompression needs to be passed to the TRAINING phase,
+        // so that it can be propagated to the ASSEMBLY phase.
+        if (runMode == RunMode.TRAINING || runMode == RunMode.ASSEMBLY) {
           cmdLine = StringArrayUtils.concat(cmdLine, "-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTCompatibleOopCompression");
         }
         return cmdLine;

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -228,6 +228,8 @@ abstract public class CDSAppTester {
         return output;
     }
 
+    // This method should be called before `vmArgs()`, so that subclasses of CDSAppTester
+    // can have a chance to override the flags set here.
     private String[] addCommonVMArgs(RunMode runMode) {
         String[] cmdLine = new String[0];
         cmdLine = addClassOrModulePath(runMode, cmdLine);

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -228,9 +228,13 @@ abstract public class CDSAppTester {
         return output;
     }
 
-    private String[] addCommonVMArgs(RunMode runMode, String[] cmdLine) {
+    private String[] addCommonVMArgs(RunMode runMode) {
+        String[] cmdLine = new String[0];
         cmdLine = addClassOrModulePath(runMode, cmdLine);
         cmdLine = addWhiteBox(cmdLine);
+        if (runMode == RunMode.TRAINING) {
+            cmdLine = StringArrayUtils.concat(cmdLine, "-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTCompatibleOopCompression");
+        }
         return cmdLine;
     }
 
@@ -261,30 +265,32 @@ abstract public class CDSAppTester {
 
     private OutputAnalyzer recordAOTConfiguration() throws Exception {
         RunMode runMode = RunMode.TRAINING;
-        String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
-                                                   "-XX:AOTMode=record",
-                                                   "-XX:AOTConfiguration=" + aotConfigurationFile,
-                                                   logToFile(aotConfigurationFileLog,
-                                                             "class+load=debug",
-                                                             "aot=debug",
-                                                             "cds=debug",
-                                                             "aot+class=debug"));
-        cmdLine = addCommonVMArgs(runMode, cmdLine);
+        String[] cmdLine = addCommonVMArgs(runMode);
+        cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
+        cmdLine = StringArrayUtils.concat(cmdLine,
+                                          "-XX:AOTMode=record",
+                                          "-XX:AOTConfiguration=" + aotConfigurationFile,
+                                          logToFile(aotConfigurationFileLog,
+                                                    "class+load=debug",
+                                                    "aot=debug",
+                                                    "cds=debug",
+                                                    "aot+class=debug"));
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, aotConfigurationFile, aotConfigurationFileLog);
     }
 
     private OutputAnalyzer createAOTCacheOneStep() throws Exception {
         RunMode runMode = RunMode.TRAINING;
-        String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
-                                                   "-XX:AOTMode=record",
-                                                   "-XX:AOTCacheOutput=" + aotCacheFile,
-                                                   logToFile(aotCacheFileLog,
-                                                             "class+load=debug",
-                                                             "aot=debug",
-                                                             "aot+class=debug",
-                                                             "cds=debug"));
-        cmdLine = addCommonVMArgs(runMode, cmdLine);
+        String[] cmdLine = addCommonVMArgs(runMode);
+        cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
+        cmdLine = StringArrayUtils.concat(cmdLine,
+                                          "-XX:AOTMode=record",
+                                          "-XX:AOTCacheOutput=" + aotCacheFile,
+                                          logToFile(aotCacheFileLog,
+                                                    "class+load=debug",
+                                                    "aot=debug",
+                                                    "aot+class=debug",
+                                                    "cds=debug"));
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         OutputAnalyzer out =  executeAndCheck(cmdLine, runMode, aotCacheFile, aotCacheFileLog);
         listOutputFile(aotCacheFileLog + ".0"); // the log file for the training run
@@ -293,52 +299,55 @@ abstract public class CDSAppTester {
 
     private OutputAnalyzer createClassList() throws Exception {
         RunMode runMode = RunMode.TRAINING;
-        String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
-                                                   "-Xshare:off",
-                                                   "-XX:DumpLoadedClassList=" + classListFile,
-                                                   logToFile(classListFileLog,
-                                                             "class+load=debug"));
-        cmdLine = addCommonVMArgs(runMode, cmdLine);
+        String[] cmdLine = addCommonVMArgs(runMode);
+        cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
+        cmdLine = StringArrayUtils.concat(cmdLine,
+                                          "-Xshare:off",
+                                          "-XX:DumpLoadedClassList=" + classListFile,
+                                          logToFile(classListFileLog,
+                                                    "class+load=debug"));
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, classListFile, classListFileLog);
     }
 
     private OutputAnalyzer dumpStaticArchive() throws Exception {
         RunMode runMode = RunMode.DUMP_STATIC;
-        String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
-                                                   "-Xlog:aot",
-                                                   "-Xlog:aot+heap=error",
-                                                   "-Xlog:cds",
-                                                   "-Xshare:dump",
-                                                   "-XX:SharedArchiveFile=" + staticArchiveFile,
-                                                   "-XX:SharedClassListFile=" + classListFile,
-                                                   logToFile(staticArchiveFileLog,
-                                                             "aot=debug",
-                                                             "cds=debug",
-                                                             "cds+class=debug",
-                                                             "aot+heap=warning",
-                                                             "aot+resolve=debug"));
-        cmdLine = addCommonVMArgs(runMode, cmdLine);
+        String[] cmdLine = addCommonVMArgs(runMode);
+        cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
+        cmdLine = StringArrayUtils.concat(cmdLine,
+                                          "-Xlog:aot",
+                                          "-Xlog:aot+heap=error",
+                                          "-Xlog:cds",
+                                          "-Xshare:dump",
+                                          "-XX:SharedArchiveFile=" + staticArchiveFile,
+                                          "-XX:SharedClassListFile=" + classListFile,
+                                          logToFile(staticArchiveFileLog,
+                                                    "aot=debug",
+                                                    "cds=debug",
+                                                    "cds+class=debug",
+                                                    "aot+heap=warning",
+                                                    "aot+resolve=debug"));
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, staticArchiveFile, staticArchiveFileLog);
     }
 
     private OutputAnalyzer createAOTCache() throws Exception {
         RunMode runMode = RunMode.ASSEMBLY;
-        String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
-                                                   "-Xlog:aot",
-                                                   "-Xlog:aot+heap=error",
-                                                   "-Xlog:cds",
-                                                   "-XX:AOTMode=create",
-                                                   "-XX:AOTConfiguration=" + aotConfigurationFile,
-                                                   "-XX:AOTCache=" + aotCacheFile,
-                                                   logToFile(aotCacheFileLog,
-                                                             "cds=debug",
-                                                             "aot=debug",
-                                                             "aot+class=debug",
-                                                             "aot+heap=warning",
-                                                             "aot+resolve=debug"));
-        cmdLine = addCommonVMArgs(runMode, cmdLine);
+        String[] cmdLine = addCommonVMArgs(runMode);
+        cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
+        cmdLine = StringArrayUtils.concat(cmdLine,
+                                          "-Xlog:aot",
+                                          "-Xlog:aot+heap=error",
+                                          "-Xlog:cds",
+                                          "-XX:AOTMode=create",
+                                          "-XX:AOTConfiguration=" + aotConfigurationFile,
+                                          "-XX:AOTCache=" + aotCacheFile,
+                                          logToFile(aotCacheFileLog,
+                                                    "cds=debug",
+                                                    "aot=debug",
+                                                    "aot+class=debug",
+                                                    "aot+heap=warning",
+                                                    "aot+resolve=debug"));
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, aotCacheFile, aotCacheFileLog);
     }
@@ -387,7 +396,9 @@ abstract public class CDSAppTester {
         String baseArchive = getBaseArchiveForDynamicArchive();
         if (isDynamicWorkflow()) {
           // "classic" dynamic archive
-          cmdLine = StringArrayUtils.concat(vmArgs(runMode),
+          cmdLine = addCommonVMArgs(runMode);
+          cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
+          cmdLine = StringArrayUtils.concat(cmdLine,
                                             "-Xlog:aot",
                                             "-Xlog:cds",
                                             "-XX:ArchiveClassesAtExit=" + dynamicArchiveFile,
@@ -397,7 +408,6 @@ abstract public class CDSAppTester {
                                                       "cds+class=debug",
                                                       "aot+resolve=debug",
                                                       "class+load=debug"));
-          cmdLine = addCommonVMArgs(runMode, cmdLine);
         }
         if (baseArchive != null) {
             cmdLine = StringArrayUtils.concat(cmdLine, "-XX:SharedArchiveFile=" + baseArchive);
@@ -418,9 +428,10 @@ abstract public class CDSAppTester {
     // using different args to the VM and application.
     public OutputAnalyzer productionRun(String[] extraVmArgs, String[] extraAppArgs) throws Exception {
         RunMode runMode = RunMode.PRODUCTION;
-        String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
-                                                   logToFile(productionRunLog(), "aot", "cds"));
-        cmdLine = addCommonVMArgs(runMode, cmdLine);
+        String[] cmdLine = addCommonVMArgs(runMode);
+        cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
+        cmdLine = StringArrayUtils.concat(cmdLine,
+                                          logToFile(productionRunLog(), "aot", "cds"));
 
         if (isStaticWorkflow()) {
             cmdLine = StringArrayUtils.concat(cmdLine, "-Xshare:on", "-XX:SharedArchiveFile=" + staticArchiveFile);

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -232,8 +232,8 @@ abstract public class CDSAppTester {
         String[] cmdLine = new String[0];
         cmdLine = addClassOrModulePath(runMode, cmdLine);
         cmdLine = addWhiteBox(cmdLine);
-        if (runMode == RunMode.ASSEMBLY) {
-            cmdLine = StringArrayUtils.concat(cmdLine, "-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTCompatibleOopCompression");
+        if (runMode == RunMode.ASSEMBLY || runMode == RunMode.TRAINING) {
+          cmdLine = StringArrayUtils.concat(cmdLine, "-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTCompatibleOopCompression");
         }
         return cmdLine;
     }


### PR DESCRIPTION
This patch updates `CDSAppTester` to always add `AOTCompatibleOopCompression` VM option when running the AOT tests. It ensures the test won't fail due to incompatible `CompressedOops::base`. It adds this option before the options supplied by the test (which is generally a sub class of CDSAppTester), so that it can be overridden by the tests if required.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387743](https://bugs.openjdk.org/browse/JDK-8387743): [aot] AOT tests fail intermittently with "incompatible CompressedOops::base()" (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31964/head:pull/31964` \
`$ git checkout pull/31964`

Update a local copy of the PR: \
`$ git checkout pull/31964` \
`$ git pull https://git.openjdk.org/jdk.git pull/31964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31964`

View PR using the GUI difftool: \
`$ git pr show -t 31964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31964.diff">https://git.openjdk.org/jdk/pull/31964.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31964#issuecomment-5017102322)
</details>
