### PR TITLE
8388561: [s390x] Prevent accidental page table expansion

### DIFF
--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -48,7 +48,7 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
   if (result == nullptr) {
     constexpr uintptr_t from = nth_bit<uintptr_t>(32);
     const uintptr_t to = os::vm_page_table_expansion_point(); // prevent accidentally expanding the page table
-    result = reserve_address_space_X(from, to, size, Metaspace::reserve_alignment(), aslr);
+    result = reserve_address_space_X(from, to, size, nth_bit<uintptr_t>(32), aslr);
   }
 
   return result;

--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -47,7 +47,7 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
   // Failing that, aim for a base that is 4G-aligned; such a base can be set with aih.
   if (result == nullptr) {
     constexpr uintptr_t from = nth_bit<uintptr_t>(32);
-    constexpr uintptr_t to = os::vm_max_mmap_hint_address(); // prevent accidentally expanding the page table
+    const uintptr_t to = os::vm_page_table_expansion_point(); // prevent accidentally expanding the page table
     result = reserve_address_space_X(from, to, size, Metaspace::reserve_alignment(), aslr);
   }
 

--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -25,6 +25,7 @@
 
 #include "memory/metaspace.hpp"
 #include "oops/compressedKlass.hpp"
+#include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size_t size, bool aslr, bool optimize_for_zero_base) {
@@ -45,9 +46,8 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
 
   // Failing that, aim for a base that is 4G-aligned; such a base can be set with aih.
   if (result == nullptr) {
-    // Never probe beyond 2^42 to prevent accidentally expanding the page table
     constexpr uintptr_t from = nth_bit<uintptr_t>(32);
-    constexpr uintptr_t to = nth_bit<uintptr_t>(42);
+    constexpr uintptr_t to = os::vm_max_mmap_hint_address(); // prevent accidentally expanding the page table
     result = reserve_address_space_X(from, to, size, Metaspace::reserve_alignment(), aslr);
   }
 

--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include "memory/metaspace.hpp"
 #include "oops/compressedKlass.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -44,7 +45,10 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
 
   // Failing that, aim for a base that is 4G-aligned; such a base can be set with aih.
   if (result == nullptr) {
-    result = reserve_address_space_for_16bit_move(size, aslr);
+    // Never probe beyond 2^42 to prevent accidentally expanding the page table
+    constexpr uintptr_t from = nth_bit(32);
+    constexpr uintptr_t to = nth_bit(42);
+    result = reserve_address_space_X(from, to, size, Metaspace::reserve_alignment(), aslr);
   }
 
   return result;

--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -24,7 +24,6 @@
  *
  */
 
-#include "memory/metaspace.hpp"
 #include "oops/compressedKlass.hpp"
 #include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"

--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -46,8 +46,8 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
   // Failing that, aim for a base that is 4G-aligned; such a base can be set with aih.
   if (result == nullptr) {
     // Never probe beyond 2^42 to prevent accidentally expanding the page table
-    constexpr uintptr_t from = nth_bit(32);
-    constexpr uintptr_t to = nth_bit(42);
+    constexpr uintptr_t from = nth_bit<uintptr_t>(32);
+    constexpr uintptr_t to = nth_bit<uintptr_t>(42);
     result = reserve_address_space_X(from, to, size, Metaspace::reserve_alignment(), aslr);
   }
 

--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -32,8 +32,6 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
 
   char* result = nullptr;
 
-  uintptr_t tried_below = 0;
-
   // First, attempt to allocate < 4GB. We do this unconditionally:
   // - if optimize_for_zero_base, a <4GB mapping start allows us to use base=0 shift=0
   // - if !optimize_for_zero_base, a <4GB mapping start allows us to use algfi

