### PR TITLE
8388475: RISC-V: Optimize MD5 intrinsics by reducing data dependency

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5198,72 +5198,128 @@ class StubGenerator: public StubCodeGenerator {
 
   typedef RegCache<8> BufRegCache;
 
+  // a += ac;
+  void m5_FF_GG_HH_II_epilogue_a(Register a, int t) {
+    // a += ac
+    __ addw(a, a, t, t1);
+  }
+
+  // a += x;
+  void m5_FF_GG_HH_II_epilogue_b(BufRegCache& reg_cache,
+                               Register a, int k) {
+    // a += x;
+    reg_cache.add_u32(a, k);
+  }
+
+  // a += value;
+  void m5_FF_GG_HH_II_epilogue_c(Register a, Register value) {
+    // a += value;
+    __ addw(a, a, value);
+  }
+
+  // a = Integer.rotateLeft(a, s) + b;
+  void m5_FF_GG_HH_II_epilogue_d(Register a, Register b, int s) {
+    // a = Integer.rotateLeft(a, s) + b;
+    __ rolw(a, a, s);
+    __ addw(a, a, b);
+  }
+
   // a += value + x + ac;
   // a = Integer.rotateLeft(a, s) + b;
   void m5_FF_GG_HH_II_epilogue(BufRegCache& reg_cache,
                                Register a, Register b, Register c, Register d,
                                int k, int s, int t,
                                Register value) {
-    // a += ac
-    __ addw(a, a, t, t1);
-
-    // a += x;
-    reg_cache.add_u32(a, k);
-    // a += value;
-    __ addw(a, a, value);
-
-    // a = Integer.rotateLeft(a, s) + b;
-    __ rolw(a, a, s);
-    __ addw(a, a, b);
+    m5_FF_GG_HH_II_epilogue_b(reg_cache, a, k);
+    m5_FF_GG_HH_II_epilogue_a(a, t);
+    m5_FF_GG_HH_II_epilogue_c(a, value);
+    m5_FF_GG_HH_II_epilogue_d(a, b, s);
   }
 
-  // a += ((b & c) | ((~b) & d)) + x + ac;
+  // a += (d ^ (b & (c ^ d))) + x + ac;
   // a = Integer.rotateLeft(a, s) + b;
   void md5_FF(BufRegCache& reg_cache,
               Register a, Register b, Register c, Register d,
               int k, int s, int t,
               Register rtmp1, Register rtmp2) {
-    // rtmp1 = b & c
-    __ andr(rtmp1, b, c);
+    // rtmp1 = c ^ d
+    __ xorr(rtmp1, c, d);
 
-    // rtmp2 = (~b) & d
-    __ andn(rtmp2, d, b);
+    m5_FF_GG_HH_II_epilogue_a(a, t);
 
-    // rtmp1 = (b & c) | ((~b) & d)
-    __ orr(rtmp1, rtmp1, rtmp2);
+    // rtmp1 = b & (c ^ d) = b & rtmp1
+    __ andr(rtmp1, b, rtmp1);
 
-    m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t, rtmp1);
+    m5_FF_GG_HH_II_epilogue_b(reg_cache, a, k);
+
+    // rtmp1 = d ^ (b & (c ^ d)) = d ^ rtmp1
+    __ xorr(rtmp1, d, rtmp1);
+
+    m5_FF_GG_HH_II_epilogue_c(a, rtmp1);
+    m5_FF_GG_HH_II_epilogue_d(a, b, s);
   }
 
