### PR TITLE
8388415: Typo "sufficent" (instead of "sufficient") in package-info.java of java.lang.classfile.attribute package

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/attribute/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/package-info.java
@@ -61,7 +61,7 @@
  * <h2 id="writing">Writing Attributes</h2>
  * Most attributes implement at least one of {@link ClassElement}, {@link FieldElement}, {@link MethodElement}, or
  * {@link CodeElement}, so they can be sent to the respective {@link ClassFileBuilder} to be written as part of those
- * structure.  Attributes define if they can {@linkplain AttributeMapper#allowMultiple() appear multiple times} in one
+ * structures.  Attributes define if they can {@linkplain AttributeMapper#allowMultiple() appear multiple times} in one
  * structure; if they cannot, the last attribute instance supplied to the builder is the one written to the final
  * structure.  Some attributes, such as {@link BootstrapMethodsAttribute}, implement none of those interfaces.  They are
  * created through other means, specified in the modeling interface for each of the attributes.  Attributes for a {@link
@@ -69,7 +69,7 @@
  * <p>
  * The attribute factories generally have two sets of factory methods: one that accepts symbolic information
  * representing the uses, and another that accepts constant pool entries.  Most of time, the symbolic factories are
- * sufficent, but the constant pool entry ones can be used for fine-grained control over {@code class} file generation;
+ * sufficient, but the constant pool entry ones can be used for fine-grained control over {@code class} file generation;
  * see "{@linkplain java.lang.classfile.constantpool##writing Writing the constant pool entries}" for more details.
  * <p>
  * Many attributes can be bulk-copied if the data it depends on does not change; this information is exposed in {@link


### PR DESCRIPTION
Please review this change. Thanks!

Fix typo in package-info.java documentation.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388415](https://bugs.openjdk.org/browse/JDK-8388415): Typo "sufficent" (instead of "sufficient") in package-info.java of java.lang.classfile.attribute package (**Bug** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31970/head:pull/31970` \
`$ git checkout pull/31970`

Update a local copy of the PR: \
`$ git checkout pull/31970` \
`$ git pull https://git.openjdk.org/jdk.git pull/31970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31970`

View PR using the GUI difftool: \
`$ git pr show -t 31970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31970.diff">https://git.openjdk.org/jdk/pull/31970.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31970#issuecomment-5109103504)
</details>