--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, IBM Corp. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -478,8 +478,9 @@ int os::extra_bang_size_in_bytes() {
 
 void os::setup_fpu() {}
 
-uintptr_t os::vm_max_mmap_hint_address() {
+uintptr_t os::vm_page_table_expansion_point() {
   // On s390x, page table will dynamically expand based on user demand
-  // (eg mmap probing with high addresses). We usually don't want that.
-  return nth_bit(42);
+  // (eg mmap probing with high addresses). First expansion happens
+  // at 2^42 (4TB).
+  return nth_bit<uintptr_t>(42);
 }

--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -477,3 +477,9 @@ int os::extra_bang_size_in_bytes() {
 }
 
 void os::setup_fpu() {}
+
+uintptr_t os::vm_max_mmap_hint_address() {
+  // On s390x, page table will dynamically expand based on user demand
+  // (eg mmap probing with high addresses). We usually don't want that.
+  return nth_bit(42);
+}

--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -480,7 +480,7 @@ static char** get_attach_addresses_for_disjoint_mode() {
     }
 #ifdef S390
     // On s390x, do not probe beyond 2^42 to prevent accidental page table expansion
-    if (addresses[start+i] >= nth_bit(42)) {
+    if (addresses[start+i] >= nth_bit<uintptr_t>(42)) {
       addresses[start+i] = 0;
       break;
     }

--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -478,6 +478,13 @@ static char** get_attach_addresses_for_disjoint_mode() {
       addresses[start+i] = 0;
       break;
     }
+#ifdef S390
+    // On s390x, do not probe beyond 2^42 to prevent accidental page table expansion
+    if (addresses[start+i] >= nth_bit(42)) {
+      addresses[start+i] = 0;
+      break;
+    }
+#endif
     i++;
   }
 

--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -471,11 +471,12 @@ static char** get_attach_addresses_for_disjoint_mode() {
   }
   uint start = i;
 
-  // Avoid more steps than requested, and avoid probing beyond the safe mmap probing limit.
+  // Avoid more steps than requested, and avoid expanding the page table
+  // by over-eager probing.
   i = 0;
   while (addresses[start+i] != 0) {
     if (i == HeapSearchSteps ||
-       (addresses[start+i] >= os::vm_max_mmap_hint_address()))
+       (addresses[start+i] >= os::vm_page_table_expansion_point()))
     {
       addresses[start+i] = 0;
       break;

--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -471,20 +471,15 @@ static char** get_attach_addresses_for_disjoint_mode() {
   }
   uint start = i;
 
-  // Avoid more steps than requested.
+  // Avoid more steps than requested, and avoid probing beyond the safe mmap probing limit.
   i = 0;
   while (addresses[start+i] != 0) {
-    if (i == HeapSearchSteps) {
+    if (i == HeapSearchSteps ||
+       (addresses[start+i] >= os::vm_max_mmap_hint_address()))
+    {
       addresses[start+i] = 0;
       break;
     }
-#ifdef S390
-    // On s390x, do not probe beyond 2^42 to prevent accidental page table expansion
-    if (addresses[start+i] >= nth_bit<uintptr_t>(42)) {
-      addresses[start+i] = 0;
-      break;
-    }
-#endif
     i++;
   }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1995,10 +1995,9 @@ static void shuffle_fisher_yates(T* arr, unsigned num, FastRandom& frand) {
 }
 
 #ifndef S390
-// Default implementation: assume that mmap probing with high addresses is safe:
-// no lasting effects on the process
-uintptr_t os::vm_max_mmap_hint_address() {
-  return align_down(right_n_bits<uintptr_t>(64), os::vm_allocation_granularity());
+// Default implementation: page table never expands.
+uintptr_t os::vm_page_table_expansion_point() {
+  return align_down(UINTPTR_MAX, os::vm_allocation_granularity());
 }
 #endif
 
@@ -2043,7 +2042,6 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   assert(alignment < SIZE_MAX / 2, "alignment too large (" ARGSFMT ")", ARGSFMTARGS);
   assert(is_aligned(bytes, os::vm_page_size()), "size not page aligned (" ARGSFMT ")", ARGSFMTARGS);
   assert(max >= min, "invalid range (" ARGSFMT ")", ARGSFMTARGS);
-  assert((uintptr_t)max <= os::vm_max_mmap_hint_address(), "Do not probe beyond probe limit");
 
   char* const absolute_max = (char*)(NOT_LP64(G * 3) LP64_ONLY(G * 128 * 1024));
   char* const absolute_min = (char*) os::vm_min_address();

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1994,6 +1994,14 @@ static void shuffle_fisher_yates(T* arr, unsigned num, FastRandom& frand) {
   }
 }
 
+#ifndef S390
+// Default implementation: assume that mmap probing with high addresses is safe:
+// no lasting effects on the process
+uintptr_t os::vm_max_mmap_hint_address() {
+  return align_down(right_n_bits<uintptr_t>(64), os::vm_allocation_granularity());
+}
+#endif
+
 // Helper for os::attempt_reserve_memory_between
 // Given an array of things, do a hemisphere split such that the resulting
 // order is: [first, last, first + 1, last - 1, ...]
@@ -2035,6 +2043,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   assert(alignment < SIZE_MAX / 2, "alignment too large (" ARGSFMT ")", ARGSFMTARGS);
   assert(is_aligned(bytes, os::vm_page_size()), "size not page aligned (" ARGSFMT ")", ARGSFMTARGS);
   assert(max >= min, "invalid range (" ARGSFMT ")", ARGSFMTARGS);
+  assert((uintptr_t)max <= os::vm_max_mmap_hint_address(), "Do not probe beyond probe limit");
 
   char* const absolute_max = (char*)(NOT_LP64(G * 3) LP64_ONLY(G * 128 * 1024));
   char* const absolute_min = (char*) os::vm_min_address();

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -503,6 +503,12 @@ class os: AllStatic {
   // Returns the lowest address the process is allowed to map against.
   static size_t vm_min_address();
 
+  // On some kernels (e.g. s390x), mmap probing with high addresses can have lasting effects on
+  // the process by expanding the page table. This function returns the lowest address value
+  // that will have such an effect; callers should avoid probing beyond this address unless
+  // it is deliberate.
+  static uintptr_t vm_max_mmap_hint_address();
+
   // Returns an upper limit beyond which reserve_memory() calls are guaranteed
   // to fail. It is not guaranteed that reserving less memory than this will
   // succeed, however.

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -503,11 +503,10 @@ class os: AllStatic {
   // Returns the lowest address the process is allowed to map against.
   static size_t vm_min_address();
 
-  // On some kernels (e.g. s390x), mmap probing with high addresses can have lasting effects on
-  // the process by expanding the page table. This function returns the lowest address value
-  // that will have such an effect; callers should avoid probing beyond this address unless
-  // it is deliberate.
-  static uintptr_t vm_max_mmap_hint_address();
+  // Some kernels (e.g. s390x) can dynamically expand the page table. This function returns
+  // the lowest user space address that will expand the page table for the first time.
+  // We typically want to avoid expanding the page table unless it is really necessary.
+  static uintptr_t vm_page_table_expansion_point();
 
   // Returns an upper limit beyond which reserve_memory() calls are guaranteed
   // to fail. It is not guaranteed that reserving less memory than this will

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -43,6 +43,9 @@ import jdk.test.lib.process.ProcessTools;
 import jtreg.SkippedException;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class CompressedCPUSpecificClassSpaceReservation {
     // Note: windows: On windows, we currently have the issue that os::reserve_memory_aligned relies on
@@ -72,7 +75,7 @@ public class CompressedCPUSpecificClassSpaceReservation {
         // an insert of the base address bits into the register holding the nK. That requires the base to not
         // intersect with nK bits (for simplicity, we always assume nK range of 32bits).
         // The upper limit of this reservation attempt is platform-dependent, though.
-        final String tryReserveFor16bitMoveIntoQ3Regex = "reserve_between.*0x0000000100000000-0x\\d{8}00000000";
+        final String tryReserveFor16bitMoveIntoQ3Regex = "reserve_between.*0x0000000100000000-0x\\d{8}00000000.*alignment 0x100000000";
         if (Platform.isAArch64()) {
             if (CDS) {
                 output.shouldNotContain(tryReserveForUnscaled);
@@ -123,6 +126,23 @@ public class CompressedCPUSpecificClassSpaceReservation {
             output.shouldContain("CDS archive(s) not mapped");
         }
         output.shouldContain("Compressed class space mapped at:");
+
+        // S390: Make very sure every reserve_between attempt we do (which we do
+        // for class space only, currently) never probes beyond 2^42 to avoid
+        // page table expansion
+        if (Platform.isS390x()) {
+            Pattern pat = Pattern.compile(".*reserve_between \\(range \\[0x[0-9a-f]{16}-0x([0-9a-f]{16})\\).*");
+            List<Matcher> matches = output.matchersForAllMatchingLinesStdout(pat);
+            if (matches.size() == 0) {
+                throw new RuntimeException("Expected matches");
+            }
+            for (Matcher mat : matches) {
+                long address_from = Long.parseLong(mat.group(1), 16);
+                if (address_from >= Math.powExact(2L, 42)) {
+                    throw new RuntimeException("Address space probing beyond 2^42?");
+                }
+            }
+        }
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -137,8 +137,9 @@ public class CompressedCPUSpecificClassSpaceReservation {
                 throw new RuntimeException("Expected matches");
             }
             for (Matcher mat : matches) {
-                long address_from = Long.parseLong(mat.group(1), 16);
-                if (address_from >= Math.powExact(2L, 42)) {
+                long address_to = Long.parseLong(mat.group(1), 16);
+                if (address_to > Math.powExact(2L, 42)) {
+                    System.out.println(mat.group(0));
                     throw new RuntimeException("Address space probing beyond 2^42?");
                 }
             }

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -68,7 +68,11 @@ public class CompressedCPUSpecificClassSpaceReservation {
         final String tryReserveForUnscaled = "reserve_between (range [0x0000000000000000-0x0000000100000000)";
         final String tryReserveBelow4G = "reserve_between (range [0x0000000000000000-0x0000000100000000)";
         final String tryReserveForZeroBased = "reserve_between (range [0x0000000100000000-0x0000000800000000)";
-        final String tryReserveFor16bitMoveIntoQ3 = "reserve_between (range [0x0000000100000000-0x0001000000000000)";
+        // Failing zero-based allocation, platforms will often attempt allocation suitable for a disjointed move:
+        // an insert of the base address bits into the register holding the nK. That requires the base to not
+        // intersect with nK bits (for simplicity, we always assume nK range of 32bits).
+        // The upper limit of this reservation attempt is platform-dependent, though.
+        final String tryReserveFor16bitMoveIntoQ3Regex = "reserve_between.*0x0000000100000000-0x\\d{8}00000000";
         if (Platform.isAArch64()) {
             if (CDS) {
                 output.shouldNotContain(tryReserveForUnscaled);
@@ -77,7 +81,7 @@ public class CompressedCPUSpecificClassSpaceReservation {
             }
             output.shouldContain("Trying to reserve at an EOR-compatible address");
             output.shouldNotContain(tryReserveForZeroBased);
-            output.shouldContain(tryReserveFor16bitMoveIntoQ3);
+            output.shouldMatch(tryReserveFor16bitMoveIntoQ3Regex);
         } else if (Platform.isPPC()) {
             if (CDS) {
                 output.shouldNotContain(tryReserveForUnscaled);
@@ -86,7 +90,7 @@ public class CompressedCPUSpecificClassSpaceReservation {
                 output.shouldContain(tryReserveForUnscaled);
                 output.shouldContain(tryReserveForZeroBased);
             }
-            output.shouldContain(tryReserveFor16bitMoveIntoQ3);
+            output.shouldMatch(tryReserveFor16bitMoveIntoQ3Regex);
         } else if (Platform.isRISCV64()) {
             output.shouldContain(tryReserveForUnscaled); // unconditionally
             // bits 32..44
@@ -100,7 +104,7 @@ public class CompressedCPUSpecificClassSpaceReservation {
             } else {
                 output.shouldContain(tryReserveForZeroBased);
             }
-            output.shouldContain(tryReserveFor16bitMoveIntoQ3);
+            output.shouldMatch(tryReserveFor16bitMoveIntoQ3Regex);
         } else if (Platform.isX64()) {
             output.shouldContain(tryReserveBelow4G);
             if (CDS) {

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -563,6 +563,32 @@ public final class OutputAnalyzer {
         return firstMatch(pattern, 0);
     }
 
+    private List<Matcher> matchersForAllMatchingLinesInternal(Pattern needleRegex, List<String> haystack) {
+        List<Matcher> matchingMatchers = haystack.stream().
+                map(needleRegex::matcher).filter(Matcher::matches).collect(Collectors.toList());
+        return matchingMatchers;
+    }
+
+    /**
+     * Given a regular expression, matches the expression against every *line* of stderr output
+     * and returns a list of all matching matchers.
+     * @param needleRegex
+     * @return List of matchers
+     */
+    public  List<Matcher> matchersForAllMatchingLinesStderr(Pattern needleRegex) {
+        return matchersForAllMatchingLinesInternal(needleRegex, stderrAsLines());
+    }
+
+    /**
+     * Given a regular expression, matches the expression against every *line* of stdout output
+     * and returns a list of all matching matchers.
+     * @param needleRegex
+     * @return List of matchers
+     */
+    public  List<Matcher> matchersForAllMatchingLinesStdout(Pattern needleRegex) {
+        return matchersForAllMatchingLinesInternal(needleRegex, stdoutAsLines());
+    }
+
     /**
      * Verify the exit value of the process
      *


### PR DESCRIPTION
Linux s390x is special in that the kernel can expand a process' page table dynamically *during its runtime*. That is pretty cool, but it poses some problems for us.

Expansion happens in three steps: 
- three levels (42 bits, max 4TB)
- 4 levels (53 bits, 8PB)
- 5 levels (64 bits, 16EB). 

It only works one-way - once switched to a higher level, there is no way back.

Expansion is triggered when an allocation attempt cannot be satisfied within the confines of the current user address space. Either because its too large, and/or the address space is too fragmented. But also if the user explicitly requests a mapping beyond the upper boundary of the current user address space.

The latter is a problem, because we do exactly that, freely, during JVM setup. We probe the address space in various places: when allocating the heap, the class space, and when setting up the ZGC colored-pointer-address-format. In all these places, we assumed that probing has no adverse effect, because it has always been this way. But on s390 we can inadvertently upgrade the process page table layout to a higher level.

A higher page table level will make every TLB miss a bit more expensive - longer latencies on memory access, and the larger page tables themselves also use more cache. A runtime like ours that does a lot of pointer hopping should really avoid expanding the page table unless we really really need that. We shouldn't unless we run with abnormally (TB-sized) heaps.

ZGC setup is not a problem here, since it's unsupported on s390 (but something to keep in mind should we ever want to port it). But we need to fix heap reservation and class space reservation.

----

The patch: It fixes the reservation for s390. I was tempted to add the fix to a lower layer, e.g. to `os::attempt_reserve_memory_at`, but it feels wrong for lower layer APIs to be "too smart" - I want them to do exactly whats on the label - and because there are places where I *want* reservations to high addresses to go through, eg. for the experimental switches `SharedBaseAddress` and `CompressedClassSpaceBaseAddress`.

CompressedClassPointersEncodingScheme.java needed fixing, too, since the upper limit of address space probing is now platform dependent.

---

Tests: hotspot tier1 and gtests on s390

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388561](https://bugs.openjdk.org/browse/JDK-8388561): [s390x] Prevent accidental page table expansion (**Bug** - P3)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Robert Toyonaga](https://openjdk.org/census#rtoyonaga) (@roberttoyonaga - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31990/head:pull/31990` \
`$ git checkout pull/31990`

Update a local copy of the PR: \
`$ git checkout pull/31990` \
`$ git pull https://git.openjdk.org/jdk.git pull/31990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31990`

View PR using the GUI difftool: \
`$ git pr show -t 31990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31990.diff">https://git.openjdk.org/jdk/pull/31990.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31990#issuecomment-5044500901)
</details>
