### PR TITLE
8386871: ZGC: Clarify ZRelocationSetSelectorGroupStats::_relocate

### DIFF
--- a/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
@@ -39,7 +39,7 @@ ZRelocationSetSelectorGroupStats::ZRelocationSetSelectorGroupStats()
     _live(0),
     _empty(0),
     _npages_selected(0),
-    _relocate(0) {}
+    _nbytes_to_relocate(0) {}
 
 ZRelocationSetSelectorGroup::ZRelocationSetSelectorGroup(const char* name,
                                                          ZPageType page_type,
@@ -187,7 +187,7 @@ void ZRelocationSetSelectorGroup::select_inner() {
 
   // Update statistics
   for (uint i = 0; i < ZPageAgeCount; ++i) {
-    _stats[i]._relocate = live_bytes_per_age[i] - rejected_live_bytes_per_age[i];
+    _stats[i]._nbytes_to_relocate = live_bytes_per_age[i] - rejected_live_bytes_per_age[i];
     _stats[i]._npages_selected = npages_per_age[i] - rejected_npages_per_age[i];
   }
 
@@ -219,11 +219,15 @@ void ZRelocationSetSelectorGroup::select() {
     s._total += _stats[i].total();
     s._empty += _stats[i].empty();
     s._npages_selected += _stats[i].npages_selected();
-    s._relocate += _stats[i].relocate();
+    s._nbytes_to_relocate += _stats[i].nbytes_to_relocate();
   }
 
   // Send event
-  event.commit((u8)_page_type, s._npages_candidates, s._total, s._empty, s._npages_selected, s._relocate);
+  event.commit((u8)_page_type,
+               s._npages_candidates,
+               s._total, s._empty,
+               s._npages_selected,
+               s._nbytes_to_relocate);
 }
 
 ZRelocationSetSelector::ZRelocationSetSelector(double fragmentation_limit)
@@ -247,7 +251,7 @@ void ZRelocationSetSelector::select() {
   _small.select();
 
   // Send event
-  event.commit(total(), empty(), relocate());
+  event.commit(total(), empty(), nbytes_to_relocate());
 }
 
 ZRelocationSetSelectorStats ZRelocationSetSelector::stats() const {

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ private:
 
   // Selected set
   size_t _npages_selected;
-  size_t _relocate;
+  size_t _nbytes_to_relocate;
 
 public:
   ZRelocationSetSelectorGroupStats();
@@ -55,7 +55,7 @@ public:
   size_t empty() const;
 
   size_t npages_selected() const;
-  size_t relocate() const;
+  size_t nbytes_to_relocate() const;
 };
 
 class ZRelocationSetSelectorStats {
@@ -129,7 +129,7 @@ private:
 
   size_t total() const;
   size_t empty() const;
-  size_t relocate() const;
+  size_t nbytes_to_relocate() const;
 
 public:
   ZRelocationSetSelector(double fragmentation_limit);

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,8 @@ inline size_t ZRelocationSetSelectorGroupStats::npages_selected() const {
   return _npages_selected;
 }
 
-inline size_t ZRelocationSetSelectorGroupStats::relocate() const {
-  return _relocate;
+inline size_t ZRelocationSetSelectorGroupStats::nbytes_to_relocate() const {
+  return _nbytes_to_relocate;
 }
 
 inline bool ZRelocationSetSelectorStats::has_relocatable_pages() const {
@@ -203,10 +203,12 @@ inline size_t ZRelocationSetSelector::empty() const {
   return sum;
 }
 
-inline size_t ZRelocationSetSelector::relocate() const {
+inline size_t ZRelocationSetSelector::nbytes_to_relocate() const {
   size_t sum = 0;
   for (ZPageAge age : ZPageAgeRangeAll) {
-    sum += _small.stats(age).relocate() + _medium.stats(age).relocate() + _large.stats(age).relocate();
+    sum += _small.stats(age).nbytes_to_relocate() +
+           _medium.stats(age).nbytes_to_relocate() +
+           _large.stats(age).nbytes_to_relocate();
   }
   return sum;
 }

--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1497,7 +1497,7 @@ void ZStatRelocation::print_page_summary() {
     summary.total += stats.total();
     summary.empty += stats.empty();
     summary.npages_selected += stats.npages_selected();
-    summary.relocate += stats.relocate();
+    summary.nbytes_to_relocate += stats.nbytes_to_relocate();
   };
 
   for (ZPageAge age : ZPageAgeRangeAll) {
@@ -1525,7 +1525,7 @@ void ZStatRelocation::print_page_summary() {
              .right("%zu", in_place_count)
              .right("%zuM", summary.total / M)
              .right("%zuM", summary.empty / M)
-             .right("%zuM", summary.relocate /M)
+             .right("%zuM", summary.nbytes_to_relocate / M)
              .end());
   };
 

--- a/src/hotspot/share/gc/z/zStat.hpp
+++ b/src/hotspot/share/gc/z/zStat.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -516,7 +516,7 @@ struct ZStatRelocationSummary {
   size_t live;
   size_t empty;
   size_t npages_selected;
-  size_t relocate;
+  size_t nbytes_to_relocate;
 };
 
 //


### PR DESCRIPTION
Please review this change, thanks!

This patch renames `_relocate` to `_nbytes_to_relocate` to clarify that it represents the number of bytes to be relocated.

**Test:**

GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386871](https://bugs.openjdk.org/browse/JDK-8386871): ZGC: Clarify ZRelocationSetSelectorGroupStats::_relocate (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31966/head:pull/31966` \
`$ git checkout pull/31966`

Update a local copy of the PR: \
`$ git checkout pull/31966` \
`$ git pull https://git.openjdk.org/jdk.git pull/31966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31966`

View PR using the GUI difftool: \
`$ git pr show -t 31966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31966.diff">https://git.openjdk.org/jdk/pull/31966.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31966#issuecomment-5018046462)
</details>
