### PR TITLE
8379016: Improve double_keccak() intrinsic on ARM when SHA3 instructions are not available

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5123,7 +5123,7 @@ class StubGenerator: public StubCodeGenerator {
     __ enter();
 
     // save the state addresses and callee-saved registers
-    __ stp(state0, state1, __ pre(sp, -128));
+    __ stp(state0, state1, __ pre(sp, -112));
     __ stp(r19, r20, Address(sp, 16));
     __ stp(r21, r22, Address(sp, 32));
     __ stp(r23, r24, Address(sp, 48));
@@ -5236,7 +5236,7 @@ class StubGenerator: public StubCodeGenerator {
     __ ldp(r27, r28, Address(sp, 80));
     if (can_use_fp && can_use_r18) {
       __ ldr(r18_tls, Address(sp, 96));
-      __ add(rfp, sp, 128); // leave() will copy rfp to sp below
+      __ add(rfp, sp, 112); // leave() will copy rfp to sp below
     } // else no need to recalculate rfp, since it wasn't changed
 
     __ leave(); // required for proper stackwalking of RuntimeStub frame

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5066,23 +5066,18 @@ class StubGenerator: public StubCodeGenerator {
   //   c_rarg0   - long[]  state0
   //   c_rarg1   - long[]  state1
   address generate_double_keccak_gpr() {
-    static const uint64_t round_consts[24] = {
-      0x0000000000000001L, 0x0000000000008082L, 0x800000000000808AL,
-      0x8000000080008000L, 0x000000000000808BL, 0x0000000080000001L,
-      0x8000000080008081L, 0x8000000000008009L, 0x000000000000008AL,
-      0x0000000000000088L, 0x0000000080008009L, 0x000000008000000AL,
-      0x000000008000808BL, 0x800000000000008BL, 0x8000000000008089L,
-      0x8000000000008003L, 0x8000000000008002L, 0x8000000000000080L,
-      0x000000000000800AL, 0x800000008000000AL, 0x8000000080008081L,
-      0x8000000000008080L, 0x0000000080000001L, 0x8000000080008008L
-    };
-
+    StubId stub_id = StubId::stubgen_double_keccak_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     // Implements the double_keccak() method of the
     // sun.secyrity.provider.SHA3Parallel class
     __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "double_keccak");
-    address start = __ pc();
-    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, stub_id);
+    start = __ pc();
 
     Register state0 = c_rarg0;
     Register state1 = c_rarg1;
@@ -5158,7 +5153,7 @@ class StubGenerator: public StubCodeGenerator {
     __ fmovs(v1, 1.0);  // exact representation
 
     // load round_constants base
-    __ lea(tmp3, ExternalAddress((address) round_consts));
+    __ lea(tmp3, ExternalAddress((address) _double_keccak_round_consts));
 
     __ BIND(rounds24_loop_0);
     keccak_round_gpr(can_use_fp, can_use_r18, tmp3,
@@ -5205,7 +5200,7 @@ class StubGenerator: public StubCodeGenerator {
     __ fmovs(v0, 24.0); // reset float loop counter,
 
     // load round_constants base
-    __ lea(tmp3, ExternalAddress((address) round_consts));
+    __ lea(tmp3, ExternalAddress((address) _double_keccak_round_consts));
 
     __ BIND(rounds24_loop_1);
     keccak_round_gpr(can_use_fp, can_use_r18, tmp3,
@@ -5247,6 +5242,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave(); // required for proper stackwalking of RuntimeStub frame
     __ mov(r0, zr); // return 0
     __ ret(lr);
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5062,6 +5062,195 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  // Inputs:
+  //   c_rarg0   - long[]  state0
+  //   c_rarg1   - long[]  state1
+  address generate_double_keccak_gpr() {
+    static const uint64_t round_consts[24] = {
+      0x0000000000000001L, 0x0000000000008082L, 0x800000000000808AL,
+      0x8000000080008000L, 0x000000000000808BL, 0x0000000080000001L,
+      0x8000000080008081L, 0x8000000000008009L, 0x000000000000008AL,
+      0x0000000000000088L, 0x0000000080008009L, 0x000000008000000AL,
+      0x000000008000808BL, 0x800000000000008BL, 0x8000000000008089L,
+      0x8000000000008003L, 0x8000000000008002L, 0x8000000000000080L,
+      0x000000000000800AL, 0x800000008000000AL, 0x8000000080008081L,
+      0x8000000000008080L, 0x0000000080000001L, 0x8000000080008008L
+    };
+
+    // Implements the double_keccak() method of the
+    // sun.secyrity.provider.SHA3Parallel class
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "double_keccak");
+    address start = __ pc();
+    __ align(CodeEntryAlignment);
+
+    Register state0 = c_rarg0;
+    Register state1 = c_rarg1;
+
+    // use r3.r17,r19..r28 to keep a0..a24.
+    // a0..a24 are respective locals from SHA3.java
+    Register a0 = r25,
+             a1 = r26,
+             a2 = r27,
+             a3 = r3,
+             a4 = r4,
+             a5 = r5,
+             a6 = r6,
+             a7 = r7,
+             a8 = rscratch1, // r8
+             a9 = rscratch2, // r9
+             a10 = r10,
+             a11 = r11,
+             a12 = r12,
+             a13 = r13,
+             a14 = r14,
+             a15 = r15,
+             a16 = r16,
+             a17 = r17,
+             a18 = r28,
+             a19 = r19,
+             a20 = r20,
+             a21 = r21,
+             a22 = r22,
+             a23 = r23,
+             a24 = r24;
+
+    Register tmp0 = r0, tmp1 = r1, tmp2 = r2, tmp3 = r30;
+
+    Label rounds24_loop_0, rounds24_loop_1;
+
+    bool can_use_r18 = false;
+#ifndef R18_RESERVED
+    can_use_r18 = true;
+#endif
+    bool can_use_fp = !PreserveFramePointer;
+
+    __ enter();
+
+    // save the state addresses and callee-saved registers
+    __ stp(state0, state1, __ pre(sp, -128));
+    __ stp(r19, r20, Address(sp, 16));
+    __ stp(r21, r22, Address(sp, 32));
+    __ stp(r23, r24, Address(sp, 48));
+    __ stp(r25, r26, Address(sp, 64));
+    __ stp(r27, r28, Address(sp, 80));
+    if (can_use_r18 && can_use_fp) {
+      __ str(r18_tls, Address(sp, 96));
+    }
+
+    // load state0
+    __ ldp(a0, a1, state0);
+    __ ldp(a2, a3, Address(state0, 16));
+    __ ldp(a4, a5, Address(state0, 32));
+    __ ldp(a6, a7, Address(state0, 48));
+    __ ldp(a8, a9, Address(state0, 64));
+    __ ldp(a10, a11, Address(state0, 80));
+    __ ldp(a12, a13, Address(state0, 96));
+    __ ldp(a14, a15, Address(state0, 112));
+    __ ldp(a16, a17, Address(state0, 128));
+    __ ldp(a18, a19, Address(state0, 144));
+    __ ldp(a20, a21, Address(state0, 160));
+    __ ldp(a22, a23, Address(state0, 176));
+    __ ldr(a24, Address(state0, 192));
+
+    // 24 keccak rounds for state0
+    __ fmovs(v0, 24.0); // float loop counter,
+    __ fmovs(v1, 1.0);  // exact representation
+
+    // load round_constants base
+    __ lea(tmp3, ExternalAddress((address) round_consts));
+
+    __ BIND(rounds24_loop_0);
+    keccak_round_gpr(can_use_fp, can_use_r18, tmp3,
+                     a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
+                     a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24,
+                     tmp0, tmp1, tmp2);
+    __ fsubs(v0, v0, v1);
+    __ fcmps(v0, 0.0);
+    __ br(__ NE, rounds24_loop_0);
+
+   // store state0 and load state1
+
+    __ ldp(state0, state1, Address(sp));
+
+    __ stp(a0, a1, Address(state0));
+    __ stp(a2, a3, Address(state0, 16));
+    __ stp(a4, a5, Address(state0, 32));
+    __ stp(a6, a7, Address(state0, 48));
+    __ stp(a8, a9, Address(state0, 64));
+    __ stp(a10, a11, Address(state0, 80));
+    __ stp(a12, a13, Address(state0, 96));
+    __ stp(a14, a15, Address(state0, 112));
+    __ stp(a16, a17, Address(state0, 128));
+    __ stp(a18, a19, Address(state0, 144));
+    __ stp(a20, a21, Address(state0, 160));
+    __ stp(a22, a23, Address(state0, 176));
+    __ str(a24, Address(state0, 192));
+
+    __ ldp(a0, a1, state1);
+    __ ldp(a2, a3, Address(state1, 16));
+    __ ldp(a4, a5, Address(state1, 32));
+    __ ldp(a6, a7, Address(state1, 48));
+    __ ldp(a8, a9, Address(state1, 64));
+    __ ldp(a10, a11, Address(state1, 80));
+    __ ldp(a12, a13, Address(state1, 96));
+    __ ldp(a14, a15, Address(state1, 112));
+    __ ldp(a16, a17, Address(state1, 128));
+    __ ldp(a18, a19, Address(state1, 144));
+    __ ldp(a20, a21, Address(state1, 160));
+    __ ldp(a22, a23, Address(state1, 176));
+    __ ldr(a24, Address(state1, 192));
+
+    // 24 keccak rounds for state1
+    __ fmovs(v0, 24.0); // reset float loop counter,
+
+    // load round_constants base
+    __ lea(tmp3, ExternalAddress((address) round_consts));
+
+    __ BIND(rounds24_loop_1);
+    keccak_round_gpr(can_use_fp, can_use_r18, tmp3,
+                     a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
+                     a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24,
+                     tmp0, tmp1, tmp2);
+    __ fsubs(v0, v0, v1);
+    __ fcmps(v0, 0.0);
+    __ br(__ NE, rounds24_loop_1);
+
+    __ ldr(state1, Address(sp, 8));
+
+   // store state1
+    __ stp(a0, a1, Address(state1));
+    __ stp(a2, a3, Address(state1, 16));
+    __ stp(a4, a5, Address(state1, 32));
+    __ stp(a6, a7, Address(state1, 48));
+    __ stp(a8, a9, Address(state1, 64));
+    __ stp(a10, a11, Address(state1, 80));
+    __ stp(a12, a13, Address(state1, 96));
+    __ stp(a14, a15, Address(state1, 112));
+    __ stp(a16, a17, Address(state1, 128));
+    __ stp(a18, a19, Address(state1, 144));
+    __ stp(a20, a21, Address(state1, 160));
+    __ stp(a22, a23, Address(state1, 176));
+    __ str(a24, Address(state1, 192));
+
+    // restore callee-saved registers
+    __ ldp(r19, r20, Address(sp, 16));
+    __ ldp(r21, r22, Address(sp, 32));
+    __ ldp(r23, r24, Address(sp, 48));
+    __ ldp(r25, r26, Address(sp, 64));
+    __ ldp(r27, r28, Address(sp, 80));
+    if (can_use_fp && can_use_r18) {
+      __ ldr(r18_tls, Address(sp, 96));
+      __ add(rfp, sp, 128); // leave() will copy rfp to sp below
+    } // else no need to recalculate rfp, since it wasn't changed
+
+    __ leave(); // required for proper stackwalking of RuntimeStub frame
+    __ mov(r0, zr); // return 0
+    __ ret(lr);
+
+    return start;
+  }
+
   // ChaCha20 block function.  This version parallelizes the 32-bit
   // state elements on each of 16 vectors, producing 4 blocks of
   // keystream at a time.
@@ -13905,6 +14094,7 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::_sha3_implCompress     = generate_sha3_implCompress(StubId::stubgen_sha3_implCompress_id);
       StubRoutines::_sha3_implCompressMB   = generate_sha3_implCompress(StubId::stubgen_sha3_implCompressMB_id);
     } else if (UseSHA3Intrinsics) {
+      StubRoutines::_double_keccak         = generate_double_keccak_gpr();
       StubRoutines::_sha3_implCompress     = generate_sha3_implCompress_gpr(StubId::stubgen_sha3_implCompress_id);
       StubRoutines::_sha3_implCompressMB   = generate_sha3_implCompress_gpr(StubId::stubgen_sha3_implCompressMB_id);
     }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5109,10 +5109,8 @@ class StubGenerator: public StubCodeGenerator {
 
     Label rounds24_loop_0, rounds24_loop_1;
 
-    bool can_use_r18 = false;
-#ifndef R18_RESERVED
-    can_use_r18 = true;
-#endif
+    const bool can_use_r18 = R18_RESERVED_ONLY(false) NOT_R18_RESERVED(true);
+
     bool can_use_fp = !PreserveFramePointer;
 
     __ enter();
@@ -5165,10 +5163,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // restore callee-saved registers
     __ pop(saved_regs, sp);
-    if (can_use_fp && can_use_r18) {
-      __ ldr(r18_tls, Address(sp, 96));
-      __ add(rfp, sp, 112); // leave() will copy rfp to sp below
-    } // else no need to recalculate rfp, since it wasn't changed
+    __ mov(rfp, sp);
 
     __ leave(); // required for proper stackwalking of RuntimeStub frame
     __ mov(r0, zr); // return 0
@@ -8919,14 +8914,17 @@ class StubGenerator: public StubCodeGenerator {
     {
 
       Register tmp3, tmp4;
+      RegSet saved_regs;
+
       if (can_use_fp && can_use_r18) {
         tmp3 = rfp;
         tmp4 = r18_tls;
       } else {
         tmp3 = a[4];
         tmp4 = a[9];
-        __ stp(tmp3, tmp4, __ pre(sp, -16));
+        saved_regs = RegSet::of(tmp3, tmp4);
       }
+      __ push(saved_regs, sp);
 
       __ eor3(tmp3, a[0], a[5], a[10]);
       __ eor3(tmp4, tmp3, a[15], a[20]); // tmp4 = a0^a5^a10^a15^a20 = c0
@@ -8956,9 +8954,8 @@ class StubGenerator: public StubCodeGenerator {
       __ eor(a[7], a[7], tmp2);
       __ eor(a[12], a[12], tmp2);
       __ rax1(tmp0, tmp0, tmp4); // d4
-      if (!can_use_fp || !can_use_r18) {
-        __ ldp(tmp3, tmp4, __ post(sp, 16));
-      }
+      __ pop(saved_regs, sp);
+
       __ eor(a[17], a[17], tmp2);
       __ eor(a[22], a[22], tmp2);
       __ eor(a[4], a[4], tmp0);
@@ -9051,10 +9048,8 @@ class StubGenerator: public StubCodeGenerator {
     Label sha3_loop, rounds24_preloop, loop_body;
     Label sha3_512_or_sha3_384, shake128;
 
-    bool can_use_r18 = false;
-#ifndef R18_RESERVED
-    can_use_r18 = true;
-#endif
+    const bool can_use_r18 = R18_RESERVED_ONLY(false) NOT_R18_RESERVED(true);
+
     bool can_use_fp = !PreserveFramePointer;
 
     __ enter();
@@ -12520,7 +12515,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     // we're now on the yield frame (which is in an address above us b/c rsp has been pushed down)
-    __ sub(sp, rscratch2, 2*wordSize); // now pointing to rfp spill
+    __ sub(sp, rscratch2, 2 * wordSize); // now pointing to rfp spill
     __ mov(rfp, sp);
 
     if (return_barrier_exception) {

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5062,18 +5062,22 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-  void store_keccak_state(Register a[], Register state) {
-    for (int i = 0; i < 24; i += 2) {
-      __ stp(a[i], a[i + 1], Address(state, i * 8));
+  void store_keccak_state(const Register a[], Register state) {
+    int i;
+
+    for (i = 0; i < 24; i += 2) {
+      __ stp(a[i], a[i + 1], Address(state, i * wordSize));
     }
-    __ str(a[24], Address(state, 192));
+    __ str(a[i], Address(state, i * wordSize));
   }
 
-  void load_keccak_state(Register a[], Register state) {
-    for (int i = 0; i < 24; i += 2) {
-      __ ldp(a[i], a[i + 1], Address(state, i * 8));
+  void load_keccak_state(const Register a[], Register state) {
+    int i;
+
+    for (i = 0; i < 24; i += 2) {
+      __ ldp(a[i], a[i + 1], Address(state, i * wordSize));
     }
-    __ ldr(a[24], Address(state, 192));
+    __ ldr(a[i], Address(state, i * wordSize));
   }
 
   // Inputs:
@@ -5098,7 +5102,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // use r3.r17,r19..r28 to keep a0..a24.
     // a0..a24 are respective locals from SHA3.java
-    Register a[25] = {
+    const Register a[25] = {
         r25, r26, r27, r3, r4, r5, r6, r7, rscratch1, rscratch2, r10, r11, r12,
         r13, r14, r15, r16, r17, r28, r19, r20, r21, r22, r23, r24 };
     Register tmp0 = r0, tmp1 = r1, tmp2 = r2, tmp3 = r30;
@@ -5160,11 +5164,7 @@ class StubGenerator: public StubCodeGenerator {
     store_keccak_state(a, state1);
 
     // restore callee-saved registers
-    __ ldp(r19, r20, Address(sp, 16));
-    __ ldp(r21, r22, Address(sp, 32));
-    __ ldp(r23, r24, Address(sp, 48));
-    __ ldp(r25, r26, Address(sp, 64));
-    __ ldp(r27, r28, Address(sp, 80));
+    __ pop(saved_regs, sp);
     if (can_use_fp && can_use_r18) {
       __ ldr(r18_tls, Address(sp, 96));
       __ add(rfp, sp, 112); // leave() will copy rfp to sp below
@@ -8909,7 +8909,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   void keccak_round_gpr(bool can_use_fp, bool can_use_r18, Register rc,
-                        Register a[], Register tmp0, Register tmp1,
+                        const Register a[], Register tmp0, Register tmp1,
                         Register tmp2) {
     __ eor3(tmp1, a[4], a[9], a[14]);
     __ eor3(tmp0, tmp1, a[19], a[24]); // tmp0 = a4^a9^a14^a19^a24 = c4
@@ -9043,7 +9043,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // use r3.r17,r19..r28 to keep a0..a24.
     // a0..a24 are respective locals from SHA3.java
-    Register a[25] = {
+    const Register a[25] = {
         r25, r26, r27, r3, r4, r5, r6, r7, rscratch1, rscratch2, r10, r11, r12,
         r13, r14, r15, r16, r17, r28, r19, r20, r21, r22, r23, r24 };
     Register tmp0 = block_size, tmp1 = buf, tmp2 = state, tmp3 = r30;
@@ -9060,20 +9060,18 @@ class StubGenerator: public StubCodeGenerator {
     __ enter();
 
     // save almost all yet unsaved gpr registers on stack
-    __ str(block_size, __ pre(sp, -128));
+    auto saved_regs = RegSet::range(r19, r28);
+    __ push(saved_regs, sp);
+    __ sub(sp, sp, 48);
+
+    __ str(block_size, sp);
     if (multi_block) {
       __ stpw(ofs, limit, Address(sp, 8));
     }
-    // 8 bytes at sp+16 will be used to keep buf
-    __ stp(r19, r20, Address(sp, 32));
-    __ stp(r21, r22, Address(sp, 48));
-    __ stp(r23, r24, Address(sp, 64));
-    __ stp(r25, r26, Address(sp, 80));
-    __ stp(r27, r28, Address(sp, 96));
     if (can_use_r18 && can_use_fp) {
-      __ stp(r18_tls, state, Address(sp, 112));
+      __ stp(r18_tls, state, Address(sp, 24));
     } else {
-      __ str(state, Address(sp, 112));
+      __ str(state, Address(sp, 24));
     }
 
     // begin sha3 calculations: loading a0..a24 from state arrary
@@ -9169,22 +9167,19 @@ class StubGenerator: public StubCodeGenerator {
       __ movw(c_rarg0, tmp2); // return offset
     }
     if (can_use_fp && can_use_r18) {
-      __ ldp(r18_tls, state, Address(sp, 112));
+      __ ldp(r18_tls, state, Address(sp, 24));
     } else {
-      __ ldr(state, Address(sp, 112));
+      __ ldr(state, Address(sp, 24));
     }
 
     // save calculated sha3 state
     store_keccak_state(a, state);
 
     // restore required registers from stack
-    __ ldp(r19, r20, Address(sp, 32));
-    __ ldp(r21, r22, Address(sp, 48));
-    __ ldp(r23, r24, Address(sp, 64));
-    __ ldp(r25, r26, Address(sp, 80));
-    __ ldp(r27, r28, Address(sp, 96));
+    __ add(sp, sp, 48);
+    __ pop(saved_regs, sp);
     if (can_use_fp && can_use_r18) {
-      __ add(rfp, sp, 128); // leave() will copy rfp to sp below
+      __ mov(rfp, sp); // leave() will copy rfp to sp below
     } // else no need to recalculate rfp, since it wasn't changed
 
     __ leave();

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -8903,6 +8903,37 @@ class StubGenerator: public StubCodeGenerator {
     __ eor(a4, a4, tmp2);
   }
 
+  // The Keccak algorithm needs to read and update 25 state registers
+  // (`a[0]` ... `a[24]`) and maintain a round-constant cursor, `rc`.
+  // It also computes up to 5 intermediate values that are all live at the
+  // same time across some part of the computation, `tmp0` ... `tmp4`.
+  // This means that up to 31 independent values are live at once,
+  // preferably stored in registers to avoid having to push and pop
+  // intermediate results. Since `sp` cannot be overwritten this means
+  // that for the best performance every other gpr register needs to be
+  // used to store this data.
+
+  // When `r18` is not reserved and frame pointers need not be preserved then
+  // `rfp` and `r18` are aliased to temporaries `tmp3` and `tmp4`, respectively.
+  // All other register mappings are determined by the emitter.
+
+  // If `r18` or `rfp` cannot be used then 2 of the 31 live register values are
+  // pushed to the stack after their values are consumed and then popped when
+  // needed, reducing the count of values that need to be held live in registers
+  // to 29. This frees the registers associated with the pushed data for reuse
+  // as temporaries.  Luckily, the algorithm consumes two state-lanes,
+  // `a[4]` and `a[9]`, well before all 5 temporary values are live and only
+  // needs to reuse those specific `a[]` lanes after two of these temporary
+  // values, `tmp3` and `tmp4` are no longer live. In this case, the values in
+  // `a[4]` and `a[9]` can be pushed once early during the computation to free
+  // two registers for use as temporaries and popped once later in the
+  // computation when those two temporaries are no longer needed.  In
+  // this case `a[4]` and `a[9]` are aliased to temporaries `tmp3`
+  // and `tmp4`, respectively, for the segment of the computation that lies
+  // between the push and pop.
+
+  // When `r18` and `rfp` are available then `saved_regs` will be empty.  In
+  // this case push/pop will not emit any instructions, introducing no spills.
   void keccak_round_gpr(bool can_use_fp, bool can_use_r18, Register rc,
                         const Register a[], Register tmp0, Register tmp1,
                         Register tmp2) {

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5062,6 +5062,20 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  void store_keccak_state(Register a[], Register state) {
+    for (int i = 0; i < 24; i += 2) {
+      __ stp(a[i], a[i + 1], Address(state, i * 8));
+    }
+    __ str(a[24], Address(state, 192));
+  }
+
+  void load_keccak_state(Register a[], Register state) {
+    for (int i = 0; i < 24; i += 2) {
+      __ ldp(a[i], a[i + 1], Address(state, i * 8));
+    }
+    __ ldr(a[24], Address(state, 192));
+  }
+
   // Inputs:
   //   c_rarg0   - long[]  state0
   //   c_rarg1   - long[]  state1
@@ -5084,32 +5098,9 @@ class StubGenerator: public StubCodeGenerator {
 
     // use r3.r17,r19..r28 to keep a0..a24.
     // a0..a24 are respective locals from SHA3.java
-    Register a0 = r25,
-             a1 = r26,
-             a2 = r27,
-             a3 = r3,
-             a4 = r4,
-             a5 = r5,
-             a6 = r6,
-             a7 = r7,
-             a8 = rscratch1, // r8
-             a9 = rscratch2, // r9
-             a10 = r10,
-             a11 = r11,
-             a12 = r12,
-             a13 = r13,
-             a14 = r14,
-             a15 = r15,
-             a16 = r16,
-             a17 = r17,
-             a18 = r28,
-             a19 = r19,
-             a20 = r20,
-             a21 = r21,
-             a22 = r22,
-             a23 = r23,
-             a24 = r24;
-
+    Register a[25] = {
+        r25, r26, r27, r3, r4, r5, r6, r7, rscratch1, rscratch2, r10, r11, r12,
+        r13, r14, r15, r16, r17, r28, r19, r20, r21, r22, r23, r24 };
     Register tmp0 = r0, tmp1 = r1, tmp2 = r2, tmp3 = r30;
 
     Label rounds24_loop_0, rounds24_loop_1;
@@ -5123,30 +5114,15 @@ class StubGenerator: public StubCodeGenerator {
     __ enter();
 
     // save the state addresses and callee-saved registers
-    __ stp(state0, state1, __ pre(sp, -112));
-    __ stp(r19, r20, Address(sp, 16));
-    __ stp(r21, r22, Address(sp, 32));
-    __ stp(r23, r24, Address(sp, 48));
-    __ stp(r25, r26, Address(sp, 64));
-    __ stp(r27, r28, Address(sp, 80));
+    auto saved_regs = RegSet::range(r19, r28) + state0 + state1;
+
     if (can_use_r18 && can_use_fp) {
-      __ str(r18_tls, Address(sp, 96));
+      saved_regs += r18_tls;
     }
+    __ push(saved_regs, sp);
 
     // load state0
-    __ ldp(a0, a1, state0);
-    __ ldp(a2, a3, Address(state0, 16));
-    __ ldp(a4, a5, Address(state0, 32));
-    __ ldp(a6, a7, Address(state0, 48));
-    __ ldp(a8, a9, Address(state0, 64));
-    __ ldp(a10, a11, Address(state0, 80));
-    __ ldp(a12, a13, Address(state0, 96));
-    __ ldp(a14, a15, Address(state0, 112));
-    __ ldp(a16, a17, Address(state0, 128));
-    __ ldp(a18, a19, Address(state0, 144));
-    __ ldp(a20, a21, Address(state0, 160));
-    __ ldp(a22, a23, Address(state0, 176));
-    __ ldr(a24, Address(state0, 192));
+    load_keccak_state(a, state0);
 
     // 24 keccak rounds for state0
     __ fmovs(v0, 24.0); // float loop counter,
@@ -5156,45 +5132,15 @@ class StubGenerator: public StubCodeGenerator {
     __ lea(tmp3, ExternalAddress((address) _double_keccak_round_consts));
 
     __ BIND(rounds24_loop_0);
-    keccak_round_gpr(can_use_fp, can_use_r18, tmp3,
-                     a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
-                     a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24,
-                     tmp0, tmp1, tmp2);
+    keccak_round_gpr(can_use_fp, can_use_r18, tmp3, a, tmp0, tmp1, tmp2);
     __ fsubs(v0, v0, v1);
     __ fcmps(v0, 0.0);
     __ br(__ NE, rounds24_loop_0);
 
    // store state0 and load state1
-
     __ ldp(state0, state1, Address(sp));
-
-    __ stp(a0, a1, Address(state0));
-    __ stp(a2, a3, Address(state0, 16));
-    __ stp(a4, a5, Address(state0, 32));
-    __ stp(a6, a7, Address(state0, 48));
-    __ stp(a8, a9, Address(state0, 64));
-    __ stp(a10, a11, Address(state0, 80));
-    __ stp(a12, a13, Address(state0, 96));
-    __ stp(a14, a15, Address(state0, 112));
-    __ stp(a16, a17, Address(state0, 128));
-    __ stp(a18, a19, Address(state0, 144));
-    __ stp(a20, a21, Address(state0, 160));
-    __ stp(a22, a23, Address(state0, 176));
-    __ str(a24, Address(state0, 192));
-
-    __ ldp(a0, a1, state1);
-    __ ldp(a2, a3, Address(state1, 16));
-    __ ldp(a4, a5, Address(state1, 32));
-    __ ldp(a6, a7, Address(state1, 48));
-    __ ldp(a8, a9, Address(state1, 64));
-    __ ldp(a10, a11, Address(state1, 80));
-    __ ldp(a12, a13, Address(state1, 96));
-    __ ldp(a14, a15, Address(state1, 112));
-    __ ldp(a16, a17, Address(state1, 128));
-    __ ldp(a18, a19, Address(state1, 144));
-    __ ldp(a20, a21, Address(state1, 160));
-    __ ldp(a22, a23, Address(state1, 176));
-    __ ldr(a24, Address(state1, 192));
+    store_keccak_state(a, state0);
+    load_keccak_state(a, state1);
 
     // 24 keccak rounds for state1
     __ fmovs(v0, 24.0); // reset float loop counter,
@@ -5203,30 +5149,15 @@ class StubGenerator: public StubCodeGenerator {
     __ lea(tmp3, ExternalAddress((address) _double_keccak_round_consts));
 
     __ BIND(rounds24_loop_1);
-    keccak_round_gpr(can_use_fp, can_use_r18, tmp3,
-                     a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
-                     a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24,
-                     tmp0, tmp1, tmp2);
+    keccak_round_gpr(can_use_fp, can_use_r18, tmp3, a, tmp0, tmp1, tmp2);
     __ fsubs(v0, v0, v1);
     __ fcmps(v0, 0.0);
     __ br(__ NE, rounds24_loop_1);
 
     __ ldr(state1, Address(sp, 8));
 
-   // store state1
-    __ stp(a0, a1, Address(state1));
-    __ stp(a2, a3, Address(state1, 16));
-    __ stp(a4, a5, Address(state1, 32));
-    __ stp(a6, a7, Address(state1, 48));
-    __ stp(a8, a9, Address(state1, 64));
-    __ stp(a10, a11, Address(state1, 80));
-    __ stp(a12, a13, Address(state1, 96));
-    __ stp(a14, a15, Address(state1, 112));
-    __ stp(a16, a17, Address(state1, 128));
-    __ stp(a18, a19, Address(state1, 144));
-    __ stp(a20, a21, Address(state1, 160));
-    __ stp(a22, a23, Address(state1, 176));
-    __ str(a24, Address(state1, 192));
+    // store state1
+    store_keccak_state(a, state1);
 
     // restore callee-saved registers
     __ ldp(r19, r20, Address(sp, 16));
@@ -8978,16 +8909,12 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   void keccak_round_gpr(bool can_use_fp, bool can_use_r18, Register rc,
-                        Register a0, Register a1, Register a2, Register a3, Register a4,
-                        Register a5, Register a6, Register a7, Register a8, Register a9,
-                        Register a10, Register a11, Register a12, Register a13, Register a14,
-                        Register a15, Register a16, Register a17, Register a18, Register a19,
-                        Register a20, Register a21, Register a22, Register a23, Register a24,
-                        Register tmp0, Register tmp1, Register tmp2) {
-    __ eor3(tmp1, a4, a9, a14);
-    __ eor3(tmp0, tmp1, a19, a24); // tmp0 = a4^a9^a14^a19^a24 = c4
-    __ eor3(tmp2, a1, a6, a11);
-    __ eor3(tmp1, tmp2, a16, a21); // tmp1 = a1^a6^a11^a16^a21 = c1
+                        Register a[], Register tmp0, Register tmp1,
+                        Register tmp2) {
+    __ eor3(tmp1, a[4], a[9], a[14]);
+    __ eor3(tmp0, tmp1, a[19], a[24]); // tmp0 = a4^a9^a14^a19^a24 = c4
+    __ eor3(tmp2, a[1], a[6], a[11]);
+    __ eor3(tmp1, tmp2, a[16], a[21]); // tmp1 = a1^a6^a11^a16^a21 = c1
     __ rax1(tmp2, tmp0, tmp1); // d0
     {
 
@@ -8996,86 +8923,85 @@ class StubGenerator: public StubCodeGenerator {
         tmp3 = rfp;
         tmp4 = r18_tls;
       } else {
-        tmp3 = a4;
-        tmp4 = a9;
+        tmp3 = a[4];
+        tmp4 = a[9];
         __ stp(tmp3, tmp4, __ pre(sp, -16));
       }
 
-      __ eor3(tmp3, a0, a5, a10);
-      __ eor3(tmp4, tmp3, a15, a20); // tmp4 = a0^a5^a10^a15^a20 = c0
-      __ eor(a0, a0, tmp2);
-      __ eor(a5, a5, tmp2);
-      __ eor(a10, a10, tmp2);
-      __ eor(a15, a15, tmp2);
-      __ eor(a20, a20, tmp2); // d0(tmp2)
-      __ eor3(tmp3, a2, a7, a12);
-      __ eor3(tmp2, tmp3, a17, a22); // tmp2 = a2^a7^a12^a17^a22 = c2
+      __ eor3(tmp3, a[0], a[5], a[10]);
+      __ eor3(tmp4, tmp3, a[15], a[20]); // tmp4 = a0^a5^a10^a15^a20 = c0
+      __ eor(a[0], a[0], tmp2);
+      __ eor(a[5], a[5], tmp2);
+      __ eor(a[10], a[10], tmp2);
+      __ eor(a[15], a[15], tmp2);
+      __ eor(a[20], a[20], tmp2); // d0(tmp2)
+      __ eor3(tmp3, a[2], a[7], a[12]);
+      __ eor3(tmp2, tmp3, a[17], a[22]); // tmp2 = a2^a7^a12^a17^a22 = c2
       __ rax1(tmp3, tmp4, tmp2); // d1
-      __ eor(a1, a1, tmp3);
-      __ eor(a6, a6, tmp3);
-      __ eor(a11, a11, tmp3);
-      __ eor(a16, a16, tmp3);
-      __ eor(a21, a21, tmp3); // d1(tmp3)
+      __ eor(a[1], a[1], tmp3);
+      __ eor(a[6], a[6], tmp3);
+      __ eor(a[11], a[11], tmp3);
+      __ eor(a[16], a[16], tmp3);
+      __ eor(a[21], a[21], tmp3); // d1(tmp3)
       __ rax1(tmp3, tmp2, tmp0); // d3
-      __ eor3(tmp2, a3, a8, a13);
-      __ eor3(tmp0, tmp2, a18, a23);  // tmp0 = a3^a8^a13^a18^a23 = c3
-      __ eor(a3, a3, tmp3);
-      __ eor(a8, a8, tmp3);
-      __ eor(a13, a13, tmp3);
-      __ eor(a18, a18, tmp3);
-      __ eor(a23, a23, tmp3);
+      __ eor3(tmp2, a[3], a[8], a[13]);
+      __ eor3(tmp0, tmp2, a[18], a[23]);  // tmp0 = a3^a8^a13^a18^a23 = c3
+      __ eor(a[3], a[3], tmp3);
+      __ eor(a[8], a[8], tmp3);
+      __ eor(a[13], a[13], tmp3);
+      __ eor(a[18], a[18], tmp3);
+      __ eor(a[23], a[23], tmp3);
       __ rax1(tmp2, tmp1, tmp0); // d2
-      __ eor(a2, a2, tmp2);
-      __ eor(a7, a7, tmp2);
-      __ eor(a12, a12, tmp2);
+      __ eor(a[2], a[2], tmp2);
+      __ eor(a[7], a[7], tmp2);
+      __ eor(a[12], a[12], tmp2);
       __ rax1(tmp0, tmp0, tmp4); // d4
       if (!can_use_fp || !can_use_r18) {
         __ ldp(tmp3, tmp4, __ post(sp, 16));
       }
-      __ eor(a17, a17, tmp2);
-      __ eor(a22, a22, tmp2);
-      __ eor(a4, a4, tmp0);
-      __ eor(a9, a9, tmp0);
-      __ eor(a14, a14, tmp0);
-      __ eor(a19, a19, tmp0);
-      __ eor(a24, a24, tmp0);
+      __ eor(a[17], a[17], tmp2);
+      __ eor(a[22], a[22], tmp2);
+      __ eor(a[4], a[4], tmp0);
+      __ eor(a[9], a[9], tmp0);
+      __ eor(a[14], a[14], tmp0);
+      __ eor(a[19], a[19], tmp0);
+      __ eor(a[24], a[24], tmp0);
     }
 
-    __ rol(tmp0, a10, 3);
-    __ rol(a10, a1, 1);
-    __ rol(a1, a6, 44);
-    __ rol(a6, a9, 20);
-    __ rol(a9, a22, 61);
-    __ rol(a22, a14, 39);
-    __ rol(a14, a20, 18);
-    __ rol(a20, a2, 62);
-    __ rol(a2, a12, 43);
-    __ rol(a12, a13, 25);
-    __ rol(a13, a19, 8) ;
-    __ rol(a19, a23, 56);
-    __ rol(a23, a15, 41);
-    __ rol(a15, a4, 27);
-    __ rol(a4, a24, 14);
-    __ rol(a24, a21, 2);
-    __ rol(a21, a8, 55);
-    __ rol(a8, a16, 45);
-    __ rol(a16, a5, 36);
-    __ rol(a5, a3, 28);
-    __ rol(a3, a18, 21);
-    __ rol(a18, a17, 15);
-    __ rol(a17, a11, 10);
-    __ rol(a11, a7, 6);
-    __ mov(a7, tmp0);
+    __ rol(tmp0, a[10], 3);
+    __ rol(a[10], a[1], 1);
+    __ rol(a[1], a[6], 44);
+    __ rol(a[6], a[9], 20);
+    __ rol(a[9], a[22], 61);
+    __ rol(a[22], a[14], 39);
+    __ rol(a[14], a[20], 18);
+    __ rol(a[20], a[2], 62);
+    __ rol(a[2], a[12], 43);
+    __ rol(a[12], a[13], 25);
+    __ rol(a[13], a[19], 8) ;
+    __ rol(a[19], a[23], 56);
+    __ rol(a[23], a[15], 41);
+    __ rol(a[15], a[4], 27);
+    __ rol(a[4], a[24], 14);
+    __ rol(a[24], a[21], 2);
+    __ rol(a[21], a[8], 55);
+    __ rol(a[8], a[16], 45);
+    __ rol(a[16], a[5], 36);
+    __ rol(a[5], a[3], 28);
+    __ rol(a[3], a[18], 21);
+    __ rol(a[18], a[17], 15);
+    __ rol(a[17], a[11], 10);
+    __ rol(a[11], a[7], 6);
+    __ mov(a[7], tmp0);
 
-    bcax5(a0, a1, a2, a3, a4, tmp0, tmp1, tmp2);
-    bcax5(a5, a6, a7, a8, a9, tmp0, tmp1, tmp2);
-    bcax5(a10, a11, a12, a13, a14, tmp0, tmp1, tmp2);
-    bcax5(a15, a16, a17, a18, a19, tmp0, tmp1, tmp2);
-    bcax5(a20, a21, a22, a23, a24, tmp0, tmp1, tmp2);
+    bcax5(a[0], a[1], a[2], a[3], a[4], tmp0, tmp1, tmp2);
+    bcax5(a[5], a[6], a[7], a[8], a[9], tmp0, tmp1, tmp2);
+    bcax5(a[10], a[11], a[12], a[13], a[14], tmp0, tmp1, tmp2);
+    bcax5(a[15], a[16], a[17], a[18], a[19], tmp0, tmp1, tmp2);
+    bcax5(a[20], a[21], a[22], a[23], a[24], tmp0, tmp1, tmp2);
 
     __ ldr(tmp1, __ post(rc, 8));
-    __ eor(a0, a0, tmp1);
-
+    __ eor(a[0], a[0], tmp1);
   }
 
   // Arguments:
@@ -9117,32 +9043,9 @@ class StubGenerator: public StubCodeGenerator {
 
     // use r3.r17,r19..r28 to keep a0..a24.
     // a0..a24 are respective locals from SHA3.java
-    Register a0 = r25,
-             a1 = r26,
-             a2 = r27,
-             a3 = r3,
-             a4 = r4,
-             a5 = r5,
-             a6 = r6,
-             a7 = r7,
-             a8 = rscratch1, // r8
-             a9 = rscratch2, // r9
-             a10 = r10,
-             a11 = r11,
-             a12 = r12,
-             a13 = r13,
-             a14 = r14,
-             a15 = r15,
-             a16 = r16,
-             a17 = r17,
-             a18 = r28,
-             a19 = r19,
-             a20 = r20,
-             a21 = r21,
-             a22 = r22,
-             a23 = r23,
-             a24 = r24;
-
+    Register a[25] = {
+        r25, r26, r27, r3, r4, r5, r6, r7, rscratch1, rscratch2, r10, r11, r12,
+        r13, r14, r15, r16, r17, r28, r19, r20, r21, r22, r23, r24 };
     Register tmp0 = block_size, tmp1 = buf, tmp2 = state, tmp3 = r30;
 
     Label sha3_loop, rounds24_preloop, loop_body;
@@ -9174,53 +9077,41 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     // begin sha3 calculations: loading a0..a24 from state arrary
-    __ ldp(a0, a1, state);
-    __ ldp(a2, a3, Address(state, 16));
-    __ ldp(a4, a5, Address(state, 32));
-    __ ldp(a6, a7, Address(state, 48));
-    __ ldp(a8, a9, Address(state, 64));
-    __ ldp(a10, a11, Address(state, 80));
-    __ ldp(a12, a13, Address(state, 96));
-    __ ldp(a14, a15, Address(state, 112));
-    __ ldp(a16, a17, Address(state, 128));
-    __ ldp(a18, a19, Address(state, 144));
-    __ ldp(a20, a21, Address(state, 160));
-    __ ldp(a22, a23, Address(state, 176));
-    __ ldr(a24, Address(state, 192));
+    load_keccak_state(a, state);
 
     __ BIND(sha3_loop);
 
     // load input
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a0, a0, tmp3);
-    __ eor(a1, a1, tmp2);
+    __ eor(a[0], a[0], tmp3);
+    __ eor(a[1], a[1], tmp2);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a2, a2, tmp3);
-    __ eor(a3, a3, tmp2);
+    __ eor(a[2], a[2], tmp3);
+    __ eor(a[3], a[3], tmp2);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a4, a4, tmp3);
-    __ eor(a5, a5, tmp2);
+    __ eor(a[4], a[4], tmp3);
+    __ eor(a[5], a[5], tmp2);
     __ ldr(tmp3, __ post(buf, 8));
-    __ eor(a6, a6, tmp3);
+    __ eor(a[6], a[6], tmp3);
 
     // block_size == 72, SHA3-512; block_size == 104, SHA3-384
     __ tbz(block_size, 7, sha3_512_or_sha3_384);
 
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a7, a7, tmp3);
-    __ eor(a8, a8, tmp2);
+    __ eor(a[7], a[7], tmp3);
+    __ eor(a[8], a[8], tmp2);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a9, a9, tmp3);
-    __ eor(a10, a10, tmp2);
+    __ eor(a[9], a[9], tmp3);
+    __ eor(a[10], a[10], tmp2);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a11, a11, tmp3);
-    __ eor(a12, a12, tmp2);
+    __ eor(a[11], a[11], tmp3);
+    __ eor(a[12], a[12], tmp2);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a13, a13, tmp3);
-    __ eor(a14, a14, tmp2);
+    __ eor(a[13], a[13], tmp3);
+    __ eor(a[14], a[14], tmp2);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a15, a15, tmp3);
-    __ eor(a16, a16, tmp2);
+    __ eor(a[15], a[15], tmp3);
+    __ eor(a[16], a[16], tmp2);
 
     // block_size == 136, bit4 == 0 and bit5 == 0, SHA3-256 or SHAKE256
     __ andw(tmp2, block_size, 48);
@@ -9228,31 +9119,31 @@ class StubGenerator: public StubCodeGenerator {
     __ tbnz(block_size, 5, shake128);
     // block_size == 144, bit5 == 0, SHA3-244
     __ ldr(tmp3, __ post(buf, 8));
-    __ eor(a17, a17, tmp3);
+    __ eor(a[17], a[17], tmp3);
     __ b(rounds24_preloop);
 
     __ BIND(shake128);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a17, a17, tmp3);
-    __ eor(a18, a18, tmp2);
+    __ eor(a[17], a[17], tmp3);
+    __ eor(a[18], a[18], tmp2);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a19, a19, tmp3);
-    __ eor(a20, a20, tmp2);
+    __ eor(a[19], a[19], tmp3);
+    __ eor(a[20], a[20], tmp2);
     __ b(rounds24_preloop); // block_size == 168, SHAKE128
 
     __ BIND(sha3_512_or_sha3_384);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a7, a7, tmp3);
-    __ eor(a8, a8, tmp2);
+    __ eor(a[7], a[7], tmp3);
+    __ eor(a[8], a[8], tmp2);
     __ tbz(block_size, 5, rounds24_preloop); // SHA3-512
 
     // SHA3-384
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a9, a9, tmp3);
-    __ eor(a10, a10, tmp2);
+    __ eor(a[9], a[9], tmp3);
+    __ eor(a[10], a[10], tmp2);
     __ ldp(tmp3, tmp2, __ post(buf, 16));
-    __ eor(a11, a11, tmp3);
-    __ eor(a12, a12, tmp2);
+    __ eor(a[11], a[11], tmp3);
+    __ eor(a[12], a[12], tmp2);
 
     __ BIND(rounds24_preloop);
     __ fmovs(v0, 24.0); // float loop counter,
@@ -9262,10 +9153,7 @@ class StubGenerator: public StubCodeGenerator {
     __ lea(tmp3, ExternalAddress((address) _sha3_round_consts));
 
     __ BIND(loop_body);
-    keccak_round_gpr(can_use_fp, can_use_r18, tmp3,
-                     a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
-                     a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24,
-                     tmp0, tmp1, tmp2);
+    keccak_round_gpr(can_use_fp, can_use_r18, tmp3, a, tmp0, tmp1, tmp2);
     __ fsubs(v0, v0, v1);
     __ fcmps(v0, 0.0);
     __ br(__ NE, loop_body);
@@ -9285,20 +9173,9 @@ class StubGenerator: public StubCodeGenerator {
     } else {
       __ ldr(state, Address(sp, 112));
     }
+
     // save calculated sha3 state
-    __ stp(a0, a1, Address(state));
-    __ stp(a2, a3, Address(state, 16));
-    __ stp(a4, a5, Address(state, 32));
-    __ stp(a6, a7, Address(state, 48));
-    __ stp(a8, a9, Address(state, 64));
-    __ stp(a10, a11, Address(state, 80));
-    __ stp(a12, a13, Address(state, 96));
-    __ stp(a14, a15, Address(state, 112));
-    __ stp(a16, a17, Address(state, 128));
-    __ stp(a18, a19, Address(state, 144));
-    __ stp(a20, a21, Address(state, 160));
-    __ stp(a22, a23, Address(state, 176));
-    __ str(a24, Address(state, 192));
+    store_keccak_state(a, state);
 
     // restore required registers from stack
     __ ldp(r19, r20, Address(sp, 32));


### PR DESCRIPTION
This enhancement provides AArch64 GPR intrinsics for doubleKeccak().  Previously, only SIMD (Neon) intrinsics were implemented for doubleKeccak() on AArch64 systems.  Performance gains for ML-KEM and ML-DSA benchmarks improve from 2 to 9% with the GPR intrinsics:

ML-KEM decapsulation: +2-6% ops/sec
ML-KEM encapsulation: +3-8% ops/sec
ML-KEM key generation: +4-6% ops/sec

ML-DSA signing: +2-4% ops/sec
ML-DSA verification: +6-9% ops/sec
ML-DSA key generation: +6-8% ops/sec

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379016](https://bugs.openjdk.org/browse/JDK-8379016): Improve double_keccak() intrinsic on ARM when SHA3 instructions are not available (**Enhancement** - P3)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Contributors
 * Andrew Haley `<aph@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32049/head:pull/32049` \
`$ git checkout pull/32049`

Update a local copy of the PR: \
`$ git checkout pull/32049` \
`$ git pull https://git.openjdk.org/jdk.git pull/32049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32049`

View PR using the GUI difftool: \
`$ git pr show -t 32049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32049.diff">https://git.openjdk.org/jdk/pull/32049.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32049#issuecomment-5321315017)
</details>
