### PR TITLE
8388018: [IR Framework] Be more lenient about system properties

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -170,9 +170,9 @@ testFramework
 The framework provides various stress and debug flags. They should mainly be used as JTreg VM and/or Javaoptions (apart from `VerifyIR`). The following (property) flags are supported:
 
 - `-DVerifyIR=false`: Explicitly disable IR verification. This is useful, for example, if some scenarios use VM flags that let `@IR` annotation rules fail and the user does not want to provide separate IR rules or add flag preconditions to the already existing IR rules.
-- `-DTest=test1,test2`: Provide a list of `@Test` method names which should be executed.
-- `-DExclude=test3`: Provide a list of `@Test` method names which should be excluded from execution.
-- `-DScenarios=1,2`: Provide a list of scenario indexes to specify which scenarios should be executed.
+- `-DTest=test1,test2`: Provide a list of `@Test` method names which should be executed. Case-insensitive, plural is allowed (`-DTests`, `-Dtest`, `Dtests` are all fine).
+- `-DExclude=test3`: Provide a list of `@Test` method names which should be excluded from execution. Case-insensitive, plural is allowed.
+- `-DScenario=1,2`: Provide a list of scenario indexes to specify which scenarios should be executed. Case-insensitive, plural is allowed.
 - `-DWarmup=200`: Provide a new default value of the number of warm-up iterations (framework default is 2000). This might have an influence on the resulting IR and could lead to matching failures (the user can also set a fixed default warm-up value in a test with `testFrameworkObject.setDefaultWarmup(200)`).
 - `-DReportStdout=true`: Print the standard output of the Test VM.
 - `-DVerbose=true`: Enable more fine-grained logging (slows the execution down).
