### PR TITLE
8388443: C2: Assertion in PhaseRegAlloc::reg2offset() is too strict

### DIFF
--- a/src/hotspot/share/opto/regalloc.cpp
+++ b/src/hotspot/share/opto/regalloc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ int PhaseRegAlloc::reg2offset( OptoReg::Name reg ) const {
            reg <  _matcher._in_arg_limit) ||
           reg >=  OptoReg::add(_matcher._new_SP, C->out_preserve_stack_slots()) ||
           // Allow return_addr in the out-preserve area.
-          reg == _matcher.return_addr(),
+          reg == _matcher.return_addr() LP64_ONLY(|| OptoReg::add(reg, -1) == _matcher.return_addr()),
           "register allocated in a preserve area" );
   return reg2offset_unchecked( reg );
 }


### PR DESCRIPTION
### Change

Very small change that relaxes the assertion in `PhaseRegAlloc::reg2offset()` allowing access to both 4 byte slots of `Matcher::return_addr()`

This is necessary because during register allocation the return address is referenced using the hi slot of `Matcher::return_addr()` and after register allocation the lo slot is used.

### Testing

compiler/igv/TestIdealGraphDump.java succeeds on ppc64 with the change.
Tier 1-4 of hotspot and jdk. All of langtools and jaxp. Renaissance Suite and SAP specific tests.
Testing was done on the main platforms and also on Linux/PPC64le and AIX.

### Details

##### Code References

During register allocation the highest slot of a register set is used to represent the selected register.
https://github.com/openjdk/jdk/blob/bb531919d6f9c2caafc823737950d34395d14cc3/src/hotspot/share/opto/regmask.cpp#L237-L240

After register allocation though the lowest slot is used.
https://github.com/openjdk/jdk/blob/bb531919d6f9c2caafc823737950d34395d14cc3/src/hotspot/share/opto/chaitin.cpp#L734-L742
The lowest slot is used to get the encoding.
https://github.com/openjdk/jdk/blob/bb531919d6f9c2caafc823737950d34395d14cc3/src/hotspot/share/opto/regalloc.hpp#L121

##### Example

IGV graphs from the c2 compilation of the following trivial method on x86_64 and ppc64 show this.
(I've added `[reg]` to the Node Text in the IGV settings)

```java
    public static long testMethod(long a) {
        return a;
    }
```

[testMethod_x86_64_before_regalloc.svg](https://github.com/user-attachments/assets/01c993f6-dba1-4e40-b3b7-090561f127a5)
[testMethod_x86_64_after_regalloc.svg](https://github.com/user-attachments/assets/ed214351-985e-4940-af6e-470157f7e103)
[testMethod_ppc64_before_regalloc.svg](https://github.com/user-attachments/assets/bf3d1128-2d8a-482c-9d99-468b3b31db40)
[testMethod_ppc64_after_regalloc.svg](https://github.com/user-attachments/assets/221ab342-b429-4f5e-a10d-ab867af64d4f)

* `return_address` offsets are not 8-byte aligned during register allocation. After register allocation they are 8-byte aligned as expected.

* registers for parameters and return value have _H suffix during register allocation and after register allocation they have their proper names.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388443](https://bugs.openjdk.org/browse/JDK-8388443): C2: Assertion in PhaseRegAlloc::reg2offset() is too strict (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31975/head:pull/31975` \
`$ git checkout pull/31975`

Update a local copy of the PR: \
`$ git checkout pull/31975` \
`$ git pull https://git.openjdk.org/jdk.git pull/31975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31975`

View PR using the GUI difftool: \
`$ git pr show -t 31975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31975.diff">https://git.openjdk.org/jdk/pull/31975.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31975#issuecomment-5043082861)
</details>
