### PR TITLE
8388338: javac shares proxy initializer trees across constructors

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LocalProxyVarsGen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LocalProxyVarsGen.java
@@ -26,18 +26,17 @@
 package com.sun.tools.javac.comp;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
-import com.sun.tools.javac.tree.JCTree.JCAssign;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
@@ -91,6 +90,7 @@ public class LocalProxyVarsGen {
     private final Target target;
     private TreeMaker make;
     private final Map<Symbol, Set<Symbol>> fieldsReadInPrologue = new HashMap<>();
+    private final Map<JCMethodDecl, Map<JCTree, JCTree>> rollback = new HashMap<>();
 
     private final boolean noLocalProxyVars;
 
@@ -136,7 +136,7 @@ public class LocalProxyVarsGen {
         }
     }
 
-    public void allFieldNormalized(Symbol.ClassSymbol csym) {
+    public void classGenerated(ClassSymbol csym) {
         fieldsReadInPrologue.remove(csym);
     }
 
@@ -164,6 +164,7 @@ public class LocalProxyVarsGen {
         for (JCStatement st : constructor.body.stats) {
             newBody = newBody.append(fieldRewriter.translate(st));
         }
+        rollback.put(constructor, fieldRewriter.rollback);
         localDeclarations.addAll(newBody);
         ListBuffer<JCStatement> assigmentsBeforeSuper = new ListBuffer<>();
         for (Symbol vsym : fieldToLocalMap.keySet()) {
@@ -207,7 +208,27 @@ public class LocalProxyVarsGen {
         return names.fromString("local" + target.syntheticNameChar() + name);
     }
 
+    public void unpatchConstructor(JCMethodDecl tree, TreeMaker make) {
+        Map<JCTree, JCTree> thisMethodRollback = rollback.remove(tree);
+
+        if (thisMethodRollback == null) {
+            return ;
+        }
+
+        new TreeTranslator() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T extends JCTree> T translate(T tree) {
+                if (tree != null && thisMethodRollback.containsKey(tree)) {
+                    return (T) thisMethodRollback.get(tree);
+                }
+                return super.translate(tree);
+            }
+        }.translate(tree.body);
+    }
+
     class FieldRewriter extends TreeTranslator {
+        Map<JCTree, JCTree> rollback = new HashMap<>();
         JCMethodDecl md;
         Map<Symbol, Symbol> fieldToLocalMap;
         boolean ctorPrologue = true;
@@ -221,6 +242,7 @@ public class LocalProxyVarsGen {
         public void visitIdent(JCTree.JCIdent tree) {
             if (ctorPrologue && fieldToLocalMap.get(tree.sym) != null) {
                 result = make.at(md).Ident(fieldToLocalMap.get(tree.sym));
+                rollback.put(result, tree);
             } else {
                 result = tree;
             }
@@ -231,6 +253,7 @@ public class LocalProxyVarsGen {
             super.visitSelect(tree);
             if (ctorPrologue && fieldToLocalMap.get(tree.sym) != null) {
                 result = make.at(md).Ident(fieldToLocalMap.get(tree.sym));
+                rollback.put(result, tree);
             } else {
                 result = tree;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -493,7 +493,6 @@ public class Gen extends JCTree.Visitor {
         for (JCTree t : methodDefs) {
             normalizeMethod((JCMethodDecl)t, initCode.toList(), initBlocks.toList(), initTAlist);
         }
-        localProxyVarsGen.allFieldNormalized(classDecl.sym);
         // If there are class initializers, create a <clinit> method
         // that contains them as its body.
         if (clinitCode.length() != 0) {
@@ -569,8 +568,6 @@ public class Gen extends JCTree.Visitor {
                 }
                 md.sym.appendUniqueTypeAttributes(initTAs);
             }
-
-            localProxyVarsGen.patchConstructor(md, make);
 
             if (md.body.bracePos == Position.NOPOS)
                 md.body.bracePos = TreeInfo.endPos(md.body.stats.last());
@@ -981,6 +978,7 @@ public class Gen extends JCTree.Visitor {
             int extras = 0;
             // Count up extra parameters
             if (meth.isConstructor()) {
+                localProxyVarsGen.patchConstructor(tree, make);
                 extras++;
                 if (meth.enclClass().isInner() &&
                     !meth.enclClass().isStatic()) {
@@ -1051,6 +1049,9 @@ public class Gen extends JCTree.Visitor {
 
                 // Fill in type annotation positions for exception parameters
                 code.fillExceptionParameterPositions();
+            }
+            if (meth.isConstructor()) {
+                localProxyVarsGen.unpatchConstructor(tree, make);
             }
         }
 
@@ -2567,6 +2568,7 @@ public class Gen extends JCTree.Visitor {
                 }
             }
             cdef.defs = List.nil(); // discard trees
+            localProxyVarsGen.classGenerated(c);
             return nerrs == 0;
         } finally {
             // note: this method does NOT support recursion.

--- a/test/langtools/tools/javac/valhalla/value-objects/LocalProxyVariablesRuntime.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/LocalProxyVariablesRuntime.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @enablePreview
+ * @compile LocalProxyVariablesRuntime.java
+ * @run main LocalProxyVariablesRuntime
+ */
+public class LocalProxyVariablesRuntime {
+    public static void main(String... args) {
+        new Value1();
+        new Value1(0);
+        new Value2();
+        new Value2(0);
+        new Value3();
+        new Value3(0);
+        new Value4();
+        new Value4(0);
+    }
+
+    private static value class Value1 {
+        int i = 0;
+        int j = i + 1;
+
+        public Value1() {}
+
+        public Value1(int x) {}
+    }
+
+    private static value class Value2 {
+        Object f1 = new String("");
+        String f2 = f1 instanceof String s ? s : "";
+
+        public Value2() {}
+
+        public Value2(int x) {}
+    }
+
+    private static value class Value3 {
+        Object f1 = new String("");
+        String f2 = !switch (f1) {
+            case String s -> true;
+            default -> false;
+        } ? "a" : "b";
+
+        public Value3() {}
+
+        public Value3(int x) {}
+    }
+
+    private static value class Value4 {
+        Object f1 = new String("");
+        String f2 = switch (0) {
+            default -> {
+                boolean r;
+                switch (f1) {
+                    case String s:
+                        r = true;
+                        break;
+                    default:
+                        r = false;
+                        break;
+                }
+                IF: if (true) break IF;
+                for (int i = 0; i < 10; i++) {
+                    if (i < 5) continue;
+                    System.err.println(i);
+                }
+                yield r;
+            }
+        } ? "a" : "b";
+
+        public Value4() {}
+
+        public Value4(int x) {}
+    }
+}


### PR DESCRIPTION
Consider code like:
```
    private static value class Value1 {
        int i = 0;
        int j = i + 1;

        public Value1() {}

        public Value1(int x) {}
    }
```

This will get changed (in `Gen`) to:
```
    private static value class Value1 {
        int i;
        int j;

        public Value1() {
            i = 0;
            j = i + 1;
        }

        public Value1(int x) {
            i = 0;
            j = i + 1;
        }
    }
```

where the `0` and (more significantly) `i + 1` in the constructors are physically the same ASTs.

Then `LocalProxyVarsGen` will convert/proxy the `i` in `i + 1` to a local variable read - but it will do so only for the first constructor, and since the AST is the same in the second constructor, there is nothing more to convert for the second constructor. But the local variable read is obviously broken in the second constructor.

The solution proposed herein is to do the `LocalProxyVarsGen` on a constructor-per-constructor basis while the code for it is generated (as opposed to the current state, where all the constructors are converted before generation). And reverting the changes back after the constructor is generated. So that for the next constructor, we create the local proxy again.

One alternative would be to create duplicated ASTs for the field initializers. `LocalProxyVarsGen` would then handle each copy separately. The issue is that this duplication would need to duplicate attributed AST, and that is a non-trivial task.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8388338: javac shares proxy initializer trees across constructors`

### Issue
 * [JDK-8388338](https://bugs.openjdk.org/browse/JDK-8388338): javac shares proxy initializer trees across constructors (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31987/head:pull/31987` \
`$ git checkout pull/31987`

Update a local copy of the PR: \
`$ git checkout pull/31987` \
`$ git pull https://git.openjdk.org/jdk.git pull/31987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31987`

View PR using the GUI difftool: \
`$ git pr show -t 31987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31987.diff">https://git.openjdk.org/jdk/pull/31987.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31987#issuecomment-5033637244)
</details>
