### PR TITLE
8309776: x86: Improve the code generation of MinF/D nodes

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -7720,6 +7720,21 @@ void Assembler::vdivss(XMMRegister dst, XMMRegister nds, XMMRegister src) {
   emit_int16(0x5E, (0xC0 | encode));
 }
 
+void Assembler::vminsd(XMMRegister dst, XMMRegister nds, XMMRegister src) {
+  assert(VM_Version::supports_avx(), "");
+  InstructionAttr attributes(AVX_128bit, /* vex_w */ VM_Version::supports_evex(), /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
+  attributes.set_rex_vex_w_reverted();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x5D, (0xC0 | encode));
+}
+
+void Assembler::vminss(XMMRegister dst, XMMRegister nds, XMMRegister src) {
+  assert(VM_Version::supports_avx(), "");
+  InstructionAttr attributes(AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x5D, (0xC0 | encode));
+}
+
 void Assembler::vfmadd231sd(XMMRegister dst, XMMRegister src1, XMMRegister src2) {
   assert(VM_Version::supports_fma(), "");
   InstructionAttr attributes(AVX_128bit, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
@@ -8254,6 +8269,21 @@ void Assembler::orpd(XMMRegister dst, XMMRegister src) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ !_legacy_mode_dq, /* legacy_mode */ _legacy_mode_dq, /* no_mask_reg */ true, /* uses_vl */ true);
   attributes.set_rex_vex_w_reverted();
   int encode = simd_prefix_and_encode(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x56, (0xC0 | encode));
+}
+
+void Assembler::vorpd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(VM_Version::supports_avx(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ !_legacy_mode_dq, /* legacy_mode */ _legacy_mode_dq, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_rex_vex_w_reverted();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x56, (0xC0 | encode));
+}
+
+void Assembler::vorps(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(VM_Version::supports_avx(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ _legacy_mode_dq, /* no_mask_reg */ true, /* uses_vl */ true);
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int16(0x56, (0xC0 | encode));
 }
 
@@ -17045,4 +17075,3 @@ void Assembler::evfmadd132ph(XMMRegister dst, XMMRegister nds, Address src, int 
   emit_int8(0x98);
   emit_operand(dst, src, 0);
 }
-

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2415,6 +2415,8 @@ private:
   void evdivsd(XMMRegister dst, XMMRegister nds, XMMRegister src, EvexRoundPrefix rmode);
   void vdivss(XMMRegister dst, XMMRegister nds, Address src);
   void vdivss(XMMRegister dst, XMMRegister nds, XMMRegister src);
+  void vminsd(XMMRegister dst, XMMRegister nds, XMMRegister src);
+  void vminss(XMMRegister dst, XMMRegister nds, XMMRegister src);
   void vfmadd231sd(XMMRegister dst, XMMRegister nds, XMMRegister src);
   void vfnmadd213sd(XMMRegister dst, XMMRegister nds, XMMRegister src);
   void evfnmadd213sd(XMMRegister dst, XMMRegister nds, XMMRegister src, EvexRoundPrefix rmode);
@@ -2521,6 +2523,8 @@ private:
 
   // Bitwise Logical OR of Packed Floating-Point Values
   void orpd(XMMRegister dst, XMMRegister src);
+  void vorpd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void vorps(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
 
   void unpckhpd(XMMRegister dst, XMMRegister src);
   void unpcklpd(XMMRegister dst, XMMRegister src);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -902,6 +902,25 @@ void C2_MacroAssembler::vpminmax(int opcode, BasicType elem_bt,
 
 // Float/Double min max
 
+void C2_MacroAssembler::smin_fp(BasicType elem_bt,
+                                XMMRegister dst, XMMRegister a, XMMRegister b,
+                                XMMRegister tmp1, XMMRegister tmp2) {
+  assert(UseAVX > 0, "required");
+  assert(elem_bt == T_FLOAT || elem_bt == T_DOUBLE, "sanity");
+  assert_different_registers(a, tmp1, tmp2);
+  assert_different_registers(b, tmp1, tmp2);
+
+  if (elem_bt == T_FLOAT) {
+    vminss(tmp1, a, b);
+    vminss(tmp2, b, a);
+    vorps(dst, tmp1, tmp2, Assembler::AVX_128bit);
+  } else {
+    vminsd(tmp1, a, b);
+    vminsd(tmp2, b, a);
+    vorpd(dst, tmp1, tmp2, Assembler::AVX_128bit);
+  }
+}
+
 void C2_MacroAssembler::vminmax_fp(int opcode, BasicType elem_bt,
                                    XMMRegister dst, XMMRegister a, XMMRegister b,
                                    XMMRegister tmp, XMMRegister atmp, XMMRegister btmp,

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -62,6 +62,10 @@ public:
                 XMMRegister dst, XMMRegister src1, Address src2,
                 int vlen_enc);
 
+  void smin_fp(BasicType elem_bt,
+               XMMRegister dst, XMMRegister a, XMMRegister b,
+               XMMRegister tmp1, XMMRegister tmp2);
+
   void vminmax_fp(int opcode, BasicType elem_bt,
                   XMMRegister dst, XMMRegister a, XMMRegister b,
                   XMMRegister tmp, XMMRegister atmp, XMMRegister btmp,

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -7384,19 +7384,30 @@ instruct minmaxF_reduction_reg_avx10_2(regF dst, regF a, regF b, rRegI rtmp, rFl
 %}
 
 // min = java.lang.Math.min(float a, float b)
+instruct minF_reg(legRegF dst, legRegF a, legRegF b, legRegF tmp1, legRegF tmp2)
+%{
+  predicate(!VM_Version::supports_avx10_2() && UseAVX > 0 && !VLoopReductions::is_reduction(n));
+  match(Set dst (MinF a b));
+  effect(USE a, USE b, TEMP tmp1, TEMP tmp2);
+
+  format %{ "minF $dst, $a, $b \t! using $tmp1 and $tmp2 as TEMP" %}
+  ins_encode %{
+    __ smin_fp(T_FLOAT, $dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister,
+               $tmp1$$XMMRegister, $tmp2$$XMMRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 // max = java.lang.Math.max(float a, float b)
-instruct minmaxF_reg(legRegF dst, legRegF a, legRegF b, legRegF tmp, legRegF atmp, legRegF btmp)
+instruct maxF_reg(legRegF dst, legRegF a, legRegF b, legRegF tmp, legRegF atmp, legRegF btmp)
 %{
   predicate(!VM_Version::supports_avx10_2() && UseAVX > 0 && !VLoopReductions::is_reduction(n));
   match(Set dst (MaxF a b));
-  match(Set dst (MinF a b));
   effect(USE a, USE b, TEMP tmp, TEMP atmp, TEMP btmp);
 
-  format %{ "minmaxF $dst, $a, $b \t! using $tmp, $atmp and $btmp as TEMP" %}
+  format %{ "maxF $dst, $a, $b \t! using $tmp, $atmp and $btmp as TEMP" %}
   ins_encode %{
-    int opcode = this->ideal_Opcode();
-    int param_opcode = (opcode == Op_MinF) ? Op_MinV : Op_MaxV;
-    __ vminmax_fp(param_opcode, T_FLOAT, $dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, $tmp$$XMMRegister,
+    __ vminmax_fp(Op_MaxV, T_FLOAT, $dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, $tmp$$XMMRegister,
                   $atmp$$XMMRegister, $btmp$$XMMRegister, Assembler::AVX_128bit);
   %}
   ins_pipe( pipe_slow );
@@ -7453,19 +7464,30 @@ instruct minmaxD_reduction_reg_avx10_2(regD dst, regD a, regD b, rRegI rtmp, rFl
 %}
 
 // min = java.lang.Math.min(double a, double b)
+instruct minD_reg(legRegD dst, legRegD a, legRegD b, legRegD tmp1, legRegD tmp2)
+%{
+  predicate(!VM_Version::supports_avx10_2() && UseAVX > 0 && !VLoopReductions::is_reduction(n));
+  match(Set dst (MinD a b));
+  effect(USE a, USE b, TEMP tmp1, TEMP tmp2);
+
+  format %{ "minD $dst, $a, $b \t! using $tmp1 and $tmp2 as TEMP" %}
+  ins_encode %{
+    __ smin_fp(T_DOUBLE, $dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister,
+               $tmp1$$XMMRegister, $tmp2$$XMMRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 // max = java.lang.Math.max(double a, double b)
-instruct minmaxD_reg(legRegD dst, legRegD a, legRegD b, legRegD tmp, legRegD atmp, legRegD btmp)
+instruct maxD_reg(legRegD dst, legRegD a, legRegD b, legRegD tmp, legRegD atmp, legRegD btmp)
 %{
   predicate(!VM_Version::supports_avx10_2() && UseAVX > 0 && !VLoopReductions::is_reduction(n));
   match(Set dst (MaxD a b));
-  match(Set dst (MinD a b));
   effect(USE a, USE b, TEMP atmp, TEMP btmp, TEMP tmp);
 
-  format %{ "minmaxD $dst, $a, $b \t! using $tmp, $atmp and $btmp as TEMP" %}
+  format %{ "maxD $dst, $a, $b \t! using $tmp, $atmp and $btmp as TEMP" %}
   ins_encode %{
-    int opcode = this->ideal_Opcode();
-    int param_opcode = (opcode == Op_MinD) ? Op_MinV : Op_MaxV;
-    __ vminmax_fp(param_opcode, T_DOUBLE, $dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, $tmp$$XMMRegister,
+    __ vminmax_fp(Op_MaxV, T_DOUBLE, $dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister, $tmp$$XMMRegister,
                   $atmp$$XMMRegister, $btmp$$XMMRegister, Assembler::AVX_128bit);
   %}
   ins_pipe( pipe_slow );

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @bug 8212043
+ * @bug 8212043 8309776
  * @summary Test compiler intrinsics of floating-point Math.min/max
  * @library /test/lib
  *
@@ -140,10 +140,10 @@ public class TestFpMinMaxIntrinsics {
     }
 
     private static void fCheck(float a, float b, float fmin, float fmax, float efmin, float efmax) {
-        int min = Float.floatToRawIntBits(fmin);
-        int max = Float.floatToRawIntBits(fmax);
-        int emin = Float.floatToRawIntBits(efmin);
-        int emax = Float.floatToRawIntBits(efmax);
+        int min = Float.floatToIntBits(fmin);
+        int max = Float.floatToIntBits(fmax);
+        int emin = Float.floatToIntBits(efmin);
+        int emax = Float.floatToIntBits(efmax);
 
         if (min != emin || max != emax) {
             throw new AssertionError("Unexpected result of float min/max: " +
@@ -169,10 +169,10 @@ public class TestFpMinMaxIntrinsics {
     }
 
     private static void dCheck(double a, double b, double dmin, double dmax, double edmin, double edmax) {
-        double min = Double.doubleToRawLongBits(dmin);
-        double max = Double.doubleToRawLongBits(dmax);
-        double emin = Double.doubleToRawLongBits(edmin);
-        double emax = Double.doubleToRawLongBits(edmax);
+        long min = Double.doubleToLongBits(dmin);
+        long max = Double.doubleToLongBits(dmax);
+        long emin = Double.doubleToLongBits(edmin);
+        long emax = Double.doubleToLongBits(edmax);
 
         if (min != emin || max != emax) {
             throw new AssertionError("Unexpected result of double min/max: " +

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1340,7 +1340,7 @@ public class IRNode {
 
     public static final String MINMAX_D_REG = PREFIX + "MINMAX_D_REG" + POSTFIX;
     static {
-        machOnlyNameRegex(MINMAX_D_REG, "minmaxD_reg");
+        machOnlyNameRegex(MINMAX_D_REG, "(minD_reg|maxD_reg|minmaxD_reg)");
     }
 
     public static final String MIN_F = PREFIX + "MIN_F" + POSTFIX;
@@ -1355,7 +1355,7 @@ public class IRNode {
 
     public static final String MINMAX_F_REG = PREFIX + "MINMAX_F_REG" + POSTFIX;
     static {
-        machOnlyNameRegex(MINMAX_F_REG, "minmaxF_reg");
+        machOnlyNameRegex(MINMAX_F_REG, "(minF_reg|maxF_reg|minmaxF_reg)");
     }
 
     public static final String MIN_I = PREFIX + "MIN_I" + POSTFIX;


### PR DESCRIPTION
C2 currently uses the generic five-instruction floating-point min/max expansion for scalar `MinF` and `MinD` nodes on x86.

This patch adds a min-specific sequence for AVX-capable, non-AVX10.2 targets:

    vmin{s,d} tmp1, a, b
    vmin{s,d} tmp2, b, a
    vor{ps,pd} dst, tmp1, tmp2

For ordinary values, both minimum instructions produce the same result. Reversing the operands preserves Java's signed-zero semantics, while OR selects `-0.0`. If either operand is NaN, one minimum selects that NaN and the final result remains NaN.

This reduces the generated sequence from five instructions and three temporary registers to three instructions and two temporaries. Scalar max, reductions, and AVX10.2 lowering are unchanged.

Testing:

- `TestFpMinMaxIntrinsics.java`
- `TestFpMinMaxReductions.java`
- Forced C2 execution with `UseAVX=1`, `UseAVX=2`, and `UseAVX=3`
- Windows x64 fastdebug HotSpot build
- Baseline versus patched release JMH runs

On an AMD Ryzen 9 9950X3D using 10 pinned JMH forks:

| Benchmark | Baseline | Patched | Change |
|-----------|----------|---------|--------|
| `fMin` | 1107.872 ns/op | 1072.181 ns/op | 3.22% faster |
| `dMin` | 1095.742 ns/op | 1072.259 ns/op | 2.14% faster |

The `dMin` measurements had higher variance, but both benchmark runs favored the patched code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8309776](https://bugs.openjdk.org/browse/JDK-8309776): x86: Improve the code generation of MinF/D nodes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32015/head:pull/32015` \
`$ git checkout pull/32015`

Update a local copy of the PR: \
`$ git checkout pull/32015` \
`$ git pull https://git.openjdk.org/jdk.git pull/32015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32015`

View PR using the GUI difftool: \
`$ git pr show -t 32015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32015.diff">https://git.openjdk.org/jdk/pull/32015.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32015#issuecomment-5051444210)
</details>
