### PR TITLE
8388833: Fix JDWP spec w.r.t. setting static final fields and provide warnings about setting final fields

### DIFF
--- a/src/java.se/share/data/jdwp/jdwp.spec
+++ b/src/java.se/share/data/jdwp/jdwp.spec
@@ -1096,8 +1096,6 @@ JDWP "Java(tm) Debug Wire Protocol"
         "field's type exactly. For object values, there must exist a "
         "widening reference conversion from the value's type to the
         "field's type and the field's type must be loaded. "
-        "<p>"
-        
         (Out
             (classType clazz "The class type ID.")
             (Repeat values "The number of fields to set."

--- a/src/java.se/share/data/jdwp/jdwp.spec
+++ b/src/java.se/share/data/jdwp/jdwp.spec
@@ -1090,11 +1090,14 @@ JDWP "Java(tm) Debug Wire Protocol"
         "Each field must be member of the class type "
         "or one of its superclasses, superinterfaces, or implemented interfaces. "
         "Access control is not enforced; for example, the values of private "
-        "fields can be set. Final fields cannot be set."
+        "fields can be set. Setting a final static field is permitted but may "
+        "result in an unexpected exception or a fatal crash. "
         "For primitive values, the value's type must match the "
         "field's type exactly. For object values, there must exist a "
         "widening reference conversion from the value's type to the
         "field's type and the field's type must be loaded. "
+        "<p>"
+        
         (Out
             (classType clazz "The class type ID.")
             (Repeat values "The number of fields to set."
@@ -1586,7 +1589,8 @@ JDWP "Java(tm) Debug Wire Protocol"
         "Each field must be member of the object's type "
         "or one of its superclasses, superinterfaces, or implemented interfaces. "
         "Access control is not enforced; for example, the values of private "
-        "fields can be set. "
+        "fields can be set. Setting a final instance field is permitted but may "
+        "result in an unexpected exception or a fatal crash. "
         "For primitive values, the value's type must match the "
         "field's type exactly. For object values, there must be a "
         "widening reference conversion from the value's type to the

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
@@ -189,13 +189,13 @@ public class setvalues001 {
 
                 log.display("\n>>> Testing JDWP ClassType.SetValues command on tested class\n");
                 testCommand(testedClassID, testedFieldIDs, targetValues);
- 
+
                 log.display("\n>>> Checking with the debuggee that the values have been set properly\n");
                 checkValuesChanged();
 
                 log.display("\n>>> Testing JDWP ClassType.SetValues command on tested final class\n");
                 testCommand(testedFinalClassID, testedFinalFieldIDs, targetValues);
- 
+
                 log.display("\n>>> Checking with JDWP ClassType.GetValues that the values have been set properly \n");
                 checkJDWPValuesChanged(testedFinalClassID, testedFinalFieldIDs, targetValues);
             } finally {
@@ -465,7 +465,7 @@ public class setvalues001 {
         for (int i = 0; i < count; i++) {
             log.display("    field #" + i +":");
             log.display("      fieldID: " + testedFieldIDs[i]);
-            
+
             JDWP.Value actuallValue = actualValues[i];
             JDWP.Value targetValue = targetValues[i];
             JDWP.UntaggedValue untaggedActualValue =

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,10 @@ public class setvalues001 {
     // tested class name and signature constants
     static final String TESTED_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "TestedClass";
     static final String TESTED_CLASS_SIGNATURE = "L" + TESTED_CLASS_NAME.replace('.', '/') + ";";
+
+    // tested final class name and signature constants
+    static final String TESTED_FINAL_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "TestedFinalClass";
+    static final String TESTED_FINAL_CLASS_SIGNATURE = "L" + TESTED_FINAL_CLASS_NAME.replace('.', '/') + ";";
 
     // target values class name and signature constants
     static final String TARGET_VALUES_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "TargetValuesClass";
@@ -147,7 +151,7 @@ public class setvalues001 {
                 log.display("Getting values of the static fields");
                 JDWP.Value targetValues[] =
                         queryClassFieldValues(targetValuesClassID, targetValuesFieldIDs);
-                log.display("  got values: " + targetValues.length);
+                log.display("  got target values: " + targetValues.length);
                 if (targetValues.length != count) {
                     throw new Failure("Unexpected number of static fields values received: "
                                     + targetValues.length + "(expected: " + count + ")");
@@ -157,7 +161,7 @@ public class setvalues001 {
                 log.display("Getting tested classID by signature:\n"
                             + "  " + TESTED_CLASS_SIGNATURE);
                 long testedClassID = debugee.getReferenceTypeID(TESTED_CLASS_SIGNATURE);
-                log.display("  got classID: " + testedClassID);
+                log.display("  got tested classID: " + testedClassID);
 
                 // query debugee for fieldIDs of tested class static fields
                 log.display("Getting fieldIDs for static fields of the tested class");
@@ -168,14 +172,32 @@ public class setvalues001 {
                                     + testedFieldIDs.length + "(expected: " + count + ")");
                 }
 
-                // perform testing JDWP command
-                log.display("\n>>> Testing JDWP command \n");
-                testCommand(testedClassID, testedFieldIDs, targetValues);
+                // query debugee for classID of the tested final class
+                log.display("Getting tested final classID by signature:\n"
+                            + "  " + TESTED_FINAL_CLASS_SIGNATURE);
+                long testedFinalClassID = debugee.getReferenceTypeID(TESTED_FINAL_CLASS_SIGNATURE);
+                log.display("  got tested final classID: " + testedClassID);
 
-                // check confirmation from debuggee that values have been set properly
-                log.display("\n>>> Checking that the values have been set properly \n");
+                // query debugee for fieldIDs of tested final class static fields
+                log.display("Getting fieldIDs for static fields of the tested final class");
+                long testedFinalFieldIDs[] = queryClassFieldIDs(testedFinalClassID);
+                log.display("  got fields: " + testedFinalFieldIDs.length);
+                if (testedFinalFieldIDs.length != count) {
+                    throw new Failure("Unexpected number of static fields of tested final class received: "
+                                      + testedFinalFieldIDs.length + "(expected: " + count + ")");
+                }
+
+                log.display("\n>>> Testing JDWP ClassType.SetValues command on tested class\n");
+                testCommand(testedClassID, testedFieldIDs, targetValues);
+ 
+                log.display("\n>>> Checking with the debuggee that the values have been set properly\n");
                 checkValuesChanged();
 
+                log.display("\n>>> Testing JDWP ClassType.SetValues command on tested final class\n");
+                testCommand(testedFinalClassID, testedFinalFieldIDs, targetValues);
+ 
+                log.display("\n>>> Checking with JDWP ClassType.GetValues that the values have been set properly \n");
+                checkJDWPValuesChanged(testedFinalClassID, testedFinalFieldIDs, targetValues);
             } finally {
                 // quit debugee
                 log.display("\n>>> Finishing test \n");
@@ -426,4 +448,37 @@ public class setvalues001 {
         }
     }
 
+    /**
+     * Check confiramtion using JDWP ClassType.GetValues that the values are changed.
+     */
+    void checkJDWPValuesChanged(long testedClassID, long testedFieldIDs[],
+                                JDWP.Value targetValues[]) {
+        // verify that JDWP ClassType.Getvalues returns the expected values
+        int count = targetValues.length;
+        log.display("\n>>> getting field values using JDWP ClassType.GetValues \n");
+        JDWP.Value[] actualValues = queryClassFieldValues(testedClassID, testedFieldIDs);
+        log.display("  got actual values: " + actualValues.length);
+        if (actualValues.length != count) {
+            throw new Failure("Unexpected number of static field values received: "
+                              + actualValues.length + "(expected: " + count + ")");
+        }
+        for (int i = 0; i < count; i++) {
+            log.display("    field #" + i +":");
+            log.display("      fieldID: " + testedFieldIDs[i]);
+            
+            JDWP.Value actuallValue = actualValues[i];
+            JDWP.Value targetValue = targetValues[i];
+            JDWP.UntaggedValue untaggedActualValue =
+                new JDWP.UntaggedValue(actuallValue.getValue());
+            JDWP.UntaggedValue untaggedTargetValue =
+                new JDWP.UntaggedValue(targetValue.getValue());
+            log.display("      untaggedActualValue: " + untaggedActualValue.getValue());
+            log.display("      untaggedTargetValue: " + untaggedTargetValue.getValue());
+            if (!untaggedActualValue.getValue().equals(untaggedTargetValue.getValue())) {
+                log.complain("JDWP found a static field that was not correctly set");
+                success = false;
+            }
+        }
+        log.display("Verfied using JDWP ClassType.Getvalues that all static fields values have been correctly set");
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
@@ -176,7 +176,7 @@ public class setvalues001 {
                 log.display("Getting tested final classID by signature:\n"
                             + "  " + TESTED_FINAL_CLASS_SIGNATURE);
                 long testedFinalClassID = debugee.getReferenceTypeID(TESTED_FINAL_CLASS_SIGNATURE);
-                log.display("  got tested final classID: " + testedClassID);
+                log.display("  got tested final classID: " + testedFinalClassID);
 
                 // query debugee for fieldIDs of tested final class static fields
                 log.display("Getting fieldIDs for static fields of the tested final class");
@@ -421,7 +421,7 @@ public class setvalues001 {
     }
 
     /**
-     * Check confiramtion from debuggee that values are changed.
+     * Check confirmation from debuggee that values are changed.
      */
     void checkValuesChanged() {
         // send debugee signal RUN
@@ -449,7 +449,7 @@ public class setvalues001 {
     }
 
     /**
-     * Check confiramtion using JDWP ClassType.GetValues that the values are changed.
+     * Check confirmation using JDWP ClassType.GetValues that the values are changed.
      */
     void checkJDWPValuesChanged(long testedClassID, long testedFieldIDs[],
                                 JDWP.Value targetValues[]) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
@@ -479,6 +479,8 @@ public class setvalues001 {
                 success = false;
             }
         }
-        log.display("Verfied using JDWP ClassType.Getvalues that all static fields values have been correctly set");
+        if (success) {
+            log.display("Verfied using JDWP ClassType.Getvalues that all static fields values have been correctly set");
+        }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001.java
@@ -453,9 +453,9 @@ public class setvalues001 {
      */
     void checkJDWPValuesChanged(long testedClassID, long testedFieldIDs[],
                                 JDWP.Value targetValues[]) {
-        // verify that JDWP ClassType.Getvalues returns the expected values
+        // verify that JDWP ClassType.GetValues returns the expected values
         int count = targetValues.length;
-        log.display("\n>>> getting field values using JDWP ClassType.GetValues \n");
+        log.display("\n>>> Getting field values using JDWP ClassType.GetValues \n");
         JDWP.Value[] actualValues = queryClassFieldValues(testedClassID, testedFieldIDs);
         log.display("  got actual values: " + actualValues.length);
         if (actualValues.length != count) {
@@ -466,10 +466,10 @@ public class setvalues001 {
             log.display("    field #" + i +":");
             log.display("      fieldID: " + testedFieldIDs[i]);
 
-            JDWP.Value actuallValue = actualValues[i];
+            JDWP.Value actualValue = actualValues[i];
             JDWP.Value targetValue = targetValues[i];
             JDWP.UntaggedValue untaggedActualValue =
-                new JDWP.UntaggedValue(actuallValue.getValue());
+                new JDWP.UntaggedValue(actualValue.getValue());
             JDWP.UntaggedValue untaggedTargetValue =
                 new JDWP.UntaggedValue(targetValue.getValue());
             log.display("      untaggedActualValue: " + untaggedActualValue.getValue());
@@ -480,7 +480,7 @@ public class setvalues001 {
             }
         }
         if (success) {
-            log.display("Verfied using JDWP ClassType.Getvalues that all static fields values have been correctly set");
+            log.display("Verfied using JDWP ClassType.GetValues that all static fields values have been correctly set");
         }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001a.java
@@ -331,7 +331,7 @@ public class setvalues001a {
                   static String   stringValue  = OriginalValuesClass.stringValue;
                   static Object   objectValue  = OriginalValuesClass.objectValue;
     }
-   
+
     // tested class with own static final fields values
     public static class TestedFinalClass {
         private   static final boolean  booleanValue = OriginalValuesClass.booleanValue;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ public class setvalues001a {
         OriginalValuesClass original = new OriginalValuesClass();
         TargetValuesClass target = new TargetValuesClass();
         TestedClass tested = new TestedClass();
+        TestedFinalClass testedFinal = new TestedFinalClass();
 
         // send debugger signal READY
         log.display("Sending signal to debugger: " + setvalues001.READY);
@@ -279,7 +280,7 @@ public class setvalues001a {
         }
 */
 
-        // check taht no any changed value differs from target
+        // check that none of the changed values differs from target
         if (different > 0) {
             log.complain("Values of " + different + " fields have not been set correctly");
             return false;
@@ -303,7 +304,7 @@ public class setvalues001a {
         static final Object  objectValue  = new OriginalValuesClass();
     }
 
-    // class with the original values of static fields
+    // class with the target values of static fields
     public static class TargetValuesClass {
         static final boolean booleanValue = false;
         static final byte    byteValue    = (byte)0x0F;
@@ -329,6 +330,20 @@ public class setvalues001a {
                   static double   doubleValue  = OriginalValuesClass.doubleValue;
                   static String   stringValue  = OriginalValuesClass.stringValue;
                   static Object   objectValue  = OriginalValuesClass.objectValue;
+    }
+   
+    // tested class with own static final fields values
+    public static class TestedFinalClass {
+        private   static final boolean  booleanValue = OriginalValuesClass.booleanValue;
+        private   static final byte     byteValue    = OriginalValuesClass.byteValue;
+        protected static final char     charValue    = OriginalValuesClass.charValue;
+        protected static final int      intValue     = OriginalValuesClass.intValue;
+        public    static final short    shortValue   = OriginalValuesClass.shortValue;
+        public    static final long     longValue    = OriginalValuesClass.longValue;
+                  static final float    floatValue   = OriginalValuesClass.floatValue;
+                  static final double   doubleValue  = OriginalValuesClass.doubleValue;
+                  static final String   stringValue  = OriginalValuesClass.stringValue;
+                  static final Object   objectValue  = OriginalValuesClass.objectValue;
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
@@ -551,7 +551,7 @@ public class setvalues001 {
         for (int i = 0; i < count; i++) {
             log.display("    field #" + i +":");
             log.display("      fieldID: " + testedFieldIDs[i]);
-            
+
             JDWP.Value actuallValue = actualValues[i];
             JDWP.Value targetValue = targetValues[i];
             JDWP.UntaggedValue untaggedActualValue =

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,16 +67,21 @@ public class setvalues001 {
     static final String TESTED_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "TestedClass";
     static final String TESTED_CLASS_SIGNATURE = "L" + TESTED_CLASS_NAME.replace('.', '/') + ";";
 
+    // tested final class name and signature constants
+    static final String TESTED_FINAL_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "TestedFinalClass";
+    static final String TESTED_FINAL_CLASS_SIGNATURE = "L" + TESTED_FINAL_CLASS_NAME.replace('.', '/') + ";";
+
     // target values class name and signature constants
     static final String TARGET_VALUES_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "TargetValuesClass";
     static final String TARGET_VALUES_CLASS_SIGNATURE = "L" + TARGET_VALUES_CLASS_NAME.replace('.', '/') + ";";
 
-    // name and siagnature of a class with static field with the tested object value
+    // name and signature of a class with static field with the tested object value
     static final String OBJECT_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "ObjectClass";
     static final String OBJECT_CLASS_SIGNATURE = "L" + OBJECT_CLASS_NAME.replace('.', '/') + ";";
 
-    // name of the static field in the tested class with the tested object value
+    // name of the static field in ObjectClass with the tested object values
     static final String OBJECT_FIELD_NAME = setvalues001a.OBJECT_FIELD_NAME;
+    static final String FINAL_OBJECT_FIELD_NAME = setvalues001a.FINAL_OBJECT_FIELD_NAME;
 
     // usual scaffold objects
     ArgumentHandler argumentHandler = null;
@@ -154,7 +159,7 @@ public class setvalues001 {
                 log.display("Getting values of the static fields");
                 JDWP.Value targetValues[] =
                         queryClassFieldValues(targetValuesClassID, targetValuesFieldIDs);
-                log.display("  got values: " + targetValues.length);
+                log.display("  got target values: " + targetValues.length);
                 if (targetValues.length != count) {
                     throw new Failure("Unexpected number of static fields values received: "
                                     + targetValues.length + "(expected: " + count + ")");
@@ -164,7 +169,7 @@ public class setvalues001 {
                 log.display("Getting tested classID by signature:\n"
                             + "  " + TESTED_CLASS_SIGNATURE);
                 long testedClassID = debugee.getReferenceTypeID(TESTED_CLASS_SIGNATURE);
-                log.display("  got classID: " + testedClassID);
+                log.display("  got tested classID: " + testedClassID);
 
                 // query debugee for fieldIDs of tested class fields
                 log.display("Getting fieldIDs for tested fields of the tested class");
@@ -173,6 +178,21 @@ public class setvalues001 {
                 if (testedFieldIDs.length != count) {
                     throw new Failure("Unexpected number of fields of tested class received: "
                                     + testedFieldIDs.length + "(expected: " + count + ")");
+                }
+
+                // query debugee for classID of the tested final class
+                log.display("Getting tested final classID by signature:\n"
+                            + "  " + TESTED_FINAL_CLASS_SIGNATURE);
+                long testedFinalClassID = debugee.getReferenceTypeID(TESTED_FINAL_CLASS_SIGNATURE);
+                log.display("  got tested final classID: " + testedClassID);
+
+                // query debugee for fieldIDs of tested final class fields
+                log.display("Getting fieldIDs for tested fields of the tested final class");
+                long testedFinalFieldIDs[] = queryClassFieldIDs(testedFinalClassID);
+                log.display("  got fields: " + testedFinalFieldIDs.length);
+                if (testedFinalFieldIDs.length != count) {
+                    throw new Failure("Unexpected number of fields of tested final class received: "
+                                      + testedFinalFieldIDs.length + "(expected: " + count + ")");
                 }
 
                 // query debugee for classID of the object class
@@ -188,14 +208,24 @@ public class setvalues001 {
                             OBJECT_FIELD_NAME, JDWP.Tag.OBJECT);
                 log.display("  got objectID: " + objectID);
 
-                // perform testing JDWP command
-                log.display("\n>>> Testing JDWP command \n");
+                // query debuggee for finalObjectID value from static field
+                log.display("Getting finalObjectID value from static field: "
+                            + FINAL_OBJECT_FIELD_NAME);
+                long finalObjectID = queryObjectID(classID,
+                            FINAL_OBJECT_FIELD_NAME, JDWP.Tag.OBJECT);
+                log.display("  got finalObjectID: " + finalObjectID);
+
+                log.display("\n>>> Testing JDWP ObjectReference.SetValues command on tested class\n");
                 testCommand(objectID, testedFieldIDs, targetValues);
 
-                // check confirmation from debuggee that values have been set properly
-                log.display("\n>>> Checking that the values have been set properly \n");
+                log.display("\n>>> Checking with the debuggee that the values have been set properly\n");
                 checkValuesChanged();
 
+                log.display("\n>>> Testing JDWP ObjectReference.SetValues command on tested final class\n");
+                testCommand(finalObjectID, testedFinalFieldIDs, targetValues);
+
+                log.display("\n>>> Checking with JDWP ObjectReference.GetValues that the values have been set properly\n");
+                checkJDWPValuesChanged(finalObjectID, testedFinalFieldIDs, targetValues);
             } finally {
                 // quit debugee
                 log.display("\n>>> Finishing test \n");
@@ -345,6 +375,43 @@ public class setvalues001 {
     }
 
     /**
+     * Query debugee for values of the object fields.
+     */
+    JDWP.Value[] queryObjectFieldValues(long objectID, long fieldIDs[]) {
+        // compose ReferenceType.Fields command packet
+        int count = fieldIDs.length;
+        CommandPacket command = new CommandPacket(JDWP.Command.ObjectReference.GetValues);
+        command.addObjectID(objectID);
+        command.addInt(count);
+        for (int i = 0; i < count; i++) {
+            command.addFieldID(fieldIDs[i]);
+        }
+        command.setLength();
+
+        // send the command and receive reply
+        ReplyPacket reply = debugee.receiveReplyFor(command);
+
+        // extract values from the reply packet
+        try {
+            reply.resetPosition();
+
+            int valuesCount = reply.getInt();
+            JDWP.Value values[] = new JDWP.Value[valuesCount];
+            for (int i = 0; i < valuesCount; i++ ) {
+                JDWP.Value value = reply.getValue();
+                values[i] = value;
+            }
+            return values;
+        } catch (BoundException e) {
+            log.complain("Unable to parse reply packet for ReferenceType.GetValues command:\n\t"
+                        + e);
+            log.complain("Received reply packet:\n"
+                        + reply);
+            throw new Failure("Error occured while getting fields values for objectID: " + objectID);
+        }
+    }
+
+    /**
      * Query debuggee for objectID value of static class field.
      */
     long queryObjectID(long classID, String fieldName, byte tag) {
@@ -467,4 +534,37 @@ public class setvalues001 {
         }
     }
 
+    /**
+     * Check confiramtion using JDWP ObjectReference.GetValues that the values are changed.
+     */
+    void checkJDWPValuesChanged(long testedObjectID, long testedFieldIDs[],
+                                JDWP.Value targetValues[]) {
+        // verify that JDWP ObjectReference.Getvalues returns the expected values
+        int count = targetValues.length;
+        log.display("\n>>> getting field values using JDWP ObjectReference.GetValues \n");
+        JDWP.Value[] actualValues = queryObjectFieldValues(testedObjectID, testedFieldIDs);
+        log.display("  got actual values: " + actualValues.length);
+        if (actualValues.length != count) {
+            throw new Failure("Unexpected number of field values received: "
+                              + actualValues.length + "(expected: " + count + ")");
+        }
+        for (int i = 0; i < count; i++) {
+            log.display("    field #" + i +":");
+            log.display("      fieldID: " + testedFieldIDs[i]);
+            
+            JDWP.Value actuallValue = actualValues[i];
+            JDWP.Value targetValue = targetValues[i];
+            JDWP.UntaggedValue untaggedActualValue =
+                new JDWP.UntaggedValue(actuallValue.getValue());
+            JDWP.UntaggedValue untaggedTargetValue =
+                new JDWP.UntaggedValue(targetValue.getValue());
+            log.display("      untaggedActualValue: " + untaggedActualValue.getValue());
+            log.display("      untaggedTargetValue: " + untaggedTargetValue.getValue());
+            if (!untaggedActualValue.getValue().equals(untaggedTargetValue.getValue())) {
+                log.complain("JDWP found a field that was not correctly set");
+                success = false;
+            }
+        }
+        log.display("Verfied using JDWP ObjectReference.Getvalues that all fields values have been correctly set");
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
@@ -507,7 +507,7 @@ public class setvalues001 {
     }
 
     /**
-     * Check confiramtion from debuggee that values are changed.
+     * Check confirmation from debuggee that values are changed.
      */
     void checkValuesChanged() {
         // send debugee signal RUN
@@ -535,7 +535,7 @@ public class setvalues001 {
     }
 
     /**
-     * Check confiramtion using JDWP ObjectReference.GetValues that the values are changed.
+     * Check confirmation using JDWP ObjectReference.GetValues that the values are changed.
      */
     void checkJDWPValuesChanged(long testedObjectID, long testedFieldIDs[],
                                 JDWP.Value targetValues[]) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
@@ -539,9 +539,9 @@ public class setvalues001 {
      */
     void checkJDWPValuesChanged(long testedObjectID, long testedFieldIDs[],
                                 JDWP.Value targetValues[]) {
-        // verify that JDWP ObjectReference.Getvalues returns the expected values
+        // verify that JDWP ObjectReference.GetValues returns the expected values
         int count = targetValues.length;
-        log.display("\n>>> getting field values using JDWP ObjectReference.GetValues \n");
+        log.display("\n>>> Getting field values using JDWP ObjectReference.GetValues \n");
         JDWP.Value[] actualValues = queryObjectFieldValues(testedObjectID, testedFieldIDs);
         log.display("  got actual values: " + actualValues.length);
         if (actualValues.length != count) {
@@ -552,10 +552,10 @@ public class setvalues001 {
             log.display("    field #" + i +":");
             log.display("      fieldID: " + testedFieldIDs[i]);
 
-            JDWP.Value actuallValue = actualValues[i];
+            JDWP.Value actualValue = actualValues[i];
             JDWP.Value targetValue = targetValues[i];
             JDWP.UntaggedValue untaggedActualValue =
-                new JDWP.UntaggedValue(actuallValue.getValue());
+                new JDWP.UntaggedValue(actualValue.getValue());
             JDWP.UntaggedValue untaggedTargetValue =
                 new JDWP.UntaggedValue(targetValue.getValue());
             log.display("      untaggedActualValue: " + untaggedActualValue.getValue());
@@ -566,7 +566,7 @@ public class setvalues001 {
             }
         }
         if (success) {
-            log.display("Verfied using JDWP ObjectReference.Getvalues that all fields values have been correctly set");
+            log.display("Verfied using JDWP ObjectReference.GetValues that all fields values have been correctly set");
         }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001.java
@@ -184,7 +184,7 @@ public class setvalues001 {
                 log.display("Getting tested final classID by signature:\n"
                             + "  " + TESTED_FINAL_CLASS_SIGNATURE);
                 long testedFinalClassID = debugee.getReferenceTypeID(TESTED_FINAL_CLASS_SIGNATURE);
-                log.display("  got tested final classID: " + testedClassID);
+                log.display("  got tested final classID: " + testedFinalClassID);
 
                 // query debugee for fieldIDs of tested final class fields
                 log.display("Getting fieldIDs for tested fields of the tested final class");
@@ -565,6 +565,8 @@ public class setvalues001 {
                 success = false;
             }
         }
-        log.display("Verfied using JDWP ObjectReference.Getvalues that all fields values have been correctly set");
+        if (success) {
+            log.display("Verfied using JDWP ObjectReference.Getvalues that all fields values have been correctly set");
+        }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.io.*;
 public class setvalues001a {
 
     public static final String OBJECT_FIELD_NAME = "object";
+    public static final String FINAL_OBJECT_FIELD_NAME = "finalObject";
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -58,6 +59,7 @@ public class setvalues001a {
         OriginalValuesClass original = new OriginalValuesClass();
         TargetValuesClass target = new TargetValuesClass();
         ObjectClass.object = new TestedClass();
+        ObjectClass.finalObject = new TestedFinalClass();
 
         // send debugger signal READY
         log.display("Sending signal to debugger: " + setvalues001.READY);
@@ -284,7 +286,7 @@ public class setvalues001a {
         }
 */
 
-        // check taht no any changed value differs from target
+        // check that none of the changed values differs from target
         if (different > 0) {
             log.complain("Values of " + different + " fields have not been set correctly");
             return false;
@@ -294,7 +296,7 @@ public class setvalues001a {
         return true;
     }
 
-    // class with the original values of static fields
+    // class with the original values of instance fields
     public static class OriginalValuesClass {
         static final boolean booleanValue = true;
         static final byte    byteValue    = (byte)0x01;
@@ -308,7 +310,7 @@ public class setvalues001a {
         static final Object  objectValue  = new OriginalValuesClass();
     }
 
-    // class with the original values of static fields
+    // class with the target values of instance fields
     public static class TargetValuesClass {
         static final boolean booleanValue = false;
         static final byte    byteValue    = (byte)0x0F;
@@ -322,7 +324,7 @@ public class setvalues001a {
         static final Object  objectValue  = new TargetValuesClass();
     }
 
-    // tested class with own static fields values
+    // tested class with own instance fields values
     public static class TestedClass {
         private   boolean  booleanValue = OriginalValuesClass.booleanValue;
         private   byte     byteValue    = OriginalValuesClass.byteValue;
@@ -336,10 +338,25 @@ public class setvalues001a {
                   Object   objectValue  = OriginalValuesClass.objectValue;
     }
 
-    // class with static field with the tested object
+    // tested class with own instance final fields values
+    public static class TestedFinalClass {
+        private   final boolean  booleanValue = OriginalValuesClass.booleanValue;
+        private   final byte     byteValue    = OriginalValuesClass.byteValue;
+        protected final char     charValue    = OriginalValuesClass.charValue;
+        protected final int      intValue     = OriginalValuesClass.intValue;
+        public    final short    shortValue   = OriginalValuesClass.shortValue;
+        public    final long     longValue    = OriginalValuesClass.longValue;
+                  final float    floatValue   = OriginalValuesClass.floatValue;
+                  final double   doubleValue  = OriginalValuesClass.doubleValue;
+                  final String   stringValue  = OriginalValuesClass.stringValue;
+                  final Object   objectValue  = OriginalValuesClass.objectValue;
+    }
+
+    // class with static fields with the tested objects
     public static class ObjectClass {
-        // static field with the tested object
+        // static field with the tested objects
         public static TestedClass object = null;
+        public static TestedFinalClass finalObject = null;
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001a.java
@@ -354,7 +354,7 @@ public class setvalues001a {
 
     // class with static fields with the tested objects
     public static class ObjectClass {
-        // static field with the tested objects
+        // static fields with the tested objects
         public static TestedClass object = null;
         public static TestedFinalClass finalObject = null;
     }


### PR DESCRIPTION
The JDWP implementation (debug agent) allows the writing of static final fields and instance final fields. This has always been the case since no checks are made to prevent it, and JNI doesn't prevent it. The JDI spec forbids the setting of final fields, and it has a check that will throw an exception if attempted. However, it is important that we continue to allow JDWP to write final fields because some debuggers allow for it at the JDI level (protected by a click through warning). Although these debuggers are not fully JDI compliant, there is no requirement that they be compliant, so JDWP should continue to support this behavior. Much of this was discussed in the PR for [JDK-8281652](https://bugs.openjdk.org/browse/JDK-8281652), which clarified in the JDI spec that writing final fields was not allowed. This was just a spec clarification. JDI already forbid the setting of final fields.

Having said all that, the JDWP spec for ClassType.SetValues says "Final fields cannot be set." This is clearly wrong as it has always been allowed. ObjectReference.SetValues says nothing about final fields, and also allows them to be set.

This PR has two spec updates:
- Get rid of the "Final fields cannot be set." text for ClassType.SetValues.
- ObjectReference.SetValues and ReferenceType.SetValues should warn against setting final fields by using language similar to JNI.

I've also updated two tests to test for setting both static final fields and instance final fields. The tests (before my changes) verified the setting of fields (not final) on the debuggee side. I tried the same with final fields and ran into problems. The compiler inlines final primitives values, so setting the final fields is not seen when the fields are referenced from java (or at least this was the case with static final fields. I'm not positive about instance final fields). So I added support for using GetValues to verify the results rather than relying on the debuggee's view of the fields.

Testing in progress.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8389222](https://bugs.openjdk.org/browse/JDK-8389222) to be approved

### Issues
 * [JDK-8388833](https://bugs.openjdk.org/browse/JDK-8388833): Fix JDWP spec w.r.t. setting static final fields and provide warnings about setting final fields (**Bug** - P4)
 * [JDK-8389222](https://bugs.openjdk.org/browse/JDK-8389222): Fix JDWP spec w.r.t. setting static final fields and provide warnings about setting final fields (**CSR**)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32029/head:pull/32029` \
`$ git checkout pull/32029`

Update a local copy of the PR: \
`$ git checkout pull/32029` \
`$ git pull https://git.openjdk.org/jdk.git pull/32029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32029`

View PR using the GUI difftool: \
`$ git pr show -t 32029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32029.diff">https://git.openjdk.org/jdk/pull/32029.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32029#issuecomment-5061174916)
</details>
