### PR TITLE
8388926: RISC-V: Skip redundant zext.w in set_narrow_klass when bit 31 is clear

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -5325,7 +5325,12 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
   relocate(metadata_Relocation::spec(index), [&] {
     li32(dst, nk);
   });
-  zext(dst, dst, 32);
+  // li32 uses addiw which sign-extends; only need zext when bit 31 is set.
+  // Safe: narrow klass immediates are never patched at runtime on RISC-V
+  // (see metadata_Relocation::pd_fix_value).
+  if ((int32_t)nk < 0) {
+    zext(dst, dst, 32);
+  }
 }
 
 address MacroAssembler::reloc_call(Address entry, Register tmp) {

--- a/src/hotspot/cpu/riscv/relocInfo_riscv.cpp
+++ b/src/hotspot/cpu/riscv/relocInfo_riscv.cpp
@@ -117,5 +117,8 @@ void poll_Relocation::fix_relocation_after_move(const CodeBuffer* src, CodeBuffe
   }
 }
 
+// Currently a no-op: no immediate patching is performed.
+// If this changes, update MacroAssembler::set_narrow_klass accordingly
+// (its conditional zext relies on the narrow klass value being immutable).
 void metadata_Relocation::pd_fix_value(address x) {
 }


### PR DESCRIPTION
Hi, please consider.
MacroAssembler::set_narrow_klass uses li32 (lui + addiw) to materialize a narrow klass constant into a register. Since addiw sign-extends the 32-bit result to 64 bits, the function previously emitted a zext.w unconditionally to clear the upper 32 bits. However, sign extension only corrupts the upper bits when bit 31 of the narrow klass value is set (i.e., (int32_t)nk < 0). When bit 31 is clear, addiw naturally produces a correctly zero-extended result, making zext.w redundant.

### Correctness Testing
- [ ] Run tier1-tier3 test with release on SG2044

### Assembly log verification
The command to print the Assembly log is as follows:
`./java -XX:+UnlockDiagnosticVMOptions -XX:+PrintAssembly -XX:CompileCommand=compileonly,java.util.HashMap::putVal -version > assembly.log` 
We can observe that after the optimization, the instruction .insn 4, 0x080888bb has been successfully eliminated, this is a Zba extension instruction. After decoding, it is add.uw a7, a7, zero, which is equivalent to zext.w a7, a7

without this patch:
```
Compiled method (c2) 775   22             java.util.HashMap::putVal (300 bytes)
...
  0x0000003f8d09409e:   addiw	s2,zero,981
  0x0000003f8d0940a2:   slli	s2,s2,0x2a
  0x0000003f8d0940a4:   addi	s2,s2,1
  0x0000003f8d0940a6:   lui	a7,0x0                      ;   {metadata('java/util/LinkedHashMap')}
  0x0000003f8d0940aa:   addiw	a7,a7,2034 # 0x00000000000007f2
  0x0000003f8d0940ae:   .insn	4, 0x080888bb
  0x0000003f8d0940b2:   slli	a4,t2,0x3                   ;*aaload {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - java.util.HashMap::putVal@40 (line 662)
  0x0000003f8d0940b6:   lui	a5,0x0                      ;   {metadata('java/util/HashMap')}
  0x0000003f8d0940ba:   addiw	a5,a5,973 # 0x00000000000003cd
  0x0000003f8d0940be:   .insn	4, 0x080787bb
  0x0000003f8d0940c2:   ld	t3,8(sp)
  0x0000003f8d0940c4:   addiw	s3,zero,985
  0x0000003f8d0940c8:   slli	s3,s3,0x2a
  0x0000003f8d0940ca:   addi	s3,s3,1
  0x0000003f8d0940cc:   ld	a2,16(sp)
  0x0000003f8d0940ce:   li	t4,1
  0x0000003f8d0940d0:   srli	a1,t3,0x3                   ;*putfield key {reexecute=0 rethrow=0 return_oop=0}
```
with this patch:
```
Compiled method (c2) 775   22             java.util.HashMap::putVal (300 bytes)
...
  0x0000003fa1093e1e:   addiw	s2,zero,981
  0x0000003fa1093e22:   slli	s2,s2,0x2a
  0x0000003fa1093e24:   addi	s2,s2,1
  0x0000003fa1093e26:   lui	a7,0x0                      ;   {metadata('java/util/LinkedHashMap')}
  0x0000003fa1093e2a:   addiw	a7,a7,2034 # 0x00000000000007f2
  0x0000003fa1093e2e:   slli	a4,t2,0x3                   ;*aaload {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - java.util.HashMap::putVal@40 (line 662)
  0x0000003fa1093e32:   lui	a5,0x0                      ;   {metadata('java/util/HashMap')}
  0x0000003fa1093e36:   addiw	a5,a5,973 # 0x00000000000003cd
  0x0000003fa1093e3a:   ld	t3,8(sp)
  0x0000003fa1093e3c:   addiw	s3,zero,985
  0x0000003fa1093e40:   slli	s3,s3,0x2a
  0x0000003fa1093e42:   addi	s3,s3,1
  0x0000003fa1093e44:   ld	a2,16(sp)
  0x0000003fa1093e46:   li	t4,1
  0x0000003fa1093e48:   srli	a1,t3,0x3                   ;*putfield key {reexecute=0 rethrow=0 return_oop=0}
```

### Performance Test:
specjbb2015 without this patch:
```
RUN RESULT: hbIR (max attempted) = 4579, hbIR (settled) = 4365, max-jOPS = 4350, critical-jOPS = 1129
```

specjbb2015 witch this patch:
```
RUN RESULT: hbIR (max attempted) = 4187, hbIR (settled) = 4038, max-jOPS = 4396, critical-jOPS = 1170
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388926](https://bugs.openjdk.org/browse/JDK-8388926): RISC-V: Skip redundant zext.w in set_narrow_klass when bit 31 is clear (**Enhancement** - P4)


### Contributors
 * gns `<wangbingzhen.riscv@isrc.iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32038/head:pull/32038` \
`$ git checkout pull/32038`

Update a local copy of the PR: \
`$ git checkout pull/32038` \
`$ git pull https://git.openjdk.org/jdk.git pull/32038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32038`

View PR using the GUI difftool: \
`$ git pr show -t 32038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32038.diff">https://git.openjdk.org/jdk/pull/32038.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32038#issuecomment-5068651916)
</details>
