### PR TITLE
8388449: GenShen: Degenerated cycle could be skipped

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -306,22 +306,25 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
 }
 
 bool ShenandoahControlThread::check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point) {
+  // Only read the cancellation cause once. Other threads may change it.
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (heap->cancelled_gc()) {
-    if (heap->cancelled_cause() == GCCause::_shenandoah_stop_vm) {
-      return true;
-    }
-
-    if (ShenandoahCollectorPolicy::is_allocation_failure(heap->cancelled_cause())) {
-      assert (_degen_point == ShenandoahGC::_degenerated_outside_cycle,
-              "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
-      _degen_point = point;
-      return true;
-    }
-
-    fatal("Unexpected reason for cancellation: %s", GCCause::to_string(heap->cancelled_cause()));
+  const GCCause::Cause cancelled_cause = heap->cancelled_cause();
+  if (cancelled_cause == GCCause::_no_gc) {
+    return false;
   }
-  return false;
+
+  if (cancelled_cause == GCCause::_shenandoah_stop_vm) {
+    return true;
+  }
+
+  if (ShenandoahCollectorPolicy::is_allocation_failure(cancelled_cause)) {
+    assert (_degen_point == ShenandoahGC::_degenerated_outside_cycle,
+            "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
+    _degen_point = point;
+    return true;
+  }
+
+  fatal("Unexpected reason for cancellation: %s", GCCause::to_string(cancelled_cause));
 }
 
 void ShenandoahControlThread::stop_service() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -590,20 +590,21 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
     return false;
   }
 
-  if (_heap->cancelled_cause() == GCCause::_shenandoah_stop_vm
-    || _heap->cancelled_cause() == GCCause::_shenandoah_concurrent_gc) {
-    log_debug(gc, thread)("Cancellation detected, reason: %s", GCCause::to_string(_heap->cancelled_cause()));
+  const GCCause::Cause cancelled_cause = _heap->cancelled_cause();
+  if (cancelled_cause == GCCause::_shenandoah_stop_vm
+      || cancelled_cause == GCCause::_shenandoah_concurrent_gc) {
+    log_debug(gc, thread)("Cancellation detected, reason: %s", GCCause::to_string(cancelled_cause));
     return true;
   }
 
-  if (ShenandoahCollectorPolicy::is_allocation_failure(_heap->cancelled_cause())) {
+  if (ShenandoahCollectorPolicy::is_allocation_failure(cancelled_cause)) {
     assert(_degen_point == ShenandoahGC::_degenerated_unset,
            "Should not be set yet: %s", ShenandoahGC::degen_point_to_string(_degen_point));
     MonitorLocker ml(&_control_lock, Mutex::_no_safepoint_check_flag);
-    _requested_gc_cause = _heap->cancelled_cause();
+    _requested_gc_cause = cancelled_cause;
     _degen_point = point;
     log_debug(gc, thread)("Cancellation detected:, reason: %s, degen point: %s",
-                          GCCause::to_string(_heap->cancelled_cause()),
+                          GCCause::to_string(cancelled_cause),
                           ShenandoahGC::degen_point_to_string(_degen_point));
     return true;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -586,11 +586,12 @@ void ShenandoahGenerationalControlThread::service_concurrent_cycle(ShenandoahGen
 }
 
 bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint point) {
-  if (!_heap->cancelled_gc()) {
+  // Only read the cancellation cause once. Other threads may change it.
+  const GCCause::Cause cancelled_cause = _heap->cancelled_cause();
+  if (cancelled_cause == GCCause::_no_gc) {
     return false;
   }
 
-  const GCCause::Cause cancelled_cause = _heap->cancelled_cause();
   if (cancelled_cause == GCCause::_shenandoah_stop_vm
       || cancelled_cause == GCCause::_shenandoah_concurrent_gc) {
     log_debug(gc, thread)("Cancellation detected, reason: %s", GCCause::to_string(cancelled_cause));
@@ -610,7 +611,6 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
   }
 
   fatal("Cancel GC either for alloc failure GC, or gracefully exiting, or to pause old generation marking");
-  return false;
 }
 
 void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2257,8 +2257,18 @@ size_t ShenandoahHeap::tlab_used() const {
 }
 
 bool ShenandoahHeap::try_cancel_gc(GCCause::Cause cause) {
-  const GCCause::Cause prev = _cancelled_gc.xchg(cause);
-  return prev == GCCause::_no_gc || prev == GCCause::_shenandoah_concurrent_gc;
+  while (true) {
+    const GCCause::Cause prev = _cancelled_gc.get();
+    if (prev != GCCause::_no_gc && prev != GCCause::_shenandoah_concurrent_gc && cause != GCCause::_shenandoah_stop_vm) {
+      // Only when the gc has not been cancelled, or it has been cancelled to interrupt an old marking cycle
+      // do we allow the new cancellation request to happen. We make an exception for stopping the VM.
+      return false;
+    }
+
+    if (_cancelled_gc.cmpxchg(cause, prev) == prev) {
+      return true;
+    }
+  }
 }
 
 void ShenandoahHeap::cancel_concurrent_mark() {


### PR DESCRIPTION
Clean backport. Only touches Shenandoah code. Two commits because non-generational mode was similarly affected.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8388449](https://bugs.openjdk.org/browse/JDK-8388449): GenShen: Degenerated cycle could be skipped (**Bug** - P2)
 * [JDK-8388809](https://bugs.openjdk.org/browse/JDK-8388809): Shenandoah: Control thread may observe incorrect cancellation reason (**Bug** - P4)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32045/head:pull/32045` \
`$ git checkout pull/32045`

Update a local copy of the PR: \
`$ git checkout pull/32045` \
`$ git pull https://git.openjdk.org/jdk.git pull/32045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32045`

View PR using the GUI difftool: \
`$ git pr show -t 32045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32045.diff">https://git.openjdk.org/jdk/pull/32045.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32045#issuecomment-5075410467)
</details>
