### PR TITLE
8388799: ClhsdbLongConstant should not assert a specific value for VM_Version::CPU_SHA

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
@@ -104,10 +104,9 @@ public class ClhsdbLongConstant {
 
         String arch = System.getProperty("os.arch");
         if (arch.equals("amd64") || arch.equals("i386") || arch.equals("x86")) {
-            // Expected value obtained from the CPU_SHA definition in vm_version_x86.hpp
-            checkLongValue("VM_Version::CPU_SHA ",
-                           longConstantOutput,
-                           33L);
+            // CPU_SHA is a feature-flag bit index that shifts when a CPU feature is added,
+            // so its value is not asserted; presence confirms output was not truncated.
+            checkLongValuePresent("VM_Version::CPU_SHA ", longConstantOutput);
         }
     }
 
@@ -121,5 +120,15 @@ public class ClhsdbLongConstant {
             throw new Exception ("Reading " + constName + ". Expected " + checkValue +
                                  ". Obtained " + readValue + " instead.");
         }
+    }
+
+    private static void checkLongValuePresent(String constName, String longConstantOutput)
+            throws Exception {
+        String[] snippets = longConstantOutput.split(constName);
+        if (snippets.length < 2) {
+            throw new Exception("Reading " + constName +
+                                ". Constant not found (output may be truncated).");
+        }
+        Long.parseLong(snippets[1].split("\\R")[0].trim()); // value intentionally not checked
     }
 }


### PR DESCRIPTION
serviceability/sa/ClhsdbLongConstant.java asserts an exact value for VM_Version::CPU_SHA in checkForTruncation(). CPU_SHA is a feature-flag bit index in vm_version_x86.hpp whose value shifts whenever a CPU feature is added, so the hardcoded expectation goes stale and the test fails (it has already been bumped once, and the in-file comment lists yet another value).

This check exists only to confirm the `longConstant` output was not truncated, using CPU_SHA as a sentinel that appears late in the output, the exact value is irrelevant to that purpose. SA reads the value correctly from the VM in every case.

Change checkForTruncation() to verify the constant is present with a parseable long value (checkLongValuePresent) instead of asserting a specific number, so the check no longer breaks on every feature-flag change. The markWord::hash_mask_in_place assertion is unchanged, since that value is derived from a stable definition.

Testing: serviceability/sa/ClhsdbLongConstant.java (x64).






---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388799](https://bugs.openjdk.org/browse/JDK-8388799): ClhsdbLongConstant should not assert a specific value for VM_Version::CPU_SHA (**Bug** - P4)


### Reviewers
 * [Ekaterina Pavlova](https://openjdk.org/census#epavlova) (@katyapav - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32017/head:pull/32017` \
`$ git checkout pull/32017`

Update a local copy of the PR: \
`$ git checkout pull/32017` \
`$ git pull https://git.openjdk.org/jdk.git pull/32017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32017`

View PR using the GUI difftool: \
`$ git pr show -t 32017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32017.diff">https://git.openjdk.org/jdk/pull/32017.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32017#issuecomment-5065401296)
</details>
