### PR TITLE
8388523: C2: Test compiler/igvn/TestMaskedStoreIdealization.java failed

### DIFF
--- a/test/hotspot/jtreg/compiler/igvn/TestMaskedStoreIdealization.java
+++ b/test/hotspot/jtreg/compiler/igvn/TestMaskedStoreIdealization.java
@@ -65,7 +65,9 @@ public class TestMaskedStoreIdealization {
             "--add-opens", "jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED"
         ));
         vmArgs.addAll(Arrays.asList(args)); // Forward args
-        vmArgs.add("-XX:-StressReflectiveCode"); // Temporarily disable stress flag that causes unrelated failures.
+        // Temporarily disable stress flag due to unrelated test failures.
+        // TODO: Remove when JDK-8388490 is fixed.
+        vmArgs.addAll(List.of("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-StressReflectiveCode"));
         String[] vmArgsArray = vmArgs.toArray(new String[0]);
 
         comp.invoke(PACKAGE + "." + CLASS_NAME, "main", new Object[] { vmArgsArray });

--- a/test/hotspot/jtreg/compiler/igvn/TestMaskedStoreIdealization.java
+++ b/test/hotspot/jtreg/compiler/igvn/TestMaskedStoreIdealization.java
@@ -120,35 +120,23 @@ public class TestMaskedStoreIdealization {
                 final PrimitiveType pty = (PrimitiveType) vec.elementType;
                 final String ptyIR = pty.abbrev().equals("S") ? "C" : pty.abbrev();
 
-                // Verify that the method contains two VectorStore{Masked|Scatter} nodes.
+                // Verify that the Scatter store for STORE_VECTOR_AFTER_SCATTER is not eliminated.
                 var opVerification = Template.make(() -> {
+                    if (op != Operation.STORE_VECTOR_AFTER_SCATTER) {
+                        return scope("");
+                    }
+
                     if (vec.length <= 2) {
                         return scope("    // No Vector nodes are emitted for vectors of length 2 or shorter.\n");
                     }
 
-                    if (Set.of(Operation.STORE_SCATTER, Operation.STORE_SCATTER_MASK, Operation.STORE_VECTOR_AFTER_SCATTER).contains(op) &&
-                        vec.elementType.byteSize() < 4) {
+                    if (vec.elementType.byteSize() < 4) {
                         return scope("    // StoreVectorScatter is not emitted for vectors of subword types.\n");
                     }
 
-                    final String opIR = switch (op) {
-                        case STORE_SCATTER              -> "STORE_VECTOR_SCATTER";
-                        case STORE_MASK                 -> "STORE_VECTOR_MASKED";
-                        case STORE_SCATTER_MASK         -> "STORE_VECTOR_SCATTER_MASKED";
-                        case STORE_VECTOR_AFTER_SCATTER -> "STORE_VECTOR_SCATTER";
-                        case RANDOM                     -> "";
-                    };
-
-                    final int numMatches = switch (op) {
-                        case STORE_VECTOR_AFTER_SCATTER -> 1;
-                        default                         -> 2;
-                    };
-
                     return scope(
-                        let("opIR", opIR),
-                        let("matches", numMatches),
                         """
-                            @IR(counts = {IRNode.#{opIR}, "=#{matches}"},
+                            @IR(counts = {IRNode.STORE_VECTOR_SCATTER, "=1"},
                                 applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"})
                         """
                     );
@@ -179,9 +167,9 @@ public class TestMaskedStoreIdealization {
                                 applyIfCPUFeatureOr = {"avx512", "true", "sve", "true"},
                                 phase = CompilePhase.BEFORE_MATCHING)
                         """;
-                        case STORE_VECTOR_AFTER_SCATTER, RANDOM -> "";
-                    },
-                    opVerification.asToken()
+                        case STORE_VECTOR_AFTER_SCATTER -> opVerification.asToken();
+                        case  RANDOM -> "";
+                    }
                 );
             });
 

--- a/test/hotspot/jtreg/compiler/igvn/TestMaskedStoreIdealization.java
+++ b/test/hotspot/jtreg/compiler/igvn/TestMaskedStoreIdealization.java
@@ -288,7 +288,7 @@ public class TestMaskedStoreIdealization {
                     let("arrVal", vec.elementType.con()),
                 """
                     @Run(test = "test#{testCaseName}")
-                    @Warmup(15_000)
+                    @Warmup(10_000)
                     static void run#{testCaseName}(RunInfo info) {
                         final #pty broadcastVal = #broadcastVal;
                         final #pty arrVal = #arrVal;


### PR DESCRIPTION
This PR fixes two issues:
- JDK-8388523: The problem here is that profile pollution during the execution of this test delays the compilation of the method into the expected shape. I thought I had fixed this before the integration of [JDK-8387073](https://bugs.openjdk.org/browse/JDK-8387073) by raising the warmup to 15'000 iterations and I ran quite a bit of testing that did not fail. Alas, I believe raising the warmup further is futile, as it will more likely than not make this kind of failure even more intermittent. Consequently, I think the way to go is to remove the IR-verification of the nodes that are failing.    
Removing that verification is fine because the shape that we care about is `VectorStoreScatterMask -> Store -> VectorStoreScatterMask`. The bug in [JDK-8387073](https://bugs.openjdk.org/browse/JDK-8387073) was that the Store in the middle was incorrectly removed and IR verification of that middle store works fine. The failing IR verification is the surrounding masked and/or scattered vector stores. Those are more of a nice to have and hence I remove them.    
As this verification was the reason for the increased 15'000 iterations of warmup, I reduced the warmup back down to 10'000
- JDK-8388539: I once again forgot to test on a release build after the addition of flags. To fix it, I added -XX:+IgnoreUnrecognizedVMOptions, as the flag in question is only part of a workaround, which I also elaborated on in the comment.

Testing:
 - [x] tier1,tier2,tier3 and stress testing
 - [x] 300 repetitions on each linux-x64-debug, linux-x64, linux-aarch64-debug, linux-aarch64, macosx-aarch64-debug, windows-x64-debug of `compiler/igvn/TestMaskedStoreIdealization.java`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8388523](https://bugs.openjdk.org/browse/JDK-8388523): C2: Test compiler/igvn/TestMaskedStoreIdealization.java failed (**Bug** - P4)
 * [JDK-8388539](https://bugs.openjdk.org/browse/JDK-8388539): [TESTBUG] compiler/igvn/TestMaskedStoreIdealization.java fails on Release Builds (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31986/head:pull/31986` \
`$ git checkout pull/31986`

Update a local copy of the PR: \
`$ git checkout pull/31986` \
`$ git pull https://git.openjdk.org/jdk.git pull/31986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31986`

View PR using the GUI difftool: \
`$ git pr show -t 31986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31986.diff">https://git.openjdk.org/jdk/pull/31986.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31986#issuecomment-5032829282)
</details>
