### PR TITLE
8388794: Short display name tests for zones with explicit DST offsets

### DIFF
--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -26,11 +26,15 @@
  * @bug 8181157 8202537 8234347 8236548 8261279 8322647 8174269 8346948
  *      8354548 8381379 8382020 8384043 8371842
  * @modules jdk.localedata
+ *      java.base/sun.util.calendar
  * @summary Checks CLDR time zone names are generated correctly at
  * either build or runtime
  * @run junit TimeZoneNamesTest
  */
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.time.ZoneId;
@@ -39,11 +43,15 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Stream;
+import sun.util.calendar.ZoneInfoFile;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -52,12 +60,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TimeZoneNamesTest {
+    private static Set<String> EXPLICIT_OFFSET_ZONES;
+
+    @BeforeAll
+    static void findExplictOffsetZones() throws IOException {
+        EXPLICIT_OFFSET_ZONES = new HashSet<>();
+        var lines = Files.readAllLines(Paths.get(System.getProperty("test.root"),
+            "../../make/data/cldr/common/supplemental/metaZones.xml"));
+        String zone = null;
+        for (var line : lines) {
+            line = line.trim();
+            if (line.startsWith("<timezone ")) {
+                zone = line.replaceFirst(".*type=\"", "").replaceFirst("\">$", "");
+            } else if (line.startsWith("<usesMetazone") &&
+                line.contains("dstOffset=") &&
+                !line.contains("to=")) {
+                EXPLICIT_OFFSET_ZONES.add(zone);
+            }
+        }
+    }
 
     private static Object[][] sampleTZs() {
         return new Object[][] {
             // tzid, locale, style, expected
 
-            // This list is as of CLDR version 48, and should be examined
+            // This list is as of CLDR version specified above, and should be examined
             // on the CLDR data upgrade.
 
             // no "metazone" zones (some of them were assigned metazones
@@ -300,13 +327,26 @@ public class TimeZoneNamesTest {
 
     private static Stream<Arguments> explicitDstOffsets() {
         return Stream.of(
-            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Irish Standard Time"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Greenwich Mean Time"),
-            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Irish Standard Time"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Greenwich Mean Time"),
-            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time")
+            // CLDR v48
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Irish Standard Time", "IST"),
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Greenwich Mean Time", "GMT"),
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Irish Standard Time", "IST"),
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Greenwich Mean Time", "GMT"),
+            // CLDR v48.2 & tz2026b. British Columbia switched to permanent DST
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time", "PDT"),
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time", "PDT"),
+            // CLDR v49 & tz2026c. Alberta switched to permanent DST
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Daylight Time", "MDT"),
+            checkVer("2026c", 49, 0) ?
+                Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Daylight Time", "MDT") :
+                Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Standard Time", "MST")
         );
+    }
+
+    // Explicit dstOffset is enabled in two steps. First step is the IANA TZ Database rule update, and the second
+    // step is CLDR metazone update with explicit offsets. This method checks the required tzdb & CLDR versions
+    private static boolean checkVer(String requiredTZVer, int requiredCLDRMajor, int requiredCLDRMMinor) {
+        return ZoneInfoFile.getVersion().compareTo(requiredTZVer) >= 0;
     }
 
     @ParameterizedTest
@@ -340,18 +380,22 @@ public class TimeZoneNamesTest {
             "getZoneStrings() returned array containing non-empty string element(s)");
     }
 
-    // Explicit metazone dst offset test. As of CLDR v48, only Europe/Dublin utilizes
-    // this attribute, but will be used for America/Vancouver once CLDR adopts the
-    // explicit offset for that zone, which warrants the test data modification.
+    // Explicit metazone dst offset test.
     @ParameterizedTest
     @MethodSource("explicitDstOffsets")
-    public void test_ExplicitMetazoneOffsets(ZonedDateTime zdt, String expected) {
+    public void test_ExplicitMetazoneOffsets(ZonedDateTime zdt, String expectedLong, String expectedShort) {
         // java.time
-        assertEquals(expected, DateTimeFormatter.ofPattern("zzzz").format(zdt));
+        assertEquals(expectedLong, DateTimeFormatter.ofPattern("zzzz").format(zdt));
+        assertEquals(expectedShort, DateTimeFormatter.ofPattern("z").format(zdt));
 
         // java.text/util
+        var date = Date.from(zdt.toInstant());
+        var tz = TimeZone.getTimeZone(zdt.getZone());
         var sdf = new SimpleDateFormat("zzzz");
-        sdf.setTimeZone(TimeZone.getTimeZone(zdt.getZone()));
-        assertEquals(expected, sdf.format(Date.from(zdt.toInstant())));
+        sdf.setTimeZone(tz);
+        assertEquals(expectedLong, sdf.format(date));
+        sdf = new SimpleDateFormat("z");
+        sdf.setTimeZone(tz);
+        assertEquals(expectedShort, sdf.format(date));
     }
 }

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -26,15 +26,11 @@
  * @bug 8181157 8202537 8234347 8236548 8261279 8322647 8174269 8346948
  *      8354548 8381379 8382020 8384043 8371842
  * @modules jdk.localedata
- *      java.base/sun.util.calendar
  * @summary Checks CLDR time zone names are generated correctly at
  * either build or runtime
  * @run junit TimeZoneNamesTest
  */
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.time.ZoneId;
@@ -43,15 +39,11 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Stream;
-import sun.util.calendar.ZoneInfoFile;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -60,32 +52,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TimeZoneNamesTest {
-    private static Set<String> EXPLICIT_OFFSET_ZONES;
-
-    @BeforeAll
-    static void findExplictOffsetZones() throws IOException {
-        EXPLICIT_OFFSET_ZONES = new HashSet<>();
-        var lines = Files.readAllLines(Paths.get(System.getProperty("test.root"),
-            "../../make/data/cldr/common/supplemental/metaZones.xml"));
-        String zone = null;
-        for (var line : lines) {
-            line = line.trim();
-            if (line.startsWith("<timezone ")) {
-                zone = line.replaceFirst(".*type=\"", "").replaceFirst("\">$", "");
-            } else if (line.startsWith("<usesMetazone") &&
-                line.contains("dstOffset=") &&
-                !line.contains("to=")) {
-                EXPLICIT_OFFSET_ZONES.add(zone);
-            }
-        }
-    }
 
     private static Object[][] sampleTZs() {
         return new Object[][] {
             // tzid, locale, style, expected
 
-            // This list is as of CLDR version specified above, and should be examined
-            // on the CLDR data upgrade.
+            // This list is current as of CLDR 48.2 and should be reviewed
+            // whenever the CLDR data is upgraded.
 
             // no "metazone" zones (some of them were assigned metazones
             // over time, thus they are not "generated" per se
@@ -332,21 +305,10 @@ public class TimeZoneNamesTest {
             Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Greenwich Mean Time", "GMT"),
             Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Irish Standard Time", "IST"),
             Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Greenwich Mean Time", "GMT"),
-            // CLDR v48.2 & tz2026b. British Columbia switched to permanent DST
+            // CLDR v48.2 & tz2026b. America/Vancouver switched to permanent DST
             Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time", "PDT"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time", "PDT"),
-            // CLDR v49 & tz2026c. Alberta switched to permanent DST
-            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Daylight Time", "MDT"),
-            checkVer("2026c", 49, 0) ?
-                Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Daylight Time", "MDT") :
-                Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Edmonton")), "Mountain Standard Time", "MST")
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time", "PDT")
         );
-    }
-
-    // Explicit dstOffset is enabled in two steps. First step is the IANA TZ Database rule update, and the second
-    // step is CLDR metazone update with explicit offsets. This method checks the required tzdb & CLDR versions
-    private static boolean checkVer(String requiredTZVer, int requiredCLDRMajor, int requiredCLDRMMinor) {
-        return ZoneInfoFile.getVersion().compareTo(requiredTZVer) >= 0;
     }
 
     @ParameterizedTest
@@ -380,7 +342,10 @@ public class TimeZoneNamesTest {
             "getZoneStrings() returned array containing non-empty string element(s)");
     }
 
-    // Explicit metazone dst offset test.
+    // Explicit metazone DST offset test. This attribute is used for Europe/Dublin
+    // to support the negative DST. Also, it is used to support permanent DST names,
+    // such as with America/Vancouver. For the latter case, both CLDR data and corresponding
+    // updated TZDB data are required (e.g., tz2026b for America/Vancouver).
     @ParameterizedTest
     @MethodSource("explicitDstOffsets")
     public void test_ExplicitMetazoneOffsets(ZonedDateTime zdt, String expectedLong, String expectedShort) {


### PR DESCRIPTION
Enhance tests for zone names with explicit DST offsets to verify both long and short names.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388794](https://bugs.openjdk.org/browse/JDK-8388794): Short display name tests for zones with explicit DST offsets (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32060/head:pull/32060` \
`$ git checkout pull/32060`

Update a local copy of the PR: \
`$ git checkout pull/32060` \
`$ git pull https://git.openjdk.org/jdk.git pull/32060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32060`

View PR using the GUI difftool: \
`$ git pr show -t 32060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32060.diff">https://git.openjdk.org/jdk/pull/32060.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32060#issuecomment-5097552518)
</details>
