### PR TITLE
8354489: Some callers of VMError::report_and_die think it can return

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2674,9 +2674,6 @@ LONG Handle_IDiv_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
 static inline void report_error(Thread* t, DWORD exception_code,
                                 address addr, void* siginfo, void* context) {
   VMError::report_and_die(t, exception_code, addr, siginfo, context);
-
-  // If UseOSErrorReporting, this will return here and save the error file
-  // somewhere where we can find it in the minidump.
 }
 
 //-----------------------------------------------------------------------------

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2671,11 +2671,6 @@ LONG Handle_IDiv_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
   return EXCEPTION_CONTINUE_EXECUTION;
 }
 
-static inline void report_error(Thread* t, DWORD exception_code,
-                                address addr, void* siginfo, void* context) {
-  VMError::report_and_die(t, exception_code, addr, siginfo, context);
-}
-
 //-----------------------------------------------------------------------------
 JNIEXPORT
 LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2743,7 +2743,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         overflow_state->disable_stack_red_zone();
         tty->print_raw_cr("An unrecoverable stack overflow has occurred.");
         VMError::report_and_die(t, exception_code, pc, exception_record,
-                      exceptionInfo->ContextRecord);
+                                exceptionInfo->ContextRecord);
       }
     } else if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
       if (in_java) {
@@ -2781,7 +2781,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
           if (stub != nullptr) return Handle_Exception(exceptionInfo, stub);
         }
         VMError::report_and_die(t, exception_code, pc, exception_record,
-                      exceptionInfo->ContextRecord);
+                                exceptionInfo->ContextRecord);
       }
 
       // Special care for fast JNI field accessors.
@@ -2794,7 +2794,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
       // Stack overflow or null pointer exception in native code.
       VMError::report_and_die(t, exception_code, pc, exception_record,
-                   exceptionInfo->ContextRecord);
+                              exceptionInfo->ContextRecord);
     } // /EXCEPTION_ACCESS_VIOLATION
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -2863,7 +2863,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
   if (should_report_error) {
     VMError::report_and_die(t, exception_code, pc, exception_record,
-                 exceptionInfo->ContextRecord);
+                            exceptionInfo->ContextRecord);
   }
 
   return EXCEPTION_CONTINUE_SEARCH;
@@ -2884,7 +2884,7 @@ LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* excepti
 
     if (exceptionCode != EXCEPTION_BREAKPOINT) {
       VMError::report_and_die(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
-                  exceptionInfo->ContextRecord);
+                              exceptionInfo->ContextRecord);
     }
   }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2742,9 +2742,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         // Fatal red zone violation.
         overflow_state->disable_stack_red_zone();
         tty->print_raw_cr("An unrecoverable stack overflow has occurred.");
-        report_error(t, exception_code, pc, exception_record,
+        VMError::report_and_die(t, exception_code, pc, exception_record,
                       exceptionInfo->ContextRecord);
-        return EXCEPTION_CONTINUE_SEARCH;
       }
     } else if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
       if (in_java) {
@@ -2781,9 +2780,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
           address stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
           if (stub != nullptr) return Handle_Exception(exceptionInfo, stub);
         }
-        report_error(t, exception_code, pc, exception_record,
+        VMError::report_and_die(t, exception_code, pc, exception_record,
                       exceptionInfo->ContextRecord);
-        return EXCEPTION_CONTINUE_SEARCH;
       }
 
       // Special care for fast JNI field accessors.
@@ -2795,9 +2793,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
       }
 
       // Stack overflow or null pointer exception in native code.
-      report_error(t, exception_code, pc, exception_record,
+      VMError::report_and_error(t, exception_code, pc, exception_record,
                    exceptionInfo->ContextRecord);
-      return EXCEPTION_CONTINUE_SEARCH;
     } // /EXCEPTION_ACCESS_VIOLATION
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -2865,7 +2862,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 #endif
 
   if (should_report_error) {
-    report_error(t, exception_code, pc, exception_record,
+    VMError::report_and_die(t, exception_code, pc, exception_record,
                  exceptionInfo->ContextRecord);
   }
 
@@ -2886,7 +2883,7 @@ LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* excepti
     Thread* thread = Thread::current_or_null_safe();
 
     if (exceptionCode != EXCEPTION_BREAKPOINT) {
-      report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
+      VMError::report_and_die(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
                   exceptionInfo->ContextRecord);
     }
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2793,7 +2793,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
       }
 
       // Stack overflow or null pointer exception in native code.
-      VMError::report_and_error(t, exception_code, pc, exception_record,
+      VMError::report_and_die(t, exception_code, pc, exception_record,
                    exceptionInfo->ContextRecord);
     } // /EXCEPTION_ACCESS_VIOLATION
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -240,10 +240,6 @@ void report_vm_out_of_memory(const char* file, int line, size_t size,
 
   VMError::report_and_die(Thread::current_or_null(), file, line, size, vm_err_type, detail_fmt, detail_args);
   va_end(detail_args);
-
-  // The UseOSErrorReporting option in report_and_die() may allow a return
-  // to here. If so then we'll have to figure out how to handle it.
-  guarantee(false, "report_and_die() should not return here");
 }
 
 void report_should_not_call(const char* file, int line) {


### PR DESCRIPTION
VMError::report_and_die is [[noreturn]] and cannot return, even when UseOSErrorReporting is enabled.

Remove misleading comments and dead code from report_error(os_windows.cpp) and report_vm_out_of_memory (debug.cpp).

JBS Issue: [JDK-8354489](https://bugs.openjdk.org/browse/JDK-8354489)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8354489](https://bugs.openjdk.org/browse/JDK-8354489): Some callers of VMError::report_and_die think it can return (**Enhancement** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32054/head:pull/32054` \
`$ git checkout pull/32054`

Update a local copy of the PR: \
`$ git checkout pull/32054` \
`$ git pull https://git.openjdk.org/jdk.git pull/32054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32054`

View PR using the GUI difftool: \
`$ git pr show -t 32054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32054.diff">https://git.openjdk.org/jdk/pull/32054.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32054#issuecomment-5092259695)
</details>
