### PR TITLE
8370493: [ubsan] aotMapLogger.cpp:864:44: runtime error: applying non-zero offset NNNNN to null pointer

### DIFF
--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -27,6 +27,7 @@
 #include "cds/aotMappedHeapWriter.hpp"
 #include "cds/aotStreamedHeapLoader.hpp"
 #include "cds/aotStreamedHeapWriter.hpp"
+#include "cds/archiveUtils.hpp"
 #include "cds/cdsConfig.hpp"
 #include "cds/filemap.hpp"
 #include "classfile/moduleEntry.hpp"
@@ -879,7 +880,7 @@ void AOTMapLogger::runtime_log_heap_region(FileMapInfo* mapinfo) {
     }
 
     address requested_base = UseCompressedOops ? (address)mapinfo->narrow_oop_base() : AOTMappedHeapLoader::heap_region_requested_address(mapinfo);
-    address requested_start = requested_base + r->mapping_offset();
+    address requested_start = ArchiveUtils::offset_to_requested_addr(requested_base, r->mapping_offset());
     log_region_range("heap", buffer_start, buffer_end, requested_start);
     log_archived_objects(AOTMappedHeapLoader::oop_iterator(mapinfo, buffer_start, buffer_end));
   }

--- a/src/hotspot/share/cds/aotMapLogger.cpp
+++ b/src/hotspot/share/cds/aotMapLogger.cpp
@@ -880,7 +880,7 @@ void AOTMapLogger::runtime_log_heap_region(FileMapInfo* mapinfo) {
     }
 
     address requested_base = UseCompressedOops ? (address)mapinfo->narrow_oop_base() : AOTMappedHeapLoader::heap_region_requested_address(mapinfo);
-    address requested_start = ArchiveUtils::offset_to_requested_addr(requested_base, r->mapping_offset());
+    address requested_start = ArchiveUtils::offset_from_requested_base(requested_base, r->mapping_offset());
     log_region_range("heap", buffer_start, buffer_end, requested_start);
     log_archived_objects(AOTMappedHeapLoader::oop_iterator(mapinfo, buffer_start, buffer_end));
   }

