### PR TITLE
8388849: javax/swing/JInternalFrame/8069348/bug8069348.java should ignore execution in non-Windows platform if sun.java2d.d3d=true

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
+++ b/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ import static sun.awt.OSInfo.*;
  * @author Alexandr Scherbatiy
  * @modules java.desktop/sun.awt
  * @run main/othervm -Dsun.java2d.uiScale=2 bug8069348
- * @run main/othervm -Dsun.java2d.d3d=true -Dsun.java2d.uiScale=2 bug8069348
  */
 public class bug8069348 {
 
@@ -63,10 +62,6 @@ public class bug8069348 {
     private static JInternalFrame internalFrame;
 
     public static void main(String[] args) throws Exception {
-
-        if (!isSupported()) {
-            return;
-        }
 
         try {
 
@@ -118,12 +113,6 @@ public class bug8069348 {
             });
         }
         System.out.println("Test Passed");
-    }
-
-    private static boolean isSupported() {
-        String d3d = System.getProperty("sun.java2d.d3d");
-        System.out.println("d3d " + d3d);
-        return !Boolean.parseBoolean(d3d) || getOSType() == OSType.WINDOWS;
     }
 
     private static Rectangle getInternalFrameScreenBounds() throws Exception {

--- a/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
+++ b/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
@@ -123,7 +123,7 @@ public class bug8069348 {
     private static boolean isSupported() {
         String d3d = System.getProperty("sun.java2d.d3d");
         System.out.println("d3d " + d3d);
-        return !Boolean.getBoolean(d3d) || getOSType() == OSType.WINDOWS;
+        return !Boolean.parseBoolean(d3d) || getOSType() == OSType.WINDOWS;
     }
 
     private static Rectangle getInternalFrameScreenBounds() throws Exception {


### PR DESCRIPTION
Test should not run in non-WIndows platform if `sun.java2d.d3d=true` but `isSupported` call in the test checks for `Boolean.getBoolean(d3d)` which returns false as it treats "true" as the name of another system property
so we need to use `Boolean.parseBoolean` which returns true and `isSupported` in that case returns false 
so that test should be ignored for non-Windows platform if d3d is true

Since 1st @run execution already tests for default pipeline in non-Windows platform, there's no need to run it again if d3d is true 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388849](https://bugs.openjdk.org/browse/JDK-8388849): javax/swing/JInternalFrame/8069348/bug8069348.java should ignore execution in non-Windows platform if sun.java2d.d3d=true (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32024/head:pull/32024` \
`$ git checkout pull/32024`

Update a local copy of the PR: \
`$ git checkout pull/32024` \
`$ git pull https://git.openjdk.org/jdk.git pull/32024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32024`

View PR using the GUI difftool: \
`$ git pr show -t 32024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32024.diff">https://git.openjdk.org/jdk/pull/32024.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32024#issuecomment-5057973746)
</details>
