### PR TITLE
8388543: AArch64: VectorAPI: replace sve_dup+mov with fmovd in sve_vmask_fromlong

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -1506,9 +1506,9 @@ void C2_MacroAssembler::sve_vmask_fromlong(FloatRegister dst, Register src,
   // Expected:  dst = 0x00 01 01 00 00 01 00 01 01 00 00 00 01 01 00 01
 
   // Put long value from general purpose register into the first lane of vector.
+  // The higher lanes are set to zero.
   // vtmp = 0x0000000000000000 | 0x000000000000658D
-  sve_dup(vtmp, B, 0);
-  mov(vtmp, D, 0, src);
+  fmovd(vtmp, src);
 
   // Transform the value in the first lane which is mask in bit now to the mask in
   // byte, which can be done by SVE2's BDEP instruction.


### PR DESCRIPTION
In the implementation `sve_vmask_fromlong` of VectorAPI `fromLong`, the following two instructions
```
sve_dup(vtmp, B, 0);
mov(vtmp, D, 0, src);
```
can be replaced with one instruction:
```
fmovd(vtmp, src);
```

They are functionally equivalent because according to Arm A profile architecture reference manual [1] B1.4.3:
```
RWKYLB  When the Effective SVE vector length (VL) at the current
Exception level is greater than 128 bits, any AArch64 instruction that
writes to an 128-bit SIMD&FP register, V0-V31, sets bits [VL-1:128] to
zero.
```

These three instructions have the same latency and throughput, thus this change saves one instruction.

JMH benchmark test results:

On a Nvidia Grace (Neoverse-V2) machine with 128-bit SVE2:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/erfang/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/erfang/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Fixed;}
.xl66
	{mso-number-format:"0\.0";}
-->
</head>

<body link="#467886" vlink="#96607D">


Benchmark | Unit | Before | Error | After | Error | Uplift
-- | -- | -- | -- | -- | -- | --
microMaskFromLong_Byte128 | ops/ms | 7.7 | 0.0 | 8.5 | 0.0 | 1.10
microMaskFromLong_Byte64 | ops/ms | 8.6 | 0.0 | 9.6 | 0.0 | 1.12
microMaskFromLong_Integer128 | ops/ms | 7.1 | 0.0 | 7.7 | 0.0 | 1.09
microMaskFromLong_Integer64 | ops/ms | 7.0 | 0.0 | 7.7 | 0.0 | 1.11
microMaskFromLong_Long128 | ops/ms | 6.5 | 0.0 | 7.1 | 0.0 | 1.09
microMaskFromLong_Long64 | ops/ms | 6.3 | 0.0 | 6.3 | 0.0 | 1.00
microMaskFromLong_Short128 | ops/ms | 7.7 | 0.0 | 8.5 | 0.0 | 1.10
microMaskFromLong_Short64 | ops/ms | 7.8 | 0.0 | 8.6 | 0.0 | 1.10



</body>

</html>


On an AWS Graviton3 (Neoverse-V1) machine with 256-bit SVE1:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/erfang/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/erfang/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Fixed;}
.xl66
	{mso-number-format:"0\.0";}
-->
</head>

<body link="#467886" vlink="#96607D">


Benchmark | Unit | Before | Error | After | Error | Uplift
-- | -- | -- | -- | -- | -- | --
microMaskFromLong_Byte128 | ops/ms | 4.9 | 0.0 | 4.9 | 0.1 | 1.01
microMaskFromLong_Byte256 | ops/ms | 5.2 | 0.1 | 5.1 | 0.0 | 0.98
microMaskFromLong_Byte64 | ops/ms | 4.9 | 0.0 | 4.9 | 0.0 | 1.00
microMaskFromLong_Integer128 | ops/ms | 5.2 | 0.1 | 5.1 | 0.0 | 0.99
microMaskFromLong_Integer256 | ops/ms | 5.1 | 0.1 | 5.1 | 0.1 | 1.01
microMaskFromLong_Integer64 | ops/ms | 5.1 | 0.0 | 5.1 | 0.1 | 1.00
microMaskFromLong_Long128 | ops/ms | 5.1 | 0.1 | 5.2 | 0.0 | 1.01
microMaskFromLong_Long256 | ops/ms | 5.2 | 0.1 | 5.4 | 0.1 | 1.02
microMaskFromLong_Long64 | ops/ms | 4.6 | 0.0 | 4.6 | 0.0 | 1.00
microMaskFromLong_Short128 | ops/ms | 4.9 | 0.1 | 4.9 | 0.0 | 0.99
microMaskFromLong_Short256 | ops/ms | 5.0 | 0.1 | 5.1 | 0.1 | 1.01
microMaskFromLong_Short64 | ops/ms | 5.1 | 0.1 | 5.1 | 0.0 | 1.01



</body>

</html>

There's almost no performance change because the `Mask.fromLong` API is not intrinsified on Neoverse-V1.

There are enough conformance and performance tests for this API, see `VectorMaskFromLongTest.java`, `test/jdk/jdk/incubator/vector/` and `MaskFromLongBenchmark.java`, so this PR doesn't add new tests. All existing tests passed with SVE2, SVE1 and NEON.

[1] https://developer.arm.com/documentation/ddi0487/mc/?lang=en




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388543](https://bugs.openjdk.org/browse/JDK-8388543): AArch64: VectorAPI: replace sve_dup+mov with fmovd in sve_vmask_fromlong (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32022/head:pull/32022` \
`$ git checkout pull/32022`

Update a local copy of the PR: \
`$ git checkout pull/32022` \
`$ git pull https://git.openjdk.org/jdk.git pull/32022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32022`

View PR using the GUI difftool: \
`$ git pr show -t 32022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32022.diff">https://git.openjdk.org/jdk/pull/32022.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32022#issuecomment-5057297388)
</details>
