### PR TITLE
8388696: DW_CFA_offset_extended and DW_CFA_restore_extended are not supported in SA

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
@@ -200,6 +200,17 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
         }
         break;
       }
+      case 0x05: { // DW_CFA_offset_extended
+        enum DWARF_Register reg = static_cast<enum DWARF_Register>(read_leb(false));
+        uintptr_t operand2 = read_leb(false);
+        _state.offset_from_cfa[reg] = operand2 * _data_factor;
+        break;
+      }
+      case 0x06: { // DW_CFA_restore_extended
+        enum DWARF_Register reg = static_cast<enum DWARF_Register>(read_leb(false));
+        _state.offset_from_cfa[reg] = _initial_state.offset_from_cfa[reg];
+        break;
+      }
       case 0x07: { // DW_CFA_undefined
         enum DWARF_Register reg = static_cast<enum DWARF_Register>(read_leb(false));
         _state.offset_from_cfa[reg] = INT_MAX;
@@ -228,7 +239,7 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
       }
       default:
         if (!process_arch_specific_dwarf_instructions(op)) {
-          print_debug("DWARF: Unknown opcode: 0x%x\n", op);
+          print_error("DWARF: Unknown opcode: 0x%x\n", op);
           return;
         }
     }

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf_regs_aarch64.h
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf_regs_aarch64.h
@@ -66,7 +66,40 @@
   DWARF_REG(FP,  29) \
   DWARF_REG(LR,  30) \
   DWARF_REG(SP,  31) \
-  DWARF_REG(PC,  32)
+  DWARF_REG(PC,  32) \
+                     \
+  DWARF_REG(V0,  64) \
+  DWARF_REG(V1,  65) \
+  DWARF_REG(V2,  66) \
+  DWARF_REG(V3,  67) \
+  DWARF_REG(V4,  68) \
+  DWARF_REG(V5,  69) \
+  DWARF_REG(V6,  70) \
+  DWARF_REG(V7,  71) \
+  DWARF_REG(V8,  72) \
+  DWARF_REG(V9,  73) \
+  DWARF_REG(V10, 74) \
+  DWARF_REG(V11, 75) \
+  DWARF_REG(V12, 76) \
+  DWARF_REG(V13, 77) \
+  DWARF_REG(V14, 78) \
+  DWARF_REG(V15, 79) \
+  DWARF_REG(V16, 80) \
+  DWARF_REG(V17, 81) \
+  DWARF_REG(V18, 82) \
+  DWARF_REG(V19, 83) \
+  DWARF_REG(V20, 84) \
+  DWARF_REG(V21, 85) \
+  DWARF_REG(V22, 86) \
+  DWARF_REG(V23, 87) \
+  DWARF_REG(V24, 88) \
+  DWARF_REG(V25, 89) \
+  DWARF_REG(V26, 90) \
+  DWARF_REG(V27, 91) \
+  DWARF_REG(V28, 92) \
+  DWARF_REG(V29, 93) \
+  DWARF_REG(V30, 94) \
+  DWARF_REG(V31, 95)
 
 // RA_SIGN_STATE might be needed in future to handle PAC.
 #define DWARF_PSEUDO_REGLIST

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/aarch64/AARCH64ThreadContext.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/aarch64/AARCH64ThreadContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -95,7 +95,40 @@ public abstract class AARCH64ThreadContext implements ThreadContext {
     public static final int PC = 32;
     public static final int PSTATE = 33;
 
-    public static final int NPRGREG = 34;
+    public static final int V0  = 34;
+    public static final int V1  = 35;
+    public static final int V2  = 36;
+    public static final int V3  = 37;
+    public static final int V4  = 38;
+    public static final int V5  = 39;
+    public static final int V6  = 40;
+    public static final int V7  = 41;
+    public static final int V8  = 42;
+    public static final int V9  = 43;
+    public static final int V10 = 44;
+    public static final int V11 = 45;
+    public static final int V12 = 46;
+    public static final int V13 = 47;
+    public static final int V14 = 48;
+    public static final int V15 = 49;
+    public static final int V16 = 50;
+    public static final int V17 = 51;
+    public static final int V18 = 52;
+    public static final int V19 = 53;
+    public static final int V20 = 54;
+    public static final int V21 = 55;
+    public static final int V22 = 56;
+    public static final int V23 = 57;
+    public static final int V24 = 58;
+    public static final int V25 = 59;
+    public static final int V26 = 60;
+    public static final int V27 = 61;
+    public static final int V28 = 62;
+    public static final int V29 = 63;
+    public static final int V30 = 64;
+    public static final int V31 = 65;
+
+    public static final int NPRGREG = 66;
 
     private long[] data;
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/aarch64/AARCH64ThreadContext.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/aarch64/AARCH64ThreadContext.java
@@ -52,6 +52,9 @@ public abstract class AARCH64ThreadContext implements ThreadContext {
     //          __u8 __reserved[4096] __attribute__((__aligned__(16)));
     //  };
 
+    // These constants are referenced by "DWARF_REG" macro in DwarfParser.cpp
+    // to map DWARF register numbers to the corresponding indices.
+    //
     // NOTE: the indices for the various registers must be maintained as
     // listed across various operating systems. However, only a small
     // subset of the registers' values are guaranteed to be present (and


### PR DESCRIPTION
In PR #31669 for [JDK-8386593](https://bugs.openjdk.org/browse/JDK-8386593), we discoverd `DW_CFA_offset_extended` and `DW_CFA_restore_extended` are not supported in SA.

GCC on Fedora 44 and Ubuntu 26.04 (at least) generates DWARF instructions in below:

```
  DW_CFA_offset_extended: r79 (v15) at cfa-16
  DW_CFA_advance_loc: 204 to 00000000006646e4
  DW_CFA_restore: r30 (x30)
  DW_CFA_restore: r29 (x29)
  DW_CFA_restore: r19 (x19)
  DW_CFA_restore: r20 (x20)
  DW_CFA_restore_extended: r79 (v15)
```

We need to add `DW_CFA_offset_extended` and `DW_CFA_restore_extended`, and vector registers for AArch64 which are defined in [DWARF for the Arm® 64-bit Architecture (AArch64)](https://github.com/ARM-software/abi-aa/blob/2025Q4/aadwarf64/aadwarf64.rst#dwarf-register-names).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388696](https://bugs.openjdk.org/browse/JDK-8388696): DW_CFA_offset_extended and DW_CFA_restore_extended are not supported in SA (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/31999/head:pull/31999` \
`$ git checkout pull/31999`

Update a local copy of the PR: \
`$ git checkout pull/31999` \
`$ git pull https://git.openjdk.org/jdk.git pull/31999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31999`

View PR using the GUI difftool: \
`$ git pr show -t 31999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/31999.diff">https://git.openjdk.org/jdk/pull/31999.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/31999#issuecomment-5040883580)
</details>
