### PR TITLE
8388706: PolynomialP256Bench::benchAssign regression after JDK-8355216

### DIFF
--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026,Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.Benchmark;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
+import java.util.Random;
 import sun.security.util.math.intpoly.MontgomeryIntegerPolynomialP256;
 import sun.security.util.math.intpoly.IntegerPolynomialP256;
 import sun.security.util.math.MutableIntegerModuloP;
@@ -94,11 +95,13 @@ public class PolynomialP256Bench {
     public MutableIntegerModuloP benchAssign() {
         MutableIntegerModuloP test1 = X.mutable();
         MutableIntegerModuloP test2 = one.mutable();
+        long seed = 1234567890L;
+        Random rand = new Random(seed);
         for (int i = 0; i< 10000; i++) {
-            test1.conditionalSet(test2, 0);
-            test1.conditionalSet(test2, 1);
-            test2.conditionalSet(test1, 0);
-            test2.conditionalSet(test1, 1);
+            test1.conditionalSet(test2, rand.nextInt(2));
+            test1.conditionalSet(test2, rand.nextInt(2));
+            test2.conditionalSet(test1, rand.nextInt(2));
+            test2.conditionalSet(test1, rand.nextInt(2));
         }
         return test2;
     }

--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -104,7 +104,7 @@ public class PolynomialP256Bench {
 
     @Benchmark
     public MutableIntegerModuloP benchAssign() {
-        MutableIntegerModuloP test1;
+        MutableIntegerModuloP test1 = X.mutable();
         MutableIntegerModuloP test2 = one.mutable();
         int[] lScalarBits = scalarBits;
 

--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -56,10 +56,14 @@ public class PolynomialP256Bench {
     final ImmutableIntegerModuloP x = residueField.getElement(refx);
     final ImmutableIntegerModuloP X = montField.getElement(refx);
     final ImmutableIntegerModuloP one = montField.get1();
+
+    // Here we assign conditional set arguments as non-constants in order to
+    // prevent constant folding.  Previously, C2 would perform constant
+    // propagation and remove the subsequent dead-code where 0 was input.
     @Param({"0"})
-    private int pZero = 0;
+    private int pZero;
     @Param({"1"})
-    private int pOne = 1;
+    private int pOne;
 
     @Param({"true", "false"})
     private boolean isMontBench;
@@ -73,7 +77,7 @@ public class PolynomialP256Bench {
             test = x.mutable();
         }
 
-        for (int i = 0; i< 10000; i++) {
+        for (int i = 0; i < 10000; i++) {
             test = test.setProduct(test);
         }
         return test;
@@ -88,7 +92,7 @@ public class PolynomialP256Bench {
             test = x.mutable();
         }
 
-        for (int i = 0; i< 10000; i++) {
+        for (int i = 0; i < 10000; i++) {
             test = test.setSquare();
         }
         return test;
@@ -98,11 +102,14 @@ public class PolynomialP256Bench {
     public MutableIntegerModuloP benchAssign() {
         MutableIntegerModuloP test1 = X.mutable();
         MutableIntegerModuloP test2 = one.mutable();
-        for (int i = 0; i< 10000; i++) {
-            test1.conditionalSet(test2, vZero);
-            test1.conditionalSet(test2, vOne);
-            test2.conditionalSet(test1, vZero);
-            test2.conditionalSet(test1, vOne);
+        int lpZero = pZero;
+        int lpOne = pOne;
+
+        for (int i = 0; i < 10000; i++) {
+            test1.conditionalSet(test2, lpZero);
+            test1.conditionalSet(test2, lpOne);
+            test2.conditionalSet(test1, lpZero);
+            test2.conditionalSet(test1, lpOne);
         }
         return test2;
     }

--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -56,17 +56,21 @@ public class PolynomialP256Bench {
     final ImmutableIntegerModuloP x = residueField.getElement(refx);
     final ImmutableIntegerModuloP X = montField.getElement(refx);
     final ImmutableIntegerModuloP one = montField.get1();
-
-    // Here we assign conditional set arguments as non-constants in order to
-    // prevent constant folding.  Previously, C2 would perform constant
-    // propagation and remove the subsequent dead-code where 0 was input.
-    @Param({"0"})
-    private int pZero;
-    @Param({"1"})
-    private int pOne;
+    final int ITERATIONS = 10_000;
+    final int[] scalarBits = new int[ITERATIONS];
 
     @Param({"true", "false"})
     private boolean isMontBench;
+
+    // Here we assign conditional set bits as non-constants in order to
+    // prevent constant folding.  Previously, C2 would perform constant
+    // propagation and remove the subsequent dead-code where 0 was input.
+    @Setup
+    public void setup() {
+        for (int i = 0; i < ITERATIONS; i++) {
+            scalarBits[i] = i & 1;
+        }
+    }
 
     @Benchmark
     public MutableIntegerModuloP benchMultiply() {
@@ -77,7 +81,7 @@ public class PolynomialP256Bench {
             test = x.mutable();
         }
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             test = test.setProduct(test);
         }
         return test;
@@ -92,7 +96,7 @@ public class PolynomialP256Bench {
             test = x.mutable();
         }
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             test = test.setSquare();
         }
         return test;
@@ -100,16 +104,18 @@ public class PolynomialP256Bench {
 
     @Benchmark
     public MutableIntegerModuloP benchAssign() {
-        MutableIntegerModuloP test1 = X.mutable();
+        MutableIntegerModuloP test1;
         MutableIntegerModuloP test2 = one.mutable();
-        int lpZero = pZero;
-        int lpOne = pOne;
+        int[] lScalarBits = scalarBits;
 
-        for (int i = 0; i < 10000; i++) {
-            test1.conditionalSet(test2, lpZero);
-            test1.conditionalSet(test2, lpOne);
-            test2.conditionalSet(test1, lpZero);
-            test2.conditionalSet(test1, lpOne);
+        for (int i = 0; i < ITERATIONS; i++) {
+            int bit = lScalarBits[i];
+            int bitCom = bit ^ 1;
+
+            test1.conditionalSet(test2, bit);
+            test1.conditionalSet(test2, bitCom);
+            test2.conditionalSet(test1, bit);
+            test2.conditionalSet(test1, bitCom);
         }
         return test2;
     }

--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2026,Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.Benchmark;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
-import java.util.Random;
 import sun.security.util.math.intpoly.MontgomeryIntegerPolynomialP256;
 import sun.security.util.math.intpoly.IntegerPolynomialP256;
 import sun.security.util.math.MutableIntegerModuloP;
@@ -57,6 +56,10 @@ public class PolynomialP256Bench {
     final ImmutableIntegerModuloP x = residueField.getElement(refx);
     final ImmutableIntegerModuloP X = montField.getElement(refx);
     final ImmutableIntegerModuloP one = montField.get1();
+    @Param({"0"})
+    private int pZero = 0;
+    @Param({"1"})
+    private int pOne = 1;
 
     @Param({"true", "false"})
     private boolean isMontBench;
@@ -95,13 +98,11 @@ public class PolynomialP256Bench {
     public MutableIntegerModuloP benchAssign() {
         MutableIntegerModuloP test1 = X.mutable();
         MutableIntegerModuloP test2 = one.mutable();
-        long seed = 1234567890L;
-        Random rand = new Random(seed);
         for (int i = 0; i< 10000; i++) {
-            test1.conditionalSet(test2, rand.nextInt(2));
-            test1.conditionalSet(test2, rand.nextInt(2));
-            test2.conditionalSet(test1, rand.nextInt(2));
-            test2.conditionalSet(test1, rand.nextInt(2));
+            test1.conditionalSet(test2, vZero);
+            test1.conditionalSet(test2, vOne);
+            test2.conditionalSet(test1, vZero);
+            test2.conditionalSet(test1, vOne);
         }
         return test2;
     }

--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -54,11 +54,12 @@ public class PolynomialP256Bench {
     final IntegerPolynomialP256 residueField = IntegerPolynomialP256.ONE;
     final BigInteger refx =
         new BigInteger("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296", 16);
-    final ImmutableIntegerModuloP x = residueField.getElement(refx);
-    final ImmutableIntegerModuloP X = montField.getElement(refx);
-    final ImmutableIntegerModuloP one = residueField.get1();
-    final ImmutableIntegerModuloP ONE = montField.get1();
+    final ImmutableIntegerModuloP xResidue = residueField.getElement(refx);
+    final ImmutableIntegerModuloP xMontgomery = montField.getElement(refx);
+    final ImmutableIntegerModuloP oneResidue = residueField.get1();
+    final ImmutableIntegerModuloP oneMontgomery = montField.get1();
     final int ITERATIONS = 10_000;
+    boolean run = false;
 
     @Param({"true", "false"})
     private boolean isMontBench;
@@ -68,9 +69,9 @@ public class PolynomialP256Bench {
         MutableIntegerModuloP test;
 
         if (isMontBench) {
-            test = X.mutable();
+            test = xMontgomery.mutable();
         } else {
-            test = x.mutable();
+            test = xResidue.mutable();
         }
         for (int i = 0; i < ITERATIONS; i++) {
             test = test.setProduct(test);
@@ -84,9 +85,9 @@ public class PolynomialP256Bench {
         MutableIntegerModuloP test;
 
         if (isMontBench) {
-            test = X.mutable();
+            test = xMontgomery.mutable();
         } else {
-            test = x.mutable();
+            test = xResidue.mutable();
         }
         for (int i = 0; i < ITERATIONS; i++) {
             test = test.setSquare();
@@ -101,11 +102,11 @@ public class PolynomialP256Bench {
         MutableIntegerModuloP test2;
 
         if (isMontBench) {
-            test1 = X.mutable();
-            test2 = ONE.mutable();
+            test1 = xMontgomery.mutable();
+            test2 = oneMontgomery.mutable();
         } else {
-            test1 = x.mutable();
-            test2 = one.mutable();
+            test1 = xResidue.mutable();
+            test2 = oneResidue.mutable();
         }
         for (int i = 0; i < ITERATIONS; i++) {
             test1.conditionalSet(test2, 0);

--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.Benchmark;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
+import java.util.Random;
 import sun.security.util.math.intpoly.MontgomeryIntegerPolynomialP256;
 import sun.security.util.math.intpoly.IntegerPolynomialP256;
 import sun.security.util.math.MutableIntegerModuloP;
@@ -55,26 +56,36 @@ public class PolynomialP256Bench {
         new BigInteger("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296", 16);
     final ImmutableIntegerModuloP x = residueField.getElement(refx);
     final ImmutableIntegerModuloP X = montField.getElement(refx);
-    final ImmutableIntegerModuloP one = montField.get1();
     final int ITERATIONS = 10_000;
-    final int[] scalarBits = new int[ITERATIONS];
+    final int SET = 16;
+    final ImmutableIntegerModuloP[] xArray = new ImmutableIntegerModuloP[SET];
+    final ImmutableIntegerModuloP[] XArray = new ImmutableIntegerModuloP[SET];
+    private MutableIntegerModuloP xM;
+    private MutableIntegerModuloP XM;
+    private int index = 0;
 
     @Param({"true", "false"})
     private boolean isMontBench;
 
-    // Here we assign conditional set bits as non-constants in order to
-    // prevent constant folding.  Previously, C2 would perform constant
-    // propagation and remove the subsequent dead-code where 0 was input.
     @Setup
     public void setup() {
-        for (int i = 0; i < ITERATIONS; i++) {
-            scalarBits[i] = i & 1;
+        Random rand = new Random(1234567890L);
+
+        // Only one coordinate constructed here instead of three for simplicity.
+        for (int i = 0; i < SET; i++) {
+            BigInteger coor = new BigInteger(256, rand);
+
+            xArray[i] = residueField.getElement(coor);
+            XArray[i] = montField.getElement(coor);
         }
+        xM = x.mutable();
+        XM = X.mutable();
     }
 
     @Benchmark
     public MutableIntegerModuloP benchMultiply() {
         MutableIntegerModuloP test;
+
         if (isMontBench) {
             test = X.mutable();
         } else {
@@ -90,6 +101,7 @@ public class PolynomialP256Bench {
     @Benchmark
     public MutableIntegerModuloP benchSquare() {
         MutableIntegerModuloP test;
+
         if (isMontBench) {
             test = X.mutable();
         } else {
@@ -102,21 +114,42 @@ public class PolynomialP256Bench {
         return test;
     }
 
+    // Duplicate lookup logic to provide production equivalent conditional
+    // set.  This emulates Montgomery P256 with secp256r1 coordinates.
+    // The non-Montgomery flag is used to emulate the generic lookup for
+    // ten-limb P256.  In production the flags are created dynamically, we do
+    // this here to better emulate production lookups despite the consistent
+    // overhead.
     @Benchmark
     public MutableIntegerModuloP benchAssign() {
-        MutableIntegerModuloP test1 = X.mutable();
-        MutableIntegerModuloP test2 = one.mutable();
-        int[] lScalarBits = scalarBits;
+        ImmutableIntegerModuloP[] testA;
+        MutableIntegerModuloP test;
 
-        for (int i = 0; i < ITERATIONS; i++) {
-            int bit = lScalarBits[i];
-            int bitCom = bit ^ 1;
-
-            test1.conditionalSet(test2, bit);
-            test1.conditionalSet(test2, bitCom);
-            test2.conditionalSet(test1, bit);
-            test2.conditionalSet(test1, bitCom);
+        if (isMontBench) {
+            test = XM;
+            testA = XArray;
+        } else {
+            test = xM;
+            testA = xArray;
         }
-        return test2;
+
+        // Here we assign conditional set bits as non-constants in order to
+        // prevent constant folding.  Previously, C2 would perform constant
+        // propagation and remove the subsequent dead-code where 0 was input.
+        for (int j = 0; j < SET; j++) {
+            int xor = index ^ j;
+            int bit3 = (xor & 0x8) >>> 3;
+            int bit2 = (xor & 0x4) >>> 2;
+            int bit1 = (xor & 0x2) >>> 1;
+            int bit0 = (xor & 0x1);
+            int inverse = bit0 | bit1 | bit2 | bit3;
+
+            test.conditionalSet(testA[j], 1 - inverse);
+        }
+        index++;
+        if (index == SET) {
+            index = 0;
+        }
+        return test;
     }
 }

--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -35,13 +35,13 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.Benchmark;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
-import java.util.Random;
 import sun.security.util.math.intpoly.MontgomeryIntegerPolynomialP256;
 import sun.security.util.math.intpoly.IntegerPolynomialP256;
 import sun.security.util.math.MutableIntegerModuloP;
 import sun.security.util.math.ImmutableIntegerModuloP;
 
-@Fork(jvmArgs = {"-XX:+AlwaysPreTouch",
+@Fork(jvmArgs = {"-XX:+AlwaysPreTouch", "-XX:+UnlockDiagnosticVMOptions",
+"-XX:CompileCommand=dontinline,sun.security.util.math.intpoly.IntegerPolynomial$MutableElement::conditionalSet",
     "--add-exports", "java.base/sun.security.util.math.intpoly=ALL-UNNAMED",
     "--add-exports", "java.base/sun.security.util.math=ALL-UNNAMED"}, value = 1)
 @Warmup(iterations = 3, time = 3)
@@ -56,31 +56,12 @@ public class PolynomialP256Bench {
         new BigInteger("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296", 16);
     final ImmutableIntegerModuloP x = residueField.getElement(refx);
     final ImmutableIntegerModuloP X = montField.getElement(refx);
+    final ImmutableIntegerModuloP one = residueField.get1();
+    final ImmutableIntegerModuloP ONE = montField.get1();
     final int ITERATIONS = 10_000;
-    final int SET = 16;
-    final ImmutableIntegerModuloP[] xArray = new ImmutableIntegerModuloP[SET];
-    final ImmutableIntegerModuloP[] XArray = new ImmutableIntegerModuloP[SET];
-    private MutableIntegerModuloP xM;
-    private MutableIntegerModuloP XM;
-    private int index = 0;
 
     @Param({"true", "false"})
     private boolean isMontBench;
-
-    @Setup
-    public void setup() {
-        Random rand = new Random(1234567890L);
-
-        // Only one coordinate constructed here instead of three for simplicity.
-        for (int i = 0; i < SET; i++) {
-            BigInteger coor = new BigInteger(256, rand);
-
-            xArray[i] = residueField.getElement(coor);
-            XArray[i] = montField.getElement(coor);
-        }
-        xM = x.mutable();
-        XM = X.mutable();
-    }
 
     @Benchmark
     public MutableIntegerModuloP benchMultiply() {
@@ -91,10 +72,10 @@ public class PolynomialP256Bench {
         } else {
             test = x.mutable();
         }
-
         for (int i = 0; i < ITERATIONS; i++) {
             test = test.setProduct(test);
         }
+
         return test;
     }
 
@@ -107,49 +88,32 @@ public class PolynomialP256Bench {
         } else {
             test = x.mutable();
         }
-
         for (int i = 0; i < ITERATIONS; i++) {
             test = test.setSquare();
         }
+
         return test;
     }
 
-    // Duplicate lookup logic to provide production equivalent conditional
-    // set.  This emulates Montgomery P256 with secp256r1 coordinates.
-    // The non-Montgomery flag is used to emulate the generic lookup for
-    // ten-limb P256.  In production the flags are created dynamically, we do
-    // this here to better emulate production lookups despite the consistent
-    // overhead.
     @Benchmark
     public MutableIntegerModuloP benchAssign() {
-        ImmutableIntegerModuloP[] testA;
-        MutableIntegerModuloP test;
+        MutableIntegerModuloP test1;
+        MutableIntegerModuloP test2;
 
         if (isMontBench) {
-            test = XM;
-            testA = XArray;
+            test1 = X.mutable();
+            test2 = ONE.mutable();
         } else {
-            test = xM;
-            testA = xArray;
+            test1 = x.mutable();
+            test2 = one.mutable();
+        }
+        for (int i = 0; i < ITERATIONS; i++) {
+            test1.conditionalSet(test2, 0);
+            test1.conditionalSet(test2, 1);
+            test2.conditionalSet(test1, 0);
+            test2.conditionalSet(test1, 1);
         }
 
-        // Here we assign conditional set bits as non-constants in order to
-        // prevent constant folding.  Previously, C2 would perform constant
-        // propagation and remove the subsequent dead-code where 0 was input.
-        for (int j = 0; j < SET; j++) {
-            int xor = index ^ j;
-            int bit3 = (xor & 0x8) >>> 3;
-            int bit2 = (xor & 0x4) >>> 2;
-            int bit1 = (xor & 0x2) >>> 1;
-            int bit0 = (xor & 0x1);
-            int inverse = bit0 | bit1 | bit2 | bit3;
-
-            test.conditionalSet(testA[j], 1 - inverse);
-        }
-        index++;
-        if (index == SET) {
-            index = 0;
-        }
-        return test;
+        return test2;
     }
 }


### PR DESCRIPTION
This fix allows for more accurate comparisons between intrinsics and Java performance for P-256 conditional set operations by emulating production lookup EC operations.  Before this fix, benchmarks showed a 53% regression for intrinsics vs. Java due to constant propagation and dead-code removal by C2.  After this fix, a 27% performance increase is observed with intrinsics vs. Java.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388706](https://bugs.openjdk.org/browse/JDK-8388706): PolynomialP256Bench::benchAssign regression after JDK-8355216 (**Bug** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32047/head:pull/32047` \
`$ git checkout pull/32047`

Update a local copy of the PR: \
`$ git checkout pull/32047` \
`$ git pull https://git.openjdk.org/jdk.git pull/32047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32047`

View PR using the GUI difftool: \
`$ git pr show -t 32047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32047.diff">https://git.openjdk.org/jdk/pull/32047.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32047#issuecomment-5080746843)
</details>
