### PR TITLE
8388792: False positives in jdk_foreign test suite

### DIFF
--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -53,9 +53,7 @@ import java.nio.LongBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.ShortBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -603,11 +601,24 @@ public class TestByteBuffer {
         }
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void testMapCustomPath() throws IOException {
-        Path path = Path.of(URI.create("jrt:/"));
-        try (FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-            fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 0L, Arena.ofAuto());
+        // Zip file systems do support creating file channels
+        // but do not support memory mapping those files
+        Path scratch = Path.of("testMapCustomPath");
+        Files.createDirectories(scratch);
+        Path zipFile = scratch.resolve("test.zip");
+
+        try (FileSystem zipFs = FileSystems.newFileSystem(zipFile, Map.of("create", true))) {
+            // create test file
+            Path testFile = zipFs.getPath("/test_file.txt");
+            Files.writeString(testFile, "testing", StandardOpenOption.CREATE_NEW);
+
+            // now try to map it
+            try (FileChannel fileChannel = FileChannel.open(testFile, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+                assertThrows(UnsupportedOperationException.class,
+                        () -> fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 0L, Arena.ofAuto()));
+            }
         }
     }
 

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -34,10 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class TestFunctionDescriptor extends NativeTestHelper {
 
@@ -114,16 +111,6 @@ public class TestFunctionDescriptor extends NativeTestHelper {
                 MemoryLayout.sequenceLayout(3, C_INT));
         MethodType cmt = fd.toMethodType();
         assertEquals(cmt, MethodType.methodType(int.class, int.class, MemorySegment.class, MemorySegment.class));
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testBadCarrierMethodType() {
-        FunctionDescriptor fd = FunctionDescriptor.of(C_INT,
-                C_INT,
-                MemoryLayout.structLayout(C_INT, C_INT),
-                MemoryLayout.sequenceLayout(3, C_INT),
-                MemoryLayout.paddingLayout(4));
-        fd.toMethodType(); // should throw
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -307,10 +307,12 @@ public class TestLayouts {
         }
     }
 
-    @Test(dataProvider="layoutsAndAlignments", expectedExceptions = IllegalArgumentException.class)
+    @Test(dataProvider="layoutsAndAlignments")
     public void testBadSequenceElementAlignmentTooBig(MemoryLayout layout, long byteAlign) {
-        layout = layout.withByteAlignment(layout.byteSize() * 2); // hyper-align
-        MemoryLayout.sequenceLayout(1, layout);
+        MemoryLayout elementLayout = layout.withByteAlignment(nextPowerOfTwo(layout.byteSize() * 2)); // hyper-align
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
+                () -> MemoryLayout.sequenceLayout(1, elementLayout));
+        assertEquals(iae.getMessage(), "Element layout size is not multiple of alignment");
     }
 
     @Test(dataProvider="layoutsAndAlignments")
@@ -348,15 +350,16 @@ public class TestLayouts {
         }
     }
 
