### PR TITLE
8386576: Calculating Area using a complex polygon creates spurious horizontal line segments

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/geom/AreaOp.java
+++ b/src/java.desktop/share/classes/sun/awt/geom/AreaOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,8 +146,6 @@ public abstract class AreaOp {
     public static final int RSTAG_INSIDE = 1;
     public static final int RSTAG_OUTSIDE = -1;
 
-    public static final int MAX_LINK_COUNT = 1024;
-
     public abstract void newRow();
 
     public abstract int classify(Edge e);
@@ -240,7 +238,6 @@ public abstract class AreaOp {
         Vector<ChainEnd> chains = new Vector<>();
         Vector<CurveLink> links = new Vector<>();
         Vector<Curve> ret = new Vector<>();
-        int linkCount = 0;
         // Active edges are between left (inclusive) and right (exclusive)
         while (left < numedges) {
             double y = yrange[0];
@@ -262,7 +259,8 @@ public abstract class AreaOp {
                 }
                 y = edgelist[right].getCurve().getYTop();
                 if (y > yrange[0]) {
-                    finalizeSubCurves(subcurves, chains);
+                    consumeSubCurves(subcurves, chains, ret);
+                    subcurves.clear();
                 }
                 yrange[0] = y;
             }
@@ -413,15 +411,6 @@ public abstract class AreaOp {
                     System.out.println("  "+link.getSubCurve());
                 }
             }
-            // If we have complex area calculation, we should consume the
-            // intermediate subcurves to optimize memory footprint
-            if (linkCount >= MAX_LINK_COUNT) {
-                consumeSubCurves(subcurves, chains, ret);
-                linkCount = 0;
-                chains.clear();
-                subcurves.clear();
-            }
-            linkCount += links.size();
             resolveLinks(subcurves, chains, links);
             links.clear();
             // Finally capture the bottom of the valid Y range as the top

--- a/src/java.desktop/share/classes/sun/awt/geom/AreaOp.java
+++ b/src/java.desktop/share/classes/sun/awt/geom/AreaOp.java
@@ -259,8 +259,7 @@ public abstract class AreaOp {
                 }
                 y = edgelist[right].getCurve().getYTop();
                 if (y > yrange[0]) {
-                    consumeSubCurves(subcurves, chains, ret);
-                    subcurves.clear();
+                    finalizeSubCurves(subcurves, chains);
                 }
                 yrange[0] = y;
             }

--- a/test/jdk/java/awt/geom/Area/AreaPath2DDrawTest.java
+++ b/test/jdk/java/awt/geom/Area/AreaPath2DDrawTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8386576
+ * @summary Checks that when we calculate Area of a path it results
+ *          in proper geometry and no horizontal spurious lines are
+ *          drawn.
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.geom.Area;
+import java.awt.geom.Path2D;
+import java.awt.image.BufferedImage;
+
+public class AreaPath2DDrawTest {
+    public static void main(String[] args) throws Exception {
+        int size = 500;
+        int segments = 2000;
+        double center = size / 2.0;
+        double radius = size / 2.0;
+
+        // Build a simple closed polygon: a circle approximated by straight
+        // line segments.
+        Path2D.Double path = new Path2D.Double();
+        path.moveTo(center + radius, center);
+
+        for (int i = 1; i < segments; i++) {
+            double angle = 2.0 * Math.PI * i / segments;
+            path.lineTo(
+                center + Math.cos(angle) * radius,
+                center + Math.sin(angle) * radius);
+        }
+
+        path.closePath();
+
+        BufferedImage image =
+            new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = image.createGraphics();
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, size, size);
+        g.setColor(Color.BLACK);
+        g.draw(new Area(path));
+        g.dispose();
+
+        // We are drawing a circle with diameter of 500, check for horizontal
+        // spurious lines within the circle
+        for (int y = 10; y < size - 10; y++) {
+            int color = image.getRGB(size / 2, y);
+            if (color != Color.WHITE.getRGB()) {
+                throw new RuntimeException("Seeing horizontal spurious" +
+                    " line at y: " + y);
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/geom/Area/AreaPath2DDrawTest.java
+++ b/test/jdk/java/awt/geom/Area/AreaPath2DDrawTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug     8386576
- * @summary Checks that when we calculate Area of a path it results
- *          in proper geometry and no horizontal spurious lines are
- *          drawn.
+ * @summary Checks that when we draw a circle using area of approximated
+ *          straight line segments, no horizontal spurious lines are
+ *          drawn within the circle.
  */
 
 import java.awt.Color;


### PR DESCRIPTION
In AreaOp.pruneEdges() we are finalizing and consuming subcurves prematurely based on link count and this causes artifacts. This PR updates the code to not finalize the subcurves based on link count. Code is updated to finalize and consume subcurves only when there is a not connected Y gap.

Regression tests draws a circle with individual line segments, without the fix we will see horizontal lines within the circle and with fix we don't see any artifacts. Code change is also verified with clientlibs CI run.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386576](https://bugs.openjdk.org/browse/JDK-8386576): Calculating Area using a complex polygon creates spurious horizontal line segments (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31971/head:pull/31971` \
`$ git checkout pull/31971`

Update a local copy of the PR: \
`$ git checkout pull/31971` \
`$ git pull https://git.openjdk.org/jdk.git pull/31971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31971`

View PR using the GUI difftool: \
`$ git pr show -t 31971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31971.diff">https://git.openjdk.org/jdk/pull/31971.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31971#issuecomment-5021239725)
</details>
