### PR TITLE
8388883: Exclude CommandLineFlagComboNegative.java from test group hotspot_appcds_dynamic

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -436,6 +436,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/ArchiveRelocationTest.java \
  -runtime/cds/appcds/BadBSM.java \
  -runtime/cds/appcds/CommandLineFlagCombo.java \
+ -runtime/cds/appcds/CommandLineFlagComboNegative.java \
  -runtime/cds/appcds/DumpClassList.java \
  -runtime/cds/appcds/DumpClassListWithLF.java \
  -runtime/cds/appcds/DumpRuntimeClassesTest.java \


### PR DESCRIPTION
Please review this trivial test fix.

When running with

```
jtreg -Dtest.dynamic.cds.archive=true \
  open/test/hotspot/jtreg:hotspot_appcds_dynamic
```

The test CommandLineFlagComboNegative.java throws `SkippedException`.

This test is not suitable for the `hotspot_appcds_dynamic` group. A similar test (CommandLineFlagCombo.java) is already excluded.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388883](https://bugs.openjdk.org/browse/JDK-8388883): Exclude CommandLineFlagComboNegative.java from test group hotspot_appcds_dynamic (**Enhancement** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32030/head:pull/32030` \
`$ git checkout pull/32030`

Update a local copy of the PR: \
`$ git checkout pull/32030` \
`$ git pull https://git.openjdk.org/jdk.git pull/32030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32030`

View PR using the GUI difftool: \
`$ git pr show -t 32030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32030.diff">https://git.openjdk.org/jdk/pull/32030.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32030#issuecomment-5062811872)
</details>
