### PR TITLE
8388827: Unused Gen.CodeSizeOverflow

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -903,13 +903,6 @@ public class Gen extends JCTree.Visitor {
  * Visitor methods for statements and definitions
  *************************************************************************/
 
-    /** Thrown when the byte code size exceeds limit.
-     */
-    public static class CodeSizeOverflow extends RuntimeException {
-        private static final long serialVersionUID = 0;
-        public CodeSizeOverflow() {}
-    }
-
     public void visitMethodDef(JCMethodDecl tree) {
         // Create a new local environment that points pack at method
         // definition.
@@ -956,13 +949,7 @@ public class Gen extends JCTree.Visitor {
                 // Create a new code structure and initialize it.
                 int startpcCrt = initCode(tree, env, fatcode);
 
-                try {
-                    genStat(tree.body, env);
-                } catch (CodeSizeOverflow e) {
-                    // Failed due to code limit, try again with jsr/ret
-                    startpcCrt = initCode(tree, env, fatcode);
-                    genStat(tree.body, env);
-                }
+                genStat(tree.body, env);
 
                 if (code.state.stacksize != 0) {
                     log.error(tree.body.pos(), Errors.StackSimError(tree.sym));


### PR DESCRIPTION
`Gen.CodeSizeOverflow` is no longer thrown after support for generating `jsr`/`ret` was removed by JDK-8011044.

This removes the unused exception and its now-unreachable handler. The existing retry for fat jumps remains unchanged.

Testing: 
- `make test TEST=langtools:tier1`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388827](https://bugs.openjdk.org/browse/JDK-8388827): Unused Gen.CodeSizeOverflow (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32035/head:pull/32035` \
`$ git checkout pull/32035`

Update a local copy of the PR: \
`$ git checkout pull/32035` \
`$ git pull https://git.openjdk.org/jdk.git pull/32035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32035`

View PR using the GUI difftool: \
`$ git pr show -t 32035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32035.diff">https://git.openjdk.org/jdk/pull/32035.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32035#issuecomment-5064633104)
</details>
