### PR TITLE
8388838: RISC-V: vectorization tests failed when UseUnalignedAccesses is false

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -36,6 +36,7 @@ import java.util.List;
  * @test
  * @bug 8300258
  * @key randomness
+ * @requires vm.opt.final.UseUnalignedAccesses == true
  * @summary C2: vectorization fails on simple ByteBuffer loop
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
@@ -32,6 +32,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8300256
+ * @requires vm.opt.final.UseUnalignedAccesses == true
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizationNotRun

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentByteSizeLongLoopLimit.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentByteSizeLongLoopLimit.java
@@ -65,7 +65,7 @@ public class TestMemorySegmentByteSizeLongLoopLimit {
                   IRNode.ADD_VI, IRNode.VECTOR_SIZE + "min(max_int, max_long)",        "> 0",
                   IRNode.STORE_VECTOR,                          "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIf = {"AlignVector", "false"},
+        applyIfAnd = {"AlignVector", "false", "UseUnalignedAccesses", "true"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"})
     public static void test() {
         for (long i = 0; i < msA.byteSize() / 8L; i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
@@ -227,6 +227,7 @@ class TestMemorySegmentUnalignedAddressImpl {
                   IRNode.ADD_VI,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0",
                   "multiversion",       "= 0"},
+        applyIf = {"UseUnalignedAccesses", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)
@@ -246,7 +247,7 @@ class TestMemorySegmentUnalignedAddressImpl {
                   IRNode.STORE_VECTOR,  "> 0",
                   "multiversion_fast",  "= 4",  // pre, main, drain, post
                   "multiversion_slow",  "= 2"}, // main, post
-        applyIf = {"AlignVector", "true"},
+        applyIfAnd = {"AlignVector", "true", "UseUnalignedAccesses", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)
@@ -277,7 +278,7 @@ class TestMemorySegmentUnalignedAddressImpl {
                   IRNode.STORE_VECTOR,  "> 0",
                   "multiversion_fast",  "= 4",  // pre, main, drain, post
                   "multiversion_slow",  "= 2"}, // main, post
-        applyIf = {"AlignVector", "true"},
+        applyIfAnd = {"AlignVector", "true", "UseUnalignedAccesses", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)

--- a/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
@@ -226,6 +226,7 @@ public class TestBufferVectorization {
                   IRNode.LOAD_VECTOR_I, ">0",
                   IRNode.ADD_VI,        ">0",
                   IRNode.STORE_VECTOR,  ">0"},
+        applyIf = {"UseUnalignedAccesses", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     public static void testArrayView(byte[] b_arr) {
         for (int k = 0; k < b_arr.length; k += 4) {


### PR DESCRIPTION
Some vectorization jtreg tests failed on riscv SG2044. The root cause is UseUnalignedAccesses is disable by default on this machine, so super word optimization is blocked in these tests. We need check this flag before testing.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388838](https://bugs.openjdk.org/browse/JDK-8388838): RISC-V: vectorization tests failed when UseUnalignedAccesses is false (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32021/head:pull/32021` \
`$ git checkout pull/32021`

Update a local copy of the PR: \
`$ git checkout pull/32021` \
`$ git pull https://git.openjdk.org/jdk.git pull/32021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32021`

View PR using the GUI difftool: \
`$ git pr show -t 32021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32021.diff">https://git.openjdk.org/jdk/pull/32021.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32021#issuecomment-5056168704)
</details>
