### PR TITLE
8388553: Proxy class generation fails when the jdk.proxy.ProxyGenerator.saveGeneratedFiles is set to true

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,7 +222,6 @@ final class ProxyGenerator {
                     path = Path.of(name + ".class");
                 }
                 Files.write(path, classFile);
-                return null;
             } catch (IOException e) {
                 throw new InternalError("I/O exception saving generated file: " + e);
             }

--- a/test/jdk/java/lang/reflect/Proxy/Basic1.java
+++ b/test/jdk/java/lang/reflect/Proxy/Basic1.java
@@ -22,12 +22,13 @@
  */
 
 /* @test
- * @bug 4227192 4487672
- * @summary This is a basic functional test of the dynamic proxy API (part 1).
- * @author Peter Jones
+ * @bug 4227192 4487672 8388553
+ * @summary This is a basic functional test of the java.lang.reflect.Proxy API
  *
- * @build Basic1
  * @run main Basic1
+ * @comment Verify that the APIs behave as expected even when the JDK internal
+ *          debug system property "jdk.proxy.ProxyGenerator.saveGeneratedFiles" is set
+ * @run main/othervm -Djdk.proxy.ProxyGenerator.saveGeneratedFiles=true Basic1
  */
 
 import java.lang.reflect.*;
@@ -37,9 +38,6 @@ import java.util.*;
 public class Basic1 {
 
     public static void main(String[] args) {
-
-        System.err.println(
-            "\nBasic functional test of dynamic proxy API, part 1\n");
 
         try {
             Class<?>[] interfaces =

--- a/test/jdk/java/lang/reflect/Proxy/Basic1.java
+++ b/test/jdk/java/lang/reflect/Proxy/Basic1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the issue noted in https://bugs.openjdk.org/browse/JDK-8388553?

`java.lang.reflect.ProxyGenerator`, a JDK internal class that relates to `java.lang.reflect.Proxy` API, has an (undocumented internal) system property which can be set to `true` to write out the bytes of the `Proxy` class generated dynamically by this code. Before Java 24, when SecurityManager was around, this code of writing out to a file, was wrapped in a `PrivilegedAction`.  When we updated this code during the removal of SecurityManager in https://bugs.openjdk.org/browse/JDK-8344011, we accidentally returned `null` from the `if` block after writing out the class bytes. This effectively results in the `ProxyGenerator.generateProxyClass(...)` method returning null for any `Proxy` class it generates when that internal system property is set to true.

The commit in this PR fixes that oversight. The pre-existing `test/jdk/java/lang/reflect/Proxy/Basic1.java` jtreg test has been updated to have a `@run` with this system property value set to `true`. The test fails (as expected) without the proposed source fix and passes (as expected) with it.

tier testing is currently in progress but I don't expect any surprises there. Tomorrow I will go through the original commit of JDK-8344011 just to check if there are any other places that might need attention.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388553](https://bugs.openjdk.org/browse/JDK-8388553): Proxy class generation fails when the jdk.proxy.ProxyGenerator.saveGeneratedFiles is set to true (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31993/head:pull/31993` \
`$ git checkout pull/31993`

Update a local copy of the PR: \
`$ git checkout pull/31993` \
`$ git pull https://git.openjdk.org/jdk.git pull/31993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31993`

View PR using the GUI difftool: \
`$ git pr show -t 31993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31993.diff">https://git.openjdk.org/jdk/pull/31993.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31993#issuecomment-5036343696)
</details>
