### PR TITLE
8388559: RISC-V: use branchless instructions for CMoveI with constant 0/1

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2057,6 +2057,38 @@ void C2_MacroAssembler::enc_cmove(int cmpFlag, Register op1, Register op2, Regis
   }
 }
 
+void C2_MacroAssembler::enc_cmove_zero_one(int cmpFlag, Register op1, Register op2, Register dst) {
+  bool is_unsigned = (cmpFlag & unsigned_branch_mask) == unsigned_branch_mask;
+  int op_select = cmpFlag & (~unsigned_branch_mask);
+
+  switch (op_select) {
+    case BoolTest::eq:
+      xorr(dst, op1, op2);
+      snez(dst, dst);
+      break;
+    case BoolTest::ne:
+      xorr(dst, op1, op2);
+      seqz(dst, dst);
+      break;
+    case BoolTest::lt:
+      is_unsigned ? sltu(dst, op1, op2) : slt(dst, op1, op2);
+      seqz(dst, dst);
+      break;
+    case BoolTest::gt:
+      is_unsigned ? sltu(dst, op2, op1) : slt(dst, op2, op1);
+      seqz(dst, dst);
+      break;
+    case BoolTest::le:
+      is_unsigned ? sltu(dst, op2, op1) : slt(dst, op2, op1);
+      break;
+    case BoolTest::ge:
+      is_unsigned ? sltu(dst, op1, op2) : slt(dst, op1, op2);
+      break;
+    default:
+      ShouldNotReachHere();
+  }
+}
+
 void C2_MacroAssembler::enc_cmove_cmp_fp(int cmpFlag, FloatRegister op1, FloatRegister op2, Register dst, Register src, bool is_single) {
   int op_select = cmpFlag & (~unsigned_branch_mask);
 
@@ -2158,6 +2190,34 @@ void C2_MacroAssembler::enc_cmove_fp_cmp_fp(int cmpFlag,
       break;
     default:
       assert(false, "unsupported compare condition");
+      ShouldNotReachHere();
+  }
+}
+
+void C2_MacroAssembler::enc_cmove_cmp_fp_zero_one(int cmpFlag, FloatRegister op1, FloatRegister op2, Register dst, bool is_single) {
+  switch (cmpFlag) {
+    case BoolTest::eq: // NaN ordered: eq false -> dst = 1
+      is_single ? feq_s(dst, op1, op2) : feq_d(dst, op1, op2);
+      seqz(dst, dst);
+      break;
+    case BoolTest::ne: // NaN unordered: ne true -> dst = 0
+      is_single ? feq_s(dst, op1, op2) : feq_d(dst, op1, op2);
+      break;
+    case BoolTest::lt: // NaN unordered: lt true -> dst = 0
+      is_single ? fle_s(dst, op2, op1) : fle_d(dst, op2, op1);
+      break;
+    case BoolTest::le: // NaN unordered: le true -> dst = 0
+      is_single ? flt_s(dst, op2, op1) : flt_d(dst, op2, op1);
+      break;
+    case BoolTest::gt: // NaN ordered: gt false -> dst = 1
+      is_single ? flt_s(dst, op2, op1) : flt_d(dst, op2, op1);
+      seqz(dst, dst);
+      break;
+    case BoolTest::ge: // NaN ordered: ge false -> dst = 1
+      is_single ? fle_s(dst, op2, op1) : fle_d(dst, op2, op1);
+      seqz(dst, dst);
+      break;
+    default:
       ShouldNotReachHere();
   }
 }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -128,6 +128,9 @@
                  Register op1, Register op2,
                  Register dst, Register src);
 
+  void enc_cmove_zero_one(int cmpFlag,
+                          Register op1, Register op2, Register dst);
+
   void enc_cmove_cmp_fp(int cmpFlag,
                         FloatRegister op1, FloatRegister op2,
                         Register dst, Register src, bool is_single);
@@ -138,6 +141,10 @@
   void enc_cmove_fp_cmp_fp(int cmpFlag, FloatRegister op1, FloatRegister op2,
                            FloatRegister dst, FloatRegister src,
                            bool cmp_single, bool cmov_single);
