### PR TITLE
8388487: Shenandoah: Robust stack watermark epoch wraparound

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahStackWatermark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStackWatermark.cpp
@@ -33,7 +33,7 @@
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "runtime/safepointVerifiers.hpp"
 
-uint32_t ShenandoahStackWatermark::_epoch_id = 1;
+uint32_t ShenandoahStackWatermark::_epoch_id = MIN_EPOCH_ID;
 
 ShenandoahOnStackNMethodClosure::ShenandoahOnStackNMethodClosure() :
     _bs_nm(BarrierSet::barrier_set()->barrier_set_nmethod()) {}
@@ -55,6 +55,9 @@ uint32_t ShenandoahStackWatermark::epoch_id() const {
 void ShenandoahStackWatermark::change_epoch_id() {
   shenandoah_assert_safepoint();
   _epoch_id++;
+  if (_epoch_id > MAX_EPOCH_ID) {
+    _epoch_id = MIN_EPOCH_ID;
+  }
 }
 
 ShenandoahStackWatermark::ShenandoahStackWatermark(JavaThread* jt) :
@@ -63,7 +66,10 @@ ShenandoahStackWatermark::ShenandoahStackWatermark(JavaThread* jt) :
   _stats(),
   _keep_alive_cl(),
   _evac_update_oop_cl(),
-  _nm_cl() {}
+  _nm_cl() {
+  assert(StackWatermarkState::epoch(_state) == _epoch_id,
+    "Should be the same: %u != %u", StackWatermarkState::epoch(_state), _epoch_id);
+}
 
 OopClosure* ShenandoahStackWatermark::closure_from_context(void* context) {
   if (context != nullptr) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahStackWatermark.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStackWatermark.hpp
@@ -49,6 +49,12 @@ public:
 
 class ShenandoahStackWatermark : public StackWatermark {
 private:
+  // Start epochs from 1 to catch uninitialized paths.
+  // Wrap the epoch around smaller range to avoid truncation
+  // in StackWatermark encoding and verify the wraparound in tests.
+  static constexpr uint32_t MIN_EPOCH_ID = 1;
+  static constexpr uint32_t MAX_EPOCH_ID = (1 << 10);
+
   static uint32_t                      _epoch_id;
   ShenandoahHeap* const                _heap;
   ThreadLocalAllocStats                _stats;


### PR DESCRIPTION
See the bug for discussion of the issue.

Additonal testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [ ] Regular testing pipelines

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388487](https://bugs.openjdk.org/browse/JDK-8388487): Shenandoah: Robust stack watermark epoch wraparound (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31977/head:pull/31977` \
`$ git checkout pull/31977`

Update a local copy of the PR: \
`$ git checkout pull/31977` \
`$ git pull https://git.openjdk.org/jdk.git pull/31977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31977`

View PR using the GUI difftool: \
`$ git pr show -t 31977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31977.diff">https://git.openjdk.org/jdk/pull/31977.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31977#issuecomment-5024623687)
</details>
