### PR TITLE
8389312: RISC-V: vector_update_crc32 wrongly assumes undisturbed tail elements

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2168,12 +2168,12 @@ void MacroAssembler::vector_update_crc32(Register crc, Register buf, Register le
     mv(tmp5, 0xff);
 
     if (MaxVectorSize == 16) {
-      vsetivli(zr, N, Assembler::e32, Assembler::m4, Assembler::ma, Assembler::ta);
+      vsetivli(zr, N, Assembler::e32, Assembler::m4, Assembler::mu, Assembler::tu);
     } else if (MaxVectorSize == 32) {
-      vsetivli(zr, N, Assembler::e32, Assembler::m2, Assembler::ma, Assembler::ta);
+      vsetivli(zr, N, Assembler::e32, Assembler::m2, Assembler::mu, Assembler::tu);
     } else {
       assert(MaxVectorSize > 32, "sanity");
-      vsetivli(zr, N, Assembler::e32, Assembler::m1, Assembler::ma, Assembler::ta);
+      vsetivli(zr, N, Assembler::e32, Assembler::m1, Assembler::mu, Assembler::tu);
     }
 
     vmv_v_x(vcrc, zr);


### PR DESCRIPTION
Hi, I found the test test/hotspot/jtreg/compiler/intrinsics/zip/TestCRC32.java fails intermittently on QEMU. After debugging, I determined that the root cause is vector_update_crc32 incorrectly assuming that the tail elements of vmv.s.x remain undisturbed under a tail-agnostic policy.

### Performance test with release on SpacemiT Key Stone K3
without this patch:
```
Benchmark                    (count)   Mode  Cnt      Score    Error   Units
TestCRC32.testCRC32Update         64  thrpt   12  10057.502 ±  1.666  ops/ms
TestCRC32.testCRC32Update        128  thrpt   12   5378.953 ± 64.140  ops/ms
TestCRC32.testCRC32Update        256  thrpt   12   2904.015 ±  3.919  ops/ms
TestCRC32.testCRC32Update        512  thrpt   12   3566.556 ±  0.246  ops/ms
TestCRC32.testCRC32Update       2048  thrpt   12   1824.679 ±  0.306  ops/ms
TestCRC32.testCRC32Update      16384  thrpt   12    328.282 ±  0.044  ops/ms
TestCRC32.testCRC32Update      65536  thrpt   12     85.272 ±  0.205  ops/ms
TestCRC32C.testCRC32CUpdate       64  thrpt   12  10048.664 ± 74.898  ops/ms
TestCRC32C.testCRC32CUpdate      128  thrpt   12   6535.728 ±  8.761  ops/ms
TestCRC32C.testCRC32CUpdate      256  thrpt   12   3849.013 ± 11.300  ops/ms
TestCRC32C.testCRC32CUpdate      512  thrpt   12   2124.941 ±  2.085  ops/ms
TestCRC32C.testCRC32CUpdate     2048  thrpt   12    559.089 ±  0.073  ops/ms
TestCRC32C.testCRC32CUpdate    16384  thrpt   12     71.455 ±  0.008  ops/ms
TestCRC32C.testCRC32CUpdate    65536  thrpt   12     17.814 ±  0.020  ops/ms
Finished running test 'micro:org.openjdk.bench.java.util.TestCRC32'
```

with this patch:
```
Benchmark                    (count)   Mode  Cnt      Score    Error   Units
TestCRC32.testCRC32Update         64  thrpt   12  10058.165 ±  0.793  ops/ms
TestCRC32.testCRC32Update        128  thrpt   12   5447.517 ±  2.162  ops/ms
TestCRC32.testCRC32Update        256  thrpt   12   2906.265 ±  3.950  ops/ms
TestCRC32.testCRC32Update        512  thrpt   12   3566.656 ±  0.181  ops/ms
TestCRC32.testCRC32Update       2048  thrpt   12   1824.727 ±  0.163  ops/ms
TestCRC32.testCRC32Update      16384  thrpt   12    328.167 ±  0.326  ops/ms
TestCRC32.testCRC32Update      65536  thrpt   12     85.375 ±  0.085  ops/ms
TestCRC32C.testCRC32CUpdate       64  thrpt   12  10118.365 ± 20.267  ops/ms
TestCRC32C.testCRC32CUpdate      128  thrpt   12   6535.747 ±  8.074  ops/ms
TestCRC32C.testCRC32CUpdate      256  thrpt   12   3845.646 ± 12.671  ops/ms
TestCRC32C.testCRC32CUpdate      512  thrpt   12   2124.729 ±  1.283  ops/ms
TestCRC32C.testCRC32CUpdate     2048  thrpt   12    559.063 ±  0.118  ops/ms
TestCRC32C.testCRC32CUpdate    16384  thrpt   12     71.452 ±  0.008  ops/ms
TestCRC32C.testCRC32CUpdate    65536  thrpt   12     17.801 ±  0.012  ops/ms
Finished running test 'micro:org.openjdk.bench.java.util.TestCRC32'
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389312](https://bugs.openjdk.org/browse/JDK-8389312): RISC-V: vector_update_crc32 wrongly assumes undisturbed tail elements (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32076/head:pull/32076` \
`$ git checkout pull/32076`

Update a local copy of the PR: \
`$ git checkout pull/32076` \
`$ git pull https://git.openjdk.org/jdk.git pull/32076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32076`

View PR using the GUI difftool: \
`$ git pr show -t 32076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32076.diff">https://git.openjdk.org/jdk/pull/32076.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32076#issuecomment-5134333920)
</details>
