### PR TITLE
8388837: RISC-V: Track card addresses directly in G1 array post-write barrier loop

### DIFF
--- a/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
@@ -108,30 +108,28 @@ void G1BarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* mas
 
   __ srli(start, start, CardTable::card_shift());
   __ srli(count, count, CardTable::card_shift());
-  __ sub(count, count, start);                            // Number of bytes to mark - 1.
 
-  // Add card table base offset to start.
+  // Add card table base offset to get card addresses directly.
   Address card_table_address(xthread, G1ThreadLocalData::card_table_base_offset());
   __ ld(tmp, card_table_address);
-  __ add(start, start, tmp);
+  __ add(start, start, tmp);                              // start := first card address
+  __ add(count, count, tmp);                              // count := last card address
 
   __ bind(loop);
   if (UseCondCardMark) {
-    __ add(tmp, start, count);
-    __ lbu(tmp, Address(tmp, 0));
+    __ lbu(tmp, Address(count, 0));
     static_assert((uint)G1CardTable::clean_card_val() == 0xff, "must be");
     __ subi(tmp, tmp, G1CardTable::clean_card_val()); // Convert to clean_card_value() to a comparison
                                                       // against zero to avoid use of an extra temp.
     __ bnez(tmp, next);
   }
 
-  __ add(tmp, start, count);
   static_assert(G1CardTable::dirty_card_val() == 0, "must be to use zr");
-  __ sb(zr, Address(tmp, 0));
+  __ sb(zr, Address(count, 0));
 
   __ bind(next);
   __ subi(count, count, 1);
-  __ bgez(count, loop);
+  __ bge(count, start, loop);
 
   __ bind(done);
 }

--- a/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
@@ -115,9 +115,10 @@ void G1BarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* mas
   __ add(start, start, tmp);                              // start := first card address
   __ add(count, count, tmp);                              // count := last card address
 
+  // Iterate from start card to end card (inclusive).
   __ bind(loop);
   if (UseCondCardMark) {
-    __ lbu(tmp, Address(count, 0));
+    __ lbu(tmp, Address(start, 0));
     static_assert((uint)G1CardTable::clean_card_val() == 0xff, "must be");
     __ subi(tmp, tmp, G1CardTable::clean_card_val()); // Convert to clean_card_value() to a comparison
                                                       // against zero to avoid use of an extra temp.
@@ -125,10 +126,10 @@ void G1BarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* mas
   }
 
   static_assert(G1CardTable::dirty_card_val() == 0, "must be to use zr");
-  __ sb(zr, Address(count, 0));
+  __ sb(zr, Address(start, 0));
 
   __ bind(next);
-  __ subi(count, count, 1);
+  __ addi(start, start, 1);
   __ bge(count, start, loop);
 
   __ bind(done);

--- a/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
@@ -130,7 +130,7 @@ void G1BarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembler* mas
 
   __ bind(next);
   __ addi(start, start, 1);
-  __ bge(count, start, loop);
+  __ ble(start, count, loop);
 
   __ bind(done);
 }


### PR DESCRIPTION
As discussed here: https://github.com/openjdk/jdk/pull/31956#issuecomment-5042736235

We can propose this array card-loop optimization and apply it on both RISC-V and AArch64. However, AArch64's indexed addressing may limit the performance benefit, so I need to run performance tests to verify it first. After that, I'll submit a new PR for AArch64. 
For now, let's only apply the optimization to the RISC-V backend here.

### Correctness Testing
- [x] Run tier1-tier3 test with release on SG2044

### Performance test:

We can observe the throughput scores increased from 604.565 to 616.446. While this may not look like a huge improvement, we can also use the perfnorm profiler to observe normalized metrics such as instructions per operation and cycles per operation. From the data below, we can see that after applying the patch, `instructions:u` decreased — which is exactly our goal.

