### PR TITLE
8388479: RISC-V: compiler/vectorapi/TestMaskedNotAllOnes.java fails after JDK-8386163

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2182,12 +2182,27 @@ static bool is_vector_bitwise_not_pattern(Node* n, Node* m) {
   return false;
 }
 
+static bool are_users_clone_compatible(Node* n, Node* m) {
+  for (DUIterator_Fast imax, i = m->fast_outs(imax); i < imax; i++) {
+    Node* use = m->fast_out(i);
+    if (use == n) {
+      continue;
+    }
+    if (!is_vector_bitwise_not_pattern(use, m) &&
+        !is_vector_scalar_bitwise_pattern(use, m)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // Should the Matcher clone input 'm' of node 'n'?
 bool Matcher::pd_clone_node(Node* n, Node* m, Matcher::MStack& mstack) {
   assert_cond(m != nullptr);
-  if (is_vshift_con_pattern(n, m) ||
-      (!n->is_predicated_vector() && is_vector_bitwise_not_pattern(n, m)) ||
-      (!n->is_predicated_vector() && is_vector_scalar_bitwise_pattern(n, m)) ||
+  if (is_vshift_con_pattern(n, m) || // ShiftV src (ShiftCntV con)
+      ((is_vector_bitwise_not_pattern(n, m) ||
+        is_vector_scalar_bitwise_pattern(n, m)) &&
+       are_users_clone_compatible(n, m)) ||
       is_encode_and_store_pattern(n, m)) {
     mstack.push(m, Visit);
     return true;

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2185,9 +2185,9 @@ static bool is_vector_bitwise_not_pattern(Node* n, Node* m) {
 // Should the Matcher clone input 'm' of node 'n'?
 bool Matcher::pd_clone_node(Node* n, Node* m, Matcher::MStack& mstack) {
   assert_cond(m != nullptr);
-  if (is_vshift_con_pattern(n, m) || // ShiftV src (ShiftCntV con)
-      is_vector_bitwise_not_pattern(n, m) ||
-      is_vector_scalar_bitwise_pattern(n, m) ||
+  if (is_vshift_con_pattern(n, m) ||
+      (!n->is_predicated_vector() && is_vector_bitwise_not_pattern(n, m)) ||
+      (!n->is_predicated_vector() && is_vector_scalar_bitwise_pattern(n, m)) ||
       is_encode_and_store_pattern(n, m)) {
     mstack.push(m, Visit);
     return true;


### PR DESCRIPTION
Hi, TestMaskedNotAllOnes.java crashed with RVV enabled on RISCV fastdebug build, for the error message, please refer to: https://bugs.openjdk.org/browse/JDK-8388479



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388479](https://bugs.openjdk.org/browse/JDK-8388479): RISC-V: compiler/vectorapi/TestMaskedNotAllOnes.java fails after JDK-8386163 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32000/head:pull/32000` \
`$ git checkout pull/32000`

Update a local copy of the PR: \
`$ git checkout pull/32000` \
`$ git pull https://git.openjdk.org/jdk.git pull/32000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32000`

View PR using the GUI difftool: \
`$ git pr show -t 32000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32000.diff">https://git.openjdk.org/jdk/pull/32000.diff</a>

</details>
