### PR TITLE
8388923: Avoid local initialized unused variables in Hotspot

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2138,9 +2138,7 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler* masm,
   OptoReg::Name dst_second = ra_->get_reg_second(this);
   OptoReg::Name dst_first = ra_->get_reg_first(this);
 
-  enum RC src_second_rc = rc_class(src_second);
   enum RC src_first_rc = rc_class(src_first);
-  enum RC dst_second_rc = rc_class(dst_second);
   enum RC dst_first_rc = rc_class(dst_first);
 
   assert(OptoReg::is_valid(src_first) && OptoReg::is_valid(dst_first),

--- a/src/hotspot/share/compiler/abstractDisassembler.cpp
+++ b/src/hotspot/share/compiler/abstractDisassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -345,9 +345,6 @@ void AbstractDisassembler::decode_range_abstract(address range_start, address ra
 // it respects the actual instruction length where possible.
 void AbstractDisassembler::decode_abstract(address start, address end, outputStream* ost,
                                            const int max_instr_size_in_bytes) {
-  int     idx = 0;
-  address pos = start;
-
   outputStream* st = (ost == nullptr) ? tty : ost;
 
   st->bol();

--- a/src/hotspot/share/opto/regmask.hpp
+++ b/src/hotspot/share/opto/regmask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -793,8 +793,6 @@ public:
     int rm_index_diff = _offset - rm._offset;
     int rm_hwm_tr = (int)rm._hwm - rm_index_diff;
     int rm_lwm_tr = (int)rm._lwm - rm_index_diff;
-    int rm_rm_max_tr = (int)rm.rm_word_max_index() - rm_index_diff;
-    int rm_rm_size_tr = (int)rm._rm_size_in_words - rm_index_diff;
     int hwm = MIN2((int)_hwm, rm_hwm_tr);
     int lwm = MAX2((int)_lwm, rm_lwm_tr);
     for (int i = lwm; i <= hwm; i++) {


### PR DESCRIPTION
While testing the MSVC warning flag for local initialized unused variables, a couple of places in the HS codebase were found.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388923](https://bugs.openjdk.org/browse/JDK-8388923): Avoid local initialized unused variables in Hotspot (**Bug** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32039/head:pull/32039` \
`$ git checkout pull/32039`

Update a local copy of the PR: \
`$ git checkout pull/32039` \
`$ git pull https://git.openjdk.org/jdk.git pull/32039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32039`

View PR using the GUI difftool: \
`$ git pr show -t 32039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32039.diff">https://git.openjdk.org/jdk/pull/32039.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32039#issuecomment-5068828421)
</details>
