### PR TITLE
8388464: New test serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java is failing with virtual threads

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
@@ -41,8 +41,10 @@
  * sub-expression _index + extra_slot overflows to INT_MIN, which is < max_locals(),
  * so the guard passes and the code goes on to index locals->at(INT_MAX).
  *
- * Expected (fixed) behavior: GetLocalLong/Double and SetLocalLong/Double with
- * slot == INT_MAX return JVMTI_ERROR_INVALID_SLOT.
+ * Expected (fixed) behavior: GetLocalLong/Double with slot == INT_MAX return
+ * JVMTI_ERROR_INVALID_SLOT. SetLocalLong/Double return JVMTI_ERROR_INVALID_SLOT
+ * on a platform thread, but JVMTI_ERROR_OPAQUE_FRAME on a mounted virtual thread
+ * (the continuation frame is rejected before the slot check is reached).
  *
  * On an unfixed VM this test does not merely fail: the out-of-bounds access
  * crashes the VM (assertion failure in fastdebug, SIGSEGV / silent corruption
@@ -52,8 +54,10 @@
 public class GetSetLocalSlotOverflow {
 
     // Invoked from runner(); the agent inspects the runner() frame at depth 1.
-    // Returns false if any accessor did not return JVMTI_ERROR_INVALID_SLOT.
-    static native boolean testOverflow(Thread thread);
+    // On a virtual thread SetLocal is rejected with OPAQUE_FRAME before the slot
+    // check, so the native side needs to know whether the thread is virtual.
+    // Returns false if any accessor did not return the expected error.
+    static native boolean testOverflow(Thread thread, boolean isVirtual);
 
     public static void main(String[] args) throws Exception {
         if (!runner()) {
@@ -67,7 +71,8 @@ public class GetSetLocalSlotOverflow {
     public static boolean runner() {
         long l = 0xCAFEBABEL;
         double d = 3.14d;
-        boolean ok = testOverflow(Thread.currentThread());
+        Thread self = Thread.currentThread();
+        boolean ok = testOverflow(self, self.isVirtual());
         // Keep locals live across the native call.
         if (l == 0 && d == 0) {
             throw new AssertionError("unreachable");

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
@@ -42,10 +42,10 @@
  * so the guard passes and the code goes on to index locals->at(INT_MAX).
  *
  * Expected (fixed) behavior: GetLocalLong/Double and SetLocalLong/Double with
- * slot == INT_MAX return JVMTI_ERROR_INVALID_SLOT. On a mounted virtual thread
- * the runner() frame is in a continuation, so SetLocal at depth != 0 is rejected
- * with JVMTI_ERROR_OPAQUE_FRAME before the slot check is reached and therefore
- * cannot exercise the overflow; the set sub-tests are skipped there.
+ * slot == INT_MAX return JVMTI_ERROR_INVALID_SLOT. JVMTI only supports SetLocal
+ * on the topmost frame of a virtual thread, and the targeted runner() frame is
+ * not topmost, so on a virtual thread SetLocal is rejected before the slot check
+ * is reached and cannot exercise the overflow; the set sub-tests are skipped there.
  *
  * On an unfixed VM this test does not merely fail: the out-of-bounds access
  * crashes the VM (assertion failure in fastdebug, SIGSEGV / silent corruption
@@ -55,8 +55,8 @@
 public class GetSetLocalSlotOverflow {
 
     // Invoked from runner(); the agent inspects the runner() frame at depth 1.
-    // On a virtual thread SetLocal is rejected with OPAQUE_FRAME before the slot
-    // check, so the agent skips the set sub-tests when the thread is virtual.
+    // JVMTI only supports SetLocal on the topmost frame of a virtual thread, so
+    // the agent skips the set sub-tests when the thread is virtual.
     // Returns false if any accessor did not return JVMTI_ERROR_INVALID_SLOT.
     static native boolean testOverflow(Thread thread, boolean isVirtual);
 

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java
@@ -41,10 +41,11 @@
  * sub-expression _index + extra_slot overflows to INT_MIN, which is < max_locals(),
  * so the guard passes and the code goes on to index locals->at(INT_MAX).
  *
- * Expected (fixed) behavior: GetLocalLong/Double with slot == INT_MAX return
- * JVMTI_ERROR_INVALID_SLOT. SetLocalLong/Double return JVMTI_ERROR_INVALID_SLOT
- * on a platform thread, but JVMTI_ERROR_OPAQUE_FRAME on a mounted virtual thread
- * (the continuation frame is rejected before the slot check is reached).
+ * Expected (fixed) behavior: GetLocalLong/Double and SetLocalLong/Double with
+ * slot == INT_MAX return JVMTI_ERROR_INVALID_SLOT. On a mounted virtual thread
+ * the runner() frame is in a continuation, so SetLocal at depth != 0 is rejected
+ * with JVMTI_ERROR_OPAQUE_FRAME before the slot check is reached and therefore
+ * cannot exercise the overflow; the set sub-tests are skipped there.
  *
  * On an unfixed VM this test does not merely fail: the out-of-bounds access
  * crashes the VM (assertion failure in fastdebug, SIGSEGV / silent corruption
@@ -55,8 +56,8 @@ public class GetSetLocalSlotOverflow {
 
     // Invoked from runner(); the agent inspects the runner() frame at depth 1.
     // On a virtual thread SetLocal is rejected with OPAQUE_FRAME before the slot
-    // check, so the native side needs to know whether the thread is virtual.
-    // Returns false if any accessor did not return the expected error.
+    // check, so the agent skips the set sub-tests when the thread is virtual.
+    // Returns false if any accessor did not return JVMTI_ERROR_INVALID_SLOT.
     static native boolean testOverflow(Thread thread, boolean isVirtual);
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
@@ -65,9 +65,9 @@ Java_GetSetLocalSlotOverflow_testOverflow(JNIEnv *env, jclass cls, jobject threa
   ok &= expect_invalid_slot("GetLocalLong",   jvmti->GetLocalLong(thread, Depth, OverflowSlot, &lval));
   ok &= expect_invalid_slot("GetLocalDouble", jvmti->GetLocalDouble(thread, Depth, OverflowSlot, &dval));
 
-  // On a mounted virtual thread the runner() frame is in a continuation, so
-  // SetLocal at depth != 0 is rejected with JVMTI_ERROR_OPAQUE_FRAME before the
-  // slot check runs -- it never exercises the overflow, so skip it there.
+  // JVMTI only supports SetLocal on the topmost frame of a virtual thread. The
+  // runner() frame is not topmost, so on a virtual thread SetLocal is rejected
+  // before the slot check runs and cannot exercise the overflow -- skip it there.
   if (!isVirtual) {
     ok &= expect_invalid_slot("SetLocalLong",   jvmti->SetLocalLong(thread, Depth, OverflowSlot, (jlong)0));
     ok &= expect_invalid_slot("SetLocalDouble", jvmti->SetLocalDouble(thread, Depth, OverflowSlot, (jdouble)0));

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
@@ -37,15 +37,16 @@ static const jint OverflowSlot = INT_MAX; // 0x7fffffff
 
 static jvmtiEnv *jvmti = nullptr;
 
-// Each access must be rejected with the expected error. On an unfixed VM the
+// Each access must come back as JVMTI_ERROR_INVALID_SLOT. On an unfixed VM the
 // overflowing bounds check is bypassed and the subsequent locals->at(INT_MAX)
 // access crashes the VM before we ever see a return code.
-static bool expect_error(const char* what, jvmtiError err, jvmtiError expected) {
-  if (err == expected) {
-    LOG(" PASS: %s returned %d for slot=INT_MAX\n", what, err);
+static bool expect_invalid_slot(const char* what, jvmtiError err) {
+  if (err == JVMTI_ERROR_INVALID_SLOT) {
+    LOG(" PASS: %s returned JVMTI_ERROR_INVALID_SLOT (%d) for slot=INT_MAX\n", what, err);
     return true;
   }
-  LOG(" FAIL: %s returned %d for slot=INT_MAX, expected %d\n", what, err, expected);
+  LOG(" FAIL: %s returned %d for slot=INT_MAX, expected JVMTI_ERROR_INVALID_SLOT (%d)\n",
+         what, err, JVMTI_ERROR_INVALID_SLOT);
   return false;
 }
 
@@ -59,16 +60,18 @@ Java_GetSetLocalSlotOverflow_testOverflow(JNIEnv *env, jclass cls, jobject threa
   jlong   lval = 0;
   jdouble dval = 0;
 
-  // On a mounted virtual thread the runner() frame is in a continuation, so
-  // SetLocal at depth != 0 is rejected with OPAQUE_FRAME before the slot check.
-  jvmtiError setExpected = isVirtual ? JVMTI_ERROR_OPAQUE_FRAME : JVMTI_ERROR_INVALID_SLOT;
-
   // T_LONG / T_DOUBLE => extra_slot == 1 => INT_MAX + 1 overflows to INT_MIN.
   bool ok = true;
-  ok &= expect_error("GetLocalLong",   jvmti->GetLocalLong(thread, Depth, OverflowSlot, &lval), JVMTI_ERROR_INVALID_SLOT);
-  ok &= expect_error("GetLocalDouble", jvmti->GetLocalDouble(thread, Depth, OverflowSlot, &dval), JVMTI_ERROR_INVALID_SLOT);
-  ok &= expect_error("SetLocalLong",   jvmti->SetLocalLong(thread, Depth, OverflowSlot, (jlong)0), setExpected);
-  ok &= expect_error("SetLocalDouble", jvmti->SetLocalDouble(thread, Depth, OverflowSlot, (jdouble)0), setExpected);
+  ok &= expect_invalid_slot("GetLocalLong",   jvmti->GetLocalLong(thread, Depth, OverflowSlot, &lval));
+  ok &= expect_invalid_slot("GetLocalDouble", jvmti->GetLocalDouble(thread, Depth, OverflowSlot, &dval));
+
+  // On a mounted virtual thread the runner() frame is in a continuation, so
+  // SetLocal at depth != 0 is rejected with JVMTI_ERROR_OPAQUE_FRAME before the
+  // slot check runs -- it never exercises the overflow, so skip it there.
+  if (!isVirtual) {
+    ok &= expect_invalid_slot("SetLocalLong",   jvmti->SetLocalLong(thread, Depth, OverflowSlot, (jlong)0));
+    ok &= expect_invalid_slot("SetLocalDouble", jvmti->SetLocalDouble(thread, Depth, OverflowSlot, (jdouble)0));
+  }
   return ok ? JNI_TRUE : JNI_FALSE;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetLocalVariable/libGetSetLocalSlotOverflow.cpp
@@ -37,21 +37,20 @@ static const jint OverflowSlot = INT_MAX; // 0x7fffffff
 
 static jvmtiEnv *jvmti = nullptr;
 
-// Each access below MUST come back as JVMTI_ERROR_INVALID_SLOT. On an unfixed
-// VM the overflowing bounds check is bypassed and the subsequent
-// locals->at(INT_MAX) access crashes the VM before we ever see a return code.
-static bool expect_invalid_slot(const char* what, jvmtiError err) {
-  if (err == JVMTI_ERROR_INVALID_SLOT) {
-    LOG(" PASS: %s returned JVMTI_ERROR_INVALID_SLOT (%d) for slot=INT_MAX\n", what, err);
+// Each access must be rejected with the expected error. On an unfixed VM the
+// overflowing bounds check is bypassed and the subsequent locals->at(INT_MAX)
+// access crashes the VM before we ever see a return code.
+static bool expect_error(const char* what, jvmtiError err, jvmtiError expected) {
+  if (err == expected) {
+    LOG(" PASS: %s returned %d for slot=INT_MAX\n", what, err);
     return true;
   }
-  LOG(" FAIL: %s returned %d for slot=INT_MAX, expected JVMTI_ERROR_INVALID_SLOT (%d)\n",
-         what, err, JVMTI_ERROR_INVALID_SLOT);
+  LOG(" FAIL: %s returned %d for slot=INT_MAX, expected %d\n", what, err, expected);
   return false;
 }
 
 JNIEXPORT jboolean JNICALL
-Java_GetSetLocalSlotOverflow_testOverflow(JNIEnv *env, jclass cls, jobject thread) {
+Java_GetSetLocalSlotOverflow_testOverflow(JNIEnv *env, jclass cls, jobject thread, jboolean isVirtual) {
   if (jvmti == nullptr) {
     LOG("JVMTI client was not properly loaded!\n");
     return JNI_FALSE;
@@ -60,12 +59,16 @@ Java_GetSetLocalSlotOverflow_testOverflow(JNIEnv *env, jclass cls, jobject threa
   jlong   lval = 0;
   jdouble dval = 0;
 
+  // On a mounted virtual thread the runner() frame is in a continuation, so
+  // SetLocal at depth != 0 is rejected with OPAQUE_FRAME before the slot check.
+  jvmtiError setExpected = isVirtual ? JVMTI_ERROR_OPAQUE_FRAME : JVMTI_ERROR_INVALID_SLOT;
+
   // T_LONG / T_DOUBLE => extra_slot == 1 => INT_MAX + 1 overflows to INT_MIN.
   bool ok = true;
-  ok &= expect_invalid_slot("GetLocalLong",   jvmti->GetLocalLong(thread, Depth, OverflowSlot, &lval));
-  ok &= expect_invalid_slot("GetLocalDouble", jvmti->GetLocalDouble(thread, Depth, OverflowSlot, &dval));
-  ok &= expect_invalid_slot("SetLocalLong",   jvmti->SetLocalLong(thread, Depth, OverflowSlot, (jlong)0));
-  ok &= expect_invalid_slot("SetLocalDouble", jvmti->SetLocalDouble(thread, Depth, OverflowSlot, (jdouble)0));
+  ok &= expect_error("GetLocalLong",   jvmti->GetLocalLong(thread, Depth, OverflowSlot, &lval), JVMTI_ERROR_INVALID_SLOT);
+  ok &= expect_error("GetLocalDouble", jvmti->GetLocalDouble(thread, Depth, OverflowSlot, &dval), JVMTI_ERROR_INVALID_SLOT);
+  ok &= expect_error("SetLocalLong",   jvmti->SetLocalLong(thread, Depth, OverflowSlot, (jlong)0), setExpected);
+  ok &= expect_error("SetLocalDouble", jvmti->SetLocalDouble(thread, Depth, OverflowSlot, (jdouble)0), setExpected);
   return ok ? JNI_TRUE : JNI_FALSE;
 }
 


### PR DESCRIPTION
The test added in JDK-8387718 (#31772) fails when run with the virtual thread factory, on Linux and Windows, x64 and aarch64.

The failure is in the test's expectation, not in the VM. GetLocalLong/Double with slot == INT_MAX still return JVMTI_ERROR_INVALID_SLOT as expected. But SetLocalLong/Double return JVMTI_ERROR_OPAQUE_FRAME on a mounted virtual thread: the runner() frame is inside a continuation, and VM_BaseGetOrSetLocal::doit() rejects a set at depth != 0 in a continuation frame before the slot bounds check is ever reached. On a platform thread there is no continuation, so the set reaches the slot check and returns INVALID_SLOT like the get accessors.

Since the set accessors cannot reach the overflow check on a virtual thread, the test skips the set sub-tests there rather than asserting a second error code. The Java side passes Thread.currentThread().isVirtual() to the agent, which runs GetLocalLong/Double in both modes and adds SetLocalLong/Double only on a platform thread. Every accessor that runs still requires INVALID_SLOT, so the original overflow is exercised on platform threads and the get path covers it on virtual threads.

Testing:

- [x] serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java passes on platform threads (all four accessors return INVALID_SLOT)
- [x] Passes with -testThreadFactory:Virtual (get accessors return INVALID_SLOT, set skipped), reproducing then clearing the reported failure
- [x] linux-x86_64 fastdebug

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388464](https://bugs.openjdk.org/browse/JDK-8388464): New test serviceability/jvmti/GetLocalVariable/GetSetLocalSlotOverflow.java is failing with virtual threads (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [8b92c680](https://git.openjdk.org/jdk/pull/31965/files/8b92c680a262426379a5c66e337c77f1292bf961)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31965/head:pull/31965` \
`$ git checkout pull/31965`

Update a local copy of the PR: \
`$ git checkout pull/31965` \
`$ git pull https://git.openjdk.org/jdk.git pull/31965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31965`

View PR using the GUI difftool: \
`$ git pr show -t 31965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31965.diff">https://git.openjdk.org/jdk/pull/31965.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31965#issuecomment-5017607676)
</details>
