### PR TITLE
8388474: RISC-V: Relax satp mode check for sv57

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * Copyright (c) 2023, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -85,11 +85,11 @@ void VM_Version::common_initialize() {
 
   setup_cpu_available_features();
 
-  // check if satp.mode is supported, currently supports up to SV48(RV64)
-  if (satp_mode.value() > VM_SV48 || satp_mode.value() < VM_MBARE) {
+  // check if satp.mode is supported, currently supports up to SV57(RV64)
+  if (satp_mode.value() > VM_SV57 || satp_mode.value() < VM_MBARE) {
     vm_exit_during_initialization(
       err_msg(
-         "Unsupported satp mode: SV%d. Only satp modes up to sv48 are supported for now.",
+         "Unsupported satp mode: SV%d. Only satp modes up to sv57 are supported for now.",
          (int)satp_mode.value()));
   }
 


### PR DESCRIPTION
Linux defaults userspace mappings to the sv48 address range even when the kernel uses sv57. HotSpot can therefore run safely on systems reporting an sv57 MMU.

This change allows SATP modes through `VM_SV57` and updates the corresponding error message. `VM_SV64` remains unsupported.

Testing:
- RISC-V fastdebug HotSpot cross-build
- QEMU RISC-V VM startup
- Verified synthetic `sv57` CPU information is accepted
- Verified `sv64` remains rejected

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388474](https://bugs.openjdk.org/browse/JDK-8388474): RISC-V: Relax satp mode check for sv57 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32043/head:pull/32043` \
`$ git checkout pull/32043`

Update a local copy of the PR: \
`$ git checkout pull/32043` \
`$ git pull https://git.openjdk.org/jdk.git pull/32043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32043`

View PR using the GUI difftool: \
`$ git pr show -t 32043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32043.diff">https://git.openjdk.org/jdk/pull/32043.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32043#issuecomment-5071305351)
</details>
