### PR TITLE
8389239: RISC-V: Optimize copy_memory_v by reducing LMUL and hoisting vsetvli out of loop

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -895,21 +895,22 @@ class StubGenerator: public StubCodeGenerator {
     const Register bytes_per_iter = x17;
     const Register tmp0 = x5;
 
-    assert_different_registers(s, d, cnt, saved_vl, bytes_per_iter, tmp0);
+    assert_different_registers(s, d, cnt, saved_vl, bytes_per_iter, tmp0, src, dst);
     Assembler::SEW sew = Assembler::elembytes_to_sew(granularity);
 
-    Label forward_main, backward_main, loop_fwd, loop_bwd,
+    Label backward_main, loop_fwd, loop_bwd,
           tail_fwd, tail_bwd, done;
 
     __ mv(dst, d);
     __ mv(src, s);
     __ mv(cnt, count);
 
-    // For very small forward copies, skip the wide m2 main loop and drain
-    // directly with the m1 tail loop. This avoids the m2 vsetvli setup cost
-    // for short copies (e.g., ≤ 32 bytes). Backward small copies are handled
-    // by the m2 main loop falling through to tail_bwd when cnt < saved_vl.
-    const int max_elems_small = 32 / granularity;
+    // For very small forward copies, skip the wide m4 main loop and drain
+    // directly with the m1 tail loop. This avoids the m4 vsetvli setup cost
+    // for short copies (e.g., ≤ MaxVectorSize bytes). Backward small copies
+    // are handled by the m4 main loop falling through to tail_bwd when
+    // cnt < saved_vl.
+    const int max_elems_small = MaxVectorSize / granularity;
     if (max_elems_small > 0 && !is_backward) {
       __ li(tmp0, max_elems_small);
       __ bleu(cnt, tmp0, tail_fwd);
@@ -920,9 +921,8 @@ class StubGenerator: public StubCodeGenerator {
     }
     // else: fall through to forward_main
 
-    /* forward main: m2 chunks */
-    __ bind(forward_main);
-    __ vsetvli(saved_vl, cnt, sew, Assembler::m2);
+    /* forward main: m4 chunks */
+    __ vsetvli(saved_vl, cnt, sew, Assembler::m4);
 
     if (granularity > 1) {
       __ slli(bytes_per_iter, saved_vl, exact_log2(granularity));
@@ -942,7 +942,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     /* forward tail: m1 drain loop. Handles arbitrary leftover cnt
-     * (in [0, vlmax_m2)) with one or more m1 iterations. */
+     * (in [0, vlmax_m4)) with one or more m1 iterations. */
     __ bind(tail_fwd);
     {
       Label loop_tail_fwd;
@@ -963,18 +963,18 @@ class StubGenerator: public StubCodeGenerator {
       __ j(done);
     }
 
-    /* backward main: m2 chunks (src/dst point one-past-end) */
+    /* backward main: m4 chunks (src/dst point one-past-end) */
     __ bind(backward_main);
 
     if (granularity > 1) {
-      __ slli(tmp0, count, exact_log2(granularity));
+      __ slli(tmp0, cnt, exact_log2(granularity));
     } else {
-      __ mv(tmp0, count);
+      __ mv(tmp0, cnt);
     }
     __ add(src, src, tmp0);
     __ add(dst, dst, tmp0);
 
-    __ vsetvli(saved_vl, cnt, sew, Assembler::m2);
+    __ vsetvli(saved_vl, cnt, sew, Assembler::m4);
 
     if (granularity > 1) {
       __ slli(bytes_per_iter, saved_vl, exact_log2(granularity));

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -888,50 +888,135 @@ class StubGenerator: public StubCodeGenerator {
     bool is_backward = step < 0;
     int granularity = g_uabs(step);
 
-    const Register src = x30, dst = x31, vl = x14, cnt = x15, tmp1 = x16, tmp2 = x17;
-    assert_different_registers(s, d, cnt, vl, tmp1, tmp2);
+    const Register src = x30;
+    const Register dst = x31;
+    const Register cnt = x15;
+    const Register saved_vl = x16;
+    const Register bytes_per_iter = x17;
+    const Register tmp0 = x5;
+
+    assert_different_registers(s, d, cnt, saved_vl, bytes_per_iter, tmp0);
     Assembler::SEW sew = Assembler::elembytes_to_sew(granularity);
-    Label loop_forward, loop_backward, done;
+
+    Label forward_main, backward_main, loop_fwd, loop_bwd,
+          tail_fwd, tail_bwd, done;
 
     __ mv(dst, d);
     __ mv(src, s);
     __ mv(cnt, count);
 
-    __ bind(loop_forward);
-    __ vsetvli(vl, cnt, sew, Assembler::m8);
-    if (is_backward) {
-      __ bne(vl, cnt, loop_backward);
+    // For very small forward copies, skip the wide m2 main loop and drain
+    // directly with the m1 tail loop. This avoids the m2 vsetvli setup cost
+    // for short copies (e.g., ≤ 32 bytes). Backward small copies are handled
+    // by the m2 main loop falling through to tail_bwd when cnt < saved_vl.
+    const int max_elems_small = 32 / granularity;
+    if (max_elems_small > 0 && !is_backward) {
+      __ li(tmp0, max_elems_small);
+      __ bleu(cnt, tmp0, tail_fwd);
     }
 
-    __ vlex_v(v0, src, sew);
-    __ sub(cnt, cnt, vl);
-    if (sew != Assembler::e8) {
-      // when sew == e8 (e.g., elem size is 1 byte), slli R, R, 0 is a nop and unnecessary
-      __ slli(vl, vl, sew);
-    }
-    __ add(src, src, vl);
-
-    __ vsex_v(v0, dst, sew);
-    __ add(dst, dst, vl);
-    __ bnez(cnt, loop_forward);
-
     if (is_backward) {
-      __ j(done);
+      __ j(backward_main);
+    }
+    // else: fall through to forward_main
 
-      __ bind(loop_backward);
-      __ sub(t0, cnt, vl);
-      if (sew != Assembler::e8) {
-        // when sew == e8 (e.g., elem size is 1 byte), slli R, R, 0 is a nop and unnecessary
-        __ slli(t0, t0, sew);
+    /* forward main: m2 chunks */
+    __ bind(forward_main);
+    __ vsetvli(saved_vl, cnt, sew, Assembler::m2);
+
+    if (granularity > 1) {
+      __ slli(bytes_per_iter, saved_vl, exact_log2(granularity));
+    } else {
+      __ mv(bytes_per_iter, saved_vl);
+    }
+
+    __ bind(loop_fwd);
+    {
+      __ blt(cnt, saved_vl, tail_fwd);
+      __ vlex_v(v0, src, sew);
+      __ vsex_v(v0, dst, sew);
+      __ add(src, src, bytes_per_iter);
+      __ add(dst, dst, bytes_per_iter);
+      __ sub(cnt, cnt, saved_vl);
+      __ bnez(cnt, loop_fwd);
+    }
+
+    /* forward tail: m1 drain loop. Handles arbitrary leftover cnt
+     * (in [0, vlmax_m2)) with one or more m1 iterations. */
+    __ bind(tail_fwd);
+    {
+      Label loop_tail_fwd;
+      __ beqz(cnt, done);
+      __ bind(loop_tail_fwd);
+      __ vsetvli(tmp0, cnt, sew, Assembler::m1);
+      __ vlex_v(v0, src, sew);
+      __ vsex_v(v0, dst, sew);
+      if (granularity > 1) {
+        __ slli(bytes_per_iter, tmp0, exact_log2(granularity));
+      } else {
+        __ mv(bytes_per_iter, tmp0);
       }
-      __ add(tmp1, s, t0);
-      __ vlex_v(v0, tmp1, sew);
-      __ add(tmp2, d, t0);
-      __ vsex_v(v0, tmp2, sew);
-      __ sub(cnt, cnt, vl);
-      __ bnez(cnt, loop_forward);
-      __ bind(done);
+      __ add(src, src, bytes_per_iter);
+      __ add(dst, dst, bytes_per_iter);
+      __ sub(cnt, cnt, tmp0);
+      __ bnez(cnt, loop_tail_fwd);
+      __ j(done);
     }
+
+    /* backward main: m2 chunks (src/dst point one-past-end) */
+    __ bind(backward_main);
+
+    if (granularity > 1) {
+      __ slli(tmp0, count, exact_log2(granularity));
+    } else {
+      __ mv(tmp0, count);
+    }
+    __ add(src, src, tmp0);
+    __ add(dst, dst, tmp0);
+
+    __ vsetvli(saved_vl, cnt, sew, Assembler::m2);
+
+    if (granularity > 1) {
+      __ slli(bytes_per_iter, saved_vl, exact_log2(granularity));
+    } else {
+      __ mv(bytes_per_iter, saved_vl);
+    }
+
+    __ bind(loop_bwd);
+    {
+      __ blt(cnt, saved_vl, tail_bwd);
+      // src/dst currently point one-past-end. Step back before the first
+      // load/store of each iteration so we copy [end - bytes_per_iter, end).
+      __ sub(src, src, bytes_per_iter);
+      __ sub(dst, dst, bytes_per_iter);
+      __ vlex_v(v0, src, sew);
+      __ vsex_v(v0, dst, sew);
+      __ sub(cnt, cnt, saved_vl);
+      __ bnez(cnt, loop_bwd);
+    }
+
+    /* backward tail: m1 drain loop */
+    __ bind(tail_bwd);
+    {
+      Label loop_tail_bwd;
+      __ beqz(cnt, done);
+      __ bind(loop_tail_bwd);
+      __ vsetvli(tmp0, cnt, sew, Assembler::m1);
+      if (granularity > 1) {
+        __ slli(bytes_per_iter, tmp0, exact_log2(granularity));
+      } else {
+        __ mv(bytes_per_iter, tmp0);
+      }
+      __ sub(src, src, bytes_per_iter);
+      __ sub(dst, dst, bytes_per_iter);
+      __ vlex_v(v0, src, sew);
+      __ vsex_v(v0, dst, sew);
+      __ sub(cnt, cnt, tmp0);
+      __ bnez(cnt, loop_tail_bwd);
+    }
+
+    /* end */
+    __ bind(done);
   }
 
   // All-singing all-dancing memory copy.


### PR DESCRIPTION
Hi, this patch optimizes copy_memory_v to reduce per-iteration overhead for RVV arraycopy stubs.

The current implementation uses a single LMUL=m8 loop that calls `vsetvli` on every iteration, which adds unnecessary configuration overhead in the hot loop. For backward copies, the load/store address is recomputed from the base pointer each iteration (`base + (cnt - vl) * granularity`), adding extra ALU instructions to the critical path

### Performance test with release on SpacemiT Key Stone K3

`make test TEST="micro:org.openjdk.bench.java.lang.ArrayCopyUnalignedBoth" JTREG="TIMEOUT_FACTOR=16"`
without this patch:
```
Benchmark                        (length)  Mode  Cnt    Score    Error  Units
ArrayCopyUnalignedBoth.testByte         1  avgt   15   41.212 ±  0.659  ns/op
ArrayCopyUnalignedBoth.testByte         3  avgt   15   41.145 ±  0.853  ns/op
ArrayCopyUnalignedBoth.testByte         5  avgt   15   41.601 ±  0.528  ns/op
ArrayCopyUnalignedBoth.testByte        10  avgt   15   41.360 ±  0.436  ns/op
ArrayCopyUnalignedBoth.testByte        20  avgt   15   41.621 ±  0.580  ns/op
ArrayCopyUnalignedBoth.testByte        70  avgt   15   41.171 ±  1.161  ns/op
ArrayCopyUnalignedBoth.testByte       150  avgt   15   42.130 ±  1.287  ns/op
ArrayCopyUnalignedBoth.testByte       300  avgt   15   60.914 ±  4.087  ns/op
ArrayCopyUnalignedBoth.testByte       600  avgt   15   89.840 ±  9.842  ns/op
ArrayCopyUnalignedBoth.testByte      1200  avgt   15  128.052 ±  4.847  ns/op
ArrayCopyUnalignedBoth.testChar         1  avgt   15   37.038 ±  0.255  ns/op
ArrayCopyUnalignedBoth.testChar         3  avgt   15   36.880 ±  0.012  ns/op
ArrayCopyUnalignedBoth.testChar         5  avgt   15   37.048 ±  0.262  ns/op
ArrayCopyUnalignedBoth.testChar        10  avgt   15   38.273 ±  0.047  ns/op
ArrayCopyUnalignedBoth.testChar        20  avgt   15   38.408 ±  0.256  ns/op
ArrayCopyUnalignedBoth.testChar        70  avgt   15   42.367 ±  3.591  ns/op
ArrayCopyUnalignedBoth.testChar       150  avgt   15   56.972 ±  7.098  ns/op
ArrayCopyUnalignedBoth.testChar       300  avgt   15   85.582 ± 11.301  ns/op
ArrayCopyUnalignedBoth.testChar       600  avgt   15  128.472 ± 26.470  ns/op
ArrayCopyUnalignedBoth.testChar      1200  avgt   15  169.612 ± 13.105  ns/op
ArrayCopyUnalignedBoth.testInt          1  avgt   15   38.235 ±  0.004  ns/op
ArrayCopyUnalignedBoth.testInt          3  avgt   15   38.389 ±  0.475  ns/op
ArrayCopyUnalignedBoth.testInt          5  avgt   15   38.238 ±  0.412  ns/op
ArrayCopyUnalignedBoth.testInt         10  avgt   15   38.090 ±  0.230  ns/op
ArrayCopyUnalignedBoth.testInt         20  avgt   15   38.241 ±  0.012  ns/op
ArrayCopyUnalignedBoth.testInt         70  avgt   15   56.515 ±  6.936  ns/op
ArrayCopyUnalignedBoth.testInt        150  avgt   15   73.546 ±  6.027  ns/op
ArrayCopyUnalignedBoth.testInt        300  avgt   15  118.550 ± 26.739  ns/op
ArrayCopyUnalignedBoth.testInt        600  avgt   15  182.664 ± 18.185  ns/op
ArrayCopyUnalignedBoth.testInt       1200  avgt   15  297.759 ± 11.467  ns/op
ArrayCopyUnalignedBoth.testLong         1  avgt   15   38.103 ±  0.259  ns/op
ArrayCopyUnalignedBoth.testLong         3  avgt   15   37.797 ±  0.040  ns/op
ArrayCopyUnalignedBoth.testLong         5  avgt   15   37.977 ±  0.288  ns/op
ArrayCopyUnalignedBoth.testLong        10  avgt   15   37.887 ±  0.233  ns/op
ArrayCopyUnalignedBoth.testLong        20  avgt   15   38.511 ±  0.782  ns/op
ArrayCopyUnalignedBoth.testLong        70  avgt   15   84.397 ±  8.221  ns/op
ArrayCopyUnalignedBoth.testLong       150  avgt   15  106.231 ±  8.346  ns/op
ArrayCopyUnalignedBoth.testLong       300  avgt   15  163.030 ± 11.775  ns/op
ArrayCopyUnalignedBoth.testLong       600  avgt   15  277.407 ± 24.985  ns/op
ArrayCopyUnalignedBoth.testLong      1200  avgt   15  536.985 ± 33.194  ns/op
Finished running test 'micro:org.openjdk.bench.java.lang.ArrayCopyUnalignedBoth'
```

witch this patch:
```
Benchmark                        (length)  Mode  Cnt    Score    Error  Units
ArrayCopyUnalignedBoth.testByte         1  avgt   15   28.935 ±  1.002  ns/op
ArrayCopyUnalignedBoth.testByte         3  avgt   15   28.890 ±  0.646  ns/op
ArrayCopyUnalignedBoth.testByte         5  avgt   15   28.804 ±  0.516  ns/op
ArrayCopyUnalignedBoth.testByte        10  avgt   15   29.244 ±  1.314  ns/op
ArrayCopyUnalignedBoth.testByte        20  avgt   15   29.999 ±  1.740  ns/op
ArrayCopyUnalignedBoth.testByte        70  avgt   15   35.060 ±  0.013  ns/op
ArrayCopyUnalignedBoth.testByte       150  avgt   15   36.039 ±  2.367  ns/op
ArrayCopyUnalignedBoth.testByte       300  avgt   15   53.182 ±  7.394  ns/op
ArrayCopyUnalignedBoth.testByte       600  avgt   15   75.367 ± 14.640  ns/op
ArrayCopyUnalignedBoth.testByte      1200  avgt   15  108.807 ± 12.306  ns/op
ArrayCopyUnalignedBoth.testChar         1  avgt   15   27.779 ±  0.028  ns/op
ArrayCopyUnalignedBoth.testChar         3  avgt   15   27.813 ±  0.128  ns/op
ArrayCopyUnalignedBoth.testChar         5  avgt   15   27.847 ±  0.150  ns/op
ArrayCopyUnalignedBoth.testChar        10  avgt   15   26.439 ±  0.105  ns/op
ArrayCopyUnalignedBoth.testChar        20  avgt   15   29.750 ±  0.581  ns/op
ArrayCopyUnalignedBoth.testChar        70  avgt   15   35.367 ±  2.513  ns/op
ArrayCopyUnalignedBoth.testChar       150  avgt   15   49.262 ±  6.754  ns/op
ArrayCopyUnalignedBoth.testChar       300  avgt   15   63.118 ±  8.622  ns/op
ArrayCopyUnalignedBoth.testChar       600  avgt   15   98.415 ± 24.066  ns/op
ArrayCopyUnalignedBoth.testChar      1200  avgt   15  145.916 ±  6.498  ns/op
ArrayCopyUnalignedBoth.testInt          1  avgt   15   26.504 ±  0.174  ns/op
ArrayCopyUnalignedBoth.testInt          3  avgt   15   26.560 ±  0.235  ns/op
ArrayCopyUnalignedBoth.testInt          5  avgt   15   26.929 ±  0.684  ns/op
ArrayCopyUnalignedBoth.testInt         10  avgt   15   29.381 ±  0.477  ns/op
ArrayCopyUnalignedBoth.testInt         20  avgt   15   29.691 ±  0.795  ns/op
ArrayCopyUnalignedBoth.testInt         70  avgt   15   46.400 ±  4.791  ns/op
ArrayCopyUnalignedBoth.testInt        150  avgt   15   72.169 ±  7.194  ns/op
ArrayCopyUnalignedBoth.testInt        300  avgt   15   96.633 ± 18.926  ns/op
ArrayCopyUnalignedBoth.testInt        600  avgt   15  146.433 ±  8.434  ns/op
ArrayCopyUnalignedBoth.testInt       1200  avgt   15  250.833 ±  9.460  ns/op
ArrayCopyUnalignedBoth.testLong         1  avgt   15   26.212 ±  0.226  ns/op
ArrayCopyUnalignedBoth.testLong         3  avgt   15   26.192 ±  0.255  ns/op
ArrayCopyUnalignedBoth.testLong         5  avgt   15   30.314 ±  0.086  ns/op
ArrayCopyUnalignedBoth.testLong        10  avgt   15   30.315 ±  0.058  ns/op
ArrayCopyUnalignedBoth.testLong        20  avgt   15   32.440 ±  1.004  ns/op
ArrayCopyUnalignedBoth.testLong        70  avgt   15   57.178 ±  6.397  ns/op
ArrayCopyUnalignedBoth.testLong       150  avgt   15   90.069 ± 19.102  ns/op
ArrayCopyUnalignedBoth.testLong       300  avgt   15  140.833 ±  6.531  ns/op
ArrayCopyUnalignedBoth.testLong       600  avgt   15  254.702 ±  9.774  ns/op
ArrayCopyUnalignedBoth.testLong      1200  avgt   15  458.953 ±  8.501  ns/op
Finished running test 'micro:org.openjdk.bench.java.lang.ArrayCopyUnalignedBoth'
```

`make test TEST="micro:org.openjdk.bench.java.lang.ArrayCopyAligned" JTREG="TIMEOUT_FACTOR=16"`

```
Benchmark                       (length)  Mode  Cnt        Score       Error  Units
ArrayCopyAligned.testByte              1  avgt   15       41.090 ±     0.815  ns/op
ArrayCopyAligned.testByte              3  avgt   15       41.589 ±     0.449  ns/op
ArrayCopyAligned.testByte              5  avgt   15       41.814 ±     0.351  ns/op
ArrayCopyAligned.testByte             10  avgt   15       41.763 ±     0.270  ns/op
ArrayCopyAligned.testByte             20  avgt   15       42.992 ±     0.300  ns/op
ArrayCopyAligned.testByte             70  avgt   15       40.797 ±     0.282  ns/op
ArrayCopyAligned.testByte            150  avgt   15       45.804 ±     3.256  ns/op
ArrayCopyAligned.testByte            300  avgt   15       66.907 ±    11.201  ns/op
ArrayCopyAligned.testByte            600  avgt   15       91.671 ±    14.009  ns/op
ArrayCopyAligned.testByte           1200  avgt   15      116.312 ±    13.060  ns/op
ArrayCopyAligned.testChar              1  avgt   15       37.500 ±     0.225  ns/op
ArrayCopyAligned.testChar              3  avgt   15       37.511 ±     0.258  ns/op
ArrayCopyAligned.testChar              5  avgt   15       37.199 ±     0.250  ns/op
ArrayCopyAligned.testChar             10  avgt   15       38.257 ±     0.028  ns/op
ArrayCopyAligned.testChar             20  avgt   15       38.429 ±     0.266  ns/op
ArrayCopyAligned.testChar             70  avgt   15       40.155 ±     2.653  ns/op
ArrayCopyAligned.testChar            150  avgt   15       56.496 ±     6.143  ns/op
ArrayCopyAligned.testChar            300  avgt   15       80.149 ±    13.582  ns/op
ArrayCopyAligned.testChar            600  avgt   15      112.058 ±    13.377  ns/op
ArrayCopyAligned.testChar           1200  avgt   15      200.005 ±    37.732  ns/op
ArrayCopyAligned.testInt               1  avgt   15       38.542 ±     0.242  ns/op
ArrayCopyAligned.testInt               3  avgt   15       38.393 ±     0.242  ns/op
ArrayCopyAligned.testInt               5  avgt   15       38.694 ±     0.012  ns/op
ArrayCopyAligned.testInt              10  avgt   15       38.717 ±     0.094  ns/op
ArrayCopyAligned.testInt              20  avgt   15       43.662 ±     7.997  ns/op
ArrayCopyAligned.testInt              70  avgt   15       68.403 ±     5.932  ns/op
ArrayCopyAligned.testInt             150  avgt   15       81.449 ±    25.439  ns/op
ArrayCopyAligned.testInt             300  avgt   15      112.677 ±    23.200  ns/op
ArrayCopyAligned.testInt             600  avgt   15      183.630 ±    13.187  ns/op
ArrayCopyAligned.testInt            1200  avgt   15      282.541 ±    10.192  ns/op
ArrayCopyAligned.testLong              1  avgt   15       37.784 ±     0.417  ns/op
ArrayCopyAligned.testLong              3  avgt   15       37.994 ±     0.617  ns/op
ArrayCopyAligned.testLong              5  avgt   15       38.125 ±     0.503  ns/op
ArrayCopyAligned.testLong             10  avgt   15       43.272 ±     5.217  ns/op
ArrayCopyAligned.testLong             20  avgt   15       48.136 ±     6.537  ns/op
ArrayCopyAligned.testLong             70  avgt   15       83.413 ±    27.625  ns/op
ArrayCopyAligned.testLong            150  avgt   15      112.618 ±    23.398  ns/op
ArrayCopyAligned.testLong            300  avgt   15      170.265 ±    14.398  ns/op
ArrayCopyAligned.testLong            600  avgt   15      283.662 ±    16.284  ns/op
ArrayCopyAligned.testLong           1200  avgt   15      516.022 ±    39.331  ns/op
ArrayCopyAlignedLarge.testByte    100000  avgt   15     5803.795 ±    28.232  ns/op
ArrayCopyAlignedLarge.testByte   1000000  avgt   15    57409.406 ±  1187.052  ns/op
ArrayCopyAlignedLarge.testByte   2000000  avgt   15   126831.536 ±  9391.069  ns/op
ArrayCopyAlignedLarge.testByte   5000000  avgt   15   753956.333 ± 16782.342  ns/op
ArrayCopyAlignedLarge.testByte  10000000  avgt   15  1592672.999 ± 66327.576  ns/op
Finished running test 'micro:org.openjdk.bench.java.lang.ArrayCopyAligned'
```

witch this patch:
```
Benchmark                       (length)  Mode  Cnt        Score       Error  Units
ArrayCopyAligned.testByte              1  avgt   15       28.980 ±     0.995  ns/op
ArrayCopyAligned.testByte              3  avgt   15       29.312 ±     1.436  ns/op
ArrayCopyAligned.testByte              5  avgt   15       29.328 ±     1.392  ns/op
ArrayCopyAligned.testByte             10  avgt   15       28.757 ±     0.327  ns/op
ArrayCopyAligned.testByte             20  avgt   15       27.698 ±     0.862  ns/op
ArrayCopyAligned.testByte             70  avgt   15       34.608 ±     0.019  ns/op
ArrayCopyAligned.testByte            150  avgt   15       37.027 ±     1.373  ns/op
ArrayCopyAligned.testByte            300  avgt   15       48.072 ±     4.547  ns/op
ArrayCopyAligned.testByte            600  avgt   15       77.819 ±    12.456  ns/op
ArrayCopyAligned.testByte           1200  avgt   15      103.924 ±    12.426  ns/op
ArrayCopyAligned.testChar              1  avgt   15       27.777 ±     0.029  ns/op
ArrayCopyAligned.testChar              3  avgt   15       27.832 ±     0.145  ns/op
ArrayCopyAligned.testChar              5  avgt   15       27.786 ±     0.056  ns/op
ArrayCopyAligned.testChar             10  avgt   15       26.468 ±     0.150  ns/op
ArrayCopyAligned.testChar             20  avgt   15       29.143 ±     0.039  ns/op
ArrayCopyAligned.testChar             70  avgt   15       35.286 ±     2.337  ns/op
ArrayCopyAligned.testChar            150  avgt   15       42.397 ±     3.432  ns/op
ArrayCopyAligned.testChar            300  avgt   15       58.995 ±     4.724  ns/op
ArrayCopyAligned.testChar            600  avgt   15       92.247 ±     9.571  ns/op
ArrayCopyAligned.testChar           1200  avgt   15      157.557 ±    13.549  ns/op
ArrayCopyAligned.testInt               1  avgt   15       27.112 ±     0.886  ns/op
ArrayCopyAligned.testInt               3  avgt   15       27.412 ±     0.674  ns/op
ArrayCopyAligned.testInt               5  avgt   15       26.566 ±     0.212  ns/op
ArrayCopyAligned.testInt              10  avgt   15       30.377 ±     0.912  ns/op
ArrayCopyAligned.testInt              20  avgt   15       29.980 ±     0.938  ns/op
ArrayCopyAligned.testInt              70  avgt   15       52.057 ±    15.158  ns/op
ArrayCopyAligned.testInt             150  avgt   15       64.427 ±     7.800  ns/op
ArrayCopyAligned.testInt             300  avgt   15      103.187 ±    25.579  ns/op
ArrayCopyAligned.testInt             600  avgt   15      149.478 ±    11.259  ns/op
ArrayCopyAligned.testInt            1200  avgt   15      262.020 ±    14.106  ns/op
ArrayCopyAligned.testLong              1  avgt   15       26.796 ±     0.856  ns/op
ArrayCopyAligned.testLong              3  avgt   15       26.187 ±     0.245  ns/op
ArrayCopyAligned.testLong              5  avgt   15       28.792 ±     0.024  ns/op
ArrayCopyAligned.testLong             10  avgt   15       32.812 ±     8.449  ns/op
ArrayCopyAligned.testLong             20  avgt   15       37.686 ±     5.276  ns/op
ArrayCopyAligned.testLong             70  avgt   15       57.429 ±     6.745  ns/op
ArrayCopyAligned.testLong            150  avgt   15       98.195 ±    15.169  ns/op
ArrayCopyAligned.testLong            300  avgt   15      144.559 ±    19.826  ns/op
ArrayCopyAligned.testLong            600  avgt   15      233.005 ±    12.213  ns/op
ArrayCopyAligned.testLong           1200  avgt   15      466.578 ±    28.665  ns/op
ArrayCopyAlignedLarge.testByte    100000  avgt   15     6310.036 ±  1113.723  ns/op
ArrayCopyAlignedLarge.testByte   1000000  avgt   15    56866.625 ±   231.286  ns/op
ArrayCopyAlignedLarge.testByte   2000000  avgt   15   123152.890 ± 11645.007  ns/op
ArrayCopyAlignedLarge.testByte   5000000  avgt   15   745166.114 ± 17726.203  ns/op
ArrayCopyAlignedLarge.testByte  10000000  avgt   15  1603663.938 ± 15385.360  ns/op
Finished running test 'micro:org.openjdk.bench.java.lang.ArrayCopyAligned'
```

`make test TEST="micro:org.openjdk.bench.java.lang.ArrayCopyAlignedLarge" JTREG="TIMEOUT_FACTOR=16"`

without this patch:
```
Benchmark                       (length)  Mode  Cnt        Score       Error  Units
ArrayCopyAlignedLarge.testByte    100000  avgt   15     5767.573 ±    19.338  ns/op
ArrayCopyAlignedLarge.testByte   1000000  avgt   15    57025.943 ±   356.339  ns/op
ArrayCopyAlignedLarge.testByte   2000000  avgt   15   118912.600 ± 10754.402  ns/op
ArrayCopyAlignedLarge.testByte   5000000  avgt   15   741292.538 ± 19379.293  ns/op
ArrayCopyAlignedLarge.testByte  10000000  avgt   15  1603983.879 ± 61497.773  ns/op
Finished running test 'micro:org.openjdk.bench.java.lang.ArrayCopyAlignedLarge'
```
witch this patch:
```
Benchmark                       (length)  Mode  Cnt        Score       Error  Units
ArrayCopyAlignedLarge.testByte    100000  avgt   15     5781.565 ±    22.177  ns/op
ArrayCopyAlignedLarge.testByte   1000000  avgt   15    57412.324 ±   595.479  ns/op
ArrayCopyAlignedLarge.testByte   2000000  avgt   15   116618.654 ±   978.254  ns/op
ArrayCopyAlignedLarge.testByte   5000000  avgt   15   780134.665 ± 47210.437  ns/op
ArrayCopyAlignedLarge.testByte  10000000  avgt   15  1616758.242 ± 58753.811  ns/op
Finished running test 'micro:org.openjdk.bench.java.lang.ArrayCopyAlignedLarge'
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389239](https://bugs.openjdk.org/browse/JDK-8389239): RISC-V: Optimize copy_memory_v by reducing LMUL and hoisting vsetvli out of loop (**Enhancement** - P4)


### Contributors
 * Libing Huang `<hlb194802@alibaba-inc.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32067/head:pull/32067` \
`$ git checkout pull/32067`

Update a local copy of the PR: \
`$ git checkout pull/32067` \
`$ git pull https://git.openjdk.org/jdk.git pull/32067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32067`

View PR using the GUI difftool: \
`$ git pr show -t 32067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32067.diff">https://git.openjdk.org/jdk/pull/32067.diff</a>

</details>
