### PR TITLE
8386957: C2 VectorAPI: Predicated operation support for intrinsified Float16Vector unary/binary/ternary operations on AVX512-FP16 targets

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -17046,3 +17046,161 @@ void Assembler::evfmadd132ph(XMMRegister dst, XMMRegister nds, Address src, int 
   emit_operand(dst, src, 0);
 }
 
+void Assembler::evaddph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x58, (0xC0 | encode));
+}
+
+void Assembler::evaddph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_NObit);
+  vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int8(0x58);
+  emit_operand(dst, src, 0);
+}
+
+void Assembler::evsubph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5C, (0xC0 | encode));
+}
+
+void Assembler::evsubph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_NObit);
+  vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int8(0x5C);
+  emit_operand(dst, src, 0);
+}
+
+void Assembler::evmulph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x59, (0xC0 | encode));
+}
+
+void Assembler::evmulph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_NObit);
+  vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int8(0x59);
+  emit_operand(dst, src, 0);
+}
+
+void Assembler::evdivph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5E, (0xC0 | encode));
+}
+
+void Assembler::evdivph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_NObit);
+  vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int8(0x5E);
+  emit_operand(dst, src, 0);
+}
+
+void Assembler::evsqrtph(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  int encode = vex_prefix_and_encode(dst->encoding(), 0, src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x51, (0xC0 | encode));
+}
+
+void Assembler::evfmadd213ph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_MAP6, &attributes);
+  emit_int16((unsigned char)0xA8, (0xC0 | encode));
+}
+
+void Assembler::evfmadd213ph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "");
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+  attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_NObit);
+  vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_MAP6, &attributes);
+  emit_int8((unsigned char)0xA8);
+  emit_operand(dst, src, 0);
+}
+

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2753,6 +2753,18 @@ private:
   void evsqrtph(XMMRegister dst, XMMRegister src1, int vector_len);
   void evsqrtph(XMMRegister dst, Address src1, int vector_len);
 