@@ -181,7 +181,7 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DPrintRuleMatchingTime=true`: Print the time of matching IR rules per method. Slows down the execution as the rules are warmed up before measurement.
 - `-DVerifyVM=true`: The framework runs the Test VM with additional verification flags (slows the execution down).
 - `-DExcludeRandom=true`: The framework randomly excludes some methods from compilation. IR verification is disabled completely with this flag.
-- `-DFlipC1C2=true`: The framework compiles all `@Test` annotated method with C1 if a C2 compilation would have been applied and vice versa. IR verification is disabled completely with this flag.
+- `-DFlipC1C2=true`: The framework compiles all `@Test` annotated methods with C1 if a C2 compilation would have been applied and vice versa. IR verification is disabled completely with this flag.
 - `-DShuffleTests=false`: Disables the random execution order of all tests (such a shuffling is always done by default).
 - `-DDumpReplay=true`: Add the `DumpReplay` directive to the Test VM.
 - `-DGCAfter=true`: Perform `System.gc()` after each test (slows the execution down).

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/Scenario.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/Scenario.java
@@ -23,6 +23,8 @@
 
 package compiler.lib.ir_framework;
 
+import compiler.lib.ir_framework.shared.SystemProperty;
+import compiler.lib.ir_framework.shared.SystemProperty.Mode;
 import compiler.lib.ir_framework.shared.TestRunException;
 
 import java.util.*;
@@ -44,7 +46,7 @@ import java.util.stream.Collectors;
  */
 public class Scenario {
     private static final String ADDITIONAL_SCENARIO_FLAGS_PROPERTY = System.getProperty("ScenarioFlags", "");
-    private static final String SCENARIOS_PROPERTY = System.getProperty("Scenarios", "");
+    private static final String SCENARIOS_PROPERTY = SystemProperty.getCaseInsensitive(Mode.CASE_INSENSITIVE_EMPTY_DEFAULT, "scenario", "scenarios");
     private static final List<String> ADDITIONAL_SCENARIO_FLAGS;
     private static final Set<Integer> ENABLED_SCENARIOS;
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -157,8 +157,8 @@ public class TestFramework {
 
     public static final boolean VERBOSE = Boolean.getBoolean("Verbose");
     public static final boolean PRINT_RULE_MATCHING_TIME = Boolean.getBoolean("PrintRuleMatchingTime");
-    public static final boolean TEST_LIST_IS_EMPTY = SystemProperty.getTestList().isEmpty();
-    public static final boolean EXCLUDE_LIST_IS_EMPTY = SystemProperty.getExcludeList().isEmpty();;
+    private static final boolean TEST_LIST_IS_EMPTY = SystemProperty.getTestList().isEmpty();
+    private static final boolean EXCLUDE_LIST_IS_EMPTY = SystemProperty.getExcludeList().isEmpty();;
     private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
     // Only used for internal testing and should not be used for normal user testing.
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -158,7 +158,7 @@ public class TestFramework {
     public static final boolean VERBOSE = Boolean.getBoolean("Verbose");
     public static final boolean PRINT_RULE_MATCHING_TIME = Boolean.getBoolean("PrintRuleMatchingTime");
     public static final boolean TEST_LIST_IS_EMPTY = SystemProperty.getTestList().isEmpty();
-    public static final boolean EXCLUDELIST = !System.getProperty("Exclude", "").isEmpty();
+    public static final boolean EXCLUDE_LIST_IS_EMPTY = SystemProperty.getExcludeList().isEmpty();;
     private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
     // Only used for internal testing and should not be used for normal user testing.
 
@@ -779,7 +779,7 @@ public class TestFramework {
             builder.append(System.lineSeparator());
         }
         System.err.println(builder);
-        if (!VERBOSE && !REPORT_STDOUT && TEST_LIST_IS_EMPTY && !EXCLUDELIST) {
+        if (!VERBOSE && !REPORT_STDOUT && TEST_LIST_IS_EMPTY && EXCLUDE_LIST_IS_EMPTY) {
             // Provide a hint to the user how to get additional output/debugging information.
             System.err.println(RERUN_HINT);
         }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -157,7 +157,7 @@ public class TestFramework {
 
     public static final boolean VERBOSE = Boolean.getBoolean("Verbose");
     public static final boolean PRINT_RULE_MATCHING_TIME = Boolean.getBoolean("PrintRuleMatchingTime");
-    public static final boolean TESTLIST = !System.getProperty("Test", "").isEmpty();
+    public static final boolean TEST_LIST_IS_EMPTY = SystemProperty.getTestList().isEmpty();
     public static final boolean EXCLUDELIST = !System.getProperty("Exclude", "").isEmpty();
     private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
     // Only used for internal testing and should not be used for normal user testing.
@@ -779,7 +779,7 @@ public class TestFramework {
             builder.append(System.lineSeparator());
         }
         System.err.println(builder);
-        if (!VERBOSE && !REPORT_STDOUT && !TESTLIST && !EXCLUDELIST) {
+        if (!VERBOSE && !REPORT_STDOUT && TEST_LIST_IS_EMPTY && !EXCLUDELIST) {
             // Provide a hint to the user how to get additional output/debugging information.
             System.err.println(RERUN_HINT);
         }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/SystemProperty.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/SystemProperty.java
@@ -43,4 +43,8 @@ public class SystemProperty {
     static public String getTestList() {
         return getCaseInsensitive(Mode.CASE_INSENSITIVE_EMPTY_DEFAULT, "test", "tests");
     }
+
+    static public String getExcludeList() {
+        return getCaseInsensitive(Mode.CASE_INSENSITIVE_EMPTY_DEFAULT, "exclude", "excludes");
+    }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/SystemProperty.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/SystemProperty.java
@@ -1,0 +1,46 @@
+package compiler.lib.ir_framework.shared;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class SystemProperty {
+    public record Mode(boolean caseSensitive, String def) {
+        static public Mode Make() {
+            return new Mode(false, null);
+        }
+
+        public Mode withCaseSensitive(boolean c) {
+            return new Mode(c, this.def);
+        }
+
+        public Mode withDefault(String def) {
+            return new Mode(this.caseSensitive, def);
+        }
+
+        public static Mode CASE_INSENSITIVE_EMPTY_DEFAULT = Make().withCaseSensitive(false).withDefault("");
+    }
+
+    static public String getCaseInsensitive(Mode mode, String... keys) {
+        java.util.function.Function<String, String> normalize =
+                mode.caseSensitive()
+                        ? (x -> x)
+                        : String::toLowerCase;
+        List<String> normalized_keys = Arrays.stream(keys).map(normalize).toList();
+        for (Map.Entry<Object, Object> e : System.getProperties().entrySet()) {
+            Object k = e.getKey();
+            Object v = e.getValue();
+            if (k instanceof String && v instanceof String) {
+                String ks = normalize.apply((String)k);
+                if (normalized_keys.contains(ks)) {
+                    return (String)v;
+                }
+            }
+        }
+        return mode.def();
+    }
+
+    static public String getTestList() {
+        return getCaseInsensitive(Mode.CASE_INSENSITIVE_EMPTY_DEFAULT, "test", "tests");
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/SystemProperty.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/SystemProperty.java
@@ -1,12 +1,38 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package compiler.lib.ir_framework.shared;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public class SystemProperty {
     public record Mode(boolean caseSensitive, String def) {
-        static public Mode Make() {
+        public static final Mode CASE_INSENSITIVE_EMPTY_DEFAULT = make().withCaseSensitive(false).withDefault("");
+
+        public static Mode make() {
             return new Mode(false, null);
         }
 
@@ -17,22 +43,20 @@ public class SystemProperty {
         public Mode withDefault(String def) {
             return new Mode(this.caseSensitive, def);
         }
-
-        public static Mode CASE_INSENSITIVE_EMPTY_DEFAULT = Make().withCaseSensitive(false).withDefault("");
     }
 
     static public String getCaseInsensitive(Mode mode, String... keys) {
-        java.util.function.Function<String, String> normalize =
+        Function<String, String> normalize =
                 mode.caseSensitive()
                         ? (x -> x)
                         : String::toLowerCase;
-        List<String> normalized_keys = Arrays.stream(keys).map(normalize).toList();
+        List<String> normalizedKeys = Arrays.stream(keys).map(normalize).toList();
         for (Map.Entry<Object, Object> e : System.getProperties().entrySet()) {
             Object k = e.getKey();
             Object v = e.getValue();
             if (k instanceof String && v instanceof String) {
                 String ks = normalize.apply((String)k);
-                if (normalized_keys.contains(ks)) {
+                if (normalizedKeys.contains(ks)) {
                     return (String)v;
                 }
             }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -96,7 +96,7 @@ public class TestVM {
     public static final boolean USE_COMPILER = WHITE_BOX.getBooleanVMFlag("UseCompiler");
     static final boolean EXCLUDE_RANDOM = Boolean.getBoolean("ExcludeRandom");
     private static final String TESTLIST = SystemProperty.getTestList();
-    private static final String EXCLUDELIST = System.getProperty("Exclude", "");
+    private static final String EXCLUDELIST = SystemProperty.getExcludeList();
     private static final boolean DUMP_REPLAY = Boolean.getBoolean("DumpReplay");
     private static final boolean GC_AFTER = Boolean.getBoolean("GCAfter");
     private static final boolean SHUFFLE_TESTS = Boolean.parseBoolean(System.getProperty("ShuffleTests", "true"));

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -95,7 +95,7 @@ public class TestVM {
     private static final boolean PRINT_TIMES = Boolean.getBoolean("PrintTimes") || VERBOSE;
     public static final boolean USE_COMPILER = WHITE_BOX.getBooleanVMFlag("UseCompiler");
     static final boolean EXCLUDE_RANDOM = Boolean.getBoolean("ExcludeRandom");
-    private static final String TESTLIST = System.getProperty("Test", "");
+    private static final String TESTLIST = SystemProperty.getTestList();
     private static final String EXCLUDELIST = System.getProperty("Exclude", "");
     private static final boolean DUMP_REPLAY = Boolean.getBoolean("DumpReplay");
     private static final boolean GC_AFTER = Boolean.getBoolean("GCAfter");

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDScenarios.java
@@ -38,8 +38,8 @@ import jdk.test.lib.process.ProcessTools;
  * @summary Test -DScenarios property flag. Run with othervm which should not be done when writing tests using the framework.
  * @library /test/lib /
  * @run main/othervm -DScenarios=1,5,10 ir_framework.tests.TestDScenarios test
- * @run main/othervm -DScenarios=1,4 ir_framework.tests.TestDScenarios test
- * @run main/othervm -DScenarios=3,4,9 ir_framework.tests.TestDScenarios test
+ * @run main/othervm -DScenario=1,4 ir_framework.tests.TestDScenarios test
+ * @run main/othervm -Dscenarios=3,4,9 ir_framework.tests.TestDScenarios test
  * @run driver ir_framework.tests.TestDScenarios test2
  * @run driver ir_framework.tests.TestDScenarios
  */

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDTestAndExclude.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDTestAndExclude.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,8 +95,9 @@ public class TestDTestAndExclude {
      * Create a VM and simulate as if it was a driver VM spawned by JTreg that has -DTest/DExclude set as VM or Javaopts
      */
     protected static void run(String dTest, String dExclude, String arg) throws Exception {
+        // Let's randomize a bit which version of -Dtest and -Dexclude we use (caps and plural).
         boolean plural = dTest.contains(",");
-        boolean capital = dTest.length() % 2 == 0;
+        boolean capital = dTest.length() % 2 == 0;  // Any criterion that is not constant or correlated with `plural` would do as well.
         String dTestFlag = capital ? "-DTest" : "-Dtest";
         String dExcludeFlag = capital ? "-DExclude" : "-Dexclude";
         if (plural) {
@@ -107,7 +108,7 @@ public class TestDTestAndExclude {
         OutputAnalyzer oa;
         ProcessBuilder process = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-Dtest.class.path=" + Utils.TEST_CLASS_PATH, "-Dtest.jdk=" + Utils.TEST_JDK,
-                "-Dtest.vm.opts=" + dTestFlag + "=" + dTest + " -DExclude=" + dExclude,
+                "-Dtest.vm.opts=" + dTestFlag + "=" + dTest + " " + dExcludeFlag + "=" + dExclude,
                 "ir_framework.tests.TestDTestAndExclude", arg);
         oa = ProcessTools.executeProcess(process);
         oa.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDTestAndExclude.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDTestAndExclude.java
@@ -95,11 +95,17 @@ public class TestDTestAndExclude {
      * Create a VM and simulate as if it was a driver VM spawned by JTreg that has -DTest/DExclude set as VM or Javaopts
      */
     protected static void run(String dTest, String dExclude, String arg) throws Exception {
-        System.out.println("Run -DTest=" + dTest + " -DExclude=" + dExclude + " arg=" + arg);
+        boolean plural = dTest.contains(",");
+        boolean capital = dTest.length() % 2 == 0;
+        String dTestFlag = capital ? "-DTest" : "-Dtest";
+        if (plural) {
+            dTestFlag = dTestFlag + "s";
+        }
+        System.out.println("Run " + dTestFlag + "=" + dTest + " -DExclude=" + dExclude + " arg=" + arg);
         OutputAnalyzer oa;
         ProcessBuilder process = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-Dtest.class.path=" + Utils.TEST_CLASS_PATH, "-Dtest.jdk=" + Utils.TEST_JDK,
-                "-Dtest.vm.opts=-DTest=" + dTest + " -DExclude=" + dExclude,
+                "-Dtest.vm.opts=" + dTestFlag + "=" + dTest + " -DExclude=" + dExclude,
                 "ir_framework.tests.TestDTestAndExclude", arg);
         oa = ProcessTools.executeProcess(process);
         oa.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDTestAndExclude.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestDTestAndExclude.java
@@ -98,10 +98,12 @@ public class TestDTestAndExclude {
         boolean plural = dTest.contains(",");
         boolean capital = dTest.length() % 2 == 0;
         String dTestFlag = capital ? "-DTest" : "-Dtest";
+        String dExcludeFlag = capital ? "-DExclude" : "-Dexclude";
         if (plural) {
             dTestFlag = dTestFlag + "s";
+            dExcludeFlag = dExcludeFlag + "s";
         }
-        System.out.println("Run " + dTestFlag + "=" + dTest + " -DExclude=" + dExclude + " arg=" + arg);
+        System.out.println("Run " + dTestFlag + "=" + dTest + " " + dExcludeFlag + "=" + dExclude + " arg=" + arg);
         OutputAnalyzer oa;
         ProcessBuilder process = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-Dtest.class.path=" + Utils.TEST_CLASS_PATH, "-Dtest.jdk=" + Utils.TEST_JDK,


### PR DESCRIPTION
When I run a sub-test in the IR framework, I often run a single scenario, since it is common it's some specific set of flags that causes the issue. But it is not rare, if not common, that I run more than one test. Yet, the system properties are `-DScenarios` (plural) and `-DTest` (singular). That doesn't reflect the common cases. Moreover, it is not quite rare to mix up the case by accident, and then nothing tells the problem.

After discussion with the grand master of the IR framework @chhagedorn, we agreed to accept plural, and arbitrary case of the trio "scenario", "test", and "exclude".

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388018](https://bugs.openjdk.org/browse/JDK-8388018): [IR Framework] Be more lenient about system properties (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32013/head:pull/32013` \
`$ git checkout pull/32013`

Update a local copy of the PR: \
`$ git checkout pull/32013` \
`$ git pull https://git.openjdk.org/jdk.git pull/32013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32013`

View PR using the GUI difftool: \
`$ git pr show -t 32013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32013.diff">https://git.openjdk.org/jdk/pull/32013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32013#issuecomment-5048500826)
</details>