Performance test command:
```
make test TEST="micro:org.openjdk.bench.java.lang.ArrayCopyObject"  MICRO="OPTIONS=-f 3 -wi 4 -i 4 -prof perfnorm -p size=8191"
```
without this patch:
```
Benchmark                                                 (size)   Mode  Cnt     Score      Error      Units
ArrayCopyObject.conjoint_micro                              8191  thrpt   12   604.565 ±   25.992     ops/ms
ArrayCopyObject.conjoint_micro:CPI                          8191  thrpt    3     2.081 ±    1.478  clks/insn
ArrayCopyObject.conjoint_micro:IPC                          8191  thrpt    3     0.481 ±    0.334  insns/clk
ArrayCopyObject.conjoint_micro:L1-dcache-load-misses:u      8191  thrpt    3     0.241 ±    1.885       #/op
ArrayCopyObject.conjoint_micro:L1-dcache-loads:u            8191  thrpt    3  2228.127 ± 1321.906       #/op
ArrayCopyObject.conjoint_micro:L1-dcache-store-misses:u     8191  thrpt    3     0.005 ±    0.042       #/op
ArrayCopyObject.conjoint_micro:L1-dcache-stores:u           8191  thrpt    3  2098.435 ± 1369.781       #/op
ArrayCopyObject.conjoint_micro:L1-icache-load-misses:u      8191  thrpt    3     0.072 ±    0.263       #/op
ArrayCopyObject.conjoint_micro:L1-icache-loads:u            8191  thrpt    3  1152.612 ±  164.830       #/op
ArrayCopyObject.conjoint_micro:branch-misses:u              8191  thrpt    3     1.067 ±    0.446       #/op
ArrayCopyObject.conjoint_micro:branches:u                   8191  thrpt    3   396.510 ±   24.555       #/op
ArrayCopyObject.conjoint_micro:cycles:u                     8191  thrpt    3  3618.339 ± 2730.820       #/op
ArrayCopyObject.conjoint_micro:dTLB-loads:u                 8191  thrpt    3  2227.473 ± 1297.338       #/op
ArrayCopyObject.conjoint_micro:dTLB-store-misses:u          8191  thrpt    3     0.004 ±    0.040       #/op
ArrayCopyObject.conjoint_micro:dTLB-stores:u                8191  thrpt    3  2099.337 ± 1412.496       #/op
ArrayCopyObject.conjoint_micro:iTLB-load-misses:u           8191  thrpt    3     0.079 ±    0.463       #/op
ArrayCopyObject.conjoint_micro:iTLB-loads:u                 8191  thrpt    3  3606.789 ± 2721.584       #/op
ArrayCopyObject.conjoint_micro:instructions:u               8191  thrpt    3  1738.801 ±  124.064       #/op
ArrayCopyObject.conjoint_micro:stalled-cycles-backend:u     8191  thrpt    3   320.011 ±   93.319       #/op
ArrayCopyObject.conjoint_micro:stalled-cycles-frontend:u    8191  thrpt    3  2666.511 ± 2685.390       #/op
ArrayCopyObject.disjoint_micro                              8191  thrpt   12   579.264 ±   18.531     ops/ms
ArrayCopyObject.disjoint_micro:CPI                          8191  thrpt    3     2.546 ±    1.062  clks/insn
ArrayCopyObject.disjoint_micro:IPC                          8191  thrpt    3     0.393 ±    0.163  insns/clk
ArrayCopyObject.disjoint_micro:L1-dcache-load-misses:u      8191  thrpt    3     0.230 ±    1.781       #/op
ArrayCopyObject.disjoint_micro:L1-dcache-loads:u            8191  thrpt    3  2261.139 ±   37.568       #/op
ArrayCopyObject.disjoint_micro:L1-dcache-store-misses:u     8191  thrpt    3     0.005 ±    0.041       #/op
ArrayCopyObject.disjoint_micro:L1-dcache-stores:u           8191  thrpt    3  2183.380 ±   33.429       #/op
ArrayCopyObject.disjoint_micro:L1-icache-load-misses:u      8191  thrpt    3     0.070 ±    0.242       #/op
ArrayCopyObject.disjoint_micro:L1-icache-loads:u            8191  thrpt    3   744.459 ±   89.813       #/op
ArrayCopyObject.disjoint_micro:branch-misses:u              8191  thrpt    3     0.060 ±    0.499       #/op
ArrayCopyObject.disjoint_micro:branches:u                   8191  thrpt    3   267.182 ±   23.352       #/op
ArrayCopyObject.disjoint_micro:cycles:u                     8191  thrpt    3  3770.776 ± 1545.010       #/op
ArrayCopyObject.disjoint_micro:dTLB-loads:u                 8191  thrpt    3  2261.116 ±   50.406       #/op
ArrayCopyObject.disjoint_micro:dTLB-store-misses:u          8191  thrpt    3     0.011 ±    0.016       #/op
ArrayCopyObject.disjoint_micro:dTLB-stores:u                8191  thrpt    3  2184.226 ±   29.152       #/op
ArrayCopyObject.disjoint_micro:iTLB-load-misses:u           8191  thrpt    3     0.057 ±    0.436       #/op
ArrayCopyObject.disjoint_micro:iTLB-loads:u                 8191  thrpt    3  3759.905 ± 1534.102       #/op
ArrayCopyObject.disjoint_micro:instructions:u               8191  thrpt    3  1480.863 ±  118.388       #/op
ArrayCopyObject.disjoint_micro:stalled-cycles-backend:u     8191  thrpt    3   396.390 ± 1054.563       #/op
ArrayCopyObject.disjoint_micro:stalled-cycles-frontend:u    8191  thrpt    3  3218.591 ± 1539.425       #/op
Finished running test 'micro:org.openjdk.bench.java.lang.ArrayCopyObject'

```