-  // a += ((b & d) | (c & (~d))) + x + ac;
+  // a += ((c & (~d)) + (b & d)) + x + ac;
   // a = Integer.rotateLeft(a, s) + b;
   void md5_GG(BufRegCache& reg_cache,
               Register a, Register b, Register c, Register d,
               int k, int s, int t,
               Register rtmp1, Register rtmp2) {
-    // rtmp1 = b & d
-    __ andr(rtmp1, b, d);
+    m5_FF_GG_HH_II_epilogue_b(reg_cache, a, k);
+    m5_FF_GG_HH_II_epilogue_a(a, t);
 
-    // rtmp2 = c & (~d)
-    __ andn(rtmp2, c, d);
+    // rtmp1 = c & (~d)
+    __ andn(rtmp1, c, d);
 
-    // rtmp1 = (b & d) | (c & (~d))
-    __ orr(rtmp1, rtmp1, rtmp2);
+    // rtmp2 = b & d
+    __ andr(rtmp2, b, d);
 
-    m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t, rtmp1);
+    // a += c & (~d)
+    m5_FF_GG_HH_II_epilogue_c(a, rtmp1);
+
+    // a += b & d
+    m5_FF_GG_HH_II_epilogue_c(a, rtmp2);
+
+    m5_FF_GG_HH_II_epilogue_d(a, b, s);
   }
 
-  // a += ((b ^ c) ^ d) + x + ac;
+  // a += (b ^ (c ^ d)) + x + ac;
   // a = Integer.rotateLeft(a, s) + b;
+  void md5_HH_a(BufRegCache& reg_cache,
+              Register a, Register b, Register c, Register d,
+              int k, int s, int t,
+              Register rtmp1, Register rtmp2) {
+    // precomputed rtmp2 = (c ^ d)
+    // rtmp1 = b ^ (c ^ d) = b ^ rtmp2
+    __ xorr(rtmp1, b, rtmp2);
+    m5_FF_GG_HH_II_epilogue_b(reg_cache, a, k);
+    m5_FF_GG_HH_II_epilogue_a(a, t);
+  }
+
+  void md5_HH_b(BufRegCache& reg_cache,
+              Register a, Register b, Register c, Register d,
+              int k, int s, int t,
+              Register rtmp1, Register rtmp2) {
+    // rtmp2 = b ^ (c ^ d) ^ d == (b ^ c)
+    // rtmp2 will be next round's (c ^ d)
+    __ xorr(rtmp2, rtmp1, d);
+  }
+
+  void md5_HH_c(BufRegCache& reg_cache,
+              Register a, Register b, Register c, Register d,
+              int k, int s, int t,
+              Register rtmp1, Register rtmp2) {
+    m5_FF_GG_HH_II_epilogue_c(a, rtmp1);
+    m5_FF_GG_HH_II_epilogue_d(a, b, s);
+  }
+
   void md5_HH(BufRegCache& reg_cache,
               Register a, Register b, Register c, Register d,
               int k, int s, int t,
               Register rtmp1, Register rtmp2) {
-    // rtmp1 = (b ^ c) ^ d
-    __ xorr(rtmp2, b, c);
-    __ xorr(rtmp1, rtmp2, d);
-
-    m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t, rtmp1);
+    md5_HH_a(reg_cache, a, b, c, d, k, s, t, rtmp1, rtmp2);
+    md5_HH_b(reg_cache, a, b, c, d, k, s, t, rtmp1, rtmp2);
+    md5_HH_c(reg_cache, a, b, c, d, k, s, t, rtmp1, rtmp2);
   }
 
   // a += (c ^ (b | (~d))) + x + ac;
@@ -5272,11 +5328,15 @@ class StubGenerator: public StubCodeGenerator {
               Register a, Register b, Register c, Register d,
               int k, int s, int t,
               Register rtmp1, Register rtmp2) {
+    m5_FF_GG_HH_II_epilogue_b(reg_cache, a, k);
+    m5_FF_GG_HH_II_epilogue_a(a, t);
+
     // rtmp1 = c ^ (b | (~d))
     __ orn(rtmp2, b, d);
     __ xorr(rtmp1, c, rtmp2);
 
-    m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t, rtmp1);
+    m5_FF_GG_HH_II_epilogue_c(a, rtmp1);
+    m5_FF_GG_HH_II_epilogue_d(a, b, s);
   }
 
   // Arguments:
