### PR TITLE
8387466: Cleanup old Windows version handling in D3D coding

### DIFF
--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBadHardware.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBadHardware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,87 +56,6 @@ static const ADAPTER_INFO badHardware[] = {
 
     // Microsoft Basic Render Driver (as maybe used in VMs such as VirtualBox)
     { 0x1414, 0x008c, NO_VERSION, OS_ALL },
-
-    // ATI Mobility Radeon X1600, X1400, X1450, X1300, X1350
-    // Reason: workaround for 6613066, 6687166
-    // X1300 (four sub ids)
-    { 0x1002, 0x714A, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x714A, D_VERSION(7,14,10,0567), OS_VISTA },
-    { 0x1002, 0x7149, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x7149, D_VERSION(7,14,10,0567), OS_VISTA },
-    { 0x1002, 0x714B, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x714B, D_VERSION(7,14,10,0567), OS_VISTA },
-    { 0x1002, 0x714C, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x714C, D_VERSION(7,14,10,0567), OS_VISTA },
-    // X1350 (three sub ids)
-    { 0x1002, 0x718B, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x718B, D_VERSION(7,14,10,0567), OS_VISTA },
-    { 0x1002, 0x718C, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x718C, D_VERSION(7,14,10,0567), OS_VISTA },
-    { 0x1002, 0x7196, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x7196, D_VERSION(7,14,10,0567), OS_VISTA },
-    // X1400
-    { 0x1002, 0x7145, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x7145, D_VERSION(7,14,10,0567), OS_VISTA },
-    // X1450 (two sub ids)
-    { 0x1002, 0x7186, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x7186, D_VERSION(7,14,10,0567), OS_VISTA },
-    { 0x1002, 0x718D, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x718D, D_VERSION(7,14,10,0567), OS_VISTA },
-    // X1600
-    { 0x1002, 0x71C5, D_VERSION(6,14,10,6706), OS_WINXP },
-    { 0x1002, 0x71C5, D_VERSION(7,14,10,0567), OS_VISTA },
-
-    // ATI Mobility Radeon 9700
-    // Reason: workaround for 6773336
-    { 0x1002, 0x4E50, D_VERSION(6,14,10,6561), OS_WINXP },
-
-    // Nvidia FX 5200
-    // Reason: workaround for 6717988
-    { 0x10DE, 0x0322, D_VERSION(6,14,11,6921), OS_WINXP },
-
-    // Nvidia FX Go5600, Go5700
-    // Reason: workaround for 6714579
-    { 0x10DE, 0x031A, D_VERSION(6,14,11,6921), OS_WINXP },
-    { 0x10DE, 0x0347, D_VERSION(6,14,11,6921), OS_WINXP },
-
-    // Nvidia Quadro NVS 110M
-    // Reason: workaround for 6629891
-    { 0x10DE, 0x01D7, D_VERSION(6,14,11,5665), OS_WINXP },
-
-    // Nvidia Quadro PCI-E series
-    // Reason: workaround for 6653860
-    { 0x10DE, 0x00FD, D_VERSION(6,14,10,6573), OS_WINXP },
-
-    // Nvidia Quadro FX family
-    // Reason: workaround for 6772137
-    { 0x10DE, 0x00F8, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x009D, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x029C, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x029D, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x029E, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x029F, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x01DE, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x039E, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x019D, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x019E, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x040A, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x040E, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x040F, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x061A, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x06F9, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x05FD, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x05FE, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x004E, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x00CD, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x00CE, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x014C, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x014D, D_VERSION(6,14,10,9381), OS_WINXP },
-    { 0x10DE, 0x014E, D_VERSION(6,14,10,9381), OS_WINXP },
-
-    // Nvidia GeForce 6200 TurboCache(TM)
-    // Reason: workaround for 6588384
-    { 0x10DE, 0x0161, NO_VERSION, OS_VISTA },
 
     // any Matrox board
     // Reason: there are no known Matrox boards with proper Direct3D support

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBadHardware.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBadHardware.h
@@ -57,6 +57,9 @@ static const ADAPTER_INFO badHardware[] = {
     // Microsoft Basic Render Driver (as maybe used in VMs such as VirtualBox)
     { 0x1414, 0x008c, NO_VERSION, OS_ALL },
 
+    // AMD / ATI - vendor ID 0x1002, no current hardware block-listed
+    // Nvidia - vendor ID 0x10DE, no current hardware block-listed
+
     // any Matrox board
     // Reason: there are no known Matrox boards with proper Direct3D support
     { 0x102B, ALL_DEVICEIDS, NO_VERSION, OS_ALL },

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,6 @@ D3DPipelineManager *D3DPipelineManager::pMgr = NULL;
 D3DPipelineManager * D3DPipelineManager::CreateInstance(void)
 {
     if (!IsD3DEnabled() ||
-        FAILED((D3DPipelineManager::CheckOSVersion())) ||
         FAILED((D3DPipelineManager::GDICheckForBadHardware())))
     {
         return NULL;
@@ -319,31 +318,6 @@ HRESULT D3DPipelineManager::InitAdapters()
 
 // static
 HRESULT
-D3DPipelineManager::CheckOSVersion()
-{
-    // require Windows XP or newer client-class OS
-    if (IS_WINVER_ATLEAST(5, 1) &&
-        !D3DPPLM_OsVersionMatches(OS_WINSERV_2008R2|OS_WINSERV_2008|
-                                  OS_WINSERV_2003))
-    {
-        J2dTraceLn(J2D_TRACE_INFO,
-                   "D3DPPLM::CheckOSVersion: Windows XP or newer client-classs"\
-                   " OS detected, passed");
-        return S_OK;
-    }
-    J2dRlsTraceLn(J2D_TRACE_ERROR,
-                  "D3DPPLM::CheckOSVersion: Windows 2000 or earlier (or a "\
-                  "server) OS detected, failed");
-    if (bNoHwCheck) {
-        J2dRlsTraceLn(J2D_TRACE_WARNING,
-                      "  OS check overridden via J2D_D3D_NO_HWCHECK");
-        return S_OK;
-    }
-    return E_FAIL;
-}
-
-// static
-HRESULT
 D3DPipelineManager::GDICheckForBadHardware()
 {
     DISPLAY_DEVICE dd;
@@ -414,40 +388,14 @@ BOOL D3DPPLM_OsVersionMatches(USHORT osInfo) {
         bVersOk = GetVersionEx((OSVERSIONINFO *) &osvi);
 
         J2dRlsTrace(J2D_TRACE_INFO, "[I] OS Version = ");
-        if (bVersOk && osvi.dwPlatformId == VER_PLATFORM_WIN32_NT &&
-            osvi.dwMajorVersion > 4)
-        {
-            if (osvi.dwMajorVersion >= 6 && osvi.dwMinorVersion == 0) {
-                if (osvi.wProductType == VER_NT_WORKSTATION) {
-                    J2dRlsTrace(J2D_TRACE_INFO, "OS_VISTA\n");
-                    currentOS = OS_VISTA;
-                } else {
-                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINSERV_2008\n");
-                    currentOS = OS_WINSERV_2008;
-                }
-            } else if (osvi.dwMajorVersion >= 6 && osvi.dwMinorVersion >= 1) {
+        if (bVersOk) {
+            if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion >= 1) {
                 if (osvi.wProductType == VER_NT_WORKSTATION) {
                     J2dRlsTrace(J2D_TRACE_INFO, "OS_WINDOWS7 or newer\n");
                     currentOS = OS_WINDOWS7;
                 } else {
                     J2dRlsTrace(J2D_TRACE_INFO, "OS_WINSERV_2008R2 or newer\n");
                     currentOS = OS_WINSERV_2008R2;
-                }
-            } else if (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2) {
-                if (osvi.wProductType == VER_NT_WORKSTATION) {
-                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINXP_64\n");
-                    currentOS = OS_WINXP_64;
-                } else {
-                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINSERV_2003\n");
-                    currentOS = OS_WINSERV_2003;
-                }
-            } else if (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 1) {
-                J2dRlsTrace(J2D_TRACE_INFO, "OS_WINXP ");
-                currentOS = OS_WINXP;
-                if (osvi.wSuiteMask & VER_SUITE_PERSONAL) {
-                    J2dRlsTrace(J2D_TRACE_INFO, "Home\n");
-                } else {
-                    J2dRlsTrace(J2D_TRACE_INFO, "Pro\n");
                 }
             } else {
                 J2dRlsTrace(J2D_TRACE_INFO,
@@ -456,13 +404,7 @@ BOOL D3DPPLM_OsVersionMatches(USHORT osInfo) {
                 currentOS = OS_UNKNOWN;
             }
         } else {
-            if (bVersOk) {
-                J2dRlsTrace(J2D_TRACE_INFO,
-                            "OS_UNKNOWN: dwPlatformId=%d dwMajorVersion=%d\n",
-                            osvi.dwPlatformId, osvi.dwMajorVersion);
-            } else {
-                J2dRlsTrace(J2D_TRACE_INFO,"OS_UNKNOWN: GetVersionEx failed\n");
-            }
+            J2dRlsTrace(J2D_TRACE_INFO,"OS_UNKNOWN: GetVersionEx failed\n");
             currentOS = OS_UNKNOWN;
         }
     }

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.cpp
@@ -400,9 +400,8 @@ BOOL D3DPPLM_OsVersionMatches(USHORT osInfo) {
             } else {
                 if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion >= 1) {
                     if (osvi.wProductType == VER_NT_WORKSTATION) {
-                        J2dRlsTrace(J2D_TRACE_INFO, "OS_WINDOWS7 or newer\n");
-                        // this detects also Win8
-                        currentOS = OS_WINDOWS7;
+                        J2dRlsTrace(J2D_TRACE_INFO, "OS_WINDOWS_7_OR_8\n");
+                        currentOS = OS_WINDOWS_7_OR_8;
                     } else {
                         J2dRlsTrace(J2D_TRACE_INFO, "OS_WINSERV_2008R2 or newer\n");
                         // this detects also 2012 (R2)

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.cpp
@@ -389,10 +389,10 @@ BOOL D3DPPLM_OsVersionMatches(USHORT osInfo) {
 
         J2dRlsTrace(J2D_TRACE_INFO, "[I] OS Version = ");
         if (bVersOk) {
-            if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0) {
+            if (osvi.dwMajorVersion >= 10) {
                 if (osvi.wProductType == VER_NT_WORKSTATION) {
-                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINDOWS10_11 or newer\n");
-                    currentOS = OS_WINDOWS10_11;
+                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINDOWS10 or newer\n");
+                    currentOS = OS_WINDOWS10_OR_LATER;
                 } else {
                     J2dRlsTrace(J2D_TRACE_INFO, "OS_WINSERV_2016 or newer\n");
                     currentOS = OS_WINSERV_2016_PLUS;

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.cpp
@@ -389,19 +389,31 @@ BOOL D3DPPLM_OsVersionMatches(USHORT osInfo) {
 
         J2dRlsTrace(J2D_TRACE_INFO, "[I] OS Version = ");
         if (bVersOk) {
-            if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion >= 1) {
+            if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0) {
                 if (osvi.wProductType == VER_NT_WORKSTATION) {
-                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINDOWS7 or newer\n");
-                    currentOS = OS_WINDOWS7;
+                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINDOWS10_11 or newer\n");
+                    currentOS = OS_WINDOWS10_11;
                 } else {
-                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINSERV_2008R2 or newer\n");
-                    currentOS = OS_WINSERV_2008R2;
+                    J2dRlsTrace(J2D_TRACE_INFO, "OS_WINSERV_2016 or newer\n");
+                    currentOS = OS_WINSERV_2016_PLUS;
                 }
             } else {
-                J2dRlsTrace(J2D_TRACE_INFO,
-                            "OS_UNKNOWN: dwMajorVersion=%d dwMinorVersion=%d\n",
-                            osvi.dwMajorVersion, osvi.dwMinorVersion);
-                currentOS = OS_UNKNOWN;
+                if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion >= 1) {
+                    if (osvi.wProductType == VER_NT_WORKSTATION) {
+                        J2dRlsTrace(J2D_TRACE_INFO, "OS_WINDOWS7 or newer\n");
+                        // this detects also Win8
+                        currentOS = OS_WINDOWS7;
+                    } else {
+                        J2dRlsTrace(J2D_TRACE_INFO, "OS_WINSERV_2008R2 or newer\n");
+                        // this detects also 2012 (R2)
+                        currentOS = OS_WINSERV_2008R2;
+                    }
+                } else {
+                    J2dRlsTrace(J2D_TRACE_INFO,
+                                "OS_UNKNOWN: dwMajorVersion=%d dwMinorVersion=%d\n",
+                                osvi.dwMajorVersion, osvi.dwMinorVersion);
+                    currentOS = OS_UNKNOWN;
+                }
             }
         } else {
             J2dRlsTrace(J2D_TRACE_INFO,"OS_UNKNOWN: GetVersionEx failed\n");

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,8 +104,6 @@ private:
     UINT    GetAdapterOrdinalByHmon(HMONITOR hMon);
     HRESULT CheckAdaptersInfo();
     HRESULT CheckDeviceCaps(UINT Adapter);
-    // Check the OS, succeeds if the OS is XP or newer client-class OS
-static HRESULT CheckOSVersion();
     // used to check attached adapters using GDI against known bad hw database
     // prior to the instantiation of the pipeline manager
 static HRESULT GDICheckForBadHardware();
@@ -135,15 +133,9 @@ private:
 };
 
 #define OS_UNDEFINED    (0 << 0)
-#define OS_VISTA        (1 << 0)
-#define OS_WINSERV_2008 (1 << 1)
-#define OS_WINXP        (1 << 2)
-#define OS_WINXP_64     (1 << 3)
-#define OS_WINSERV_2003 (1 << 4)
 #define OS_WINDOWS7     (1 << 5)
 #define OS_WINSERV_2008R2 (1 << 6)
-#define OS_ALL (OS_VISTA|OS_WINSERV_2008|OS_WINXP|OS_WINXP_64|OS_WINSERV_2003|\
-                OS_WINDOWS7|OS_WINSERV_2008R2)
+#define OS_ALL (OS_WINDOWS7|OS_WINSERV_2008R2)
 #define OS_UNKNOWN      (~OS_ALL)
 BOOL D3DPPLM_OsVersionMatches(USHORT osInfo);
 

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
@@ -136,11 +136,11 @@ private:
 #define OS_WINDOWS7     (1 << 0)
 #define OS_WINSERV_2008R2 (1 << 1)
 // Windows 10 and 11
-#define OS_WINDOWS10_11 (1 << 2)
+#define OS_WINDOWS10_OR_LATER (1 << 2)
 // Windows server 2016 or higher
 #define OS_WINSERV_2016_PLUS (1 << 3)
 
-#define OS_ALL (OS_WINDOWS7|OS_WINSERV_2008R2|OS_WINDOWS10_11|OS_WINSERV_2016_PLUS)
+#define OS_ALL (OS_WINDOWS7|OS_WINSERV_2008R2|OS_WINDOWS10_OR_LATER|OS_WINSERV_2016_PLUS)
 #define OS_UNKNOWN      (~OS_ALL)
 BOOL D3DPPLM_OsVersionMatches(USHORT osInfo);
 

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
@@ -133,9 +133,14 @@ private:
 };
 
 #define OS_UNDEFINED    (0 << 0)
-#define OS_WINDOWS7     (1 << 5)
-#define OS_WINSERV_2008R2 (1 << 6)
-#define OS_ALL (OS_WINDOWS7|OS_WINSERV_2008R2)
+#define OS_WINDOWS7     (1 << 0)
+#define OS_WINSERV_2008R2 (1 << 1)
+// Windows 10 and 11
+#define OS_WINDOWS10_11 (1 << 2)
+// Windows server 2016 or higher
+#define OS_WINSERV_2016_PLUS (1 << 3)
+
+#define OS_ALL (OS_WINDOWS7|OS_WINSERV_2008R2|OS_WINDOWS10_11|OS_WINSERV_2016_PLUS)
 #define OS_UNKNOWN      (~OS_ALL)
 BOOL D3DPPLM_OsVersionMatches(USHORT osInfo);
 

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DPipelineManager.h
@@ -133,14 +133,14 @@ private:
 };
 
 #define OS_UNDEFINED    (0 << 0)
-#define OS_WINDOWS7     (1 << 0)
+#define OS_WINDOWS_7_OR_8 (1 << 0)
 #define OS_WINSERV_2008R2 (1 << 1)
 // Windows 10 and 11
 #define OS_WINDOWS10_OR_LATER (1 << 2)
 // Windows server 2016 or higher
 #define OS_WINSERV_2016_PLUS (1 << 3)
 
-#define OS_ALL (OS_WINDOWS7|OS_WINSERV_2008R2|OS_WINDOWS10_OR_LATER|OS_WINSERV_2016_PLUS)
+#define OS_ALL (OS_WINDOWS_7_OR_8|OS_WINSERV_2008R2|OS_WINDOWS10_OR_LATER|OS_WINSERV_2016_PLUS)
 #define OS_UNKNOWN      (~OS_ALL)
 BOOL D3DPPLM_OsVersionMatches(USHORT osInfo);
 


### PR DESCRIPTION
There are a few more XP/Win200X/Vista references in the D3D coding that could be cleaned up .
I left the win7/Win server 2008R2 - related macros in D3DPipelineManager.h, those Windows versions are old too but not as ancient as the others I removed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387466](https://bugs.openjdk.org/browse/JDK-8387466): Cleanup old Windows version handling in D3D coding (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32011/head:pull/32011` \
`$ git checkout pull/32011`

Update a local copy of the PR: \
`$ git checkout pull/32011` \
`$ git pull https://git.openjdk.org/jdk.git pull/32011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32011`

View PR using the GUI difftool: \
`$ git pr show -t 32011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32011.diff">https://git.openjdk.org/jdk/pull/32011.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32011#issuecomment-5047905680)
</details>
