### PR TITLE
8379830: The warnings for value-based classes need updating to include use of the Reference API

### DIFF
--- a/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
+++ b/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
- Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,10 @@ A value-based class has the following properties:
 <p>Synchronization on instances of value-based classes is strongly discouraged,
     because the programmer cannot guarantee exclusive ownership of the
     associated monitor.</p>
+
+<p>Use of instances of value-based classes in {@linkplain
+    java.lang.ref.Reference reference objects} is strongly discouraged,
+    because these instances do not have reliable identity.</p>
 
 <p>Identity-related behavior of value-based classes may change in a future release.
     For example, synchronization may fail.</p>

--- a/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
+++ b/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
@@ -65,7 +65,7 @@ A value-based class has the following properties:
     because the programmer cannot guarantee exclusive ownership of the
     associated monitor.</p>
 
-<p>Use of instances of value-based classes in {@linkplain
+<p>Use of instances of value-based classes as referents in {@linkplain
     java.lang.ref.Reference reference objects} is strongly discouraged,
     because these instances do not have reliable identity.</p>
 


### PR DESCRIPTION
The warnings for value-based classes does not mention the use of VBC instances in Reference objects. We are adding warnings for failures in JEP 401 integration; and it's beneficial for us to add something in 27 before JEP 401 lands in 28.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8389188](https://bugs.openjdk.org/browse/JDK-8389188) to be approved

### Issues
 * [JDK-8379830](https://bugs.openjdk.org/browse/JDK-8379830): The warnings for value-based classes need updating to include use of the Reference API (**Enhancement** - P3)
 * [JDK-8389188](https://bugs.openjdk.org/browse/JDK-8389188): The warnings for value-based classes need updating to include use of the Reference API (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) Review applies to [a340a677](https://git.openjdk.org/jdk/pull/32055/files/a340a677b5c17b0e598af5bbaa9a6f48d42af231)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32055/head:pull/32055` \
`$ git checkout pull/32055`

Update a local copy of the PR: \
`$ git checkout pull/32055` \
`$ git pull https://git.openjdk.org/jdk.git pull/32055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32055`

View PR using the GUI difftool: \
`$ git pr show -t 32055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32055.diff">https://git.openjdk.org/jdk/pull/32055.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32055#issuecomment-5093124567)
</details>
