### PR TITLE
8388695: Remove PrintRewrites

### DIFF
--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -2242,9 +2242,9 @@ void GenerateOopMap::rewrite_refval_conflicts()
   // Tracing flag
   _did_rewriting = true;
 
-  if (log_is_enabled(Trace, generateoopmap)) {
+  if (log_is_enabled(Debug, generateoopmap)) {
     ResourceMark rm;
-    LogStream st(Log(generateoopmap)::trace());
+    LogStream st(Log(generateoopmap)::debug());
     st.print_cr("ref/value conflict for method %s - bytecodes are getting rewritten", method()->name()->as_C_string());
     method()->print_on(&st);
     method()->print_codes_on(&st);
@@ -2502,32 +2502,9 @@ void GenerateOopMap::update_ret_adr_at_TOS(int bci, int delta) {
 
 // ===================================================================
 
-#ifndef PRODUCT
-int ResolveOopMapConflicts::_nof_invocations  = 0;
-int ResolveOopMapConflicts::_nof_rewrites     = 0;
-int ResolveOopMapConflicts::_nof_relocations  = 0;
-#endif
-
 methodHandle ResolveOopMapConflicts::do_potential_rewrite(TRAPS) {
   if (!compute_map(THREAD)) {
     THROW_HANDLE_(exception(), methodHandle());
   }
-
-#ifndef PRODUCT
-  // Tracking and statistics
-  if (PrintRewrites) {
-    _nof_invocations++;
-    if (did_rewriting()) {
-      _nof_rewrites++;
-      if (did_relocation()) _nof_relocations++;
-      tty->print("Method was rewritten %s: ", (did_relocation()) ? "and relocated" : "");
-      method()->print_value(); tty->cr();
-      tty->print_cr("Cand.: %d rewrts: %d (%d%%) reloc.: %d (%d%%)",
-          _nof_invocations,
-          _nof_rewrites,    (_nof_rewrites    * 100) / _nof_invocations,
-          _nof_relocations, (_nof_relocations * 100) / _nof_invocations);
-    }
-  }
-#endif
   return methodHandle(THREAD, method());
 }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -281,9 +281,6 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, TraceCodeBlobStacks, false,                                 \
           "Trace stack-walk of codeblobs")                                  \
                                                                             \
-  develop(bool, PrintRewrites, false,                                       \
-          "Print methods that are being rewritten")                         \
-                                                                            \
   product(bool, UseInlineCaches, true,                                      \
           "Use Inline Caches for virtual calls ")                           \
                                                                             \


### PR DESCRIPTION
Please remove this simple change to remove PrintRewrites.  GenerateOopMap logging covers the case we care about (tested locally) and it seems useless to print statistics for some jsr/ret rewriting when the bytecodes were deprecated a long time ago.

Tested with logging tests, including new one already added for GenerateOopMap.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388695](https://bugs.openjdk.org/browse/JDK-8388695): Remove PrintRewrites (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32007/head:pull/32007` \
`$ git checkout pull/32007`

Update a local copy of the PR: \
`$ git checkout pull/32007` \
`$ git pull https://git.openjdk.org/jdk.git pull/32007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32007`

View PR using the GUI difftool: \
`$ git pr show -t 32007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32007.diff">https://git.openjdk.org/jdk/pull/32007.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32007#issuecomment-5045541121)
</details>
