### PR TITLE
8388507: DecimalFormat Strict Parsing NaN and Grouping Size Zero Fixes

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2059,7 +2059,7 @@ public class DecimalFormat extends NumberFormat {
                 // Output grouping separator if necessary.  Don't output a
                 // grouping separator if i==0 though; that's at the end of
                 // the integer part.
-                if (isGroupingRelevant() && i > 0 && i % groupingSize == 0) {
+                if (isGroupingEnabled() && i > 0 && i % groupingSize == 0) {
                     int gStart = result.length();
                     result.append(grouping);
                     delegate.formatted(Field.GROUPING_SEPARATOR,
@@ -2573,7 +2573,7 @@ public class DecimalFormat extends NumberFormat {
                 }
 
                 // Enforce the grouping size on the first group
-                if (parseStrict && isGroupingRelevant()
+                if (parseStrict && isGroupingEnabled()
                         && position == startPos + groupingSize
                         && prevSeparatorIndex == -groupingSize && !sawDecimal
                         && digit >= 0 && digit <= 9) {
@@ -2618,7 +2618,7 @@ public class DecimalFormat extends NumberFormat {
                         return new NumericPosition(-1, intIndex);
                     }
                     // Check grouping size on decimal separator
-                    if (parseStrict && isGroupingRelevant()
+                    if (parseStrict && isGroupingEnabled()
                             && isGroupingViolation(position, prevSeparatorIndex)) {
                         return new NumericPosition(
                                 groupingViolationIndex(position, prevSeparatorIndex), intIndex);
@@ -2632,7 +2632,7 @@ public class DecimalFormat extends NumberFormat {
                     digits.decimalAt = digitCount; // Not digits.count!
                     sawDecimal = true;
                 } else if (!isExponent && ch == grouping &&
-                        (parseStrict ? isGroupingRelevant() : isGroupingUsed())) {
+                        (parseStrict ? isGroupingEnabled() : isGroupingUsed())) {
                     if (parseStrict) {
                         // text should not start with grouping when strict
                         if (position == startPos) {
@@ -2690,7 +2690,7 @@ public class DecimalFormat extends NumberFormat {
             // if we have not seen a decimal separator, to prevent a grouping check in the
             // fraction portion for ex: "1,234.", "1,234.12"
             if (parseStrict) {
-                if (!sawDecimal && isGroupingRelevant()
+                if (!sawDecimal && isGroupingEnabled()
                         && isGroupingViolation(position, prevSeparatorIndex)) {
                     // -1, since position is incremented by one too many when loop is finished
                     // "1,234%" and "1,234" both end with pos = 5, since '%' breaks
@@ -2757,9 +2757,9 @@ public class DecimalFormat extends NumberFormat {
      * These operate independent of each other, and setting a grouping size of 0 does not mean that
      * isGroupingUsed() returns false. As a result, to effectively check if grouping is used,
      * both values need to be verified. Lenient parsing does not require this exhaustive check
-     * because the legacy parsing does not validate grouping size positioning.
+     * because the legacy behavior does not validate grouping size positioning.
      */
-    private boolean isGroupingRelevant() {
+    private boolean isGroupingEnabled() {
         return isGroupingUsed() && groupingSize > 0;
     }
 
@@ -3605,7 +3605,7 @@ public class DecimalFormat extends NumberFormat {
             int digitCount = useExponentialNotation ? getMaximumIntegerDigits() :
                     Math.max(groupingSize, getMinimumIntegerDigits()) + 1;
             for (int i = digitCount; i > 0; --i) {
-                if (i != digitCount && isGroupingRelevant() &&
+                if (i != digitCount && isGroupingEnabled() &&
                         i % groupingSize == 0) {
                     result.append(groupingSymbol);
                 }

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2059,8 +2059,7 @@ public class DecimalFormat extends NumberFormat {
                 // Output grouping separator if necessary.  Don't output a
                 // grouping separator if i==0 though; that's at the end of
                 // the integer part.
-                if (isGroupingUsed() && i>0 && (groupingSize != 0) &&
-                        (i % groupingSize == 0)) {
+                if (isGroupingRelevant() && i > 0 && i % groupingSize == 0) {
                     int gStart = result.length();
                     result.append(grouping);
                     delegate.formatted(Field.GROUPING_SEPARATOR,
@@ -2574,7 +2573,8 @@ public class DecimalFormat extends NumberFormat {
                 }
 
                 // Enforce the grouping size on the first group
-                if (parseStrict && isGroupingUsed() && position == startPos + groupingSize
+                if (parseStrict && isGroupingRelevant()
+                        && position == startPos + groupingSize
                         && prevSeparatorIndex == -groupingSize && !sawDecimal
                         && digit >= 0 && digit <= 9) {
                     return new NumericPosition(position, intIndex);
@@ -2618,7 +2618,8 @@ public class DecimalFormat extends NumberFormat {
                         return new NumericPosition(-1, intIndex);
                     }
                     // Check grouping size on decimal separator
-                    if (parseStrict && isGroupingViolation(position, prevSeparatorIndex)) {
+                    if (parseStrict && isGroupingRelevant()
+                            && isGroupingViolation(position, prevSeparatorIndex)) {
                         return new NumericPosition(
                                 groupingViolationIndex(position, prevSeparatorIndex), intIndex);
                     }
@@ -2630,7 +2631,8 @@ public class DecimalFormat extends NumberFormat {
                     intIndex = position;
                     digits.decimalAt = digitCount; // Not digits.count!
                     sawDecimal = true;
-                } else if (!isExponent && ch == grouping && isGroupingUsed()) {
+                } else if (!isExponent && ch == grouping &&
+                        (parseStrict ? isGroupingRelevant() : isGroupingUsed())) {
                     if (parseStrict) {
                         // text should not start with grouping when strict
                         if (position == startPos) {
@@ -2685,10 +2687,11 @@ public class DecimalFormat extends NumberFormat {
             // (When strict), within the loop we enforce grouping when encountering
             // decimal/grouping symbols. Once outside loop, we need to check
             // the final grouping, ex: "1,234". Only check the final grouping
-            // if we have not seen a decimal separator, to prevent a non needed check,
-            // for ex: "1,234.", "1,234.12"
+            // if we have not seen a decimal separator, to prevent a grouping check in the
+            // fraction portion for ex: "1,234.", "1,234.12"
             if (parseStrict) {
-                if (!sawDecimal && isGroupingViolation(position, prevSeparatorIndex)) {
+                if (!sawDecimal && isGroupingRelevant()
+                        && isGroupingViolation(position, prevSeparatorIndex)) {
                     // -1, since position is incremented by one too many when loop is finished
                     // "1,234%" and "1,234" both end with pos = 5, since '%' breaks
                     // the loop before incrementing position. In both cases, check
@@ -2749,12 +2752,22 @@ public class DecimalFormat extends NumberFormat {
         return decimalAt;
     }
 
+    /*
+     * DecimalFormat defines both setGroupingUsed(boolean) and setGroupingSize(int)
+     * These operate independent of each other, and setting a grouping size of 0 does not mean that
+     * isGroupingUsed() returns false. As a result, to effectively check if grouping is used,
+     * both values need to be verified. Lenient parsing does not require this exhaustive check
+     * because the legacy parsing does not validate grouping size positioning.
+     */
+    private boolean isGroupingRelevant() {
+        return isGroupingUsed() && groupingSize > 0;
+    }
+
     // Checks to make sure grouping size is not violated. Used when strict.
     private boolean isGroupingViolation(int pos, int prevGroupingPos) {
         assert parseStrict : "Grouping violations should only occur when strict";
-        return isGroupingUsed() && // Only violates if using grouping
-                // Checks if a previous grouping symbol was seen.
-                prevGroupingPos != -groupingSize &&
+        // Checks if a previous grouping symbol was seen.
+        return prevGroupingPos != -groupingSize &&
                 // The check itself, - 1 to account for grouping/decimal symbol
                 pos - 1 != prevGroupingPos + groupingSize;
     }
@@ -3592,7 +3605,7 @@ public class DecimalFormat extends NumberFormat {
             int digitCount = useExponentialNotation ? getMaximumIntegerDigits() :
                     Math.max(groupingSize, getMinimumIntegerDigits()) + 1;
             for (int i = digitCount; i > 0; --i) {
-                if (i != digitCount && isGroupingUsed() && groupingSize != 0 &&
+                if (i != digitCount && isGroupingRelevant() &&
                         i % groupingSize == 0) {
                     result.append(groupingSymbol);
                 }

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2753,11 +2753,12 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /*
-     * DecimalFormat defines both setGroupingUsed(boolean) and setGroupingSize(int)
-     * These operate independent of each other, and setting a grouping size of 0 does not mean that
-     * isGroupingUsed() returns false. As a result, to effectively check if grouping is used,
-     * both values need to be verified. Lenient parsing does not require this exhaustive check
-     * because the legacy behavior does not validate grouping size positioning.
+     * DecimalFormat defines both setGroupingUsed(boolean) and setGroupingSize(int).
+     * These operate independently, and setting a grouping size of 0 does not mean that
+     * isGroupingUsed() returns false. As a result, to effectively check whether grouping is used
+     * for strict parsing, both values need to be verified. Lenient parsing, which preserves the
+     * legacy parsing behavior, does not require this exhaustive check because grouping size positioning
+     * is not checked.
      */
     private boolean isGroupingEnabled() {
         return isGroupingUsed() && groupingSize > 0;

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2242,8 +2242,14 @@ public class DecimalFormat extends NumberFormat {
     public Number parse(String text, ParsePosition pos) {
         // special case NaN
         if (text.regionMatches(pos.index, symbols.getNaN(), 0, symbols.getNaN().length())) {
-            pos.index = pos.index + symbols.getNaN().length();
-            return Double.valueOf(Double.NaN);
+            var nanEnd = pos.index + symbols.getNaN().length();
+            // When strict, parsing NaN must be exact
+            if (parseStrict && nanEnd != text.length()) {
+                pos.errorIndex = nanEnd;
+                return null;
+            }
+            pos.index = nanEnd;
+            return Double.NaN;
         }
 
         boolean[] status = new boolean[STATUS_LENGTH];

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -250,7 +250,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *          <td>{@link DecimalFormatSymbols#getExponentSeparator()}
  *          <td>Number
  *          <td>Separates mantissa and exponent in scientific notation. This value
- *              is case sensistive. <em>Need not be quoted in prefix or suffix.</em>
+ *              is case sensitive. <em>Need not be quoted in prefix or suffix.</em>
  *     <tr>
  *          <th scope="row">{@code ;}
  *          <td>{@link DecimalFormatSymbols#getPatternSeparator()}

--- a/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8327640 8331485 8333456 8335668
+ * @bug 8327640 8331485 8333456 8335668 8388507
  * @summary Test suite for NumberFormat parsing when lenient.
  * @run junit/othervm -Duser.language=en -Duser.country=US LenientParseTest
  * @run junit/othervm -Duser.language=ja -Duser.country=JP LenientParseTest
@@ -160,6 +160,12 @@ public class LenientParseTest {
         assertEquals(1.23E45, successParse(fmt, "1.23E45.123", 7));
         assertEquals(1.23E45, successParse(fmt, "1.23E45.", 7));
         assertEquals(1.23E45, successParse(fmt, "1.23E45FOO3222", 7));
+    }
+
+    @Test // Non-localized, only run once
+    @EnabledIfSystemProperty(named = "user.language", matches = "en")
+    public void nanNumberFormatTest() {
+        assertEquals(Double.NaN, successParse(new DecimalFormat(), "NaNFoo", 3));
     }
 
     // ---- CurrencyFormat tests ----

--- a/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
@@ -124,7 +124,7 @@ public class StrictParseTest {
         fmt.setGroupingSize(0);
         fmt.setGroupingUsed(true);
         var pp = new ParsePosition(0);
-        assertThrows(ParseException.class, () -> fmt.parse("555,000.0", pp));
+        assertNull(fmt.parse("555,000.0", pp));
         assertEquals(3, pp.getErrorIndex());
         assertDoesNotThrow(() -> fmt.parse("555.0"));
     }

--- a/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
@@ -117,6 +117,16 @@ public class StrictParseTest {
         // Special case: NaN
         failParse(nonLocalizedDFmt, "NaNFoo", 3);
         successParse(nonLocalizedDFmt, "NaN");
+
+        // Grouping size == 0 cases
+        var fmt = new DecimalFormat();
+        fmt.setStrict(true);
+        fmt.setGroupingSize(0);
+        fmt.setGroupingUsed(true);
+        var pp = new ParsePosition(0);
+        assertThrows(ParseException.class, () -> fmt.parse("555,000.0", pp));
+        assertEquals(3, pp.getErrorIndex());
+        assertDoesNotThrow(() -> fmt.parse("555.0"));
     }
 
     // 8333755: Check that parsing with integer only against a suffix value works

--- a/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8327640 8331485 8333755 8335668
+ * @bug 8327640 8331485 8333755 8335668 8388507
  * @summary Test suite for NumberFormat parsing with strict leniency
  * @run junit/othervm -Duser.language=en -Duser.country=US StrictParseTest
  * @run junit/othervm -Duser.language=ja -Duser.country=JP StrictParseTest
@@ -114,8 +114,10 @@ public class StrictParseTest {
         successParse(nonLocalizedDFmt, "a12345,67890b");
         successParse(nonLocalizedDFmt, "a1234,67890b");
         failParse(nonLocalizedDFmt, "a123456,7890b", 6);
+        // Special case: NaN
+        failParse(nonLocalizedDFmt, "NaNFoo", 3);
+        successParse(nonLocalizedDFmt, "NaN");
     }
-
 
     // 8333755: Check that parsing with integer only against a suffix value works
     @Test // Non-localized, run once


### PR DESCRIPTION
This PR corrects two parsing issues for `DecimalFormat` during strict parsing.

  1. The special parsing path for NaN was shared by lenient and strict parsing. As a result, subsequent text after the "NaN" was accepted in strict mode, although the trailing characters should have caused parsing to fail. Strict parsing needs to add additional logic for that special case.

  2. In strict mode, a grouping size of zero causes all numeric input to be rejected since it tries to check for the first group immediately. A grouping size of zero is implies that grouping is not used. However, `isGroupingUsed` is independent of `setGroupingSize`. The implementation needs to check for both the int size and boolean status value when checking grouping during strict parsing.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388507](https://bugs.openjdk.org/browse/JDK-8388507): DecimalFormat Strict Parsing NaN and Grouping Size Zero Fixes (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31980/head:pull/31980` \
`$ git checkout pull/31980`

Update a local copy of the PR: \
`$ git checkout pull/31980` \
`$ git pull https://git.openjdk.org/jdk.git pull/31980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31980`

View PR using the GUI difftool: \
`$ git pr show -t 31980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31980.diff">https://git.openjdk.org/jdk/pull/31980.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31980#issuecomment-5028206853)
</details>
