### PR TITLE
8388474: RISC-V: Relax satp mode check for sv57

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -85,8 +85,10 @@ void VM_Version::common_initialize() {
 
   setup_cpu_available_features();
 
-  // check if satp.mode is supported, currently supports up to SV48(RV64)
-  if (satp_mode.value() > VM_SV48 || satp_mode.value() < VM_MBARE) {
+    // check if satp.mode is supported, currently supports up to SV57(RV64).
+    // On Sv57 systems the Linux kernel keeps the default userspace address
+    // window within the Sv48 range, so userspace pointers stay below 2^48
+    if (satp_mode.value() > VM_SV57 || satp_mode.value() < VM_MBARE) {
     vm_exit_during_initialization(
       err_msg(
          "Unsupported satp mode: SV%d. Only satp modes up to sv48 are supported for now.",


### PR DESCRIPTION
The RISC-V currently refuses to start when the kernel reports an sv57 MMU in /proc/cpuinfo, exiting during VM initialization with "Unsupported satp mode:". This is overly conservative: although sv57 hardware supports 57-bit virtual addresses, userspace never actually sees addresses beyond the sv48 range under the kernel's default address-space policy[1].

[1] https://patchew.org/linux/20230705190002.384799-1-charlie@rivosinc.com/20230705190002.384799-2-charlie@rivosinc.com/

### Testing
- [ ] Run tier1 release on qemu-system with sv57 enabled


qemu with sv57 cpuinfo:
```
root@riscv64-xuantie:~# /home/root/jdk/bin/java -version
openjdk version "27-internal" 2026-09-15
OpenJDK Runtime Environment (build 27-internal-adhoc.ocg02554262.openjdk)
OpenJDK 64-Bit Server VM (build 27-internal-adhoc.ocg02554262.openjdk, mixed mode)
root@riscv64-xuantie:~# cat /proc/cpuinfo
processor	: 0
hart		: 1
isa		: rv64imafdcvh_zicbom_zicbop_zicboz_zicfilp_zicfiss_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zawrs_zacas_zabha_zalasr_ziccrse_zfa_zfh_zfhmin_zca_zcb_zcd_zcmop_zba_zbb_zbc_zbs_zkr_zkt_zvbb_zvbc_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_smaia_smmpm_smnpm_smcdeleg_smctr_smstateen_smcntrpmf_smcsrind_ssaia_sscsrind_ssccfg_sscofpmf_ssctr_ssdbltrp_ssnpm_ssqosid_sstc_svade_svadu_svinval_svnapot_svpbmt_xtheadmatrix
mmu		: sv57
mvendorid	: 0x5b7
marchid		: 0x800000009241600
mimpid		: 0x45000
```


linux version:
```
root@riscv64-xuantie:~# uname -a
Linux riscv64-xuantie 6.6.36-yocto-standard+ #1 SMP Fri Feb  6 14:51:56 CST 2026 riscv64 GNU/Linux
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388474](https://bugs.openjdk.org/browse/JDK-8388474): RISC-V: Relax satp mode check for sv57 (**Enhancement** - P4)


### Contributors
 * April Ivy `<aivy@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32001/head:pull/32001` \
`$ git checkout pull/32001`

Update a local copy of the PR: \
`$ git checkout pull/32001` \
`$ git pull https://git.openjdk.org/jdk.git pull/32001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32001`

View PR using the GUI difftool: \
`$ git pr show -t 32001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32001.diff">https://git.openjdk.org/jdk/pull/32001.diff</a>

</details>
