### PR TITLE
8386884: GC.heap_dump -parallel accepts values outside uint range and silently wraps

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -501,7 +501,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   if (_parallel.is_set()) {
     parallel = _parallel.value();
 
-    if (parallel < 0) {
+    if (parallel < 0 || parallel > max_juint) {
       output()->print_cr("Invalid number of parallel dump threads.");
       return;
     } else if (parallel == 0) {

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
@@ -104,6 +104,10 @@ public class HeapDumpParallelTest {
             OutputAnalyzer out = attachJcmdHeapDump(heapDumpFile, theApp.getPid(), "-parallel=" + -1);
             out.shouldContain("Invalid number of parallel dump threads.");
 
+            // Expect error message on value above 32 bit unsigned range
+            out = attachJcmdHeapDump(heapDumpFile, theApp.getPid(), "-parallel=" + 4294967297);
+            out.shouldContain("Invalid number of parallel dump threads.");
+
             // Expect serial dump because 0 implies to disable parallel dump
             test(heapDumpFile, "-parallel=" + 0, true);
 

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
@@ -105,7 +105,7 @@ public class HeapDumpParallelTest {
             out.shouldContain("Invalid number of parallel dump threads.");
 
             // Expect error message on value above 32 bit unsigned range
-            out = attachJcmdHeapDump(heapDumpFile, theApp.getPid(), "-parallel=" + 4294967297);
+            out = attachJcmdHeapDump(heapDumpFile, theApp.getPid(), "-parallel=" + 4294967297L);
             out.shouldContain("Invalid number of parallel dump threads.");
 
             // Expect serial dump because 0 implies to disable parallel dump


### PR DESCRIPTION
GC.heap_dump -parallel accepts values outside uint range, before the acceptance now making the condition to handle the case.
Also verifed with the modification on test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java testcase

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386884](https://bugs.openjdk.org/browse/JDK-8386884): GC.heap_dump -parallel accepts values outside uint range and silently wraps (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32073/head:pull/32073` \
`$ git checkout pull/32073`

Update a local copy of the PR: \
`$ git checkout pull/32073` \
`$ git pull https://git.openjdk.org/jdk.git pull/32073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32073`

View PR using the GUI difftool: \
`$ git pr show -t 32073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32073.diff">https://git.openjdk.org/jdk/pull/32073.diff</a>

</details>
