### PR TITLE
8388991: Adjust relauncher.c to avoid unused variable and init STARTUPINFO as suggested

### DIFF
--- a/src/java.base/windows/native/launcher/relauncher.c
+++ b/src/java.base/windows/native/launcher/relauncher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,6 @@ int main(int argc, char* argv[]) {
     // Windows needs the command line as a single string, not as an array of char*
     size_t total_length = 0;
     for (int i = 0; java_args[i] != NULL; i++) {
-        char* arg = java_args[i];
         total_length += strlen(java_args[i]) + 1;
     }
 
@@ -220,6 +219,7 @@ int main(int argc, char* argv[]) {
     PROCESS_INFORMATION pi;
 
     memset(&si, 0, sizeof(si));
+    si.cb = sizeof(si);
     memset(&pi, 0, sizeof(pi));
 
     // Windows has no equivalent of exec, so start the process and wait for it


### PR DESCRIPTION
The windows relauncher.c has some unused local variable that should be removed.
And the STARTUPINFO  used in the coding needs some init step additional to just zeroing it.
See
https://learn.microsoft.com/en-us/windows/win32/procthread/creating-processes
where the usage of STARTUPINFO  with CreateProcess is described.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388991](https://bugs.openjdk.org/browse/JDK-8388991): Adjust relauncher.c to avoid unused variable and init STARTUPINFO as suggested (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32071/head:pull/32071` \
`$ git checkout pull/32071`

Update a local copy of the PR: \
`$ git checkout pull/32071` \
`$ git pull https://git.openjdk.org/jdk.git pull/32071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32071`

View PR using the GUI difftool: \
`$ git pr show -t 32071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32071.diff">https://git.openjdk.org/jdk/pull/32071.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32071#issuecomment-5106012613)
</details>
