### PR TITLE
8387143: Test containers/docker/TestMemoryAwareness.java fails in testOOM

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -213,7 +213,7 @@ public class TestMemoryAwareness {
         System.out.println("sizeToAllocInMb is:" + sizeToAllocInMb + " sizeToAllocInMb/2 is:" + sizeToAllocInMb/2);
         String javaHeapSize = sizeToAllocInMb/2 + "m";
         opts.addJavaOptsAppended("-Xmx" + javaHeapSize);
-        // reduce the number of CPUs to 2, so that the number of GC threads is not too 
+        // reduce the number of CPUs to 2, so that the number of GC threads is not too
         // high for the small memory limit (each thread reserves 2MB stacksize).
         opts.addJavaOptsAppended("-XX:ActiveProcessorCount=2");
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -213,6 +213,7 @@ public class TestMemoryAwareness {
         System.out.println("sizeToAllocInMb is:" + sizeToAllocInMb + " sizeToAllocInMb/2 is:" + sizeToAllocInMb/2);
         String javaHeapSize = sizeToAllocInMb/2 + "m";
         opts.addJavaOptsAppended("-Xmx" + javaHeapSize);
+        opts.addJavaOptsAppended("-XX:ActiveProcessorCount=2");
 
         OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -213,6 +213,8 @@ public class TestMemoryAwareness {
         System.out.println("sizeToAllocInMb is:" + sizeToAllocInMb + " sizeToAllocInMb/2 is:" + sizeToAllocInMb/2);
         String javaHeapSize = sizeToAllocInMb/2 + "m";
         opts.addJavaOptsAppended("-Xmx" + javaHeapSize);
+        // reduce the number of CPUs to 2, so that the number of GC threads is not too 
+        // high for the small memory limit (each thread reserves 2MB stacksize).
         opts.addJavaOptsAppended("-XX:ActiveProcessorCount=2");
 
         OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);


### PR DESCRIPTION
The OOM test fails often on machines with high number of CPUs (64/128) - this might be caused by creating a lot of GC threads because of a lot of CPUs. Each GC thread has 2MB stacksize - that will sum up easily to a high amount of additional memory causing the Linux kernel OOM killer to kill the process because of the cgroup limit. The easy solution is to force the VM to only see 2 CPUs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387143](https://bugs.openjdk.org/browse/JDK-8387143): Test containers/docker/TestMemoryAwareness.java fails in testOOM (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [a8680204](https://git.openjdk.org/jdk/pull/32010/files/a86802048f343533cb6e6a4468571d69f16fac7e)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32010/head:pull/32010` \
`$ git checkout pull/32010`

Update a local copy of the PR: \
`$ git checkout pull/32010` \
`$ git pull https://git.openjdk.org/jdk.git pull/32010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32010`

View PR using the GUI difftool: \
`$ git pr show -t 32010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32010.diff">https://git.openjdk.org/jdk/pull/32010.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32010#issuecomment-5046193927)
</details>
