### PR TITLE
8389116: Improve comments on memory semantics in LazyCollections

### DIFF
--- a/src/java.base/share/classes/java/util/LazyCollections.java
+++ b/src/java.base/share/classes/java/util/LazyCollections.java
@@ -592,13 +592,13 @@ final class LazyCollections {
         private volatile AtomicInteger counter;
 
         private Mutexes(int length) {
-            this.mutexes = new Object[length];
-            this.counter = new AtomicInteger(length);
+            this.mutexes = new Object[length];        // Volatile access
+            this.counter = new AtomicInteger(length); // Volatile access
         }
 
         private Object acquireMutex(long offset) {
             // Snapshot
-            var mutexes = this.mutexes;
+            final var mutexes = this.mutexes; // Volatile access
             if (mutexes == null) {
                 // We have already computed all the elements and if we end up here
                 // there was at least one unchecked exception thrown by the
@@ -619,9 +619,10 @@ final class LazyCollections {
         private void releaseMutex(long offset) {
             // Replace the old mutex with a tomb stone since now the old mutex can be collected.
             UNSAFE.putReferenceVolatile(mutexes, offset, TOMB_STONE);
+            // Volatile access on `counter`
             if (counter != null && counter.decrementAndGet() == 0) {
-                mutexes = null;
-                counter = null;
+                mutexes = null; // Volatile access
+                counter = null; // Volatile access
             }
         }
 


### PR DESCRIPTION
This PR proposes to add comments in `LazyConstants.Mutexes` so that it becomes more evident where we have `volatile` access.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389116](https://bugs.openjdk.org/browse/JDK-8389116): Improve comments on memory semantics in LazyCollections (**Enhancement** - P5) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32069/head:pull/32069` \
`$ git checkout pull/32069`

Update a local copy of the PR: \
`$ git checkout pull/32069` \
`$ git pull https://git.openjdk.org/jdk.git pull/32069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32069`

View PR using the GUI difftool: \
`$ git pr show -t 32069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32069.diff">https://git.openjdk.org/jdk/pull/32069.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32069#issuecomment-5104196906)
</details>
