### PR TITLE
8388439: [s390x] LoadNKlass rule doesn't kill CC

### DIFF
--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,10 +42,12 @@ void C2_MacroAssembler::fast_unlock(Register obj, Register box, Register temp1, 
 }
 
 void C2_MacroAssembler::load_narrow_klass_compact_c2(Register dst, Address src) {
+  BLOCK_COMMENT("load_narrow_klass_compact_c2 {");
   // The incoming address is pointing into obj-start + klass_offset_in_bytes. We need to extract
   // obj-start, so that we can load from the object's mark-word instead.
   z_lg(dst, src.plus_disp(-oopDesc::klass_offset_in_bytes()));
-  z_srlg(dst, dst, markWord::klass_shift); // TODO: could be z_sra
+  z_srlg(dst, dst, markWord::klass_shift);
+  BLOCK_COMMENT("} load_narrow_klass_compact_c2");
 }
 
 //------------------------------------------------------

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -4816,17 +4816,15 @@ instruct loadNKlass(iRegN dst, memory mem) %{
   ins_pipe(pipe_class_dummy);
 %}
 
-instruct loadNKlassCompactHeaders(iRegN dst, memory mem, flagsReg cr) %{
+instruct loadNKlassCompactHeaders(iRegN dst, memory mem) %{
   match(Set dst (LoadNKlass mem));
   predicate(UseCompactObjectHeaders);
-  effect(KILL cr);
   ins_cost(MEMORY_REF_COST);
   format %{ "load_narrow_klass_compact $dst,$mem \t# compressed class ptr" %}
-  // TODO: size()
+  // z_lg (6 bytes) + z_srlg (6 bytes); neither instruction modifies the CC.
+  size(12);
   ins_encode %{
-    __ block_comment("load_narrow_klass_compact_c2 {");
     __ load_narrow_klass_compact_c2($dst$$Register, $mem$$Address);
-    __ block_comment("} load_narrow_klass_compact");
   %}
   ins_pipe(pipe_class_dummy);
 %}


### PR DESCRIPTION
effect(KILL cr); for the rule loadNKlassCompactHeaders is wrong. it uses two instruction lg + srlg both of which are not killing CC according to Z operations book.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388439](https://bugs.openjdk.org/browse/JDK-8388439): [s390x] LoadNKlass rule doesn't kill CC (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31967/head:pull/31967` \
`$ git checkout pull/31967`

Update a local copy of the PR: \
`$ git checkout pull/31967` \
`$ git pull https://git.openjdk.org/jdk.git pull/31967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31967`

View PR using the GUI difftool: \
`$ git pr show -t 31967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31967.diff">https://git.openjdk.org/jdk/pull/31967.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31967#issuecomment-5018962790)
</details>
