### PR TITLE
8389175: NMT: Total malloc peak should account for overhead

### DIFF
--- a/src/hotspot/share/nmt/mallocTracker.hpp
+++ b/src/hotspot/share/nmt/mallocTracker.hpp
@@ -181,7 +181,7 @@ class MallocMemorySnapshot {
 
   // Total peak malloc
   size_t total_peak() const {
-    return _all_mallocs.peak_size();
+    return _all_mallocs.peak_size() + _all_mallocs.peak_count() * MallocHeader::malloc_overhead();
   }
 
   // Total peak count

--- a/test/hotspot/gtest/nmt/test_nmt_totals.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_totals.cpp
@@ -40,21 +40,33 @@ static size_t get_total_malloc_size() {
   return MallocMemorySummary::as_snapshot()->total();
 }
 
+static size_t get_peak_total_malloc_size() {
+  return MallocMemorySummary::as_snapshot()->total_peak();
+}
+
+static size_t get_total_arena_size() {
+  return MallocMemorySummary::as_snapshot()->total_arena();
+}
+
 static size_t get_malloc_overhead() {
   return MallocMemorySummary::as_snapshot()->malloc_overhead();
 }
 
-struct totals_t { size_t n; size_t s; size_t ovrh; };
+struct totals_t { size_t n; size_t s; size_t ps; size_t a; size_t ovrh; };
 
 static totals_t get_totals() {
   totals_t tot;
   tot.n = get_total_malloc_invocs();
   tot.s = get_total_malloc_size();
+  tot.a = get_total_arena_size();
+  tot.ps = get_peak_total_malloc_size();
   tot.ovrh = get_malloc_overhead();
   return tot;
 }
 
 // Concurrent code can malloc and free too, therefore we need to compare with a leeway factor
+// Note that a snapshot is never taken, thus make_adjustment(), does not undo arena chunk double counting.
+// Therefore we need to subtract arena size when verifying peak total malloc size.
 #define compare_totals(t_real, t_expected) {                                  \
   double leeway_factor = 0.33;                                                \
   size_t leeway_n = (size_t)(((double)t_expected.n) * leeway_factor);         \
@@ -65,6 +77,7 @@ static totals_t get_totals() {
   EXPECT_LE(t_real.s, t_expected.s + leeway_s);                               \
   EXPECT_GE(t_real.ovrh, t_expected.ovrh - (leeway_n * sizeof(MallocHeader)));   \
   EXPECT_LE(t_real.ovrh, t_expected.ovrh + (leeway_n * sizeof(MallocHeader)));   \
+  EXPECT_GE(t_real.ps, t_real.s - t_real.a);                                     \
   LOG("Deviation: n=%zd, s=%zd, ovrh=%zd",   \
       (ssize_t)t_real.n - (ssize_t)t_expected.n,                                 \
       (ssize_t)t_real.s - (ssize_t)t_expected.s,                                 \


### PR DESCRIPTION
### Summary of changes:
Previously, NMT reported peak total malloc amounts without taking into account malloc header overhead.  This is a pretty small amount, but it can add up with many allocations. 

It's even possible for the peak amount to be reported as less than the current amount. That would be confusing for users. For example like this:
```
Total: ...
       malloc: 89480KB #82463, peak=88033KB #82444
``` 

The solution is just to add the malloc header overhead to `total_peak()` the same way we already do for `total()`.

#### Note:
Note that `total()` also adds on the arena size: `_all_mallocs.size() + malloc_overhead() + total_arena();`. This is because `make_adjustment` has already removed the total arena size from  `_all_mallocs.size()` (so we need to add it back before reporting). 
However, `total_peak()` does **not** need to add on  arena size because `make_adjustment` has no affect on the peak values. And the original `_all_mallocs.peak_size() ` already **implicitly** accounts for arena memory because of how `mtChunk` accounts for heap chunks backing arenas.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389175](https://bugs.openjdk.org/browse/JDK-8389175): NMT: Total malloc peak should account for overhead (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32074/head:pull/32074` \
`$ git checkout pull/32074`

Update a local copy of the PR: \
`$ git checkout pull/32074` \
`$ git pull https://git.openjdk.org/jdk.git pull/32074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32074`

View PR using the GUI difftool: \
`$ git pr show -t 32074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32074.diff">https://git.openjdk.org/jdk/pull/32074.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32074#issuecomment-5256189793)
</details>
