### PR TITLE
8388463: Aarch64+Zero build is broken by JDK-8387652

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -270,8 +270,8 @@ public:
   // Returns true if address points into protection zone (for error reporting)
   static bool is_in_protection_zone(address addr);
 
-  // platform-specific initializations
-  static void initialize_pd() NOT_AARCH64({});
+  // platform-specific initializations (needed only on non-zero aarch64 builds)
+  static void initialize_pd() ZERO_ONLY({}) NOT_ZERO(NOT_AARCH64({}));
 };
 
 #endif // SHARE_OOPS_COMPRESSEDKLASS_HPP


### PR DESCRIPTION
`CompressedKlassPointers::initialize_pd()` is defined in compressedKlass_aarch64.cpp and is needed only on **real** aarch64 builds.

I added some macro gymnastics to make this function a no-op for zero builds.

An alternative is to add a new compressedKlass_zero.cpp file and define an empty `initialize_pd()` function only for aarch64 builds. I prefer the current fix as all the conditional logic is in a single place.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388463](https://bugs.openjdk.org/browse/JDK-8388463): Aarch64+Zero build is broken by JDK-8387652 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31997/head:pull/31997` \
`$ git checkout pull/31997`

Update a local copy of the PR: \
`$ git checkout pull/31997` \
`$ git pull https://git.openjdk.org/jdk.git pull/31997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31997`

View PR using the GUI difftool: \
`$ git pr show -t 31997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31997.diff">https://git.openjdk.org/jdk/pull/31997.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31997#issuecomment-5039024288)
</details>