@@ -5474,6 +5534,8 @@ class StubGenerator: public StubCodeGenerator {
     md5_GG(reg_cache, b, c, d, a, 12, S24, 0x8d2a4c8a, rtmp1, rtmp2);
 
     // Round 3
+    // pre-compute (c ^ d) for the first HH round.
+    __ xorr (rtmp2, c, d);
     md5_HH(reg_cache, a, b, c, d,  5, S31, 0xfffa3942, rtmp1, rtmp2);
     md5_HH(reg_cache, d, a, b, c,  8, S32, 0x8771f681, rtmp1, rtmp2);
     md5_HH(reg_cache, c, d, a, b, 11, S33, 0x6d9d6122, rtmp1, rtmp2);
@@ -5489,7 +5551,8 @@ class StubGenerator: public StubCodeGenerator {
     md5_HH(reg_cache, a, b, c, d,  9, S31, 0xd9d4d039, rtmp1, rtmp2);
     md5_HH(reg_cache, d, a, b, c, 12, S32, 0xe6db99e5, rtmp1, rtmp2);
     md5_HH(reg_cache, c, d, a, b, 15, S33, 0x1fa27cf8, rtmp1, rtmp2);
-    md5_HH(reg_cache, b, c, d, a,  2, S34, 0xc4ac5665, rtmp1, rtmp2);
+    md5_HH_a(reg_cache, b, c, d, a,  2, S34, 0xc4ac5665, rtmp1, rtmp2);
+    md5_HH_c(reg_cache, b, c, d, a,  2, S34, 0xc4ac5665, rtmp1, rtmp2);
 
     // Round 4
     md5_II(reg_cache, a, b, c, d,  0, S41, 0xf4292244, rtmp1, rtmp2);


### PR DESCRIPTION
Hi, As suggested in https://github.com/animetosho/md5-optimisation?tab=readme-ov-file#dependency-shortcut-in-g-function, and already applied to x86/aarch64 in JDK-8341013, we extend the same "reduce data dependency" technique to the RISC-V MD5 intrinsic.

### Correctness Testing
- [x] Run tier1-tier3 test with release on SpacemiT Key Stone K3 

### Performance Testing
##### MessageDigestBench.digest 
witchout this patch:
```Benchmark                  (algorithm)  (dataSize)  (provider)   Mode  Cnt    Score   Error  Units
MessageDigestBench.digest          MD5     1048576              thrpt   40  272.922 ± 2.532  ops/s
Finished running test 'micro:org.openjdk.bench.javax.crypto.full.MessageDigestBench'

```
with this patch:
```
Benchmark                  (algorithm)  (dataSize)  (provider)   Mode  Cnt    Score   Error  Units
MessageDigestBench.digest          MD5     1048576              thrpt   40  284.151 ± 1.735  ops/s
Finished running test 'micro:org.openjdk.bench.javax.crypto.full.MessageDigestBench'
```

#### MessageDigests
without this patch:
```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt     Score    Error   Units
MessageDigests.digest                   md5        64     DEFAULT  thrpt   15  2024.452 ± 12.158  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   15    23.539 ±  0.095  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   15   976.647 ±  9.073  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   15    23.141 ±  0.036  ops/ms
Finished running test 'micro:org.openjdk.bench.java.security.MessageDigests'
```

with this patch:
```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt     Score    Error   Units
MessageDigests.digest                   md5        64     DEFAULT  thrpt   15  2040.211 ± 11.652  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   15    24.668 ±  0.007  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   15   996.653 ± 14.273  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   15    24.217 ±  0.014  ops/ms
Finished running test 'micro:org.openjdk.bench.java.security.MessageDigests'
```

Co-authored-by: wangbingzhen [wangbingzhen.riscv@isrc.iscas.ac.cn](mailto:wangbingzhen.riscv@isrc.iscas.ac.cn)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388475](https://bugs.openjdk.org/browse/JDK-8388475): RISC-V: Optimize MD5 intrinsics by reducing data dependency (**Enhancement** - P4)


### Contributors
 * gns `<wangbingzhen.riscv@isrc.iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31973/head:pull/31973` \
`$ git checkout pull/31973`

Update a local copy of the PR: \
`$ git checkout pull/31973` \
`$ git pull https://git.openjdk.org/jdk.git pull/31973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31973`

View PR using the GUI difftool: \
`$ git pr show -t 31973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31973.diff">https://git.openjdk.org/jdk/pull/31973.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31973#issuecomment-5029924400)
</details>
