### PR TITLE
8388694: Refactor metaspace_pointers_do() operations for BSMAttributeEntries

### DIFF
--- a/src/hotspot/share/oops/bsmAttribute.hpp
+++ b/src/hotspot/share/oops/bsmAttribute.hpp
@@ -30,6 +30,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 class ClassLoaderData;
+class MetaspaceClosure;
 
 class BSMAttributeEntry {
   friend class ConstantPool;
@@ -130,10 +131,8 @@ public:
     return _offsets == nullptr && _bootstrap_methods == nullptr;
   }
 
-  Array<u4>*& offsets() { return _offsets; }
-  const Array<u4>* const& offsets() const { return _offsets; }
-  Array<u2>*& bootstrap_methods() { return _bootstrap_methods; }
-  const Array<u2>* const& bootstrap_methods() const { return _bootstrap_methods; }
+  Array<u4>* offsets() const { return _offsets; }
+  Array<u2>* bootstrap_methods() const { return _bootstrap_methods; }
 
   BSMAttributeEntry* entry(int bsms_attribute_index) {
     return reinterpret_cast<BSMAttributeEntry*>(_bootstrap_methods->adr_at(_offsets->at(bsms_attribute_index)));
@@ -164,6 +163,8 @@ public:
   void end_extension(InsertionIterator& iter, ClassLoaderData* loader_data, TRAPS);
   // Append all of the BSMAEs in other into this.
   void append(const BSMAttributeEntries& other, ClassLoaderData* loader_data, TRAPS);
+
+  void metaspace_pointers_do(MetaspaceClosure* it);
 };
 
 #endif // SHARE_OOPS_BSMATTRIBUTE_HPP

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,9 +152,8 @@ void ConstantPool::metaspace_pointers_do(MetaspaceClosure* it) {
   it->push(&_tags, MetaspaceClosure::_writable);
   it->push(&_cache);
   it->push(&_pool_holder);
-  it->push(&bsm_entries().offsets());
-  it->push(&bsm_entries().bootstrap_methods());
   it->push(&_resolved_klasses, MetaspaceClosure::_writable);
+  bsm_entries().metaspace_pointers_do(it);
 
   for (int i = 0; i < length(); i++) {
     // The only MSO's embedded in the CP entries are Symbols:
@@ -2423,4 +2422,9 @@ void BSMAttributeEntries::end_extension(InsertionIterator& iter, ClassLoaderData
   deallocate_contents(loader_data);
   _offsets = new_offsets;
   _bootstrap_methods = new_array;
+}
+
+void BSMAttributeEntries::metaspace_pointers_do(MetaspaceClosure* it) {
+  it->push(&_offsets);
+  it->push(&_bootstrap_methods);
 }


### PR DESCRIPTION
Please review this small refactoring PR that replaces these obscured, overloaded accessors that return a reference:

```
  Array<u4>*& offsets() { return _offsets; }
  const Array<u4>* const& offsets() const { return _offsets; }
  Array<u2>*& bootstrap_methods() { return _bootstrap_methods; }
  const Array<u2>* const& bootstrap_methods() const { return _bootstrap_methods; }
```
with the usual style of accessors

```
  Array<u4>* offsets() const { return _offsets; }
  Array<u2>* bootstrap_methods() const { return _bootstrap_methods; }
```



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388694](https://bugs.openjdk.org/browse/JDK-8388694): Refactor metaspace_pointers_do() operations for BSMAttributeEntries (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31998/head:pull/31998` \
`$ git checkout pull/31998`

Update a local copy of the PR: \
`$ git checkout pull/31998` \
`$ git pull https://git.openjdk.org/jdk.git pull/31998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31998`

View PR using the GUI difftool: \
`$ git pr show -t 31998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31998.diff">https://git.openjdk.org/jdk/pull/31998.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31998#issuecomment-5039746319)
</details>
