### PR TITLE
8388882: Disable automatic integer spills to floating point registers on Intel platforms

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1794,7 +1794,7 @@ void VM_Version::get_processor_features() {
     }
 #ifdef COMPILER2
     if (FLAG_IS_DEFAULT(UseFPUForSpilling) && supports_sse4_2()) {
-      FLAG_SET_DEFAULT(UseFPUForSpilling, true);
+      FLAG_SET_DEFAULT(UseFPUForSpilling, false);
     }
 #endif
   }

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1794,7 +1794,12 @@ void VM_Version::get_processor_features() {
     }
 #ifdef COMPILER2
     if (FLAG_IS_DEFAULT(UseFPUForSpilling) && supports_sse4_2()) {
-      FLAG_SET_DEFAULT(UseFPUForSpilling, false);
+      // Spilling to FPU registers not beneficial on Haswell and beyond
+      if (UseAVX > 1) {
+        FLAG_SET_DEFAULT(UseFPUForSpilling, false);
+      } else {
+        FLAG_SET_DEFAULT(UseFPUForSpilling, true);
+      }
     }
 #endif
   }


### PR DESCRIPTION
When operating on integer variables using supported Intel CPUs, the current approach is to spill onto floating point registers when general purpose registers aren't available. Unfortunately, it appears that the cost of doing this is higher than just leaving those variables on the stack. This change disables the `UseFPUForSpilling` flag by default on Intel CPUs starting with Haswell.

To measure performance, the `SpillCode.testSpillForManyInts` micro-benchmark was run on the parts listed below.

- [Intel® Xeon® E5-2699 v3](https://www.cpubenchmark.net/cpu.php?cpu=Intel+Xeon+E5-2699+v3)
- [Intel® Xeon® E5-2699 v4](https://www.cpubenchmark.net/cpu.php?cpu=Intel+Xeon+E5-2699+v4)
- [Intel® Xeon® Platinum 8252C](https://www.cpu-world.com/CPUs/Xeon/Intel-Xeon%208252C.html)
- [Intel® Xeon® Platinum 8375C](https://www.cpu-world.com/CPUs/Xeon/Intel-Xeon%208375C.html)
- [Intel® Xeon® Platinum 8488C](https://www.cpubenchmark.net/cpu.php?cpu=Intel+Xeon+Platinum+8488C)
- [Intel® Xeon® Platinum 8559C](https://www.cpubenchmark.net/cpu.php?cpu=Intel+Xeon+Platinum+8559C&id=7069&cpuCount=2)
- [Intel® Xeon® 6780E](https://www.cpubenchmark.net/cpu.php?cpu=Intel+Xeon+6780E)
- [Intel® Xeon® 6975P-C](https://www.cpubenchmark.net/cpu.php?cpu=Intel+Xeon+6975P-C)

The table below shows how performance changed using the [OpenJDK v28-b6](https://github.com/openjdk/jdk/releases/tag/jdk-28%2B6) build. The **Baseline** column represents runs where the flag was enabled, and the **New** columns represents runs where the flag was disabled. Each result is the mean of 4 individual runs. Overall, setting `UseFPUForSpilling` to false provides an uplift between 1% and 10%.

| Part ID                                           | Baseline runtime (ns/op) | New runtime (ns/op) | Speedup |
| :-------------------------------: | :-----------------------: | :-------------------: | :--------: |
| Intel® Xeon® E5-2699 v3            | 1024.666                         | 1018.896                    | 1.01x       |
| Intel® Xeon® E5-2699 v4            | 543.039                           | 513.085                     | 1.06x       |
| Intel® Xeon® Platinum 8252C     | 551.357                            | 516.526                      | 1.07x       |
| Intel® Xeon® Platinum 8375C     | 726.729                            | 661.194                      | 1.10x       |
| Intel® Xeon® Platinum 8488C     | 644.611                            | 597.476                      | 1.08x      |
| Intel® Xeon® Platinum 8559C     | 613.719                            | 567.634                      | 1.08x      |
| Intel® Xeon® 6780E                     | 840.810                           | 772.914                      | 1.09x      |
| Intel® Xeon® Platinum 6975P-C | 627.716                             | 581.841                     | 1.08x       |

Additionally, other micro-benchmarks show improvements when disabling the flag.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388882](https://bugs.openjdk.org/browse/JDK-8388882): Disable automatic integer spills to floating point registers on Intel platforms (**Enhancement** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Derek White](https://openjdk.org/census#drwhite) (@dwhite-intel - Committer) Review applies to [31efcb31](https://git.openjdk.org/jdk/pull/32031/files/31efcb3168b3da6fa405f8ab4c661270165739fb)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32031/head:pull/32031` \
`$ git checkout pull/32031`

Update a local copy of the PR: \
`$ git checkout pull/32031` \
`$ git pull https://git.openjdk.org/jdk.git pull/32031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32031`

View PR using the GUI difftool: \
`$ git pr show -t 32031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32031.diff">https://git.openjdk.org/jdk/pull/32031.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32031#issuecomment-5064153493)
</details>
