### PR TITLE
8388809: Shenandoah: Control thread may observe incorrect cancellation reason

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -307,19 +307,20 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
 
 bool ShenandoahControlThread::check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  const GCCause::Cause cancelled_cause = heap->cancelled_cause();
   if (heap->cancelled_gc()) {
-    if (heap->cancelled_cause() == GCCause::_shenandoah_stop_vm) {
+    if (cancelled_cause == GCCause::_shenandoah_stop_vm) {
       return true;
     }
 
-    if (ShenandoahCollectorPolicy::is_allocation_failure(heap->cancelled_cause())) {
+    if (ShenandoahCollectorPolicy::is_allocation_failure(cancelled_cause)) {
       assert (_degen_point == ShenandoahGC::_degenerated_outside_cycle,
               "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
       _degen_point = point;
       return true;
     }
 
-    fatal("Unexpected reason for cancellation: %s", GCCause::to_string(heap->cancelled_cause()));
+    fatal("Unexpected reason for cancellation: %s", GCCause::to_string(cancelled_cause));
   }
   return false;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -306,23 +306,25 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
 }
 
 bool ShenandoahControlThread::check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point) {
+  // Only read the cancellation cause once. Other threads may change it.
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   const GCCause::Cause cancelled_cause = heap->cancelled_cause();
-  if (heap->cancelled_gc()) {
-    if (cancelled_cause == GCCause::_shenandoah_stop_vm) {
-      return true;
-    }
-
-    if (ShenandoahCollectorPolicy::is_allocation_failure(cancelled_cause)) {
-      assert (_degen_point == ShenandoahGC::_degenerated_outside_cycle,
-              "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
-      _degen_point = point;
-      return true;
-    }
-
-    fatal("Unexpected reason for cancellation: %s", GCCause::to_string(cancelled_cause));
+  if (cancelled_cause == GCCause::_no_gc) {
+    return false;
   }
-  return false;
+
+  if (cancelled_cause == GCCause::_shenandoah_stop_vm) {
+    return true;
+  }
+
+  if (ShenandoahCollectorPolicy::is_allocation_failure(cancelled_cause)) {
+    assert (_degen_point == ShenandoahGC::_degenerated_outside_cycle,
+            "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
+    _degen_point = point;
+    return true;
+  }
+
+  fatal("Unexpected reason for cancellation: %s", GCCause::to_string(cancelled_cause));
 }
 
 void ShenandoahControlThread::stop_service() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -601,7 +601,6 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
   }
 
   fatal("Cancel GC either for alloc failure GC, or gracefully exiting, or to pause old generation marking");
-  return false;
 }
 
 void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -576,11 +576,12 @@ void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGen
 }
 
 bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point) {
-  if (!_heap->cancelled_gc()) {
+  // Only read the cancellation cause once. Other threads may change it.
+  const GCCause::Cause cancelled_cause = _heap->cancelled_cause();
+  if (cancelled_cause == GCCause::_no_gc) {
     return false;
   }
 
-  const GCCause::Cause cancelled_cause = _heap->cancelled_cause();
   if (cancelled_cause == GCCause::_shenandoah_stop_vm
       || cancelled_cause == GCCause::_shenandoah_concurrent_gc) {
     log_debug(gc, thread)("Cancellation detected, reason: %s", GCCause::to_string(cancelled_cause));


### PR DESCRIPTION
This is the non-generational mode variant of [JDK-8388449](https://bugs.openjdk.org/browse/JDK-8388449). The right sequence of events could see the JVM assert with a `fatal` error message instead of shutting down cleanly. Specifically, the code here: https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp#L308, could
1. Observe a cancellation due to allocation failure.
2. The test `cause == GCCause::_shenandoah_stop_vm` fails.
3. Another thread changes the cancellation reason to _shenandoah_stop_vm
4. The test `ShenandoahCollectorPolicy::is_allocation_failure` would fail
5. Execution reaches the `fatal` condition

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388809](https://bugs.openjdk.org/browse/JDK-8388809): Shenandoah: Control thread may observe incorrect cancellation reason (**Bug** - P4)


### Reviewers
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Committer) Review applies to [008e8a2d](https://git.openjdk.org/jdk/pull/32018/files/008e8a2dad12a468ec8319ec7abf7c1a91d01357)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32018/head:pull/32018` \
`$ git checkout pull/32018`

Update a local copy of the PR: \
`$ git checkout pull/32018` \
`$ git pull https://git.openjdk.org/jdk.git pull/32018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32018`

View PR using the GUI difftool: \
`$ git pr show -t 32018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32018.diff">https://git.openjdk.org/jdk/pull/32018.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32018#issuecomment-5052355656)
</details>
