### PR TITLE
8388872: Avoid unused variables warnings in libj2pkcs11

### DIFF
--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -79,10 +79,11 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     jstring jGetFunctionList)
 {
     HINSTANCE hModule;
-    int i = 0;
+#ifdef DEBUG
     CK_ULONG ulCount = 0;
     CK_C_GetInterfaceList C_GetInterfaceList = NULL;
     CK_INTERFACE_PTR iList = NULL;
+#endif
     CK_C_GetInterface C_GetInterface = NULL;
     CK_INTERFACE_PTR interface = NULL;
     CK_C_GetFunctionList C_GetFunctionList = NULL;
@@ -139,7 +140,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
             iList = (CK_INTERFACE_PTR)
                     malloc(ulCount*sizeof(CK_INTERFACE));
             rv = C_GetInterfaceList(iList, &ulCount);
-            for (i=0; i < (int)ulCount; i++) {
+            for (int i=0; i < (int)ulCount; i++) {
                 printf("interface %s version %d.%d funcs %p flags 0x%lu\n",
                         iList[i].pInterfaceName,
                         ((CK_VERSION *)iList[i].pFunctionList)->major,

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
@@ -79,11 +79,6 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     jstring jGetFunctionList)
 {
     HINSTANCE hModule;
-#ifdef DEBUG
-    CK_ULONG ulCount = 0;
-    CK_C_GetInterfaceList C_GetInterfaceList = NULL;
-    CK_INTERFACE_PTR iList = NULL;
-#endif
     CK_C_GetInterface C_GetInterface = NULL;
     CK_INTERFACE_PTR interface = NULL;
     CK_C_GetFunctionList C_GetFunctionList = NULL;
@@ -127,10 +122,12 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     }
 
 #ifdef DEBUG
+    CK_ULONG ulCount = 0;
+    CK_INTERFACE_PTR iList = NULL;
     /*
      * Get function pointer to C_GetInterfaceList
      */
-    C_GetInterfaceList = (CK_C_GetInterfaceList) GetProcAddress(hModule,
+    CK_C_GetInterfaceList C_GetInterfaceList = (CK_C_GetInterfaceList) GetProcAddress(hModule,
             "C_GetInterfaceList");
     if (C_GetInterfaceList != NULL) {
         TRACE0("Found C_GetInterfaceList func\n");

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
@@ -122,27 +122,30 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     }
 
 #ifdef DEBUG
-    CK_ULONG ulCount = 0;
-    CK_INTERFACE_PTR iList = NULL;
     /*
      * Get function pointer to C_GetInterfaceList
      */
     CK_C_GetInterfaceList C_GetInterfaceList = (CK_C_GetInterfaceList) GetProcAddress(hModule,
             "C_GetInterfaceList");
     if (C_GetInterfaceList != NULL) {
+        CK_ULONG ulCount = 0;
         TRACE0("Found C_GetInterfaceList func\n");
         rv = (C_GetInterfaceList)(NULL, &ulCount);
         if (rv == CKR_OK) {
             /* get copy of interfaces */
-            iList = (CK_INTERFACE_PTR)
-                    malloc(ulCount*sizeof(CK_INTERFACE));
-            rv = C_GetInterfaceList(iList, &ulCount);
-            for (int i=0; i < (int)ulCount; i++) {
-                printf("interface %s version %d.%d funcs %p flags 0x%lu\n",
-                        iList[i].pInterfaceName,
-                        ((CK_VERSION *)iList[i].pFunctionList)->major,
-                        ((CK_VERSION *)iList[i].pFunctionList)->minor,
-                        iList[i].pFunctionList, iList[i].flags);
+            CK_INTERFACE_PTR iList = (CK_INTERFACE_PTR) malloc(ulCount*sizeof(CK_INTERFACE));
+            if (iList == NULL) {
+                TRACE0("Connect: error allocating interface list\n");
+            } else {
+                rv = C_GetInterfaceList(iList, &ulCount);
+                for (int i=0; i < (int)ulCount; i++) {
+                    printf("interface %s version %d.%d funcs %p flags 0x%lu\n",
+                            iList[i].pInterfaceName,
+                            ((CK_VERSION *)iList[i].pFunctionList)->major,
+                            ((CK_VERSION *)iList[i].pFunctionList)->minor,
+                            iList[i].pFunctionList, iList[i].flags);
+                }
+                free(iList);
             }
         } else {
             TRACE0("Connect: error polling interface list size\n");


### PR DESCRIPTION
When building a product build with additionally enabled unused initialized variables warnings (e.g. C4189 MSVC warning) we get some warnings/errors in libj2pkcs11 because of variables only used in debug code.
This can and should be avoided.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388872](https://bugs.openjdk.org/browse/JDK-8388872): Avoid unused variables warnings in libj2pkcs11 (**Bug** - P4)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**) Review applies to [cdadc288](https://git.openjdk.org/jdk/pull/32028/files/cdadc2888d44e18a1961d5c8ba72d9233ee6eefe)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32028/head:pull/32028` \
`$ git checkout pull/32028`

Update a local copy of the PR: \
`$ git checkout pull/32028` \
`$ git pull https://git.openjdk.org/jdk.git pull/32028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32028`

View PR using the GUI difftool: \
`$ git pr show -t 32028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32028.diff">https://git.openjdk.org/jdk/pull/32028.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32028#issuecomment-5060599464)
</details>