+
+  void enc_cmove_cmp_fp_zero_one(int cmpFlag,
+                                 FloatRegister op1, FloatRegister op2,
+                                 Register dst, bool is_single);
 
   void spill(Register r, bool is64, int offset) {
     is64 ? sd(r, Address(sp, offset))

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10228,6 +10228,22 @@ instruct far_cmpP_narrowOop_imm0_branch(cmpOpEqNe cmp, iRegN op1, immP0 zero, la
 
 // --------- CMoveI ---------
 
+instruct cmovI_cmpI_zero_one(iRegINoSp dst, iRegI op1, iRegI op2,
+                              cmpOp cop, immI_1 one, immI0 zero) %{
+  match(Set dst (CMoveI (Binary cop (CmpI op1 op2)) (Binary one zero)));
+
+  ins_cost(ALU_COST * 2);
+  format %{ "CMoveI $dst, ($op1 $cop $op2), 1, 0\t#@cmovI_cmpI_zero_one" %}
+
+  ins_encode %{
+    __ enc_cmove_zero_one($cop$$cmpcode,
+                         as_Register($op1$$reg), as_Register($op2$$reg),
+                         as_Register($dst$$reg));
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
 instruct cmovI_cmpI(iRegINoSp dst, iRegI src, iRegI op1, iRegI op2, cmpOp cop) %{
   match(Set dst (CMoveI (Binary cop (CmpI op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
@@ -10240,6 +10256,22 @@ instruct cmovI_cmpI(iRegINoSp dst, iRegI src, iRegI op1, iRegI op2, cmpOp cop) %
     __ enc_cmove($cop$$cmpcode,
                  as_Register($op1$$reg), as_Register($op2$$reg),
                  as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
+instruct cmovI_cmpU_zero_one(iRegINoSp dst, iRegI op1, iRegI op2,
+                              cmpOpU cop, immI_1 one, immI0 zero) %{
+  match(Set dst (CMoveI (Binary cop (CmpU op1 op2)) (Binary one zero)));
+
+  ins_cost(ALU_COST * 2);
+  format %{ "CMoveI $dst, ($op1 $cop $op2), 1, 0\t#@cmovI_cmpU_zero_one" %}
+
+  ins_encode %{
+    __ enc_cmove_zero_one($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
+                         as_Register($op1$$reg), as_Register($op2$$reg),
+                         as_Register($dst$$reg));
   %}
 
   ins_pipe(pipe_class_compare);
@@ -10279,6 +10311,22 @@ instruct cmovI_cmpL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOp cop) %
   ins_pipe(pipe_class_compare);
 %}
 
+instruct cmovI_cmpUL_zero_one(iRegINoSp dst, iRegL op1, iRegL op2,
+                               cmpOpU cop, immI_1 one, immI0 zero) %{
+  match(Set dst (CMoveI (Binary cop (CmpUL op1 op2)) (Binary one zero)));
+
+  ins_cost(ALU_COST * 2);
+  format %{ "CMoveI $dst, ($op1 $cop $op2), 1, 0\t#@cmovI_cmpUL_zero_one" %}
+
+  ins_encode %{
+    __ enc_cmove_zero_one($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
+                         as_Register($op1$$reg), as_Register($op2$$reg),
+                         as_Register($dst$$reg));
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
 instruct cmovI_cmpUL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOpU cop) %{
   match(Set dst (CMoveI (Binary cop (CmpUL op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
@@ -10291,6 +10339,22 @@ instruct cmovI_cmpUL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOpU cop)
     __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
                  as_Register($op1$$reg), as_Register($op2$$reg),
                  as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
+instruct cmovI_cmpF_zero_one(iRegINoSp dst, fRegF op1, fRegF op2,
+                              cmpOp cop, immI_1 one, immI0 zero) %{
+  match(Set dst (CMoveI (Binary cop (CmpF op1 op2)) (Binary one zero)));
+
+  ins_cost(ALU_COST * 2);
+  format %{ "CMoveI $dst, ($op1 $cop $op2), 1, 0\t#@cmovI_cmpF_zero_one" %}
+
+  ins_encode %{
+    __ enc_cmove_cmp_fp_zero_one($cop$$cmpcode,
+                                as_FloatRegister($op1$$reg), as_FloatRegister($op2$$reg),
+                                as_Register($dst$$reg), true /* is_single */);
   %}
 
   ins_pipe(pipe_class_compare);
@@ -10518,6 +10582,22 @@ instruct cmovL_cmpF(iRegLNoSp dst, iRegL src, fRegF op1, fRegF op2, cmpOp cop) %
   ins_pipe(pipe_class_compare);
 %}
 
+instruct cmovI_cmpD_zero_one(iRegINoSp dst, fRegD op1, fRegD op2,
+                              cmpOp cop, immI_1 one, immI0 zero) %{
+  match(Set dst (CMoveI (Binary cop (CmpD op1 op2)) (Binary one zero)));
+
+  ins_cost(ALU_COST * 2);
+  format %{ "CMoveI $dst, ($op1 $cop $op2), 1, 0\t#@cmovI_cmpD_zero_one" %}
+
+  ins_encode %{
+    __ enc_cmove_cmp_fp_zero_one($cop$$cmpcode,
+                                as_FloatRegister($op1$$reg), as_FloatRegister($op2$$reg),
+                                as_Register($dst$$reg), false /* is_single */);
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
 instruct cmovL_cmpD(iRegLNoSp dst, iRegL src, fRegD op1, fRegD op2, cmpOp cop) %{
   match(Set dst (CMoveL (Binary cop (CmpD op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
@@ -10596,6 +10676,22 @@ instruct cmovL_cmpUL_zero(iRegLNoSp dst, immL0 src, iRegL op1, iRegL op2, cmpOpU
     __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
                  as_Register($op1$$reg), as_Register($op2$$reg),
                  as_Register($dst$$reg), zr);
+  %}
+
+  ins_pipe(pipe_class_compare);
+%}
+
+instruct cmovI_cmpL_zero_one(iRegINoSp dst, iRegL op1, iRegL op2,
+                              cmpOp cop, immI_1 one, immI0 zero) %{
+  match(Set dst (CMoveI (Binary cop (CmpL op1 op2)) (Binary one zero)));
+
+  ins_cost(ALU_COST * 2);
+  format %{ "CMoveI $dst, ($op1 $cop $op2), 1, 0\t#@cmovI_cmpL_zero_one" %}
+
+  ins_encode %{
+    __ enc_cmove_zero_one($cop$$cmpcode,
+                         as_Register($op1$$reg), as_Register($op2$$reg),
+                         as_Register($dst$$reg));
   %}
 
   ins_pipe(pipe_class_compare);


### PR DESCRIPTION
Hi, this patch referencing the AArch64 `cmovI_reg_zero_one` / `cmovUI_reg_zero_one` optimization aarch64.ad, this patch adds branchless CMoveI rules for the boolean 0/1 case on RISC-V.

### Correctness Testing

- [ ] Run tier1-tier3 test with release on SpacemiT Key Stone K3

### Performance test on hardware with Zicond extension:

without this patch:
```
Benchmark               Mode  Cnt     Score    Error  Units
CMoveIZeroOne.cmpD_eq   avgt   15  1416.411 ± 42.636  ns/op
CMoveIZeroOne.cmpD_ge   avgt   15  1748.516 ± 18.098  ns/op
CMoveIZeroOne.cmpD_gt   avgt   15  1607.318 ± 20.882  ns/op
CMoveIZeroOne.cmpD_le   avgt   15  1752.919 ± 32.564  ns/op
CMoveIZeroOne.cmpD_lt   avgt   15  1599.549 ± 37.696  ns/op
CMoveIZeroOne.cmpD_ne   avgt   15  1669.366 ±  5.230  ns/op
CMoveIZeroOne.cmpF_eq   avgt   15  1348.839 ± 13.469  ns/op
CMoveIZeroOne.cmpF_ge   avgt   15  1614.961 ±  8.378  ns/op
CMoveIZeroOne.cmpF_gt   avgt   15  1485.386 ± 11.684  ns/op
CMoveIZeroOne.cmpF_le   avgt   15  1621.437 ± 12.695  ns/op
CMoveIZeroOne.cmpF_lt   avgt   15  1464.641 ± 21.394  ns/op
CMoveIZeroOne.cmpF_ne   avgt   15  1569.403 ± 34.596  ns/op
CMoveIZeroOne.cmpI_eq   avgt   15  1249.726 ± 22.055  ns/op
CMoveIZeroOne.cmpI_ge   avgt   15  1490.252 ±  6.163  ns/op
CMoveIZeroOne.cmpI_gt   avgt   15  1379.748 ± 23.491  ns/op
CMoveIZeroOne.cmpI_le   avgt   15  1480.494 ±  9.768  ns/op
CMoveIZeroOne.cmpI_lt   avgt   15  1366.956 ±  6.262  ns/op
CMoveIZeroOne.cmpI_ne   avgt   15  1463.938 ± 11.874  ns/op
CMoveIZeroOne.cmpL_eq   avgt   15  1225.964 ± 23.578  ns/op
CMoveIZeroOne.cmpL_ge   avgt   15  1357.693 ± 19.403  ns/op
CMoveIZeroOne.cmpL_gt   avgt   15  1328.339 ± 18.531  ns/op
CMoveIZeroOne.cmpL_le   avgt   15  1368.841 ±  4.905  ns/op
CMoveIZeroOne.cmpL_lt   avgt   15  1352.817 ± 21.015  ns/op
CMoveIZeroOne.cmpL_ne   avgt   15  1266.692 ± 18.156  ns/op
CMoveIZeroOne.cmpUL_eq  avgt   15  1249.111 ± 31.119  ns/op
CMoveIZeroOne.cmpUL_ge  avgt   15  1366.783 ± 19.365  ns/op
CMoveIZeroOne.cmpUL_gt  avgt   15  1335.998 ± 17.502  ns/op
CMoveIZeroOne.cmpUL_le  avgt   15  1380.298 ± 15.907  ns/op
CMoveIZeroOne.cmpUL_lt  avgt   15  1340.216 ± 22.148  ns/op
CMoveIZeroOne.cmpUL_ne  avgt   15  1282.560 ± 36.041  ns/op
CMoveIZeroOne.cmpU_eq   avgt   15  1256.098 ± 16.930  ns/op
CMoveIZeroOne.cmpU_ge   avgt   15  1484.100 ±  5.959  ns/op
CMoveIZeroOne.cmpU_gt   avgt   15  1395.554 ± 23.350  ns/op
CMoveIZeroOne.cmpU_le   avgt   15  1515.417 ± 23.037  ns/op
CMoveIZeroOne.cmpU_lt   avgt   15  1395.237 ± 24.170  ns/op
CMoveIZeroOne.cmpU_ne   avgt   15  1452.869 ± 19.064  ns/op
Finished running test 'micro:org.openjdk.bench.vm.compiler.CMoveIZeroOne'
```

with this patch:
```
Benchmark               Mode  Cnt     Score    Error  Units
CMoveIZeroOne.cmpD_eq   avgt   15   901.972 ± 10.034  ns/op
CMoveIZeroOne.cmpD_ge   avgt   15   916.617 ±  7.552  ns/op
CMoveIZeroOne.cmpD_gt   avgt   15   909.789 ±  1.563  ns/op
CMoveIZeroOne.cmpD_le   avgt   15   916.466 ± 13.269  ns/op
CMoveIZeroOne.cmpD_lt   avgt   15   914.349 ± 15.419  ns/op
CMoveIZeroOne.cmpD_ne   avgt   15  1014.605 ±  4.250  ns/op
CMoveIZeroOne.cmpF_eq   avgt   15   840.287 ±  5.016  ns/op
CMoveIZeroOne.cmpF_ge   avgt   15   837.575 ±  1.612  ns/op
CMoveIZeroOne.cmpF_gt   avgt   15   836.779 ±  2.904  ns/op
CMoveIZeroOne.cmpF_le   avgt   15   842.074 ±  8.812  ns/op
CMoveIZeroOne.cmpF_lt   avgt   15   838.574 ±  5.112  ns/op
CMoveIZeroOne.cmpF_ne   avgt   15   917.211 ± 12.091  ns/op
CMoveIZeroOne.cmpI_eq   avgt   15   927.084 ± 10.822  ns/op
CMoveIZeroOne.cmpI_ge   avgt   15   933.709 ± 21.029  ns/op
CMoveIZeroOne.cmpI_gt   avgt   15   881.324 ±  8.436  ns/op
CMoveIZeroOne.cmpI_le   avgt   15   921.233 ±  9.183  ns/op
CMoveIZeroOne.cmpI_lt   avgt   15   885.681 ± 18.117  ns/op
CMoveIZeroOne.cmpI_ne   avgt   15   939.231 ± 12.466  ns/op
CMoveIZeroOne.cmpL_eq   avgt   15   979.171 ±  5.839  ns/op
CMoveIZeroOne.cmpL_ge   avgt   15   974.855 ± 12.124  ns/op
CMoveIZeroOne.cmpL_gt   avgt   15   858.557 ± 11.383  ns/op
CMoveIZeroOne.cmpL_le   avgt   15   969.695 ±  6.762  ns/op
CMoveIZeroOne.cmpL_lt   avgt   15   847.491 ±  2.380  ns/op
CMoveIZeroOne.cmpL_ne   avgt   15   979.577 ±  7.896  ns/op
CMoveIZeroOne.cmpUL_eq  avgt   15   982.397 ± 18.811  ns/op
CMoveIZeroOne.cmpUL_ge  avgt   15   976.651 ±  7.056  ns/op
CMoveIZeroOne.cmpUL_gt  avgt   15   851.686 ±  4.041  ns/op
CMoveIZeroOne.cmpUL_le  avgt   15   972.086 ±  6.493  ns/op
CMoveIZeroOne.cmpUL_lt  avgt   15   852.064 ±  3.100  ns/op
CMoveIZeroOne.cmpUL_ne  avgt   15   984.517 ± 19.074  ns/op
CMoveIZeroOne.cmpU_eq   avgt   15   930.906 ±  8.993  ns/op
CMoveIZeroOne.cmpU_ge   avgt   15   927.293 ±  7.084  ns/op
CMoveIZeroOne.cmpU_gt   avgt   15   877.317 ± 10.005  ns/op
CMoveIZeroOne.cmpU_le   avgt   15   921.002 ± 10.395  ns/op
CMoveIZeroOne.cmpU_lt   avgt   15   886.219 ± 12.001  ns/op
CMoveIZeroOne.cmpU_ne   avgt   15   930.257 ±  1.826  ns/op
Finished running test 'micro:org.openjdk.bench.vm.compiler.CMoveIZeroOne'
```

The CMoveIZeroOne test code is as follows:
```
package org.openjdk.bench.vm.compiler;

import org.openjdk.jmh.annotations.*;

import java.util.concurrent.TimeUnit;
import java.util.random.RandomGenerator;

@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Thread)
@Warmup(iterations = 5, time = 1)
@Measurement(iterations = 5, time = 5)
@Fork(3)
public class CMoveIZeroOne {
    static final int SIZE = 1024;

    int[] i1, i2;
    long[] l1, l2;
    float[] f1, f2;
    double[] d1, d2;
    int[] res;

    @Setup
    public void setup() {
        var random = RandomGenerator.getDefault();
        i1 = new int[SIZE];
        i2 = new int[SIZE];
        l1 = new long[SIZE];
        l2 = new long[SIZE];
        f1 = new float[SIZE];
        f2 = new float[SIZE];
        d1 = new double[SIZE];
        d2 = new double[SIZE];
        res = new int[SIZE];
        for (int i = 0; i < SIZE; i++) {
            i1[i] = random.nextInt(4);
            i2[i] = random.nextInt(4);
            l1[i] = random.nextLong(4);
            l2[i] = random.nextLong(4);
            f1[i] = random.nextInt(4);
            f2[i] = random.nextInt(4);
            d1[i] = random.nextInt(4);
            d2[i] = random.nextInt(4);
        }
    }

    // --------- CmpI (signed int) ---------

    @Benchmark
    public void cmpI_eq() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (i1[i] == i2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpI_ne() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (i1[i] != i2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpI_lt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (i1[i] < i2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpI_le() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (i1[i] <= i2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpI_gt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (i1[i] > i2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpI_ge() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (i1[i] >= i2[i]) ? 1 : 0;
        }
    }

    // --------- CmpL (signed long) ---------

    @Benchmark
    public void cmpL_eq() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (l1[i] == l2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpL_ne() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (l1[i] != l2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpL_lt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (l1[i] < l2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpL_le() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (l1[i] <= l2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpL_gt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (l1[i] > l2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpL_ge() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (l1[i] >= l2[i]) ? 1 : 0;
        }
    }

    // --------- CmpF (float) ---------

    @Benchmark
    public void cmpF_eq() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (f1[i] == f2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpF_ne() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (f1[i] != f2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpF_lt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (f1[i] < f2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpF_le() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (f1[i] <= f2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpF_gt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (f1[i] > f2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpF_ge() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (f1[i] >= f2[i]) ? 1 : 0;
        }
    }

    // --------- CmpD (double) ---------

    @Benchmark
    public void cmpD_eq() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (d1[i] == d2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpD_ne() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (d1[i] != d2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpD_lt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (d1[i] < d2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpD_le() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (d1[i] <= d2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpD_gt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (d1[i] > d2[i]) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpD_ge() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (d1[i] >= d2[i]) ? 1 : 0;
        }
    }

    // --------- CmpU (unsigned int via Integer.compareUnsigned) ---------

    @Benchmark
    public void cmpU_eq() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Integer.compareUnsigned(i1[i], i2[i]) == 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpU_ne() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Integer.compareUnsigned(i1[i], i2[i]) != 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpU_lt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Integer.compareUnsigned(i1[i], i2[i]) < 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpU_le() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Integer.compareUnsigned(i1[i], i2[i]) <= 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpU_gt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Integer.compareUnsigned(i1[i], i2[i]) > 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpU_ge() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Integer.compareUnsigned(i1[i], i2[i]) >= 0) ? 1 : 0;
        }
    }

    // --------- CmpUL (unsigned long via Long.compareUnsigned) ---------

    @Benchmark
    public void cmpUL_eq() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Long.compareUnsigned(l1[i], l2[i]) == 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpUL_ne() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Long.compareUnsigned(l1[i], l2[i]) != 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpUL_lt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Long.compareUnsigned(l1[i], l2[i]) < 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpUL_le() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Long.compareUnsigned(l1[i], l2[i]) <= 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpUL_gt() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Long.compareUnsigned(l1[i], l2[i]) > 0) ? 1 : 0;
        }
    }

    @Benchmark
    public void cmpUL_ge() {
        for (int i = 0; i < SIZE; i++) {
            res[i] = (Long.compareUnsigned(l1[i], l2[i]) >= 0) ? 1 : 0;
        }
    }
}

```

Co-authored-by: wangbingzhen wangbingzhen.riscv@isrc.iscas.ac.cn

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388559](https://bugs.openjdk.org/browse/JDK-8388559): RISC-V: use branchless instructions for CMoveI with constant 0/1 (**Enhancement** - P4)


### Contributors
 * gns `<wangbingzhen.riscv@isrc.iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31989/head:pull/31989` \
`$ git checkout pull/31989`

Update a local copy of the PR: \
`$ git checkout pull/31989` \
`$ git pull https://git.openjdk.org/jdk.git pull/31989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31989`

View PR using the GUI difftool: \
`$ git pr show -t 31989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31989.diff">https://git.openjdk.org/jdk/pull/31989.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31989#issuecomment-5047828373)
</details>
