### PR TITLE
8387722: The race during initialization or lazy constants in and Map/Set

### DIFF
--- a/src/java.base/share/classes/java/util/LazyCollections.java
+++ b/src/java.base/share/classes/java/util/LazyCollections.java
@@ -675,6 +675,12 @@ final class LazyCollections {
         final long offset = offsetFor(index);
         final Object mutex = mutexes.acquireMutex(offset);
         if (mutex == null) {
+            // There might be a race where the value is alredy computed and
+            // the mutex is cleared, so we need to re-check the value again
+            final T t = (T) UNSAFE.getReferenceAcquire(array, offset);
+            if (t != null) {
+                return t;
+            }
             throwIfPreviousException(index, throwables, input);
             // There must be an exception
             throw cannotReachHere(functionHolder, input);

--- a/src/java.base/share/classes/java/util/LazyCollections.java
+++ b/src/java.base/share/classes/java/util/LazyCollections.java
@@ -675,7 +675,7 @@ final class LazyCollections {
         final long offset = offsetFor(index);
         final Object mutex = mutexes.acquireMutex(offset);
         if (mutex == null) {
-            // There might be a race where the value is alredy computed and
+            // There might be a race where the value is already computed and
             // the mutex is cleared, so we need to re-check the value again
             final T t = (T) UNSAFE.getReferenceAcquire(array, offset);
             if (t != null) {


### PR DESCRIPTION
This PR proposes to fix a race condition.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387722](https://bugs.openjdk.org/browse/JDK-8387722): The race during initialization or lazy constants in and Map/Set (**Bug** - P2)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31979/head:pull/31979` \
`$ git checkout pull/31979`

Update a local copy of the PR: \
`$ git checkout pull/31979` \
`$ git pull https://git.openjdk.org/jdk.git pull/31979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31979`

View PR using the GUI difftool: \
`$ git pr show -t 31979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31979.diff">https://git.openjdk.org/jdk/pull/31979.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31979#issuecomment-5030373579)
</details>