+  void evaddph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len);
+  void evaddph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len);
+  void evsubph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len);
+  void evsubph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len);
+  void evmulph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len);
+  void evmulph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len);
+  void evdivph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len);
+  void evdivph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len);
+  void evsqrtph(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len);
+  void evfmadd213ph(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len);
+  void evfmadd213ph(XMMRegister dst, KRegister mask, XMMRegister nds, Address src, bool merge, int vector_len);
+
   // Sub packed integers
   void psubb(XMMRegister dst, XMMRegister src);
   void psubw(XMMRegister dst, XMMRegister src);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4789,6 +4789,18 @@ void C2_MacroAssembler::evmasked_op(int ideal_opc, BasicType eType, KRegister ma
       evpfma213ps(dst, mask, src1, src2, merge, vlen_enc); break;
     case Op_FmaVD:
       evpfma213pd(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_AddVHF:
+      evaddph(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_SubVHF:
+      evsubph(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_MulVHF:
+      evmulph(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_DivVHF:
+      evdivph(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_SqrtVHF:
+      evsqrtph(dst, mask, src2, merge, vlen_enc); break;
+    case Op_FmaVHF:
+      evfmadd213ph(dst, mask, src1, src2, merge, vlen_enc); break;
     case Op_VectorRearrange:
       evperm(eType, dst, mask, src2, src1, merge, vlen_enc); break;
     case Op_LShiftVS:
@@ -4878,6 +4890,16 @@ void C2_MacroAssembler::evmasked_op(int ideal_opc, BasicType eType, KRegister ma
       evpfma213ps(dst, mask, src1, src2, merge, vlen_enc); break;
     case Op_FmaVD:
       evpfma213pd(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_AddVHF:
+      evaddph(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_SubVHF:
+      evsubph(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_MulVHF:
+      evmulph(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_DivVHF:
+      evdivph(dst, mask, src1, src2, merge, vlen_enc); break;
+    case Op_FmaVHF:
+      evfmadd213ph(dst, mask, src1, src2, merge, vlen_enc); break;
     case Op_MaxV:
       evpmaxs(eType, dst, mask, src1, src2, merge, vlen_enc); break;
     case Op_MinV:
@@ -7158,6 +7180,26 @@ void C2_MacroAssembler::vminmax_fp16_avx10_2(int opcode, XMMRegister dst, XMMReg
     assert(opcode == Op_MinVHF, "");
     // dst = min(src1, src2)
     evminmaxph(dst, ktmp, src1, src2, true, AVX10_2_MINMAX_MIN_COMPARE_SIGN, vlen_enc);
+  }
+}
+
+void C2_MacroAssembler::vminmax_fp16_avx10_2_masked(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2,
+                                                    KRegister mask, int vlen_enc) {
+  if (opcode == Op_MaxVHF) {
+    evminmaxph(dst, mask, src1, src2, /*merge*/ true, AVX10_2_MINMAX_MAX_COMPARE_SIGN, vlen_enc);
+  } else {
+    assert(opcode == Op_MinVHF, "");
+    evminmaxph(dst, mask, src1, src2, /*merge*/ true, AVX10_2_MINMAX_MIN_COMPARE_SIGN, vlen_enc);
+  }
+}
+
+void C2_MacroAssembler::vminmax_fp16_avx10_2_masked(int opcode, XMMRegister dst, XMMRegister src1, Address src2,
+                                                    KRegister mask, int vlen_enc) {
+  if (opcode == Op_MaxVHF) {
+    evminmaxph(dst, mask, src1, src2, /*merge*/ true, AVX10_2_MINMAX_MAX_COMPARE_SIGN, vlen_enc);
+  } else {
+    assert(opcode == Op_MinVHF, "");
+    evminmaxph(dst, mask, src1, src2, /*merge*/ true, AVX10_2_MINMAX_MIN_COMPARE_SIGN, vlen_enc);
   }
 }
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -588,6 +588,12 @@ public:
   void vminmax_fp16_avx10_2(int opcode, XMMRegister dst, XMMRegister src1, Address src2,
                             KRegister ktmp, int vlen_enc);
 
+  void vminmax_fp16_avx10_2_masked(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2,
+                                   KRegister mask, int vlen_enc);
+
+  void vminmax_fp16_avx10_2_masked(int opcode, XMMRegister dst, XMMRegister src1, Address src2,
+                                   KRegister mask, int vlen_enc);
+
   void sminmax_fp16(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2,
                     KRegister ktmp, XMMRegister xtmp1, XMMRegister xtmp2);
 

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3700,6 +3700,19 @@ bool Matcher::match_rule_supported_vector_masked(int opcode, int vlen, BasicType
     case Op_StoreVectorScatterMasked:
       return true;
 
+    case Op_AddVHF:
+    case Op_SubVHF:
+    case Op_MulVHF:
+    case Op_DivVHF:
+    case Op_SqrtVHF:
+    case Op_FmaVHF:
+      return true;
+
+    case Op_MinVHF:
+    case Op_MaxVHF:
+      // Only AVX10.2 provides a native predicated FP16 min/max.
+      return VM_Version::supports_avx10_2();
+
     case Op_UMinV:
     case Op_UMaxV:
       if (size_in_bits < 512 && !VM_Version::supports_avx512vl()) {
@@ -24997,6 +25010,112 @@ instruct vector_minmax_HF_reg(vec dst, vec src1, vec src2, kReg ktmp, vec xtmp1,
     int opcode = this->ideal_Opcode();
     __ vminmax_fp16(opcode, $dst$$XMMRegister, $src2$$XMMRegister, $src1$$XMMRegister, $ktmp$$KRegister,
                     $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vector_binOps_HF_reg_masked(vec dst, vec src2, kReg mask)
+%{
+  match(Set dst (AddVHF (Binary dst src2) mask));
+  match(Set dst (SubVHF (Binary dst src2) mask));
+  match(Set dst (MulVHF (Binary dst src2) mask));
+  match(Set dst (DivVHF (Binary dst src2) mask));
+  format %{ "vector_binop_fp16_masked $dst, $dst, $src2, $mask" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int opc = this->ideal_Opcode();
+    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
+                   $dst$$XMMRegister, $src2$$XMMRegister, true, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vector_binOps_HF_mem_masked(vec dst, memory src2, kReg mask)
+%{
+  match(Set dst (AddVHF (Binary dst (VectorReinterpret (LoadVector src2))) mask));
+  match(Set dst (SubVHF (Binary dst (VectorReinterpret (LoadVector src2))) mask));
+  match(Set dst (MulVHF (Binary dst (VectorReinterpret (LoadVector src2))) mask));
+  match(Set dst (DivVHF (Binary dst (VectorReinterpret (LoadVector src2))) mask));
+  format %{ "vector_binop_fp16_mem_masked $dst, $dst, $src2, $mask" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int opc = this->ideal_Opcode();
+    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
+                   $dst$$XMMRegister, $src2$$Address, true, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vector_sqrt_HF_masked(vec dst, kReg mask)
+%{
+  match(Set dst (SqrtVHF dst mask));
+  format %{ "vector_sqrt_fp16_masked $dst, $mask" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int opc = this->ideal_Opcode();
+    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
+                   $dst$$XMMRegister, $dst$$XMMRegister, true, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vector_fma_HF_reg_masked(vec dst, vec src2, vec src3, kReg mask)
+%{
+  match(Set dst (FmaVHF (Binary dst src2) (Binary src3 mask)));
+  format %{ "vector_fma_fp16_masked $dst, $src2, $src3, $mask\t# $dst = $dst * $src2 + $src3 fma packedH masked" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int opc = this->ideal_Opcode();
+    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
+                   $src2$$XMMRegister, $src3$$XMMRegister, true, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vector_fma_HF_mem_masked(vec dst, vec src2, memory src3, kReg mask)
+%{
+  match(Set dst (FmaVHF (Binary dst src2) (Binary (VectorReinterpret (LoadVector src3)) mask)));
+  format %{ "vector_fma_fp16_mem_masked $dst, $src2, $src3, $mask\t# $dst = $dst * $src2 + $src3 fma packedH masked" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int opc = this->ideal_Opcode();
+    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
+                   $src2$$XMMRegister, $src3$$Address, true, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vector_minmax_HF_reg_masked_avx10_2(vec dst, vec src2, kReg mask)
+%{
+  predicate(VM_Version::supports_avx10_2());
+  match(Set dst (MinVHF (Binary dst src2) mask));
+  match(Set dst (MaxVHF (Binary dst src2) mask));
+  format %{ "vector_min_max_fp16_masked $dst, $dst, $src2, $mask" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    int opcode = this->ideal_Opcode();
+    __ vminmax_fp16_avx10_2_masked(opcode, $dst$$XMMRegister, $dst$$XMMRegister, $src2$$XMMRegister,
+                                   $mask$$KRegister, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vector_minmax_HF_mem_masked_avx10_2(vec dst, memory src2, kReg mask)
+%{
+  predicate(VM_Version::supports_avx10_2());
+  match(Set dst (MinVHF (Binary dst (VectorReinterpret (LoadVector src2))) mask));
+  match(Set dst (MaxVHF (Binary dst (VectorReinterpret (LoadVector src2))) mask));
+  format %{ "vector_min_max_fp16_mem_masked $dst, $dst, $src2, $mask" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    int opcode = this->ideal_Opcode();
+    __ vminmax_fp16_avx10_2_masked(opcode, $dst$$XMMRegister, $dst$$XMMRegister, $src2$$Address,
+                                   $mask$$KRegister, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -486,6 +486,24 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
     }
   }
 
+  // Canonicalize Float16 vector operations to the same IR shape produced by
+  // auto-vectorization.
+  bool bridge_float16_with_reinterpret =
+      vltype == VectorSupport::LaneType::LT_FLOAT16 && !is_vector_mask(vbox_klass) &&
+      arch_supports_vector(Op_VectorReinterpret, num_elem, elem_bt, VecMaskNotUsed);
+  if (bridge_float16_with_reinterpret) {
+    const TypeVect* hf_vect_type = TypeVect::make(elem_bt, num_elem);
+    if (opd1 != nullptr) {
+      opd1 = gvn().transform(new VectorReinterpretNode(opd1, opd1->bottom_type()->is_vect(), hf_vect_type));
+    }
+    if (opd2 != nullptr) {
+      opd2 = gvn().transform(new VectorReinterpretNode(opd2, opd2->bottom_type()->is_vect(), hf_vect_type));
+    }
+    if (opd3 != nullptr) {
+      opd3 = gvn().transform(new VectorReinterpretNode(opd3, opd3->bottom_type()->is_vect(), hf_vect_type));
+    }
+  }
+
   Node* operation = nullptr;
   const TypeVect* vt = TypeVect::make(elem_bt, num_elem, is_vector_mask(vbox_klass));
   switch (n) {
@@ -512,6 +530,11 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
     }
   }
   operation = gvn().transform(operation);
+
+  if (bridge_float16_with_reinterpret) {
+    const TypeVect* hf_vect_type = TypeVect::make(elem_bt, num_elem);
+    operation = gvn().transform(new VectorReinterpretNode(operation, operation->bottom_type()->is_vect(), hf_vect_type));
+  }
 
   // Wrap it up in VectorBox to keep object type information.
   Node* vbox = box_vector(operation, vbox_type, elem_bt, num_elem);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestFloat16MaskedVectorOperations.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestFloat16MaskedVectorOperations.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @bug 8386957
+* @summary Verify that predicated (masked) Float16Vector operations generate
+*          native predicated IR and do not fall back to a VectorBlend.
+* @modules jdk.incubator.vector
+* @library /test/lib /
+* @compile TestFloat16MaskedVectorOperations.java
+* @run driver compiler.vectorapi.TestFloat16MaskedVectorOperations
+*/
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.verify.Verify;
+import jdk.incubator.vector.*;
+import static jdk.incubator.vector.Float16.*;
+import static java.lang.Float.*;
+import compiler.lib.generators.Generator;
+import static compiler.lib.generators.Generators.G;
+
+public class TestFloat16MaskedVectorOperations {
+    static final VectorSpecies<Float16> SPECIES = Float16Vector.SPECIES_PREFERRED;
+    static final int LEN = 1024;
+
+    short[] input1;
+    short[] input2;
+    short[] input3;
+    short[] output;
+    boolean[] mask;
+
+    public TestFloat16MaskedVectorOperations() {
+        input1 = new short[LEN];
+        input2 = new short[LEN];
+        input3 = new short[LEN];
+        output = new short[LEN];
+        mask   = new boolean[LEN];
+
+        Generator<Short> gen = G.float16s();
+        for (int i = 0; i < LEN; ++i) {
+            input1[i] = gen.next();
+            input2[i] = gen.next();
+            input3[i] = gen.next();
+            mask[i]   = (i % 3) != 0;
+        }
+    }
+
+    public static void main(String args[]) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+
+    static void assertLane(short expected, short actual) {
+        Verify.checkEQ(shortBitsToFloat16(actual), shortBitsToFloat16(expected));
+    }
+
+    @Test
+    @IR(counts = {IRNode.ADD_VHF, " >0 "},
+        failOn = {IRNode.VECTOR_BLEND_S},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {"vector_binOps_HF_mem_masked", " >0 "},
+        phase = {CompilePhase.FINAL_CODE},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    public void maskedAddFloat16() {
+        for (int i = 0; i < SPECIES.loopBound(LEN); i += SPECIES.length()) {
+            VectorMask<Float16> m = VectorMask.fromArray(SPECIES, mask, i);
+            Float16Vector.fromArray(SPECIES, input1, i)
+                         .lanewise(VectorOperators.ADD,
+                                   Float16Vector.fromArray(SPECIES, input2, i), m)
+                         .intoArray(output, i);
+        }
+    }
+
+    @Check(test="maskedAddFloat16")
+    public void checkMaskedAdd() {
+        for (int i = 0; i < LEN; ++i) {
+            short expected = mask[i]
+                ? floatToFloat16(float16ToFloat(input1[i]) + float16ToFloat(input2[i]))
+                : input1[i];
+            assertLane(expected, output[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_VHF, " >0 "},
+        failOn = {IRNode.VECTOR_BLEND_S},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {"vector_binOps_HF_mem_masked", " >0 "},
+        phase = {CompilePhase.FINAL_CODE},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    public void maskedSubFloat16() {
+        for (int i = 0; i < SPECIES.loopBound(LEN); i += SPECIES.length()) {
+            VectorMask<Float16> m = VectorMask.fromArray(SPECIES, mask, i);
+            Float16Vector.fromArray(SPECIES, input1, i)
+                         .lanewise(VectorOperators.SUB,
+                                   Float16Vector.fromArray(SPECIES, input2, i), m)
+                         .intoArray(output, i);
+        }
+    }
+
+    @Check(test="maskedSubFloat16")
+    public void checkMaskedSub() {
+        for (int i = 0; i < LEN; ++i) {
+            short expected = mask[i]
+                ? floatToFloat16(float16ToFloat(input1[i]) - float16ToFloat(input2[i]))
+                : input1[i];
+            assertLane(expected, output[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.MUL_VHF, " >0 "},
+        failOn = {IRNode.VECTOR_BLEND_S},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {"vector_binOps_HF_mem_masked", " >0 "},
+        phase = {CompilePhase.FINAL_CODE},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    public void maskedMulFloat16() {
+        for (int i = 0; i < SPECIES.loopBound(LEN); i += SPECIES.length()) {
+            VectorMask<Float16> m = VectorMask.fromArray(SPECIES, mask, i);
+            Float16Vector.fromArray(SPECIES, input1, i)
+                         .lanewise(VectorOperators.MUL,
+                                   Float16Vector.fromArray(SPECIES, input2, i), m)
+                         .intoArray(output, i);
+        }
+    }
+
+    @Check(test="maskedMulFloat16")
+    public void checkMaskedMul() {
+        for (int i = 0; i < LEN; ++i) {
+            short expected = mask[i]
+                ? floatToFloat16(float16ToFloat(input1[i]) * float16ToFloat(input2[i]))
+                : input1[i];
+            assertLane(expected, output[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.DIV_VHF, " >0 "},
+        failOn = {IRNode.VECTOR_BLEND_S},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {"vector_binOps_HF_mem_masked", " >0 "},
+        phase = {CompilePhase.FINAL_CODE},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    public void maskedDivFloat16() {
+        for (int i = 0; i < SPECIES.loopBound(LEN); i += SPECIES.length()) {
+            VectorMask<Float16> m = VectorMask.fromArray(SPECIES, mask, i);
+            Float16Vector.fromArray(SPECIES, input1, i)
+                         .lanewise(VectorOperators.DIV,
+                                   Float16Vector.fromArray(SPECIES, input2, i), m)
+                         .intoArray(output, i);
+        }
+    }
+
+    @Check(test="maskedDivFloat16")
+    public void checkMaskedDiv() {
+        for (int i = 0; i < LEN; ++i) {
+            short expected = mask[i]
+                ? floatToFloat16(float16ToFloat(input1[i]) / float16ToFloat(input2[i]))
+                : input1[i];
+            assertLane(expected, output[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.SQRT_VHF, " >0 "},
+        failOn = {IRNode.VECTOR_BLEND_S},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    public void maskedSqrtFloat16() {
+        for (int i = 0; i < SPECIES.loopBound(LEN); i += SPECIES.length()) {
+            VectorMask<Float16> m = VectorMask.fromArray(SPECIES, mask, i);
+            Float16Vector.fromArray(SPECIES, input1, i)
+                         .lanewise(VectorOperators.SQRT, m)
+                         .intoArray(output, i);
+        }
+    }
+
+    @Check(test="maskedSqrtFloat16")
+    public void checkMaskedSqrt() {
+        for (int i = 0; i < LEN; ++i) {
+            short expected = mask[i]
+                ? float16ToRawShortBits(sqrt(shortBitsToFloat16(input1[i])))
+                : input1[i];
+            assertLane(expected, output[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        failOn = {IRNode.VECTOR_BLEND_S},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    public void maskedFmaFloat16() {
+        for (int i = 0; i < SPECIES.loopBound(LEN); i += SPECIES.length()) {
+            VectorMask<Float16> m = VectorMask.fromArray(SPECIES, mask, i);
+            Float16Vector.fromArray(SPECIES, input1, i)
+                         .lanewise(VectorOperators.FMA,
+                                   Float16Vector.fromArray(SPECIES, input2, i),
+                                   Float16Vector.fromArray(SPECIES, input3, i), m)
+                         .intoArray(output, i);
+        }
+    }
+
+    @Check(test="maskedFmaFloat16")
+    public void checkMaskedFma() {
+        for (int i = 0; i < LEN; ++i) {
+            short expected = mask[i]
+                ? float16ToRawShortBits(fma(shortBitsToFloat16(input1[i]), shortBitsToFloat16(input2[i]),
+                                            shortBitsToFloat16(input3[i])))
+                : input1[i];
+            assertLane(expected, output[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.MIN_VHF, " >0 "},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(failOn = {IRNode.VECTOR_BLEND_S},
+        applyIfCPUFeature = {"avx10_2", "true"})
+    @IR(counts = {"vector_minmax_HF_mem_masked_avx10_2", " >0 "},
+        phase = {CompilePhase.FINAL_CODE},
+        applyIfCPUFeature = {"avx10_2", "true"})
+    public void maskedMinFloat16() {
+        for (int i = 0; i < SPECIES.loopBound(LEN); i += SPECIES.length()) {
+            VectorMask<Float16> m = VectorMask.fromArray(SPECIES, mask, i);
+            Float16Vector.fromArray(SPECIES, input1, i)
+                         .lanewise(VectorOperators.MIN,
+                                   Float16Vector.fromArray(SPECIES, input2, i), m)
+                         .intoArray(output, i);
+        }
+    }
+
+    @Check(test="maskedMinFloat16")
+    public void checkMaskedMin() {
+        for (int i = 0; i < LEN; ++i) {
+            short expected = mask[i]
+                ? floatToFloat16(Math.min(float16ToFloat(input1[i]), float16ToFloat(input2[i])))
+                : input1[i];
+            assertLane(expected, output[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.MAX_VHF, " >0 "},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(failOn = {IRNode.VECTOR_BLEND_S},
+        applyIfCPUFeature = {"avx10_2", "true"})
+    @IR(counts = {"vector_minmax_HF_mem_masked_avx10_2", " >0 "},
+        phase = {CompilePhase.FINAL_CODE},
+        applyIfCPUFeature = {"avx10_2", "true"})
+    public void maskedMaxFloat16() {
+        for (int i = 0; i < SPECIES.loopBound(LEN); i += SPECIES.length()) {
+            VectorMask<Float16> m = VectorMask.fromArray(SPECIES, mask, i);
+            Float16Vector.fromArray(SPECIES, input1, i)
+                         .lanewise(VectorOperators.MAX,
+                                   Float16Vector.fromArray(SPECIES, input2, i), m)
+                         .intoArray(output, i);
+        }
+    }
+
+    @Check(test="maskedMaxFloat16")
+    public void checkMaskedMax() {
+        for (int i = 0; i < LEN; ++i) {
+            short expected = mask[i]
+                ? floatToFloat16(Math.max(float16ToFloat(input1[i]), float16ToFloat(input2[i])))
+                : input1[i];
+            assertLane(expected, output[i]);
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/Float16MaskedVectorOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/Float16MaskedVectorOperationsBenchmark.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.*;
+import org.openjdk.jmh.annotations.*;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector", "-Xbatch", "-XX:-TieredCompilation"})
+public class Float16MaskedVectorOperationsBenchmark {
+    @Param({"1024", "2057"})
+    int vectorDim;
+
+    static final VectorSpecies<Float16> HSPECIES = Float16Vector.SPECIES_PREFERRED;
+    static final ByteOrder BO = ByteOrder.nativeOrder();
+    static final long ELEMENT_SIZE = 2; // bytes per Float16 (short carrier)
+    static final long ALIGNMENT = 64;   // cache-line aligned base
+
+    Arena arena;
+    MemorySegment segment1;
+    MemorySegment segment2;
+    MemorySegment segment3;
+    MemorySegment segmentRes;
+
+    // Loop-body predicate: a mixture of set/unset lanes so the merge-masking
+    // semantics are meaningfully exercised for the whole segment (not just the tail).
+    VectorMask<Float16> mask;
+
+    @Setup(Level.Trial)
+    public void BmSetup() {
+        long bytes = (long) vectorDim * ELEMENT_SIZE;
+        arena = Arena.ofShared();
+        segment1   = arena.allocate(bytes, ALIGNMENT);
+        segment2   = arena.allocate(bytes, ALIGNMENT);
+        segment3   = arena.allocate(bytes, ALIGNMENT);
+        segmentRes = arena.allocate(bytes, ALIGNMENT);
+
+        // Positive, well-scaled inputs keep DIV/SQRT away from NaN/Inf/denormals.
+        for (int i = 0; i < vectorDim; i++) {
+            segment1.setAtIndex(ValueLayout.JAVA_SHORT_UNALIGNED, i, Float.floatToFloat16(1.0f + (i % 17)));
+            segment2.setAtIndex(ValueLayout.JAVA_SHORT_UNALIGNED, i, Float.floatToFloat16(1.0f + (i % 13)));
+            segment3.setAtIndex(ValueLayout.JAVA_SHORT_UNALIGNED, i, Float.floatToFloat16(0.5f + (i %  7)));
+        }
+
+        boolean[] pred = new boolean[HSPECIES.length()];
+        for (int i = 0; i < pred.length; i++) {
+            pred[i] = (i % 3) != 0;
+        }
+        mask = VectorMask.fromArray(HSPECIES, pred, 0);
+    }
+
+    @TearDown(Level.Trial)
+    public void BmTearDown() {
+        arena.close();
+    }
+
+    // ======================================================================
+    // Realistic load-op-store kernels (explicit loads/stores).
+    // ======================================================================
+
+    @Benchmark
+    public void addMaskedBenchmark() {
+        int i = 0;
+        for (; i < HSPECIES.loopBound(vectorDim); i += HSPECIES.length()) {
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO)
+                         .lanewise(VectorOperators.ADD,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO), mask))
+                         .intoMemorySegment(segmentRes, off, BO);
+        }
+        if (i < vectorDim) {
+            VectorMask<Float16> tail = HSPECIES.indexInRange(i, vectorDim);
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO, tail)
+                         .lanewise(VectorOperators.ADD,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO, tail), tail))
+                         .intoMemorySegment(segmentRes, off, BO, tail);
+        }
+    }
+
+    @Benchmark
+    public void subMaskedBenchmark() {
+        int i = 0;
+        for (; i < HSPECIES.loopBound(vectorDim); i += HSPECIES.length()) {
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO)
+                         .lanewise(VectorOperators.SUB,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO), mask))
+                         .intoMemorySegment(segmentRes, off, BO);
+        }
+        if (i < vectorDim) {
+            VectorMask<Float16> tail = HSPECIES.indexInRange(i, vectorDim);
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO, tail)
+                         .lanewise(VectorOperators.SUB,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO, tail), tail))
+                         .intoMemorySegment(segmentRes, off, BO, tail);
+        }
+    }
+
+    @Benchmark
+    public void mulMaskedBenchmark() {
+        int i = 0;
+        for (; i < HSPECIES.loopBound(vectorDim); i += HSPECIES.length()) {
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO)
+                         .lanewise(VectorOperators.MUL,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO), mask))
+                         .intoMemorySegment(segmentRes, off, BO);
+        }
+        if (i < vectorDim) {
+            VectorMask<Float16> tail = HSPECIES.indexInRange(i, vectorDim);
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO, tail)
+                         .lanewise(VectorOperators.MUL,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO, tail), tail))
+                         .intoMemorySegment(segmentRes, off, BO, tail);
+        }
+    }
+
+    @Benchmark
+    public void divMaskedBenchmark() {
+        int i = 0;
+        for (; i < HSPECIES.loopBound(vectorDim); i += HSPECIES.length()) {
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO)
+                         .lanewise(VectorOperators.DIV,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO), mask))
+                         .intoMemorySegment(segmentRes, off, BO);
+        }
+        if (i < vectorDim) {
+            VectorMask<Float16> tail = HSPECIES.indexInRange(i, vectorDim);
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO, tail)
+                         .lanewise(VectorOperators.DIV,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO, tail), tail))
+                         .intoMemorySegment(segmentRes, off, BO, tail);
+        }
+    }
+
+    @Benchmark
+    public void minMaskedBenchmark() {
+        int i = 0;
+        for (; i < HSPECIES.loopBound(vectorDim); i += HSPECIES.length()) {
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO)
+                         .lanewise(VectorOperators.MIN,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO), mask))
+                         .intoMemorySegment(segmentRes, off, BO);
+        }
+        if (i < vectorDim) {
+            VectorMask<Float16> tail = HSPECIES.indexInRange(i, vectorDim);
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO, tail)
+                         .lanewise(VectorOperators.MIN,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO, tail), tail))
+                         .intoMemorySegment(segmentRes, off, BO, tail);
+        }
+    }
+
+    @Benchmark
+    public void maxMaskedBenchmark() {
+        int i = 0;
+        for (; i < HSPECIES.loopBound(vectorDim); i += HSPECIES.length()) {
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO)
+                         .lanewise(VectorOperators.MAX,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO), mask))
+                         .intoMemorySegment(segmentRes, off, BO);
+        }
+        if (i < vectorDim) {
+            VectorMask<Float16> tail = HSPECIES.indexInRange(i, vectorDim);
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO, tail)
+                         .lanewise(VectorOperators.MAX,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO, tail), tail))
+                         .intoMemorySegment(segmentRes, off, BO, tail);
+        }
+    }
+
+    @Benchmark
+    public void sqrtMaskedBenchmark() {
+        int i = 0;
+        for (; i < HSPECIES.loopBound(vectorDim); i += HSPECIES.length()) {
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO)
+                         .lanewise(VectorOperators.SQRT, mask))
+                         .intoMemorySegment(segmentRes, off, BO);
+        }
+        if (i < vectorDim) {
+            VectorMask<Float16> tail = HSPECIES.indexInRange(i, vectorDim);
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO, tail)
+                         .lanewise(VectorOperators.SQRT, tail))
+                         .intoMemorySegment(segmentRes, off, BO, tail);
+        }
+    }
+
+    @Benchmark
+    public void fmaMaskedBenchmark() {
+        int i = 0;
+        for (; i < HSPECIES.loopBound(vectorDim); i += HSPECIES.length()) {
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO)
+                         .lanewise(VectorOperators.FMA,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO),
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment3, off, BO), mask))
+                         .intoMemorySegment(segmentRes, off, BO);
+        }
+        if (i < vectorDim) {
+            VectorMask<Float16> tail = HSPECIES.indexInRange(i, vectorDim);
+            long off = (long) i * ELEMENT_SIZE;
+            ((Float16Vector) Float16Vector.fromMemorySegment(HSPECIES, segment1, off, BO, tail)
+                         .lanewise(VectorOperators.FMA,
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment2, off, BO, tail),
+                                   Float16Vector.fromMemorySegment(HSPECIES, segment3, off, BO, tail), tail))
+                         .intoMemorySegment(segmentRes, off, BO, tail);
+        }
+    }
+
+    // ======================================================================
+    // Register-resident latency variants (serial dependency chain per op).
+    // ======================================================================
+
+    // Float16 bit-encodings of the operand constants.
+    static final short HF_ZERO = Float.floatToFloat16(0.0f); // additive identity
+    static final short HF_ONE  = Float.floatToFloat16(1.0f); // multiplicative identity
+    static final short HF_TWO  = Float.floatToFloat16(2.0f); // ADD addend
+
+    // Number of chained masked ops per invocation (so per-op cost, not JMH call
+    // overhead, dominates).
+    @Param({"1024"})
+    int regIters;
+
+    // Pre-allocated sink; a store here keeps the accumulator from escaping while
+    // still preventing dead-code elimination.
+    MemorySegment resSeg;
+
+    @Setup(Level.Trial)
+    public void RegSetup() {
+        resSeg = MemorySegment.ofArray(new short[HSPECIES.length()]);
+    }
+
+    @Benchmark
+    public void addMaskedRegLat() {
+        Vector<Float16> a  = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        Vector<Float16> op = Float16Vector.broadcast(HSPECIES, HF_TWO);
+        for (int i = 0; i < regIters; i++) {
+            a = a.lanewise(VectorOperators.ADD, op, mask);
+        }
+        a.intoMemorySegment(resSeg, 0, BO);
+    }
+
+    @Benchmark
+    public void subMaskedRegLat() {
+        Vector<Float16> a  = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        Vector<Float16> op = Float16Vector.broadcast(HSPECIES, HF_ZERO);
+        for (int i = 0; i < regIters; i++) {
+            a = a.lanewise(VectorOperators.SUB, op, mask);
+        }
+        a.intoMemorySegment(resSeg, 0, BO);
+    }
+
+    @Benchmark
+    public void mulMaskedRegLat() {
+        Vector<Float16> a  = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        Vector<Float16> op = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        for (int i = 0; i < regIters; i++) {
+            a = a.lanewise(VectorOperators.MUL, op, mask);
+        }
+        a.intoMemorySegment(resSeg, 0, BO);
+    }
+
+    @Benchmark
+    public void divMaskedRegLat() {
+        Vector<Float16> a  = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        Vector<Float16> op = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        for (int i = 0; i < regIters; i++) {
+            a = a.lanewise(VectorOperators.DIV, op, mask);
+        }
+        a.intoMemorySegment(resSeg, 0, BO);
+    }
+
+    @Benchmark
+    public void minMaskedRegLat() {
+        Vector<Float16> a  = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        Vector<Float16> op = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        for (int i = 0; i < regIters; i++) {
+            a = a.lanewise(VectorOperators.MIN, op, mask);
+        }
+        a.intoMemorySegment(resSeg, 0, BO);
+    }
+
+    @Benchmark
+    public void maxMaskedRegLat() {
+        Vector<Float16> a  = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        Vector<Float16> op = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        for (int i = 0; i < regIters; i++) {
+            a = a.lanewise(VectorOperators.MAX, op, mask);
+        }
+        a.intoMemorySegment(resSeg, 0, BO);
+    }
+
+    @Benchmark
+    public void sqrtMaskedRegLat() {
+        Vector<Float16> a = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        for (int i = 0; i < regIters; i++) {
+            a = a.lanewise(VectorOperators.SQRT, mask);
+        }
+        a.intoMemorySegment(resSeg, 0, BO);
+    }
+
+    // acc = acc * 1.0 + 0.0 == acc (accumulator stays 1.0, merge into acc).
+    @Benchmark
+    public void fmaMaskedRegLat() {
+        Vector<Float16> a   = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        Vector<Float16> mul = Float16Vector.broadcast(HSPECIES, HF_ONE);
+        Vector<Float16> add = Float16Vector.broadcast(HSPECIES, HF_ZERO);
+        for (int i = 0; i < regIters; i++) {
+            a = a.lanewise(VectorOperators.FMA, mul, add, mask);
+        }
+        a.intoMemorySegment(resSeg, 0, BO);
+    }
+}


### PR DESCRIPTION
-	Currently for masked Float16 intrinsified vector operation we emit a sequence of BLEND instruction which merges the result of complete vector operation with passthrough vector under the influence of mask.
-	Targets supporting AVX512-FP16 feature offers direct predicated instructions.
-	This patch adds the support to infer predicated vector ADD/SUB/MUL/DIV/FMA/SQRT/MIN/MAX operation on AVX512-FP16 targets

Following are the performance numbers of benchmark included with the patch on AVX512-FP16 target (Intel Granite Rapids)
<img width="1497" height="857" alt="image" src="https://github.com/user-attachments/assets/5600449e-e946-4bab-ae99-2e13dc454b56" />

Kindly review and share your feedback.

Best Regards,
Jatin



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386957](https://bugs.openjdk.org/browse/JDK-8386957): C2 VectorAPI: Predicated operation support for intrinsified Float16Vector unary/binary/ternary operations on AVX512-FP16 targets (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32004/head:pull/32004` \
`$ git checkout pull/32004`

Update a local copy of the PR: \
`$ git checkout pull/32004` \
`$ git pull https://git.openjdk.org/jdk.git pull/32004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32004`

View PR using the GUI difftool: \
`$ git pr show -t 32004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32004.diff">https://git.openjdk.org/jdk/pull/32004.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32004#issuecomment-5043422656)
</details>
