### PR TITLE
8380453: Add the hotspot compiler testlibrary to the test-image

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -751,6 +751,18 @@ $(eval $(call SetupTarget, test-image-lib, \
     DEPS := build-test-lib, \
 ))
 
+$(eval $(call SetupTarget, build-compiler-testlibrary, \
+    MAKEFILE := hotspot/test/BuildCompilerTestlibrary, \
+    TARGET := build-compiler-testlibrary, \
+    DEPS := exploded-image build-test-lib, \
+))
+
+$(eval $(call SetupTarget, test-image-compiler-testlibrary, \
+    MAKEFILE := hotspot/test/BuildCompilerTestlibrary, \
+    TARGET := test-image-compiler-testlibrary, \
+    DEPS := build-compiler-testlibrary, \
+))
+
 $(eval $(call SetupTarget, build-test-setup-aot, \
     MAKEFILE := test/BuildTestSetupAOT, \
     DEPS := interim-langtools exploded-image, \
@@ -1289,7 +1301,7 @@ all-docs-bundles: docs-jdk-bundles docs-javase-bundles docs-reference-bundles
 test-image: prepare-test-image test-image-jdk-jtreg-native \
     test-image-demos-jdk test-image-libtest-jtreg-native \
     test-image-lib test-image-lib-native \
-    test-image-setup-aot
+    test-image-setup-aot test-image-compiler-testlibrary
 
 ifneq ($(JVM_TEST_IMAGE_TARGETS), )
   # If JVM_TEST_IMAGE_TARGETS is externally defined, use it instead of the

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -751,16 +751,16 @@ $(eval $(call SetupTarget, test-image-lib, \
     DEPS := build-test-lib, \
 ))
 
-$(eval $(call SetupTarget, build-compiler-testlibrary, \
+$(eval $(call SetupTarget, build-hotspot-compiler-testlibrary, \
     MAKEFILE := hotspot/test/BuildCompilerTestlibrary, \
-    TARGET := build-compiler-testlibrary, \
+    TARGET := build-hotspot-compiler-testlibrary, \
     DEPS := exploded-image build-test-lib, \
 ))
 
-$(eval $(call SetupTarget, test-image-compiler-testlibrary, \
+$(eval $(call SetupTarget, test-image-hotspot-compiler-testlibrary, \
     MAKEFILE := hotspot/test/BuildCompilerTestlibrary, \
-    TARGET := test-image-compiler-testlibrary, \
-    DEPS := build-compiler-testlibrary, \
+    TARGET := test-image-hotspot-compiler-testlibrary, \
+    DEPS := build-hotspot-compiler-testlibrary, \
 ))
 
 $(eval $(call SetupTarget, build-test-setup-aot, \
@@ -1301,7 +1301,7 @@ all-docs-bundles: docs-jdk-bundles docs-javase-bundles docs-reference-bundles
 test-image: prepare-test-image test-image-jdk-jtreg-native \
     test-image-demos-jdk test-image-libtest-jtreg-native \
     test-image-lib test-image-lib-native \
-    test-image-setup-aot test-image-compiler-testlibrary
+    test-image-setup-aot test-image-hotspot-compiler-testlibrary
 
 ifneq ($(JVM_TEST_IMAGE_TARGETS), )
   # If JVM_TEST_IMAGE_TARGETS is externally defined, use it instead of the

--- a/make/hotspot/test/BuildCompilerTestlibrary.gmk
+++ b/make/hotspot/test/BuildCompilerTestlibrary.gmk
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+include MakeFileStart.gmk
+
+################################################################################
+# This file builds the Hotspot compiler testlibrary.
+################################################################################
+
+include CopyFiles.gmk
+include JavaCompilation.gmk
+
+###############################################################################
+
+COMPILER_TESTLIBRARY_BASEDIR := $(TOPDIR)/test/hotspot/jtreg/compiler/lib
+COMPILER_TESTLIBRARY_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/compiler-testlibrary
+COMPILER_TESTLIBRARY_JAR := $(COMPILER_TESTLIBRARY_SUPPORT)/compiler-testlibrary.jar
+TEST_LIB_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/lib
+WB_CP := $(TEST_LIB_SUPPORT)/wb_classes
+TEST_LIB_CP := $(TEST_LIB_SUPPORT)/test-lib_classes
+
+$(eval $(call SetupJavaCompilation, BUILD_COMPILER_TESTLIBRARY, \
+    TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
+    SRC := $(COMPILER_TESTLIBRARY_BASEDIR), \
+    BIN := $(COMPILER_TESTLIBRARY_SUPPORT)/classes, \
+    JAR := $(COMPILER_TESTLIBRARY_JAR), \
+    JAVAC_FLAGS := -cp $(WB_CP) \
+        -cp $(TEST_LIB_CP) \
+        --add-exports java.base/jdk.internal.math=ALL-UNNAMED, \
+))
+
+TARGETS += $(BUILD_COMPILER_TESTLIBRARY)
+
+build-compiler-testlibrary: $(TARGETS)
+
+################################################################################
+# Targets for building test-image.
+################################################################################
+
+# Copy to hotspot jtreg test image
+$(eval $(call SetupCopyFiles, COPY_COMPILER_TESTLIBRARY, \
+    DEST := $(TEST_IMAGE_DIR)/compiler-testlibrary, \
+    FILES := $(COMPILER_TESTLIBRARY_JAR), \
+))
+
+IMAGE_TARGETS += $(COPY_COMPILER_TESTLIBRARY)
+
+test-image-compiler-testlibrary: $(IMAGE_TARGETS)
+
+.PHONY: build-compiler-testlibrary test-image-compiler-testlibrary
+
+################################################################################
+
+include MakeFileEnd.gmk

--- a/make/hotspot/test/BuildCompilerTestlibrary.gmk
+++ b/make/hotspot/test/BuildCompilerTestlibrary.gmk
@@ -53,7 +53,7 @@ $(eval $(call SetupJavaCompilation, BUILD_COMPILER_TESTLIBRARY, \
 
 TARGETS += $(BUILD_COMPILER_TESTLIBRARY)
 
-build-compiler-testlibrary: $(TARGETS)
+build-hotspot-compiler-testlibrary: $(TARGETS)
 
 ################################################################################
 # Targets for building test-image.
@@ -67,9 +67,9 @@ $(eval $(call SetupCopyFiles, COPY_COMPILER_TESTLIBRARY, \
 
 IMAGE_TARGETS += $(COPY_COMPILER_TESTLIBRARY)
 
-test-image-compiler-testlibrary: $(IMAGE_TARGETS)
+test-image-hotspot-compiler-testlibrary: $(IMAGE_TARGETS)
 
-.PHONY: build-compiler-testlibrary test-image-compiler-testlibrary
+.PHONY: build-hotspot-compiler-testlibrary test-image-hotspot-compiler-testlibrary
 
 ################################################################################
 


### PR DESCRIPTION
This PR aims to compile the compiler testlibrary in `tests/hotspot/jtreg/compiler/lib` into the `test-image`. However, this does not change how compiler tests using these libraries are run; they are still compiled by jtreg when running tests. This change is a convenience to be able to mechanically reduce tests using the IR or template frameworks without jtreg and thus needing those dependencies.

Testing:
 - [x] Github Actions
 - [x] tier1,tier2,tier3

Thanks,
Manuel

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8380453](https://bugs.openjdk.org/browse/JDK-8380453): Add the hotspot compiler testlibrary to the test-image (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32066/head:pull/32066` \
`$ git checkout pull/32066`

Update a local copy of the PR: \
`$ git checkout pull/32066` \
`$ git pull https://git.openjdk.org/jdk.git pull/32066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32066`

View PR using the GUI difftool: \
`$ git pr show -t 32066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32066.diff">https://git.openjdk.org/jdk/pull/32066.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32066#issuecomment-5102330944)
</details>
