### PR TITLE
8387722: The race during initialization or lazy constants in and Map/Set

### DIFF
--- a/src/java.base/share/classes/java/util/LazyCollections.java
+++ b/src/java.base/share/classes/java/util/LazyCollections.java
@@ -675,6 +675,12 @@ final class LazyCollections {
         final long offset = offsetFor(index);
         final Object mutex = mutexes.acquireMutex(offset);
         if (mutex == null) {
+            // There might be a race where the value is already computed and
+            // the mutex is cleared, so we need to re-check the value again
+            final T t = (T) UNSAFE.getReferenceAcquire(array, offset);
+            if (t != null) {
+                return t;
+            }
             throwIfPreviousException(index, throwables, input);
             // There must be an exception
             throw cannotReachHere(functionHolder, input);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3412d4c0](https://github.com/openjdk/jdk/commit/3412d4c0dd5250f14cc6fe594355bdf2ff976417) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Per Minborg on 25 Jul 2026 and was reviewed by Jorn Vernee.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387722](https://bugs.openjdk.org/browse/JDK-8387722): The race during initialization or lazy constants in and Map/Set (**Bug** - P2)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32050/head:pull/32050` \
`$ git checkout pull/32050`

Update a local copy of the PR: \
`$ git checkout pull/32050` \
`$ git pull https://git.openjdk.org/jdk.git pull/32050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32050`

View PR using the GUI difftool: \
`$ git pr show -t 32050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32050.diff">https://git.openjdk.org/jdk/pull/32050.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32050#issuecomment-5087871660)
</details>
