### PR TITLE
8388477: Replace false with 0 in IntelJccErratum::compute_padding

### DIFF
--- a/src/hotspot/cpu/x86/c2_intelJccErratum_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_intelJccErratum_x86.cpp
@@ -103,7 +103,7 @@ int IntelJccErratum::compute_padding(uintptr_t current_offset, const MachNode* m
   }
   if (jcc_size > largest_jcc_size()) {
     // Let's not try fixing this for nodes that seem unreasonably large
-    return false;
+    return 0;
   }
   if (is_crossing_or_ending_at_32_byte_boundary(current_offset, current_offset + jcc_size)) {
     return int(align_up(current_offset, 32) - current_offset);


### PR DESCRIPTION
Trivial changing `false` to `0` to match the return type.

Test: build

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388477](https://bugs.openjdk.org/browse/JDK-8388477): Replace false with 0 in IntelJccErratum::compute_padding (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31972/head:pull/31972` \
`$ git checkout pull/31972`

Update a local copy of the PR: \
`$ git checkout pull/31972` \
`$ git pull https://git.openjdk.org/jdk.git pull/31972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31972`

View PR using the GUI difftool: \
`$ git pr show -t 31972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31972.diff">https://git.openjdk.org/jdk/pull/31972.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31972#issuecomment-5022068829)
</details>
