### PR TITLE
8388486: javax/swing/JInternalFrame/8069348/bug8069348.java fails with Internal frame is not correctly dragged!

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
+++ b/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
@@ -30,6 +30,7 @@ import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.awt.event.InputEvent;
+import javax.swing.DesktopManager;
 import javax.swing.JDesktopPane;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
@@ -78,14 +79,10 @@ public class bug8069348 {
             int dx = screenBounds.width / 2;
             int dy = screenBounds.height / 2;
 
-            robot.mouseMove(x, y);
+            dragInternalFrame(dx, dy);
             robot.waitForIdle();
 
-            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-            robot.mouseMove(x + dx, y + dy);
-            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-            robot.waitForIdle();
-
+            waitForFrameBounds(robot, screenBounds.x + dx, screenBounds.y + dy);
             int cx = screenBounds.x + screenBounds.width + dx / 2;
             int cy = screenBounds.y + screenBounds.height + dy / 2;
 
@@ -114,6 +111,37 @@ public class bug8069348 {
         }
         System.out.println("Test Passed");
     }
+
+    private static void dragInternalFrame(int dx, int dy) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            DesktopManager dm = internalFrame.getDesktopPane().getDesktopManager();
+            Rectangle bounds = internalFrame.getBounds();
+
+            dm.beginDraggingFrame(internalFrame);
+            try {
+                dm.dragFrame(internalFrame, bounds.x + dx, bounds.y + dy);
+            } finally {
+                dm.endDraggingFrame(internalFrame);
+            }
+        });
+    }
+
+    private static void waitForFrameBounds(Robot robot, int x, int y)
+            throws Exception {
+        for (int i = 0; i < 10; i++) {
+            Rectangle bounds = getInternalFrameScreenBounds();
+            if (bounds.x == x && bounds.y == y) {
+                return;
+            }
+            robot.delay(100);
+            robot.waitForIdle();
+        }
+
+        Rectangle bounds = getInternalFrameScreenBounds();
+        throw new RuntimeException("Internal frame was not dragged to expected"
+                + " location. Expected: " + x + ", " + y
+                + "; actual: " + bounds.x + ", " + bounds.y);
+     }
 
     private static Rectangle getInternalFrameScreenBounds() throws Exception {
         Rectangle[] points = new Rectangle[1];


### PR DESCRIPTION
Test sometimes fails due to Robot drag not happening for JInternalFrame..It is somewhat rare and fails probably 2 out of 30 iterations in mainline citing the following
```

----------System.out:(2/23)----------
d3d null
cx 437 cy 246
----------System.err:(14/854)----------
FRAME_COLOR Red: 255; Green: 200; Blue: 0
Pixel color Red: 255; Green: 255; Blue: 0
java.lang.RuntimeException: Internal frame is not correctly dragged!
at bug8069348.main(bug8069348.java:111)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:583)
at com.sun.javatest.regtest.agent.MainMethodHelper.executeModernMainClass(MainMethodHelper.java:56)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:140)
at java.base/java.lang.Thread.run(Thread.java:1527) 

```

I tried to fix using staggered drag so instead of dragging from x1->x2, I used drag from x1->x11->x12->..x2 so that one big drag is avoided and it improves failure rate from 2/30 to 2/50 but it still fails sometimes.

So, I used `DefaultDesktopManager `fast internal-frame dragging and not rely on flaky native Robot drag where sometimes mouse drag events is seen to be missed/not-delivered in linux..It still tests the intended `SunGraphic2D.copyArea` as it follows the path
DesktopManager.beginDraggingFrame -> DesktopManager.dragFrame -> DefaultDesktopManager.dragFrameFaster -> RepaintManager.copyArea -> Graphics.copyArea -> SunGraphics2D.copyArea
and it passes for 100 iterations

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388486](https://bugs.openjdk.org/browse/JDK-8388486): javax/swing/JInternalFrame/8069348/bug8069348.java fails with Internal frame is not correctly dragged! (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32063/head:pull/32063` \
`$ git checkout pull/32063`

Update a local copy of the PR: \
`$ git checkout pull/32063` \
`$ git pull https://git.openjdk.org/jdk.git pull/32063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32063`

View PR using the GUI difftool: \
`$ git pr show -t 32063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32063.diff">https://git.openjdk.org/jdk/pull/32063.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32063#issuecomment-5101410670)
</details>
