### PR TITLE
8388697: Typo "maxiumum" instead of "maximum" in jdk.httpserver's module-info.java

### DIFF
--- a/src/jdk.httpserver/share/classes/module-info.java
+++ b/src/jdk.httpserver/share/classes/module-info.java
@@ -68,7 +68,7 @@ import com.sun.net.httpserver.*;
  * cache. If not, then it will be closed.
  * </li>
  * <li><p><b>{@systemProperty sun.net.httpserver.maxReqHeaders}</b> (default: 200)<br>
- * The maxiumum number of header fields accepted in a request. If this limit is exceeded
+ * The maximum number of header fields accepted in a request. If this limit is exceeded
  * while the headers are being read, then the connection is terminated and the request ignored.
  * If the value is less than or equal to zero, then the default value is used.
  * </li>


### PR DESCRIPTION
Can I please get a review of this trivial typo fix in the `module-info.java` of `jdk.httpserver` module?




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388697](https://bugs.openjdk.org/browse/JDK-8388697): Typo "maxiumum" instead of "maximum" in jdk.httpserver's module-info.java (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32002/head:pull/32002` \
`$ git checkout pull/32002`

Update a local copy of the PR: \
`$ git checkout pull/32002` \
`$ git pull https://git.openjdk.org/jdk.git pull/32002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32002`

View PR using the GUI difftool: \
`$ git pr show -t 32002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32002.diff">https://git.openjdk.org/jdk/pull/32002.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32002#issuecomment-5042685917)
</details>
