### PR TITLE
8390040: RISC-V: Use Zfa fround.d for double rounding operations

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1802,6 +1802,11 @@ protected:
     fp_base<D_64_dp, 0b00101>(Rd, Rs1, Rs2, 0b011);
   }
 
+  void fround_d(FloatRegister Rd, FloatRegister Rs1, RoundingMode rm = rtz) {
+    assert_cond(UseZfa);
+    fp_base<D_64_dp, 0b01000>(Rd, Rs1, 0b00100, rm);
+  }
+
 // ==========================
 // RISC-V Vector Extension
 // ==========================

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2295,6 +2295,32 @@ void C2_MacroAssembler::round_double_mode(FloatRegister dst, FloatRegister src, 
   bind(done);
 }
 
+// Use zfa instruction to round double value.
+void C2_MacroAssembler::round_double_mode_zfa(FloatRegister dst, FloatRegister src, int round_mode) {
+  assert_different_registers(dst, src);
+
+  // Set rounding mode for conversions
+  // Here we use similar modes to double->long and long->double conversions
+  // Different mode for long->double conversion matter only if long value was not representable as double,
+  // we got long value as a result of double->long conversion so, it is definitely representable
+  RoundingMode rm;
+  switch (round_mode) {
+    case RoundDoubleModeNode::rmode_ceil:
+    rm = RoundingMode::rup;
+    break;
+    case RoundDoubleModeNode::rmode_floor:
+    rm = RoundingMode::rdn;
+    break;
+    case RoundDoubleModeNode::rmode_rint:
+    rm = RoundingMode::rne;
+    break;
+    default:
+    ShouldNotReachHere();
+  }
+  // fround.d
+  fround_d(dst, src, rm);
+}
+
 // According to Java SE specification, for floating-point signum operations, if
 // on input we have NaN or +/-0.0 value we should return it,
 // otherwise return +/- 1.0 using sign of input.

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -195,6 +195,8 @@
   void round_double_mode(FloatRegister dst, FloatRegister src, int round_mode,
                          Register tmp1, Register tmp2, Register tmp3);
 
+  void round_double_mode_zfa(FloatRegister dst, FloatRegister src, int round_mode);
+
   void signum_fp(FloatRegister dst, FloatRegister one, bool is_double);
 
   void float16_to_float(FloatRegister dst, Register src, Register tmp);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7862,6 +7862,7 @@ instruct sqrtD_reg(fRegD dst, fRegD src) %{
 
 // Round Instruction
 instruct roundD_reg(fRegD dst, fRegD src, immI rmode, iRegLNoSp tmp1, iRegLNoSp tmp2, iRegLNoSp tmp3) %{
+  predicate(!UseZfa);
   match(Set dst (RoundDoubleMode src rmode));
   ins_cost(2 * XFER_COST + BRANCH_COST);
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2, TEMP tmp3);
@@ -7870,6 +7871,19 @@ instruct roundD_reg(fRegD dst, fRegD src, immI rmode, iRegLNoSp tmp1, iRegLNoSp 
   ins_encode %{
     __ round_double_mode(as_FloatRegister($dst$$reg),
                as_FloatRegister($src$$reg), $rmode$$constant, $tmp1$$Register, $tmp2$$Register, $tmp3$$Register);
+  %}
+  ins_pipe(pipe_class_default);
+%}
+
+instruct roundD_reg_zfa(fRegD dst, fRegD src, immI rmode) %{
+  predicate(UseZfa);
+  match(Set dst (RoundDoubleMode src rmode));
+  ins_cost(XFER_COST);
+  effect(TEMP_DEF dst);
+
+  format %{ "RoundDoubleMode $src, $rmode" %}
+  ins_encode %{
+    __ round_double_mode_zfa(as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg), $rmode$$constant);
   %}
   ins_pipe(pipe_class_default);
 %}


### PR DESCRIPTION
Use the Zfa `fround.d` instruction to implement C2 double rounding
operations on RISC-V processors that support the Zfa extension.

Map the C2 rounding modes to the corresponding RISC-V rounding modes:

- ceil to `rup`
- floor to `rdn`
- rint to `rne`

When `UseZfa` is enabled, select the new instruction pattern that emits
`fround.d` directly. Keep the existing software implementation as the
fallback when Zfa is unavailable.

This reduces the instruction sequence and eliminates the temporary
integer registers previously required by the software implementation.

### Performance test on hardware with Zfa extension:
without this patch:
```bash
Benchmark                       (TESTSIZE)   Mode  Cnt    Score    Error   Units
FpRoundingBenchmark.test_ceil         2048  thrpt   15  226.987 ± 15.483  ops/ms
FpRoundingBenchmark.test_floor        2048  thrpt   15  223.604 ±  9.098  ops/ms
FpRoundingBenchmark.test_rint         2048  thrpt   15  222.839 ±  8.402  ops/ms
```
with this patch:
```bash
Benchmark                       (TESTSIZE)   Mode  Cnt    Score    Error   Units
FpRoundingBenchmark.test_ceil         2048  thrpt   15  292.057 ± 41.352  ops/ms
FpRoundingBenchmark.test_floor        2048  thrpt   15  314.515 ± 14.154  ops/ms
FpRoundingBenchmark.test_rint         2048  thrpt   15  315.518 ± 26.807  ops/ms
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8390040](https://bugs.openjdk.org/browse/JDK-8390040): RISC-V: Use Zfa fround.d for double rounding operations (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32077/head:pull/32077` \
`$ git checkout pull/32077`

Update a local copy of the PR: \
`$ git checkout pull/32077` \
`$ git pull https://git.openjdk.org/jdk.git pull/32077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32077`

View PR using the GUI difftool: \
`$ git pr show -t 32077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32077.diff">https://git.openjdk.org/jdk/pull/32077.diff</a>

</details>
