### PR TITLE
8386595: Two java/net/MulticastSocket tests fail on machines with no ipv6 address other than loopback

### DIFF
--- a/test/jdk/java/net/MulticastSocket/NoLoopbackPackets.java
+++ b/test/jdk/java/net/MulticastSocket/NoLoopbackPackets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class NoLoopbackPackets {
             }
 
             NetworkConfiguration nc = NetworkConfiguration.probe();
-            if (IPSupport.hasIPv6() && nc.hasTestableIPv6Address()) {
+            if (IPSupport.hasIPv6() && nc.ip6MulticastInterfaces().findAny().isPresent()) {
                 groups.add(new InetSocketAddress(InetAddress.getByName("::ffff:224.1.1.2"), port));
                 groups.add(new InetSocketAddress(InetAddress.getByName("ff02::1:1"), port));
             }

--- a/test/jdk/java/net/MulticastSocket/Test.java
+++ b/test/jdk/java/net/MulticastSocket/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,7 +141,7 @@ public class Test {
         doTest("224.80.80.80");
 
         // If IPv6 is enabled perform multicast tests with various scopes
-        if (nc.hasTestableIPv6Address()) {
+        if (nc.ip6MulticastInterfaces().findAny().isPresent()) {
             doTest("ff01::a");
         }
 


### PR DESCRIPTION
This PR is a backport of for two failing tests in a special environment. It is a test only fix and would be nice to have it in JDK 27 too.
Low risk - test only change

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386595](https://bugs.openjdk.org/browse/JDK-8386595): Two java/net/MulticastSocket tests fail on machines with no ipv6 address other than loopback (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32072/head:pull/32072` \
`$ git checkout pull/32072`

Update a local copy of the PR: \
`$ git checkout pull/32072` \
`$ git pull https://git.openjdk.org/jdk.git pull/32072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32072`

View PR using the GUI difftool: \
`$ git pr show -t 32072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32072.diff">https://git.openjdk.org/jdk/pull/32072.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32072#issuecomment-5105955952)
</details>