-    @Test(dataProvider="layoutsAndAlignments", expectedExceptions = IllegalArgumentException.class)
+    @Test(dataProvider="layoutsAndAlignments")
     public void testBadStruct(MemoryLayout layout, long byteAlign) {
-        layout = layout.withByteAlignment(layout.byteSize() * 2); // hyper-align
-        MemoryLayout.structLayout(layout, layout);
+        MemoryLayout elementLayout = layout.withByteAlignment(nextPowerOfTwo(layout.byteSize() * 2)); // hyper-align
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
+                () -> MemoryLayout.structLayout(elementLayout, elementLayout));
+        assertTrue(iae.getMessage().contains("Invalid alignment constraint for member layout"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSequenceElement() {
-        SequenceLayout layout = MemoryLayout.sequenceLayout(10, JAVA_INT);
         // Step must be != 0
         PathElement.sequenceElement(3, 0);
     }
@@ -543,4 +546,8 @@ public class TestLayouts {
             ValueLayout.JAVA_LONG,
             ValueLayout.JAVA_DOUBLE,
     };
+
+    private static long nextPowerOfTwo(long input) {
+        return 1L << -Long.numberOfLeadingZeros(input - 1);
+    }
 }

--- a/test/jdk/java/foreign/TestMemoryAlignment.java
+++ b/test/jdk/java/foreign/TestMemoryAlignment.java
@@ -74,24 +74,6 @@ public class TestMemoryAlignment {
     }
 
     @Test(dataProvider = "alignments")
-    public void testUnalignedAccess(long align) {
-        ValueLayout layout = ValueLayout.JAVA_INT
-                .withOrder(ByteOrder.BIG_ENDIAN);
-        assertEquals(layout.byteAlignment(), 4);
-        ValueLayout aligned = layout.withByteAlignment(align);
-        try (Arena arena = Arena.ofConfined()) {
-            MemoryLayout alignedGroup = MemoryLayout.structLayout(MemoryLayout.paddingLayout(1), aligned);
-            assertEquals(alignedGroup.byteAlignment(), align);
-            VarHandle vh = aligned.varHandle();
-            MemorySegment segment = arena.allocate(alignedGroup);;
-            vh.set(segment.asSlice(1L), 0L, -42);
-            assertEquals(align, 8); //this is the only case where access is aligned
-        } catch (IllegalArgumentException ex) {
-            assertNotEquals(align, 8); //if align != 8, access is always unaligned
-        }
-    }
-
-    @Test(dataProvider = "alignments")
     public void testUnalignedPath(long align) {
         MemoryLayout layout = ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN);
         MemoryLayout aligned = layout.withByteAlignment(align).withName("value");

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -29,9 +29,7 @@
 import java.lang.foreign.*;
 
 import java.lang.invoke.VarHandle;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Spliterator;
+import java.util.*;
 import java.util.concurrent.CountedCompleter;
 import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.atomic.AtomicLong;
@@ -147,13 +145,19 @@ public class TestSpliterator {
                 .elements(MemoryLayout.sequenceLayout(0, ValueLayout.JAVA_INT));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testHyperAligned() {
         Arena scope = Arena.ofAuto();
         MemorySegment segment = scope.allocate(8, 1);
         // compute an alignment constraint (in bytes) which exceed that of the native segment
         long bigByteAlign = Long.lowestOneBit(segment.address()) << 1;
-        segment.elements(MemoryLayout.sequenceLayout(2, ValueLayout.JAVA_INT.withByteAlignment(bigByteAlign)));
+        MemoryLayout elementLayout = MemoryLayout.structLayout(
+                Collections.nCopies(Math.toIntExact(bigByteAlign), ValueLayout.JAVA_BYTE).toArray(MemoryLayout[]::new))
+                .withByteAlignment(bigByteAlign);
+        SequenceLayout layout = MemoryLayout.sequenceLayout(2, elementLayout);
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
+                () -> segment.elements(layout));
+        assertEquals(iae.getMessage(), "Incompatible alignment constraints");
     }
 
     static long sumSingle(long acc, MemorySegment segment) {


### PR DESCRIPTION
Copied from the JBS issue:

While converting these tests to use JUnit instead of TestNG, I noticed some false positives in the following tests:

- `TestByteBuffer::testMapCustomPath` tries to provoke an `UnsupportedOperationException` when calling `FileChannel::map`, but instead causes one when opening the file channel.

- `TestFunctionDescriptor::testBadCarrierMethodType` looks for an `IllegalArgumentException` when calling `FunctionDescriptor::toMethodType`, but this method is no longer specified to throw that exception. The exception instead occurs when creating the function descriptor itself.

- `testBadSequenceElementAlignmentTooBig` and `testBadStruct` in `TestLayouts` try to provoke exceptions when using hyper-aligned layouts, but instead trigger exceptions when using an alignment that is not a power of 2 in some cases.

- `TestMemoryAlignment::testUnalignedAccess` tries to provoke an exception on unaligned access, but the exception is instead thrown when creating the layout upfront.

- `TestSpliterator::testHyperAligned` tries to provoke an exception when calling `MemorySegments::elements` with a layout that isn't aligned for that segment, but instead fails when creating the layout. 

I've switched some of these to use `assertThrows` instead of `expectedException`, since that can be used to more precisely check that a particular line throws an exception.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388792](https://bugs.openjdk.org/browse/JDK-8388792): False positives in jdk_foreign test suite (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32014/head:pull/32014` \
`$ git checkout pull/32014`

Update a local copy of the PR: \
`$ git checkout pull/32014` \
`$ git pull https://git.openjdk.org/jdk.git pull/32014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32014`

View PR using the GUI difftool: \
`$ git pr show -t 32014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32014.diff">https://git.openjdk.org/jdk/pull/32014.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32014#issuecomment-5060024388)
</details>
