### PR TITLE
8388485: javax/swing/JInternalFrame/Test6505027.java fails with Cannot invoke "Object.getClass()" because "<local0>" is null

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/Test6505027.java
+++ b/test/jdk/javax/swing/JInternalFrame/Test6505027.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  * @library ..
  */
 
-import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
@@ -38,6 +37,7 @@ import java.awt.KeyboardFocusManager;
 import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
+import java.beans.PropertyVetoException;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JComboBox;
 import javax.swing.JDesktopPane;
@@ -67,45 +67,59 @@ public class Test6505027 {
         SwingTest.start(Test6505027.class);
     }
 
-    private final JTable table = new JTable(new DefaultTableModel(COLUMNS, 2));
+    private static JTable table;
 
     public Test6505027(JFrame main) {
+        table = new JTable(new DefaultTableModel(COLUMNS, 2));
         Container container = main;
         if (INTERNAL) {
             JInternalFrame frame = new JInternalFrame();
             frame.setBounds(OFFSET, OFFSET, WIDTH, HEIGHT);
-            frame.setVisible(true);
 
             JDesktopPane desktop = new JDesktopPane();
             desktop.add(frame, new Integer(1));
+            frame.setVisible(true);
 
             container.add(desktop);
+            try {
+                frame.setSelected(true);
+            } catch (PropertyVetoException ex) {
+                throw new Error("could not select internal frame", ex);
+            }
             container = frame;
         }
         if (TERMINATE) {
-            this.table.putClientProperty(KEY, Boolean.TRUE);
+            table.putClientProperty(KEY, Boolean.TRUE);
         }
-        TableColumn column = this.table.getColumn(COLUMNS[1]);
+        TableColumn column = table.getColumn(COLUMNS[1]);
         column.setCellEditor(new DefaultCellEditor(new JComboBox(ITEMS)));
 
         container.add(BorderLayout.NORTH, new JTextField());
-        container.add(BorderLayout.CENTER, new JScrollPane(this.table));
+        container.add(BorderLayout.CENTER, new JScrollPane(table));
     }
 
-    public void press() throws AWTException {
-        Point point = this.table.getCellRect(1, 1, false).getLocation();
-        SwingUtilities.convertPointToScreen(point, this.table);
+    public static void press() throws Exception {
+        Point point = new Point();
+
+        SwingUtilities.invokeAndWait(() -> {
+            point.setLocation(table.getCellRect(1, 1, false).getLocation());
+            SwingUtilities.convertPointToScreen(point, table);
+        });
 
         Robot robot = new Robot();
         robot.setAutoDelay(50);
         robot.mouseMove(point.x + 1, point.y + 1);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.waitForIdle();
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        robot.delay(500);
     }
 
     public static void validate() {
         Component component = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
-        if (!component.getClass().equals(JComboBox.class)) {
+        System.out.println("Component " + component);
+        if (!(component instanceof JComboBox)) {
             throw new Error("unexpected focus owner: " + component);
         }
     }

--- a/test/jdk/javax/swing/JInternalFrame/Test6505027.java
+++ b/test/jdk/javax/swing/JInternalFrame/Test6505027.java
@@ -84,7 +84,7 @@ public class Test6505027 {
             try {
                 frame.setSelected(true);
             } catch (PropertyVetoException ex) {
-                throw new Error("could not select internal frame", ex);
+                throw new RuntimeException("could not select internal frame", ex);
             }
             container = frame;
         }
@@ -120,7 +120,7 @@ public class Test6505027 {
         Component component = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
         System.out.println("Component " + component);
         if (!(component instanceof JComboBox)) {
-            throw new Error("unexpected focus owner: " + component);
+            throw new RuntimeException("unexpected focus owner: " + component);
         }
     }
 }


### PR DESCRIPTION
Test fails with NPE citing
```
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "<local0>" is null
at Test6505027.validate(Test6505027.java:108)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:583)
at SwingTest.run(SwingTest.java:96)
at SwingTest.start(SwingTest.java:131)
at SwingTest.start(SwingTest.java:54)
at Test6505027.main(Test6505027.java:67) 
```

which can happen when the internal frame has not received native focus yet, or the Robot click’s focus transfer has not completed. The test validates focus owner immediately after clicking cell (1,1).
Robot `waitForIdle` and `delay `is added after cell click to give time before current focus owner check is called. 
Also, explicitly activated the internal frame after it has been added to the desktop pane:
Also, `instanceof` check is used instead of `component.getClass().equals(JComboBox.class)` because it handles null cleanly and does not reject a valid subclass

Additionally, `press()` and `validate() `was called in separate EDT and main thread respectively which can cause issues like this, so made sure they are called in same thread as SwingTest calls static methods in main thread.


Recurrent CI test execution is found to be ok.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388485](https://bugs.openjdk.org/browse/JDK-8388485): javax/swing/JInternalFrame/Test6505027.java fails with Cannot invoke "Object.getClass()" because "&lt;local0&gt;" is null (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32019/head:pull/32019` \
`$ git checkout pull/32019`

Update a local copy of the PR: \
`$ git checkout pull/32019` \
`$ git pull https://git.openjdk.org/jdk.git pull/32019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32019`

View PR using the GUI difftool: \
`$ git pr show -t 32019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32019.diff">https://git.openjdk.org/jdk/pull/32019.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32019#issuecomment-5055343459)
</details>