with this patch:
```
Benchmark                                                 (size)   Mode  Cnt     Score      Error      Units
ArrayCopyObject.conjoint_micro                              8191  thrpt   12   616.446 ±   20.798     ops/ms
ArrayCopyObject.conjoint_micro:CPI                          8191  thrpt    3     2.120 ±    1.094  clks/insn
ArrayCopyObject.conjoint_micro:IPC                          8191  thrpt    3     0.472 ±    0.242  insns/clk
ArrayCopyObject.conjoint_micro:L1-dcache-load-misses:u      8191  thrpt    3     0.251 ±    1.386       #/op
ArrayCopyObject.conjoint_micro:L1-dcache-loads:u            8191  thrpt    3  2184.269 ± 1359.380       #/op
ArrayCopyObject.conjoint_micro:L1-dcache-store-misses:u     8191  thrpt    3     0.006 ±    0.043       #/op
ArrayCopyObject.conjoint_micro:L1-dcache-stores:u           8191  thrpt    3  2141.624 ± 1374.834       #/op
ArrayCopyObject.conjoint_micro:L1-icache-load-misses:u      8191  thrpt    3     0.070 ±    0.190       #/op
ArrayCopyObject.conjoint_micro:L1-icache-loads:u            8191  thrpt    3  3242.818 ± 4713.124       #/op
ArrayCopyObject.conjoint_micro:branch-misses:u              8191  thrpt    3     1.067 ±    0.521       #/op
ArrayCopyObject.conjoint_micro:branches:u                   8191  thrpt    3   396.447 ±   21.196       #/op
ArrayCopyObject.conjoint_micro:cycles:u                     8191  thrpt    3  3546.340 ± 2001.676       #/op
ArrayCopyObject.conjoint_micro:dTLB-loads:u                 8191  thrpt    3  2184.483 ± 1365.906       #/op
ArrayCopyObject.conjoint_micro:dTLB-store-misses:u          8191  thrpt    3     0.046 ±    0.282       #/op
ArrayCopyObject.conjoint_micro:dTLB-stores:u                8191  thrpt    3  2141.689 ± 1344.038       #/op
ArrayCopyObject.conjoint_micro:iTLB-load-misses:u           8191  thrpt    3     0.080 ±    0.350       #/op
ArrayCopyObject.conjoint_micro:iTLB-loads:u                 8191  thrpt    3  3535.857 ± 1996.573       #/op
ArrayCopyObject.conjoint_micro:instructions:u               8191  thrpt    3  1672.908 ±  103.335       #/op
ArrayCopyObject.conjoint_micro:stalled-cycles-backend:u     8191  thrpt    3   356.269 ±   56.656       #/op
ArrayCopyObject.conjoint_micro:stalled-cycles-frontend:u    8191  thrpt    3  2607.772 ± 1967.460       #/op
ArrayCopyObject.disjoint_micro                              8191  thrpt   12   593.736 ±   20.701     ops/ms
ArrayCopyObject.disjoint_micro:CPI                          8191  thrpt    3     2.596 ±    1.396  clks/insn
ArrayCopyObject.disjoint_micro:IPC                          8191  thrpt    3     0.385 ±    0.207  insns/clk
ArrayCopyObject.disjoint_micro:L1-dcache-load-misses:u      8191  thrpt    3     0.297 ±    0.073       #/op
ArrayCopyObject.disjoint_micro:L1-dcache-loads:u            8191  thrpt    3  2262.918 ±   27.918       #/op
ArrayCopyObject.disjoint_micro:L1-dcache-store-misses:u     8191  thrpt    3     0.008 ±    0.002       #/op
ArrayCopyObject.disjoint_micro:L1-dcache-stores:u           8191  thrpt    3  2183.234 ±   17.175       #/op
ArrayCopyObject.disjoint_micro:L1-icache-load-misses:u      8191  thrpt    3     0.082 ±    0.029       #/op
ArrayCopyObject.disjoint_micro:L1-icache-loads:u            8191  thrpt    3   783.750 ±   83.736       #/op
ArrayCopyObject.disjoint_micro:branch-misses:u              8191  thrpt    3     0.083 ±    0.107       #/op
ArrayCopyObject.disjoint_micro:branches:u                   8191  thrpt    3   268.309 ±    3.777       #/op
ArrayCopyObject.disjoint_micro:cycles:u                     8191  thrpt    3  3689.134 ± 1978.110       #/op
ArrayCopyObject.disjoint_micro:dTLB-loads:u                 8191  thrpt    3  2262.315 ±   12.862       #/op
ArrayCopyObject.disjoint_micro:dTLB-store-misses:u          8191  thrpt    3     0.074 ±    0.218       #/op
ArrayCopyObject.disjoint_micro:dTLB-stores:u                8191  thrpt    3  2182.850 ±   18.595       #/op
ArrayCopyObject.disjoint_micro:iTLB-load-misses:u           8191  thrpt    3     0.102 ±    0.104       #/op
ArrayCopyObject.disjoint_micro:iTLB-loads:u                 8191  thrpt    3  3677.326 ± 1991.190       #/op
ArrayCopyObject.disjoint_micro:instructions:u               8191  thrpt    3  1421.135 ±    2.488       #/op
ArrayCopyObject.disjoint_micro:stalled-cycles-backend:u     8191  thrpt    3   239.125 ±  974.147       #/op
ArrayCopyObject.disjoint_micro:stalled-cycles-frontend:u    8191  thrpt    3  3133.978 ± 1983.534       #/op
Finished running test 'micro:org.openjdk.bench.java.lang.ArrayCopyObject'
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388837](https://bugs.openjdk.org/browse/JDK-8388837): RISC-V: Track card addresses directly in G1 array post-write barrier loop (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32020/head:pull/32020` \
`$ git checkout pull/32020`

Update a local copy of the PR: \
`$ git checkout pull/32020` \
`$ git pull https://git.openjdk.org/jdk.git pull/32020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32020`

View PR using the GUI difftool: \
`$ git pr show -t 32020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32020.diff">https://git.openjdk.org/jdk/pull/32020.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32020#issuecomment-5057328891)
</details>
