### PR TITLE
8388712: [s390x, ppc] runtime/CompressedOops/CompressedClassPointersEncodingScheme.java fails since JDK-8387652

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -241,12 +241,9 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
     // a cacheline size.
     _base = addr;
 
+    const int log2_len_to_cover = log2i_ceil(len);
     const int log_cacheline = exact_log2(DEFAULT_CACHE_LINE_SIZE);
-    int s = max_shift();
-    while (s > log_cacheline && ((size_t)nth_bit(narrow_klass_pointer_bits() + s - 1) > len)) {
-      s--;
-    }
-    _shift = s;
+    _shift = MAX2(log_cacheline, log2_len_to_cover - narrow_klass_pointer_bits());
 
   } else {
 

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
@@ -36,7 +36,6 @@
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import jtreg.SkippedException;
 
 import java.io.IOException;
 

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
@@ -102,14 +102,18 @@ public class CompressedClassPointersEncodingScheme {
         // Compact Object Header Mode:
         // We expect the VM to chose the smallest possible shift value needed to cover the encoding range.
         // We expect the encoding Base to start at the class space start - but to enforce that,
-        // we choose unsuited to even shift-extended zero-based mode.
+        // we choose a base unsuited to even shift-extended zero-based mode.
         forceAddress = 32 * G;
+        int minShift = 6;
+        if (Platform.isPPC()) minShift = 7;
+        if (Platform.isS390x()) minShift = 8;
 
-        test(forceAddress, true, 128 * M, forceAddress, 6);
-        test(forceAddress, true, 256 * M, forceAddress, 7);
-        test(forceAddress, true, 512 * M, forceAddress, 8);
-        test(forceAddress, true, G, forceAddress, 9);
-        test(forceAddress, true, 3 * G, forceAddress, 10);
+        test(forceAddress, true, 128 * M, forceAddress, Math.max(minShift, 5));
+        test(forceAddress, true, 256 * M, forceAddress, Math.max(minShift, 6));
+        test(forceAddress, true, 512 * M, forceAddress, Math.max(minShift, 7));
+        test(forceAddress, true, G, forceAddress, Math.max(minShift, 8));
+        test(forceAddress, true, 2 * G, forceAddress, Math.max(minShift, 9));
+        test(forceAddress, true, 4 * G, forceAddress, 10);
 
         // Test a "crooked" base address:
         // - just aligned enough to pass metaspace reserve alignment test of 16MB.

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
@@ -122,8 +122,8 @@ public class CompressedClassPointersEncodingScheme {
         // - small enough to not cause test errors on small devices (e.g. arm64 39bit address space)
         // - large enough to not end up with zero-based encoding
         forceAddress = 0x0000000d55000000L;
-        test(forceAddress, true, 32 * M, forceAddress, 6);
-        test(forceAddress, false, 32 * M, forceAddress, 0);
+        test(forceAddress, true, 4 * G, forceAddress, 10);
+        test(forceAddress, false, 4 * G, forceAddress, 0);
 
     }
 }


### PR DESCRIPTION
See bug description.

The patch makes the test work on platforms with larger cacheline sizes and also fixes a small (but benign) off-by-one error that would cause the shift larger than necessary.

Tested on s390 and x64

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388712](https://bugs.openjdk.org/browse/JDK-8388712): [s390x, ppc] runtime/CompressedOops/CompressedClassPointersEncodingScheme.java fails since JDK-8387652 (**Enhancement** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32008/head:pull/32008` \
`$ git checkout pull/32008`

Update a local copy of the PR: \
`$ git checkout pull/32008` \
`$ git pull https://git.openjdk.org/jdk.git pull/32008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32008`

View PR using the GUI difftool: \
`$ git pr show -t 32008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32008.diff">https://git.openjdk.org/jdk/pull/32008.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32008#issuecomment-5048282241)
</details>
