### PR TITLE
8388842: VER_PLATFORM_WIN32_NT checks in WPrinterJob are obsolete

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/WPrinterJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/WPrinterJob.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,45 +53,33 @@ Java_sun_print_PrintServiceLookupProvider_getDefaultPrinterName(JNIEnv *env,
     TRY;
 
     TCHAR cBuffer[250];
-    OSVERSIONINFO osv;
-    PRINTER_INFO_2 *ppi2 = NULL;
-    DWORD dwNeeded = 0;
-    DWORD dwReturned = 0;
     LPTSTR pPrinterName = NULL;
     jstring jPrinterName;
 
-    // What version of Windows are you running?
-    osv.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-    GetVersionEx(&osv);
-
-    // If Windows 2000, XP, Vista
-    if (osv.dwPlatformId == VER_PLATFORM_WIN32_NT) {
-
-       // Retrieve the default string from Win.ini (the registry).
-       // String will be in form "printername,drivername,portname".
-
-       if (GetProfileString(TEXT("windows"), TEXT("device"), TEXT(",,,"),
-                            cBuffer, 250) <= 0) {
-           return NULL;
-       }
-       // Copy printer name into passed-in buffer...
-       int index = 0;
-       int len = lstrlen(cBuffer);
-       while ((index < len) && cBuffer[index] != _T(',')) {
-              index++;
-       }
-       if (index==0) {
-         return NULL;
-       }
-
-       pPrinterName = (LPTSTR)GlobalAlloc(GPTR, (index+1)*sizeof(TCHAR));
-       lstrcpyn(pPrinterName, cBuffer, index+1);
-       jPrinterName = JNU_NewStringPlatform(env, pPrinterName);
-       GlobalFree(pPrinterName);
-       return jPrinterName;
-    } else {
+    // Retrieve the default string from Win.ini (the registry).
+    // String will be in form "printername,drivername,portname".
+    if (GetProfileString(TEXT("windows"), TEXT("device"), TEXT(",,,"),
+                         cBuffer, 250) <= 0) {
         return NULL;
     }
+    // Copy printer name into passed-in buffer...
+    int index = 0;
+    int len = lstrlen(cBuffer);
+    while ((index < len) && cBuffer[index] != _T(',')) {
+        index++;
+    }
+    if (index==0) {
+        return NULL;
+    }
+
+    pPrinterName = (LPTSTR)GlobalAlloc(GPTR, (index+1)*sizeof(TCHAR));
+    if (pPrinterName == NULL) {
+        return NULL;
+    }
+    lstrcpyn(pPrinterName, cBuffer, index+1);
+    jPrinterName = JNU_NewStringPlatform(env, pPrinterName);
+    GlobalFree(pPrinterName);
+    return jPrinterName;
 
     CATCH_BAD_ALLOC_RET(NULL);
 }


### PR DESCRIPTION
At some places in the coding we still check for VER_PLATFORM_WIN32_NT, but this should be obsolete.
All Windows versions from at least Windows XP fall in this category
https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa

There is another usage in java.base (java.base/windows/native/libjava/java_props_md.c), I can handle this here or do the java.base adjustment in another PR.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388842](https://bugs.openjdk.org/browse/JDK-8388842): VER_PLATFORM_WIN32_NT checks in WPrinterJob are obsolete (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32037/head:pull/32037` \
`$ git checkout pull/32037`

Update a local copy of the PR: \
`$ git checkout pull/32037` \
`$ git pull https://git.openjdk.org/jdk.git pull/32037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32037`

View PR using the GUI difftool: \
`$ git pr show -t 32037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32037.diff">https://git.openjdk.org/jdk/pull/32037.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32037#issuecomment-5067356832)
</details>
