### PR TITLE
8388756: Shenandoah: Re-learning at explicit GC request considered harmful

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -290,9 +290,7 @@ void ShenandoahHeuristics::record_allocation_failure_gc() {
 }
 
 void ShenandoahHeuristics::record_requested_gc() {
-  // Assume users call System.gc() when external state changes significantly,
-  // which forces us to re-learn the GC timings and allocation rates.
-  _gc_times_learned = 0;
+  // Do nothing.
 }
 
 bool ShenandoahHeuristics::can_unload_classes() {


### PR DESCRIPTION
See more discussion in the bug.

Additional testing:
 - [x] Ad-hoc performance tests
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x] Regular testing pipelines

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388756](https://bugs.openjdk.org/browse/JDK-8388756): Shenandoah: Re-learning at explicit GC request considered harmful (**Enhancement** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32006/head:pull/32006` \
`$ git checkout pull/32006`

Update a local copy of the PR: \
`$ git checkout pull/32006` \
`$ git pull https://git.openjdk.org/jdk.git pull/32006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32006`

View PR using the GUI difftool: \
`$ git pr show -t 32006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32006.diff">https://git.openjdk.org/jdk/pull/32006.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32006#issuecomment-5045485822)
</details>