--- a/src/hotspot/share/cds/aotMappedHeapLoader.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapLoader.cpp
@@ -771,7 +771,7 @@ AOTMapLogger::OopDataIterator* AOTMappedHeapLoader::oop_iterator(FileMapInfo* in
 
   FileMapRegion* r = info->region_at(AOTMetaspace::hp);
   address requested_base = UseCompressedOops ? (address)info->narrow_oop_base() : heap_region_requested_address(info);
-  address requested_start = requested_base + r->mapping_offset();
+  address requested_start = ArchiveUtils::offset_to_requested_addr(requested_base, r->mapping_offset());
   int requested_shift = info->narrow_oop_shift();
 
   return new MappedLoaderOopIterator(buffer_start,

--- a/src/hotspot/share/cds/aotMappedHeapLoader.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapLoader.cpp
@@ -771,7 +771,7 @@ AOTMapLogger::OopDataIterator* AOTMappedHeapLoader::oop_iterator(FileMapInfo* in
 
   FileMapRegion* r = info->region_at(AOTMetaspace::hp);
   address requested_base = UseCompressedOops ? (address)info->narrow_oop_base() : heap_region_requested_address(info);
-  address requested_start = ArchiveUtils::offset_to_requested_addr(requested_base, r->mapping_offset());
+  address requested_start = ArchiveUtils::offset_from_requested_base(requested_base, r->mapping_offset());
   int requested_shift = info->narrow_oop_shift();
 
   return new MappedLoaderOopIterator(buffer_start,

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -367,7 +367,7 @@ address ArchiveBuilder::reserve_buffer() {
     size_t static_archive_size = _mapped_static_archive_top - _mapped_static_archive_bottom;
 
     // At run time, we will mmap the dynamic archive at my_archive_requested_bottom
-    _requested_static_archive_top = _requested_static_archive_bottom + static_archive_size;
+    _requested_static_archive_top = ArchiveUtils::offset_to_requested_addr(_requested_static_archive_bottom, static_archive_size);
     my_archive_requested_bottom = align_up(_requested_static_archive_top, AOTMetaspace::core_region_alignment());
 
     _requested_dynamic_archive_bottom = my_archive_requested_bottom;
@@ -375,7 +375,7 @@ address ArchiveBuilder::reserve_buffer() {
 
   _buffer_to_requested_delta = my_archive_requested_bottom - _buffer_bottom;
 
-  address my_archive_requested_top = my_archive_requested_bottom + buffer_size;
+  address my_archive_requested_top = ArchiveUtils::offset_to_requested_addr(my_archive_requested_bottom, buffer_size);
   if (my_archive_requested_bottom <  _requested_static_archive_bottom ||
       my_archive_requested_top    <= _requested_static_archive_bottom) {
     // Size overflow.
@@ -982,7 +982,7 @@ size_t ArchiveBuilder::any_to_offset(address p) const {
 }
 
 address ArchiveBuilder::offset_to_buffered_address(size_t offset) const {
-  address requested_addr = _requested_static_archive_bottom + offset;
+  address requested_addr = ArchiveUtils::offset_to_requested_addr(_requested_static_archive_bottom, offset);
   address buffered_addr = requested_addr - _buffer_to_requested_delta;
   assert(is_in_buffer_space(buffered_addr), "bad offset");
   return buffered_addr;
@@ -1048,7 +1048,7 @@ class RelocateBufferToRequested : public BitMapClosure {
 
     address bottom = _builder->buffer_bottom();
     address top = _builder->buffer_top();
-    address new_bottom = bottom + _buffer_to_requested_delta;
+    address new_bottom = ArchiveUtils::offset_to_requested_addr(bottom, _buffer_to_requested_delta);
     address new_top = top + _buffer_to_requested_delta;
     aot_log_debug(aot)("Relocating archive from [" INTPTR_FORMAT " - " INTPTR_FORMAT "] to "
                    "[" INTPTR_FORMAT " - " INTPTR_FORMAT "]",
@@ -1109,7 +1109,7 @@ void ArchiveBuilder::relocate_to_requested() {
   size_t my_archive_size = buffer_top() - buffer_bottom();
 
   if (CDSConfig::is_dumping_static_archive()) {
-    _requested_static_archive_top = _requested_static_archive_bottom + my_archive_size;
+    _requested_static_archive_top = ArchiveUtils::offset_to_requested_addr(_requested_static_archive_bottom, my_archive_size);
     RelocateBufferToRequested<true> patcher(this);
     patcher.doit();
   } else {

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -367,7 +367,7 @@ address ArchiveBuilder::reserve_buffer() {
     size_t static_archive_size = _mapped_static_archive_top - _mapped_static_archive_bottom;
 
     // At run time, we will mmap the dynamic archive at my_archive_requested_bottom
-    _requested_static_archive_top = ArchiveUtils::offset_to_requested_addr(_requested_static_archive_bottom, static_archive_size);
+    _requested_static_archive_top = ArchiveUtils::offset_from_requested_base(_requested_static_archive_bottom, static_archive_size);
     my_archive_requested_bottom = align_up(_requested_static_archive_top, AOTMetaspace::core_region_alignment());
 
     _requested_dynamic_archive_bottom = my_archive_requested_bottom;
@@ -375,7 +375,7 @@ address ArchiveBuilder::reserve_buffer() {
 
   _buffer_to_requested_delta = my_archive_requested_bottom - _buffer_bottom;
 
-  address my_archive_requested_top = ArchiveUtils::offset_to_requested_addr(my_archive_requested_bottom, buffer_size);
+  address my_archive_requested_top = ArchiveUtils::offset_from_requested_base(my_archive_requested_bottom, buffer_size);
   if (my_archive_requested_bottom <  _requested_static_archive_bottom ||
       my_archive_requested_top    <= _requested_static_archive_bottom) {
     // Size overflow.
@@ -982,7 +982,7 @@ size_t ArchiveBuilder::any_to_offset(address p) const {
 }
 
 address ArchiveBuilder::offset_to_buffered_address(size_t offset) const {
-  address requested_addr = ArchiveUtils::offset_to_requested_addr(_requested_static_archive_bottom, offset);
+  address requested_addr = ArchiveUtils::offset_from_requested_base(_requested_static_archive_bottom, offset);
   address buffered_addr = requested_addr - _buffer_to_requested_delta;
   assert(is_in_buffer_space(buffered_addr), "bad offset");
   return buffered_addr;
@@ -1109,7 +1109,7 @@ void ArchiveBuilder::relocate_to_requested() {
   size_t my_archive_size = buffer_top() - buffer_bottom();
 
   if (CDSConfig::is_dumping_static_archive()) {
-    _requested_static_archive_top = ArchiveUtils::offset_to_requested_addr(_requested_static_archive_bottom, my_archive_size);
+    _requested_static_archive_top = ArchiveUtils::offset_from_requested_base(_requested_static_archive_bottom, my_archive_size);
     RelocateBufferToRequested<true> patcher(this);
     patcher.doit();
   } else {

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1048,7 +1048,7 @@ class RelocateBufferToRequested : public BitMapClosure {
 
     address bottom = _builder->buffer_bottom();
     address top = _builder->buffer_top();
-    address new_bottom = ArchiveUtils::offset_to_requested_addr(bottom, _buffer_to_requested_delta);
+    address new_bottom = bottom +  _buffer_to_requested_delta;
     address new_top = top + _buffer_to_requested_delta;
     aot_log_debug(aot)("Relocating archive from [" INTPTR_FORMAT " - " INTPTR_FORMAT "] to "
                    "[" INTPTR_FORMAT " - " INTPTR_FORMAT "]",

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -290,6 +290,12 @@ public:
   static Array<T>* archive_array(GrowableArray<T>* tmp_array) {
     return archive_ptr_array(tmp_array);
   }
+
+  template <typename T>
+  static address offset_to_requested_addr(T requested_base, size_t offset) {
+    // As zero is allowed for requested_base, use integer arithmetic to avoid UB pointer arithmetic.
+    return (address)((uintptr_t)requested_base + offset);
+  }
 };
 
 class HeapRootSegments {

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -291,8 +291,10 @@ public:
     return archive_ptr_array(tmp_array);
   }
 
+  // Compute the address at the given offset from requested_base. It's possible for
+  // requested_base to have the numerical value of 0x0.
   template <typename T>
-  static address offset_to_requested_addr(T requested_base, size_t offset) {
+  static address offset_from_requested_base(T requested_base, size_t offset) {
     // As zero is allowed for requested_base, use integer arithmetic to avoid UB pointer arithmetic.
     return (address)((uintptr_t)requested_base + offset);
   }

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -291,8 +291,10 @@ public:
     return archive_ptr_array(tmp_array);
   }
 
-  // Compute the address at the given offset from requested_base. It's possible for
-  // requested_base to have the numerical value of 0x0.
+  // Compute the address at the given offset from requested_base, which must be the
+  // requested address of the bottom of the static or dynamic archive. In the case of
+  // the static archive, it's possible for requested_base to have the numerical value
+  // of 0x0, so we use integer arithmetic to avoid UB pointer arithmetic.
   template <typename T>
   static address offset_from_requested_base(T requested_base, size_t offset) {
     // As zero is allowed for requested_base, use integer arithmetic to avoid UB pointer arithmetic.

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -297,7 +297,6 @@ public:
   // of 0x0, so we use integer arithmetic to avoid UB pointer arithmetic.
   template <typename T>
   static address offset_from_requested_base(T requested_base, size_t offset) {
-    // As zero is allowed for requested_base, use integer arithmetic to avoid UB pointer arithmetic.
     return (address)((uintptr_t)requested_base + offset);
   }
 };


### PR DESCRIPTION
The UBSAN tool found undefined behavior in the aotMapLogger which relates to [JDK-8366062](https://bugs.openjdk.org/browse/JDK-8366062). This patch applies an updated fix for both issues that places `address + offset` calculations in archiveUtils with proper casting to avoid the UBSAN error. Verified with tier 1-5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8370493](https://bugs.openjdk.org/browse/JDK-8370493): [ubsan] aotMapLogger.cpp:864:44: runtime error: applying non-zero offset NNNNN to null pointer (**Enhancement** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32057/head:pull/32057` \
`$ git checkout pull/32057`

Update a local copy of the PR: \
`$ git checkout pull/32057` \
`$ git pull https://git.openjdk.org/jdk.git pull/32057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32057`

View PR using the GUI difftool: \
`$ git pr show -t 32057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32057.diff">https://git.openjdk.org/jdk/pull/32057.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32057#issuecomment-5093737689)
</details>
