### PR TITLE
8390039: RISC-V: Optimize RVV vset instruction generation in C2

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -3098,10 +3098,9 @@ void C2_MacroAssembler::reduce_mul_integral_v(Register dst, Register src1, Vecto
   }
 }
 
-// Set vl and vtype for full and partial vector operations.
-// (vma = mu, vta = tu, vill = false)
 void C2_MacroAssembler::vsetvli_helper(BasicType bt, uint vector_length, LMUL vlmul, Register tmp) {
   Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
+
   if (vector_length <= 31) {
     vsetivli(tmp, vector_length, sew, vlmul);
   } else if (vector_length == (MaxVectorSize / type2aelembytes(bt))) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2546,8 +2546,11 @@ void C2_MacroAssembler::float_to_float16_v(VectorRegister dst, VectorRegister sr
   bind(stub->continuation());
 }
 
-void C2_MacroAssembler::signum_fp_v(VectorRegister dst, VectorRegister one, BasicType bt, int vlen) {
-  vsetvli_helper(bt, vlen, Assembler::mu);
+void C2_MacroAssembler::signum_fp_v(VectorRegister dst, VectorRegister one, BasicType bt, int vlen,
+                                    bool set_vtype) {
+  if (set_vtype) {
+    vsetvli_helper(bt, vlen, Assembler::mu);
+  }
 
   // check if input is -0, +0, signaling NaN or quiet NaN
   vfclass_v(v0, dst);
@@ -2566,7 +2569,7 @@ void C2_MacroAssembler::signum_fp_v(VectorRegister dst, VectorRegister one, Basi
 //    float >= Integer.MAX_VALUE,
 //    float <= Integer.MIN_VALUE.
 void C2_MacroAssembler::java_round_float_v(VectorRegister dst, VectorRegister src, FloatRegister ftmp,
-                                           BasicType bt, uint vector_length) {
+                                           BasicType bt, uint vector_length, bool set_vtype) {
   // In riscv, there is no straight corresponding rounding mode to satisfy the behaviour defined,
   // in java api spec, i.e. any rounding mode can not handle some corner cases, e.g.
   //  RNE is the closest one, but it ties to "even", which means 1.5/2.5 both will be converted
@@ -2584,7 +2587,9 @@ void C2_MacroAssembler::java_round_float_v(VectorRegister dst, VectorRegister sr
   // Check MacroAssembler::java_round_float and C2_MacroAssembler::vector_round_sve in aarch64 for more details.
 
   csrwi(CSR_FRM, C2_MacroAssembler::rdn);
-  vsetvli_helper(bt, vector_length, Assembler::mu);
+  if (set_vtype) {
+    vsetvli_helper(bt, vector_length, Assembler::mu);
+  }
 
   // don't rearrage the instructions sequence order without performance testing.
   // check MacroAssembler::java_round_float in riscv64 for more details.
@@ -2942,10 +2947,12 @@ void C2_MacroAssembler::string_indexof_char_v(Register str1, Register cnt1,
 
 // Set dst to NaN if any NaN input.
 void C2_MacroAssembler::minmax_fp_v(VectorRegister dst, VectorRegister src1, VectorRegister src2,
-                                    BasicType bt, bool is_min, uint vector_length) {
+                                    BasicType bt, bool is_min, uint vector_length, bool set_vtype) {
   assert_different_registers(dst, src1, src2);
 
-  vsetvli_helper(bt, vector_length, Assembler::mu);
+  if (set_vtype) {
+    vsetvli_helper(bt, vector_length, Assembler::mu);
+  }
 
   is_min ? vfmin_vv(dst, src1, src2)
          : vfmax_vv(dst, src1, src2);
@@ -2961,9 +2968,11 @@ void C2_MacroAssembler::minmax_fp_v(VectorRegister dst, VectorRegister src1, Vec
 // are handled with a mask-undisturbed policy.
 void C2_MacroAssembler::minmax_fp_masked_v(VectorRegister dst, VectorRegister src1, VectorRegister src2,
                                            VectorRegister vmask, VectorRegister tmp1, VectorRegister tmp2,
-                                           BasicType bt, bool is_min, uint vector_length) {
+                                           BasicType bt, bool is_min, uint vector_length, bool set_vtype) {
   assert_different_registers(src1, src2, tmp1, tmp2);
-  vsetvli_helper(bt, vector_length, Assembler::mu);
+  if (set_vtype) {
+    vsetvli_helper(bt, vector_length, Assembler::mu);
+  }
 
   // Check vector elements of src1 and src2 for NaN.
   vmfeq_vv(tmp1, src1, src1);
@@ -2984,7 +2993,8 @@ void C2_MacroAssembler::minmax_fp_masked_v(VectorRegister dst, VectorRegister sr
 void C2_MacroAssembler::reduce_minmax_fp_v(FloatRegister dst,
                                            FloatRegister src1, VectorRegister src2,
                                            VectorRegister tmp1, VectorRegister tmp2,
-                                           bool is_double, bool is_min, uint vector_length, VectorMask vm) {
+                                           bool is_double, bool is_min, uint vector_length, VectorMask vm,
+                                           bool set_vtype) {
   assert_different_registers(dst, src1);
   assert_different_registers(src2, tmp1, tmp2);
 
@@ -2994,7 +3004,9 @@ void C2_MacroAssembler::reduce_minmax_fp_v(FloatRegister dst,
             : feq_s(t0, src1, src1);
   beqz(t0, L_NaN_2);
 
-  vsetvli_helper(is_double ? T_DOUBLE : T_FLOAT, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
+  if (set_vtype) {
+    vsetvli_helper(is_double ? T_DOUBLE : T_FLOAT, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
+  }
   vfmv_s_f(tmp2, src1);
 
   is_min ? vfredmin_vs(tmp1, src2, tmp2, vm)
@@ -3029,9 +3041,12 @@ bool C2_MacroAssembler::in_scratch_emit_size() {
 
 void C2_MacroAssembler::reduce_integral_v(Register dst, Register src1,
                                           VectorRegister src2, VectorRegister tmp,
-                                          int opc, BasicType bt, uint vector_length, VectorMask vm) {
+                                          int opc, BasicType bt, uint vector_length, VectorMask vm,
+                                          bool set_vtype) {
   assert(bt == T_BYTE || bt == T_SHORT || bt == T_INT || bt == T_LONG, "unsupported element type");
-  vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
+  if (set_vtype) {
+    vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
+  }
   vmv_s_x(tmp, src1);
   switch (opc) {
     case Op_AddReductionVI:
@@ -3113,10 +3128,13 @@ void C2_MacroAssembler::vsetvli_helper(BasicType bt, uint vector_length, LMUL vl
 }
 
 void C2_MacroAssembler::compare_integral_v(VectorRegister vd, VectorRegister src1, VectorRegister src2,
-                                           int cond, BasicType bt, uint vector_length, VectorMask vm) {
+                                           int cond, BasicType bt, uint vector_length, VectorMask vm,
+                                           bool set_vtype) {
   assert(is_integral_type(bt), "unsupported element type");
   assert(vm == Assembler::v0_t ? vd != v0 : true, "should be different registers");
-  vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
+  if (set_vtype) {
+    vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
+  }
   if (vm == Assembler::v0_t) {
     vmclr_m(vd);
   }
@@ -3138,10 +3156,13 @@ void C2_MacroAssembler::compare_integral_v(VectorRegister vd, VectorRegister src
 }
 
 void C2_MacroAssembler::compare_fp_v(VectorRegister vd, VectorRegister src1, VectorRegister src2,
-                                     int cond, BasicType bt, uint vector_length, VectorMask vm) {
+                                     int cond, BasicType bt, uint vector_length, VectorMask vm,
+                                     bool set_vtype) {
   assert(is_floating_point_type(bt), "unsupported element type");
   assert(vm == Assembler::v0_t ? vd != v0 : true, "should be different registers");
-  vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
+  if (set_vtype) {
+    vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
+  }
   if (vm == Assembler::v0_t) {
     vmclr_m(vd);
   }
@@ -3174,7 +3195,8 @@ void C2_MacroAssembler::unspill_vmask(VectorRegister v, int offset) {
 }
 
 void C2_MacroAssembler::integer_extend_v(VectorRegister dst, BasicType dst_bt, uint vector_length,
-                                         VectorRegister src, BasicType src_bt, bool is_signed) {
+                                         VectorRegister src, BasicType src_bt, bool is_signed,
+                                         bool set_vtype) {
   assert(type2aelembytes(dst_bt) > type2aelembytes(src_bt) && type2aelembytes(dst_bt) <= 8 && type2aelembytes(src_bt) <= 4, "invalid element size");
   assert(dst_bt != T_FLOAT && dst_bt != T_DOUBLE && src_bt != T_FLOAT && src_bt != T_DOUBLE, "unsupported element type");
   // https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#52-vector-operands
@@ -3183,7 +3205,9 @@ void C2_MacroAssembler::integer_extend_v(VectorRegister dst, BasicType dst_bt, u
   // Since LMUL=1, vd and vs cannot be the same.
   assert_different_registers(dst, src);
 
-  vsetvli_helper(dst_bt, vector_length);
+  if (set_vtype) {
+    vsetvli_helper(dst_bt, vector_length);
+  }
   if (is_signed) {
     if (src_bt == T_BYTE) {
       switch (dst_bt) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2410,7 +2410,7 @@ static void float16_to_float_v_slow_path(C2_MacroAssembler& masm, C2GeneralStub<
   // we need the payloads of non-canonical NaNs to be preserved.
 
   // adjust vector type to 2 * SEW.
-  __ vsetvli_helper(T_FLOAT, vector_length, Assembler::m1);
+  __ vsetvli_helper(T_FLOAT, vector_length, Assembler::m1, Assembler::mu);
   // widen and sign-extend src data.
   __ vsext_vf2(dst, src, Assembler::v0_t);
   __ mv(t0, 0x7f800000);
@@ -2535,7 +2535,7 @@ void C2_MacroAssembler::float_to_float16_v(VectorRegister dst, VectorRegister sr
   vmfne_vv(v0, src, src);
   vcpop_m(t0, v0);
 
-  vsetvli_helper(BasicType::T_SHORT, vector_length, Assembler::mf2, tmp);
+  vsetvli_helper(BasicType::T_SHORT, vector_length, Assembler::mf2, Assembler::ma, Assembler::ta, tmp);
 
   // For non-NaN cases, just use built-in instructions.
   vfncvt_f_f_w(dst, src);
@@ -2547,7 +2547,7 @@ void C2_MacroAssembler::float_to_float16_v(VectorRegister dst, VectorRegister sr
 }
 
 void C2_MacroAssembler::signum_fp_v(VectorRegister dst, VectorRegister one, BasicType bt, int vlen) {
-  vsetvli_helper(bt, vlen);
+  vsetvli_helper(bt, vlen, Assembler::mu);
 
   // check if input is -0, +0, signaling NaN or quiet NaN
   vfclass_v(v0, dst);
@@ -2584,7 +2584,7 @@ void C2_MacroAssembler::java_round_float_v(VectorRegister dst, VectorRegister sr
   // Check MacroAssembler::java_round_float and C2_MacroAssembler::vector_round_sve in aarch64 for more details.
 
   csrwi(CSR_FRM, C2_MacroAssembler::rdn);
-  vsetvli_helper(bt, vector_length);
+  vsetvli_helper(bt, vector_length, Assembler::mu);
 
   // don't rearrage the instructions sequence order without performance testing.
   // check MacroAssembler::java_round_float in riscv64 for more details.
@@ -2610,7 +2610,7 @@ void C2_MacroAssembler::java_round_double_v(VectorRegister dst, VectorRegister s
   // check C2_MacroAssembler::java_round_float_v above for more details.
 
   csrwi(CSR_FRM, C2_MacroAssembler::rdn);
-  vsetvli_helper(bt, vector_length);
+  vsetvli_helper(bt, vector_length, Assembler::mu);
 
   mv(t0, julong_cast(0.5));
   fmv_d_x(ftmp, t0);
@@ -2634,7 +2634,7 @@ void C2_MacroAssembler::element_compare(Register a1, Register a2, Register resul
   Assembler::SEW sew = islatin ? Assembler::e8 : Assembler::e16;
 
   bind(loop);
-  vsetvli(tmp1, cnt, sew, lmul);
+  vsetvli(tmp1, cnt, sew, lmul, Assembler::ma, Assembler::ta);
   vlex_v(vr1, a1, sew);
   vlex_v(vr2, a2, sew);
   vmsne_vv(vrs, vr1, vr2);
@@ -2773,9 +2773,9 @@ void C2_MacroAssembler::string_compare_v(Register str1, Register str2, Register 
     VectorRegister vstr2 = encLU ? v4 : v8;
 
     bind(loop);
-    vsetvli(tmp1, cnt2, Assembler::e8, Assembler::m2);
+    vsetvli(tmp1, cnt2, Assembler::e8, Assembler::m2, Assembler::ma, Assembler::ta);
     vle8_v(vstr1, strL);
-    vsetvli(tmp1, cnt2, Assembler::e16, Assembler::m4);
+    vsetvli(tmp1, cnt2, Assembler::e16, Assembler::m4, Assembler::ma, Assembler::ta);
     vzext_vf2(vstr2, vstr1);
     vle16_v(vstr1, strU);
     vmsne_vv(v4, vstr2, vstr1);
@@ -2945,7 +2945,7 @@ void C2_MacroAssembler::minmax_fp_v(VectorRegister dst, VectorRegister src1, Vec
                                     BasicType bt, bool is_min, uint vector_length) {
   assert_different_registers(dst, src1, src2);
 
-  vsetvli_helper(bt, vector_length);
+  vsetvli_helper(bt, vector_length, Assembler::mu);
 
   is_min ? vfmin_vv(dst, src1, src2)
          : vfmax_vv(dst, src1, src2);
@@ -2963,7 +2963,7 @@ void C2_MacroAssembler::minmax_fp_masked_v(VectorRegister dst, VectorRegister sr
                                            VectorRegister vmask, VectorRegister tmp1, VectorRegister tmp2,
                                            BasicType bt, bool is_min, uint vector_length) {
   assert_different_registers(src1, src2, tmp1, tmp2);
-  vsetvli_helper(bt, vector_length);
+  vsetvli_helper(bt, vector_length, Assembler::mu);
 
   // Check vector elements of src1 and src2 for NaN.
   vmfeq_vv(tmp1, src1, src1);
@@ -2994,7 +2994,7 @@ void C2_MacroAssembler::reduce_minmax_fp_v(FloatRegister dst,
             : feq_s(t0, src1, src1);
   beqz(t0, L_NaN_2);
 
-  vsetvli_helper(is_double ? T_DOUBLE : T_FLOAT, vector_length);
+  vsetvli_helper(is_double ? T_DOUBLE : T_FLOAT, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
   vfmv_s_f(tmp2, src1);
 
   is_min ? vfredmin_vs(tmp1, src2, tmp2, vm)
@@ -3031,7 +3031,7 @@ void C2_MacroAssembler::reduce_integral_v(Register dst, Register src1,
                                           VectorRegister src2, VectorRegister tmp,
                                           int opc, BasicType bt, uint vector_length, VectorMask vm) {
   assert(bt == T_BYTE || bt == T_SHORT || bt == T_INT || bt == T_LONG, "unsupported element type");
-  vsetvli_helper(bt, vector_length);
+  vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
   vmv_s_x(tmp, src1);
   switch (opc) {
     case Op_AddReductionVI:
@@ -3063,7 +3063,7 @@ void C2_MacroAssembler::reduce_mul_integral_v(Register dst, Register src1, Vecto
                                               VectorRegister vtmp1, VectorRegister vtmp2,
                                               BasicType bt, uint vector_length, VectorMask vm) {
   assert(bt == T_BYTE || bt == T_SHORT || bt == T_INT || bt == T_LONG, "unsupported element type");
-  vsetvli_helper(bt, vector_length);
+  vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
 
   vector_length /= 2;
   if (vm != Assembler::unmasked) {
@@ -3074,7 +3074,7 @@ void C2_MacroAssembler::reduce_mul_integral_v(Register dst, Register src1, Vecto
     vmerge_vvm(vtmp2, vtmp1, src2); // vm == v0
     slidedown_v(vtmp1, vtmp2, vector_length);
 
-    vsetvli_helper(bt, vector_length);
+    vsetvli_helper(bt, vector_length, Assembler::mu);
     vmul_vv(vtmp1, vtmp1, vtmp2);
   } else {
     slidedown_v(vtmp1, src2, vector_length);
@@ -3086,7 +3086,7 @@ void C2_MacroAssembler::reduce_mul_integral_v(Register dst, Register src1, Vecto
   while (vector_length > 1) {
     vector_length /= 2;
     slidedown_v(vtmp2, vtmp1, vector_length);
-    vsetvli_helper(bt, vector_length);
+    vsetvli_helper(bt, vector_length, Assembler::mu);
     vmul_vv(vtmp1, vtmp1, vtmp2);
   }
 
@@ -3098,16 +3098,17 @@ void C2_MacroAssembler::reduce_mul_integral_v(Register dst, Register src1, Vecto
   }
 }
 
-void C2_MacroAssembler::vsetvli_helper(BasicType bt, uint vector_length, LMUL vlmul, Register tmp) {
+void C2_MacroAssembler::vsetvli_helper(BasicType bt, uint vector_length, LMUL vlmul,
+                                       Assembler::VMA vma, Assembler::VTA vta, Register tmp) {
   Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
 
   if (vector_length <= 31) {
-    vsetivli(tmp, vector_length, sew, vlmul);
+    vsetivli(tmp, vector_length, sew, vlmul, vma, vta);
   } else if (vector_length == (MaxVectorSize / type2aelembytes(bt))) {
-    vsetvli(tmp, x0, sew, vlmul);
+    vsetvli(tmp, x0, sew, vlmul, vma, vta);
   } else {
     mv(tmp, vector_length);
-    vsetvli(tmp, tmp, sew, vlmul);
+    vsetvli(tmp, tmp, sew, vlmul, vma, vta);
   }
 }
 
@@ -3115,7 +3116,7 @@ void C2_MacroAssembler::compare_integral_v(VectorRegister vd, VectorRegister src
                                            int cond, BasicType bt, uint vector_length, VectorMask vm) {
   assert(is_integral_type(bt), "unsupported element type");
   assert(vm == Assembler::v0_t ? vd != v0 : true, "should be different registers");
-  vsetvli_helper(bt, vector_length);
+  vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
   if (vm == Assembler::v0_t) {
     vmclr_m(vd);
   }
@@ -3140,7 +3141,7 @@ void C2_MacroAssembler::compare_fp_v(VectorRegister vd, VectorRegister src1, Vec
                                      int cond, BasicType bt, uint vector_length, VectorMask vm) {
   assert(is_floating_point_type(bt), "unsupported element type");
   assert(vm == Assembler::v0_t ? vd != v0 : true, "should be different registers");
-  vsetvli_helper(bt, vector_length);
+  vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
   if (vm == Assembler::v0_t) {
     vmclr_m(vd);
   }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -200,13 +200,16 @@
   void float16_to_float(FloatRegister dst, Register src, Register tmp);
   void float_to_float16(Register dst, FloatRegister src, FloatRegister ftmp, Register xtmp);
 
-  void signum_fp_v(VectorRegister dst, VectorRegister one, BasicType bt, int vlen);
+  void signum_fp_v(VectorRegister dst, VectorRegister one, BasicType bt, int vlen,
+                   bool set_vtype = true);
 
 
   // intrinsic methods implemented by rvv instructions
 
-  void java_round_float_v(VectorRegister dst, VectorRegister src, FloatRegister ftmp, BasicType bt, uint vector_length);
-  void java_round_double_v(VectorRegister dst, VectorRegister src, FloatRegister ftmp, BasicType bt, uint vector_length);
+  void java_round_float_v(VectorRegister dst, VectorRegister src, FloatRegister ftmp,
+                          BasicType bt, uint vector_length, bool set_vtype = true);
+  void java_round_double_v(VectorRegister dst, VectorRegister src, FloatRegister ftmp,
+                           BasicType bt, uint vector_length, bool set_vtype = true);
 
   void float16_to_float_v(VectorRegister dst, VectorRegister src, uint vector_length);
   void float_to_float16_v(VectorRegister dst, VectorRegister src, VectorRegister vtmp, Register tmp, uint vector_length);
@@ -247,22 +250,26 @@
 
   void minmax_fp_v(VectorRegister dst,
                   VectorRegister src1, VectorRegister src2,
-                  BasicType bt, bool is_min, uint vector_length);
+                  BasicType bt, bool is_min, uint vector_length,
+                  bool set_vtype = true);
 
   void minmax_fp_masked_v(VectorRegister dst, VectorRegister src1, VectorRegister src2,
                           VectorRegister vmask, VectorRegister tmp1, VectorRegister tmp2,
-                          BasicType bt, bool is_min, uint vector_length);
+                          BasicType bt, bool is_min, uint vector_length,
+                          bool set_vtype = true);
 
   void reduce_minmax_fp_v(FloatRegister dst,
                           FloatRegister src1, VectorRegister src2,
                           VectorRegister tmp1, VectorRegister tmp2,
                           bool is_double, bool is_min, uint vector_length,
-                          VectorMask vm = Assembler::unmasked);
+                          VectorMask vm = Assembler::unmasked,
+                          bool set_vtype = true);
 
   void reduce_integral_v(Register dst, Register src1,
                         VectorRegister src2, VectorRegister tmp,
                         int opc, BasicType bt, uint vector_length,
-                        VectorMask vm = Assembler::unmasked);
+                        VectorMask vm = Assembler::unmasked,
+                        bool set_vtype = true);
 
   void reduce_mul_integral_v(Register dst, Register src1, VectorRegister src2,
                              VectorRegister vtmp1, VectorRegister vtmp2, BasicType bt,
@@ -276,10 +283,12 @@
   }
 
   void compare_integral_v(VectorRegister dst, VectorRegister src1, VectorRegister src2, int cond,
-                          BasicType bt, uint vector_length, VectorMask vm = Assembler::unmasked);
+                          BasicType bt, uint vector_length, VectorMask vm = Assembler::unmasked,
+                          bool set_vtype = true);
 
   void compare_fp_v(VectorRegister dst, VectorRegister src1, VectorRegister src2, int cond,
-                    BasicType bt, uint vector_length, VectorMask vm = Assembler::unmasked);
+                    BasicType bt, uint vector_length, VectorMask vm = Assembler::unmasked,
+                    bool set_vtype = true);
 
   void spill_vmask(VectorRegister v, int offset);
 
@@ -294,7 +303,8 @@
   }
 
   void integer_extend_v(VectorRegister dst, BasicType dst_bt, uint vector_length,
-                        VectorRegister src, BasicType src_bt, bool is_signed);
+                        VectorRegister src, BasicType src_bt, bool is_signed,
+                        bool set_vtype = true);
 
   void integer_narrow_v(VectorRegister dst, BasicType dst_bt, uint vector_length,
                         VectorRegister src, BasicType src_bt);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -268,7 +268,12 @@
                              VectorRegister vtmp1, VectorRegister vtmp2, BasicType bt,
                              uint vector_length, VectorMask vm = Assembler::unmasked);
 
-  void vsetvli_helper(BasicType bt, uint vector_length, LMUL vlmul = Assembler::m1, Register tmp = t0);
+  void vsetvli_helper(BasicType bt, uint vector_length, LMUL vlmul = Assembler::m1,
+                      Assembler::VMA vma = Assembler::ma, Assembler::VTA vta = Assembler::ta, Register tmp = t0);
+
+  void vsetvli_helper(BasicType bt, uint vector_length, Assembler::VMA vma, Assembler::VTA vta = Assembler::ta) {
+    vsetvli_helper(bt, vector_length, Assembler::m1, vma, vta);
+  }
 
   void compare_integral_v(VectorRegister dst, VectorRegister src1, VectorRegister src2, int cond,
                           BasicType bt, uint vector_length, VectorMask vm = Assembler::unmasked);

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -99,6 +99,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseRVA23U64, false, EXPERIMENTAL, "Use RVA23U64 profile")        \
   product(bool, UseRVC, false, DIAGNOSTIC, "Use RVC instructions")               \
   product(bool, UseRVV, false, DIAGNOSTIC, "Use RVV instructions")               \
+  product(bool, UseRiscVVSetLICM, false, DIAGNOSTIC,                             \
+          "Hoist loop-invariant RVV vset instructions")                          \
   product(bool, UseZba, false, DIAGNOSTIC, "Use Zba instructions")               \
   product(bool, UseZbb, false, DIAGNOSTIC, "Use Zbb instructions")               \
   product(bool, UseZbkb, false, EXPERIMENTAL, "Use Zbkb instructions")           \

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2609,6 +2609,8 @@ ins_attrib ins_alignment(4);    // Required alignment attribute (must
                                 // compute_padding() function must be
                                 // provided for the instruction
 
+ins_attrib ins_riscv_vset(false);
+
 // Whether this node is expanded during code emission into a sequence of
 // instructions and the first instruction can perform an implicit null check.
 ins_attrib ins_is_late_expanded_null_check_candidate(false);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -33,9 +33,12 @@ source %{
 
   static void loadStore(C2_MacroAssembler* masm, bool is_store,
                         VectorRegister reg, BasicType bt, Register base,
-                        uint vector_length, Assembler::VectorMask vm = Assembler::unmasked) {
+                        uint vector_length, Assembler::VectorMask vm = Assembler::unmasked,
+                        bool set_vtype = true) {
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, vector_length);
+    if (set_vtype) {
+      __ vsetvli_helper(bt, vector_length);
+    }
 
     if (is_store) {
       __ vsex_v(reg, base, sew, vm);
@@ -192,22 +195,26 @@ source %{
 // vector load/store
 instruct loadV(vReg dst, vmemA mem) %{
   match(Set dst (LoadVector mem));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "loadV $dst, $mem\t# vector (rvv)" %}
   ins_encode %{
     VectorRegister dst_reg = as_VectorRegister($dst$$reg);
     loadStore(masm, false, dst_reg,
-              Matcher::vector_element_basic_type(this), as_Register($mem$$base), Matcher::vector_length(this));
+              Matcher::vector_element_basic_type(this), as_Register($mem$$base),
+              Matcher::vector_length(this), Assembler::unmasked, false);
   %}
   ins_pipe(pipe_slow);
 %}
 
 instruct storeV(vReg src, vmemA mem) %{
   match(Set mem (StoreVector mem src));
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "storeV $mem, $src\t# vector (rvv)" %}
   ins_encode %{
     VectorRegister src_reg = as_VectorRegister($src$$reg);
     loadStore(masm, true, src_reg,
-              Matcher::vector_element_basic_type(this, $src), as_Register($mem$$base), Matcher::vector_length(this, $src));
+              Matcher::vector_element_basic_type(this, $src), as_Register($mem$$base),
+              Matcher::vector_length(this, $src), Assembler::unmasked, false);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -216,9 +223,9 @@ instruct storeV(vReg src, vmemA mem) %{
 
 instruct vloadmask(vRegMask dst, vReg src) %{
   match(Set dst (VectorLoadMask src));
+  ins_riscv_vset(riscv_vset_fixed(T_BOOLEAN, Matcher::vector_length(this), req));
   format %{ "vloadmask $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_BOOLEAN, Matcher::vector_length(this));
     __ vmsne_vx(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), zr);
   %}
   ins_pipe(pipe_slow);
@@ -226,9 +233,9 @@ instruct vloadmask(vRegMask dst, vReg src) %{
 
 instruct vloadmask_masked(vRegMask dst, vReg src, vRegMask_V0 v0) %{
   match(Set dst (VectorLoadMask src v0));
+  ins_riscv_vset(riscv_vset_fixed(T_BOOLEAN, Matcher::vector_length(this), req));
   format %{ "vloadmask_masked $dst, $src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BOOLEAN, Matcher::vector_length(this));
     __ vmsne_vx(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), zr, Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -238,9 +245,9 @@ instruct vloadmask_masked(vRegMask dst, vReg src, vRegMask_V0 v0) %{
 
 instruct vstoremask(vReg dst, vRegMask_V0 v0, immI size) %{
   match(Set dst (VectorStoreMask v0 size));
+  ins_riscv_vset(riscv_vset_fixed(T_BOOLEAN, Matcher::vector_length(this), req));
   format %{ "vstoremask $dst, V0 # elem size is $size byte[s]" %}
   ins_encode %{
-    __ vsetvli_helper(T_BOOLEAN, Matcher::vector_length(this));
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
     __ vmerge_vim(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), 1);
   %}
@@ -255,6 +262,7 @@ instruct vmaskcmp(vRegMask dst, vReg src1, vReg src2, immI cond) %{
             Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
+  ins_riscv_vset(false);
   format %{ "vmaskcmp $dst, $src1, $src2, $cond" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -273,6 +281,7 @@ instruct vmaskcmp_masked(vRegMask dst, vReg src1, vReg src2, immI cond, vRegMask
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond v0)));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vmaskcmp_masked $dst, $src1, $src2, $cond, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -290,6 +299,7 @@ instruct vmaskcmp_fp(vRegMask dst, vReg src1, vReg src2, immI cond) %{
   predicate(Matcher::vector_element_basic_type(n) == T_FLOAT ||
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
+  ins_riscv_vset(false);
   format %{ "vmaskcmp_fp $dst, $src1, $src2, $cond" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -306,6 +316,7 @@ instruct vmaskcmp_fp_masked(vRegMask dst, vReg src1, vReg src2, immI cond, vRegM
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond v0)));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vmaskcmp_fp_masked $dst, $src1, $src2, $cond, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -325,10 +336,9 @@ instruct vabs(vReg dst, vReg src, vReg tmp) %{
   match(Set dst (AbsVI src));
   match(Set dst (AbsVL src));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vabs $dst, $src\t# KILL $tmp" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
@@ -338,10 +348,9 @@ instruct vabs(vReg dst, vReg src, vReg tmp) %{
 instruct vabs_fp(vReg dst, vReg src) %{
   match(Set dst (AbsVF src));
   match(Set dst (AbsVD src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vabs_fp $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfabs_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -355,10 +364,9 @@ instruct vabs_masked(vReg dst_src, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst_src (AbsVI dst_src v0));
   match(Set dst_src (AbsVL dst_src v0));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vabs_masked $dst_src, $dst_src, $v0\t# KILL $tmp" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($dst_src$$reg), 0,
                 Assembler::v0_t);
     __ vmax_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($tmp$$reg),
@@ -370,10 +378,9 @@ instruct vabs_masked(vReg dst_src, vRegMask_V0 v0, vReg tmp) %{
 instruct vabs_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (AbsVF dst_src v0));
   match(Set dst_src (AbsVD dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vabs_fp_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfabs_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -386,10 +393,9 @@ instruct vadd(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AddVS src1 src2));
   match(Set dst (AddVI src1 src2));
   match(Set dst (AddVL src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vadd_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -399,11 +405,11 @@ instruct vadd(vReg dst, vReg src1, vReg src2) %{
 
 instruct vadd_hfp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AddVHF src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
     assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfadd_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -414,10 +420,9 @@ instruct vadd_hfp(vReg dst, vReg src1, vReg src2) %{
 instruct vadd_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AddVF src1 src2));
   match(Set dst (AddVD src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd_fp $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfadd_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -432,10 +437,9 @@ instruct vadd_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVS (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVL (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vadd_vv(as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -446,10 +450,9 @@ instruct vadd_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVD (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfadd_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -463,10 +466,9 @@ instruct vadd_vi(vReg dst, vReg src1, immI5 con) %{
   match(Set dst (AddVB src1 (Replicate con)));
   match(Set dst (AddVS src1 (Replicate con)));
   match(Set dst (AddVI src1 (Replicate con)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd_vi $dst, $src1, $con" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vadd_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                $con$$constant);
@@ -476,9 +478,9 @@ instruct vadd_vi(vReg dst, vReg src1, immI5 con) %{
 
 instruct vaddL_vi(vReg dst, vReg src1, immL5 con) %{
   match(Set dst (AddVL src1 (Replicate con)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vaddL_vi $dst, $src1, $con" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                $con$$constant);
@@ -492,10 +494,9 @@ instruct vadd_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (AddVB src1 (Replicate src2)));
   match(Set dst (AddVS src1 (Replicate src2)));
   match(Set dst (AddVI src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd_vx $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -505,9 +506,9 @@ instruct vadd_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
 
 instruct vaddL_vx(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (AddVL src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vaddL_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -521,10 +522,9 @@ instruct vadd_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVB (Binary dst_src (Replicate con)) v0));
   match(Set dst_src (AddVS (Binary dst_src (Replicate con)) v0));
   match(Set dst_src (AddVI (Binary dst_src (Replicate con)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vadd_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -534,9 +534,9 @@ instruct vadd_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
 
 instruct vaddL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate con)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vaddL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -550,10 +550,9 @@ instruct vadd_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (AddVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (AddVI (Binary dst_src (Replicate src2)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vadd_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -563,9 +562,9 @@ instruct vadd_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
 
 instruct vaddL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate src2)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vaddL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -580,10 +579,9 @@ instruct vsub(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (SubVS src1 src2));
   match(Set dst (SubVI src1 src2));
   match(Set dst (SubVL src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsub $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -592,11 +590,11 @@ instruct vsub(vReg dst, vReg src1, vReg src2) %{
 
 instruct vsub_hfp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (SubVHF src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsub_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
     assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -606,10 +604,9 @@ instruct vsub_hfp(vReg dst, vReg src1, vReg src2) %{
 instruct vsub_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (SubVF src1 src2));
   match(Set dst (SubVD src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsub_fp $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfsub_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -623,10 +620,9 @@ instruct vsub_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVS (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVL (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsub_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -636,10 +632,9 @@ instruct vsub_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVD (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsub_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -652,10 +647,9 @@ instruct vsub_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (SubVB src1 (Replicate src2)));
   match(Set dst (SubVS src1 (Replicate src2)));
   match(Set dst (SubVI src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsub_vx $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -665,9 +659,9 @@ instruct vsub_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
 
 instruct vsubL_vx(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (SubVL src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vsubL_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -681,10 +675,9 @@ instruct vsub_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (SubVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (SubVI (Binary dst_src (Replicate src2)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsub_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -694,9 +687,9 @@ instruct vsub_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
 
 instruct vsubL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVL (Binary dst_src (Replicate src2)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vsubL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -711,11 +704,11 @@ instruct vsubL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
 instruct vsadd(vReg dst, vReg src1, vReg src2) %{
   predicate(n->is_SaturatingVector() && !n->as_SaturatingVector()->is_unsigned());
   match(Set dst (SaturatingAddV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsadd $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsadd_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -727,11 +720,11 @@ instruct vsadd(vReg dst, vReg src1, vReg src2) %{
 instruct vsaddu(vReg dst, vReg src1, vReg src2) %{
   predicate(n->is_SaturatingVector() && n->as_SaturatingVector()->is_unsigned());
   match(Set dst (SaturatingAddV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsaddu $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsaddu_vv(as_VectorRegister($dst$$reg),
                  as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -743,11 +736,11 @@ instruct vsaddu(vReg dst, vReg src1, vReg src2) %{
 instruct vsadd_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   predicate(n->is_SaturatingVector() && !n->as_SaturatingVector()->is_unsigned());
   match(Set dst_src (SaturatingAddV (Binary dst_src src1) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsadd_masked $dst_src, $dst_src, $src1, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsadd_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                 as_VectorRegister($src1$$reg), Assembler::v0_t);
   %}
@@ -759,11 +752,11 @@ instruct vsadd_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
 instruct vsaddu_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   predicate(n->is_SaturatingVector() && n->as_SaturatingVector()->is_unsigned());
   match(Set dst_src (SaturatingAddV (Binary dst_src src1) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsaddu_masked $dst_src, $dst_src, $src1, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsaddu_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($src1$$reg), Assembler::v0_t);
   %}
@@ -775,11 +768,11 @@ instruct vsaddu_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
 instruct vssub(vReg dst, vReg src1, vReg src2) %{
   predicate(n->is_SaturatingVector() && !n->as_SaturatingVector()->is_unsigned());
   match(Set dst (SaturatingSubV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vssub $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vssub_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -791,11 +784,11 @@ instruct vssub(vReg dst, vReg src1, vReg src2) %{
 instruct vssubu(vReg dst, vReg src1, vReg src2) %{
   predicate(n->is_SaturatingVector() && n->as_SaturatingVector()->is_unsigned());
   match(Set dst (SaturatingSubV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vssubu $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vssubu_vv(as_VectorRegister($dst$$reg),
                  as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -807,11 +800,11 @@ instruct vssubu(vReg dst, vReg src1, vReg src2) %{
 instruct vssub_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   predicate(n->is_SaturatingVector() && !n->as_SaturatingVector()->is_unsigned());
   match(Set dst_src (SaturatingSubV (Binary dst_src src1) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vssub_masked $dst_src, $dst_src, $src1, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vssub_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                 as_VectorRegister($src1$$reg), Assembler::v0_t);
   %}
@@ -823,11 +816,11 @@ instruct vssub_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
 instruct vssubu_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   predicate(n->is_SaturatingVector() && n->as_SaturatingVector()->is_unsigned());
   match(Set dst_src (SaturatingSubV (Binary dst_src src1) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vssubu_masked $dst_src, $dst_src, $src1, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vssubu_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($src1$$reg), Assembler::v0_t);
   %}
@@ -838,10 +831,9 @@ instruct vssubu_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
 
 instruct vand(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (AndV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vand $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vand_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -853,10 +845,9 @@ instruct vand(vReg dst, vReg src1, vReg src2) %{
 
 instruct vand_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AndV (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vand_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vand_vv(as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -871,10 +862,9 @@ instruct vand_vi(vReg dst, vReg src1, immI5 con) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (AndV src1 (Replicate con)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vand_vi $dst, $src1, $con" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vand_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                $con$$constant);
@@ -885,9 +875,9 @@ instruct vand_vi(vReg dst, vReg src1, immI5 con) %{
 instruct vandL_vi(vReg dst, vReg src1, immL5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (AndV src1 (Replicate con)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vandL_vi $dst, $src1, $con" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vand_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                $con$$constant);
@@ -902,10 +892,9 @@ instruct vand_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (AndV src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vand_vx $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vand_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -916,9 +905,9 @@ instruct vand_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
 instruct vandL_vx(vReg dst, vReg src1, iRegL src2) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (AndV src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vandL_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vand_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -933,10 +922,9 @@ instruct vand_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (AndV (Binary dst_src (Replicate con)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vand_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vand_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -947,9 +935,9 @@ instruct vand_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
 instruct vandL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (AndV (Binary dst_src (Replicate con)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vandL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vand_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -964,10 +952,9 @@ instruct vand_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (AndV (Binary dst_src (Replicate src)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vand_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vand_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src$$reg), Assembler::v0_t);
@@ -978,9 +965,9 @@ instruct vand_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
 instruct vandL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (AndV (Binary dst_src (Replicate src)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vandL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vand_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src$$reg), Assembler::v0_t);
@@ -992,10 +979,9 @@ instruct vandL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
 
 instruct vor(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (OrV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vor $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vor_vv(as_VectorRegister($dst$$reg),
               as_VectorRegister($src1$$reg),
               as_VectorRegister($src2$$reg));
@@ -1007,10 +993,9 @@ instruct vor(vReg dst, vReg src1, vReg src2) %{
 
 instruct vor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (OrV (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vor_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vor_vv(as_VectorRegister($dst_src1$$reg),
               as_VectorRegister($dst_src1$$reg),
               as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -1025,10 +1010,9 @@ instruct vor_vi(vReg dst, vReg src1, immI5 con) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (OrV src1 (Replicate con)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vor_vi $dst, $src1, $con" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vor_vi(as_VectorRegister($dst$$reg),
               as_VectorRegister($src1$$reg),
               $con$$constant);
@@ -1039,9 +1023,9 @@ instruct vor_vi(vReg dst, vReg src1, immI5 con) %{
 instruct vorL_vi(vReg dst, vReg src1, immL5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (OrV src1 (Replicate con)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vorL_vi $dst, $src1, $con" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vor_vi(as_VectorRegister($dst$$reg),
               as_VectorRegister($src1$$reg),
               $con$$constant);
@@ -1056,10 +1040,9 @@ instruct vor_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (OrV src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vor_vx $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vor_vx(as_VectorRegister($dst$$reg),
               as_VectorRegister($src1$$reg),
               as_Register($src2$$reg));
@@ -1070,9 +1053,9 @@ instruct vor_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
 instruct vorL_vx(vReg dst, vReg src1, iRegL src2) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (OrV src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vorL_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vor_vx(as_VectorRegister($dst$$reg),
               as_VectorRegister($src1$$reg),
               as_Register($src2$$reg));
@@ -1087,10 +1070,9 @@ instruct vor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (OrV (Binary dst_src (Replicate con)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vor_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vor_vi(as_VectorRegister($dst_src$$reg),
               as_VectorRegister($dst_src$$reg),
               $con$$constant, Assembler::v0_t);
@@ -1101,9 +1083,9 @@ instruct vor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
 instruct vorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (OrV (Binary dst_src (Replicate con)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vorL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vor_vi(as_VectorRegister($dst_src$$reg),
               as_VectorRegister($dst_src$$reg),
               $con$$constant, Assembler::v0_t);
@@ -1118,10 +1100,9 @@ instruct vor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (OrV (Binary dst_src (Replicate src)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vor_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vor_vx(as_VectorRegister($dst_src$$reg),
               as_VectorRegister($dst_src$$reg),
               as_Register($src$$reg), Assembler::v0_t);
@@ -1132,9 +1113,9 @@ instruct vor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
 instruct vorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (OrV (Binary dst_src (Replicate src)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vorL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vor_vx(as_VectorRegister($dst_src$$reg),
               as_VectorRegister($dst_src$$reg),
               as_Register($src$$reg), Assembler::v0_t);
@@ -1146,10 +1127,9 @@ instruct vorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
 
 instruct vxor(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (XorV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vxor $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -1161,10 +1141,9 @@ instruct vxor(vReg dst, vReg src1, vReg src2) %{
 
 instruct vxor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (XorV (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vxor_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vv(as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -1179,10 +1158,9 @@ instruct vxor_vi(vReg dst, vReg src1, immI5 con) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (XorV src1 (Replicate con)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vxor_vi $dst, $src1, $con" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                $con$$constant);
@@ -1193,9 +1171,9 @@ instruct vxor_vi(vReg dst, vReg src1, immI5 con) %{
 instruct vxorL_vi(vReg dst, vReg src1, immL5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (XorV src1 (Replicate con)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vxorL_vi $dst, $src1, $con" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                $con$$constant);
@@ -1210,10 +1188,9 @@ instruct vxor_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (XorV src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vxor_vx $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -1224,9 +1201,9 @@ instruct vxor_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
 instruct vxorL_vx(vReg dst, vReg src1, iRegL src2) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (XorV src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vxorL_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -1241,10 +1218,9 @@ instruct vxor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (XorV (Binary dst_src (Replicate con)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vxor_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -1255,9 +1231,9 @@ instruct vxor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
 instruct vxorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV (Binary dst_src (Replicate con)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vxorL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -1272,10 +1248,9 @@ instruct vxor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (XorV (Binary dst_src (Replicate src)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vxor_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src$$reg), Assembler::v0_t);
@@ -1286,9 +1261,9 @@ instruct vxor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
 instruct vxorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV (Binary dst_src (Replicate src)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vxorL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src$$reg), Assembler::v0_t);
@@ -1303,9 +1278,9 @@ instruct vxorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
 instruct vand_notB(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vand_notB $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1316,9 +1291,9 @@ instruct vand_notB(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
 instruct vand_notS(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vand_notS $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1329,9 +1304,9 @@ instruct vand_notS(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
 instruct vand_notI(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vand_notI $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1342,9 +1317,9 @@ instruct vand_notI(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
 instruct vand_notL(vReg dst, vReg src1, vReg src2, immL_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vand_notL $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1355,9 +1330,9 @@ instruct vand_notL(vReg dst, vReg src1, vReg src2, immL_M1 m1) %{
 instruct vand_notB_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vand_notB_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1369,9 +1344,9 @@ instruct vand_notB_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
 instruct vand_notS_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vand_notS_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1383,9 +1358,9 @@ instruct vand_notS_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
 instruct vand_notI_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vand_notI_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1397,9 +1372,9 @@ instruct vand_notI_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
 instruct vand_notL_masked(vReg dst_src1, vReg src2, immL_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vand_notL_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg),
@@ -1411,9 +1386,9 @@ instruct vand_notL_masked(vReg dst_src1, vReg src2, immL_M1 m1, vRegMask_V0 v0) 
 instruct vand_notB_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (AndV src1 (Replicate (XorI src2 m1))));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vand_notB_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_Register($src2$$reg));
@@ -1424,9 +1399,9 @@ instruct vand_notB_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
 instruct vand_notS_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (AndV src1 (Replicate (XorI src2 m1))));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vand_notS_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_Register($src2$$reg));
@@ -1437,9 +1412,9 @@ instruct vand_notS_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
 instruct vand_notI_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (AndV src1 (Replicate (XorI src2 m1))));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vand_notI_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_Register($src2$$reg));
@@ -1450,9 +1425,9 @@ instruct vand_notI_vx(vReg dst, vReg src1, iRegIorL2I src2, immI_M1 m1) %{
 instruct vand_notL_vx(vReg dst, vReg src1, iRegL src2, immL_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (AndV src1 (Replicate (XorL src2 m1))));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vand_notL_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_Register($src2$$reg));
@@ -1463,9 +1438,9 @@ instruct vand_notL_vx(vReg dst, vReg src1, iRegL src2, immL_M1 m1) %{
 instruct vand_notB_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vand_notB_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),
@@ -1477,9 +1452,9 @@ instruct vand_notB_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
 instruct vand_notS_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vand_notS_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),
@@ -1491,9 +1466,9 @@ instruct vand_notS_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
 instruct vand_notI_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vand_notI_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),
@@ -1505,9 +1480,9 @@ instruct vand_notI_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
 instruct vand_notL_vx_masked(vReg dst_src1, iRegL src2, immL_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorL src2 m1))) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vand_notL_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_Register($src2$$reg),
@@ -1525,10 +1500,9 @@ instruct vnot(vReg dst, vReg src, immI_M1 m1) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (XorV src (Replicate m1)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vnot $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src$$reg),
                -1);
@@ -1539,9 +1513,9 @@ instruct vnot(vReg dst, vReg src, immI_M1 m1) %{
 instruct vnotL(vReg dst, vReg src, immL_M1 m1) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (XorV src (Replicate m1)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vnotL $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src$$reg),
                -1);
@@ -1556,10 +1530,9 @@ instruct vnot_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (XorV (Binary dst_src (Replicate m1)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vnot_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                -1, Assembler::v0_t);
@@ -1570,9 +1543,9 @@ instruct vnot_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
 instruct vnotL_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV (Binary dst_src (Replicate m1)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vnotL_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                -1, Assembler::v0_t);
@@ -1584,11 +1557,11 @@ instruct vnotL_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
 
 instruct vdiv_hfp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (DivVHF src1 src2));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vdiv_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
     assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfdiv_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1599,10 +1572,9 @@ instruct vdiv_hfp(vReg dst, vReg src1, vReg src2) %{
 instruct vdiv_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (DivVF src1 src2));
   match(Set dst (DivVD src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vdiv_fp $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfdiv_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -1615,10 +1587,9 @@ instruct vdiv_fp(vReg dst, vReg src1, vReg src2) %{
 instruct vdiv_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (DivVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (DivVD (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vdiv_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfdiv_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
@@ -1632,10 +1603,9 @@ instruct vmax(vReg dst, vReg src1, vReg src2) %{
   predicate(Matcher::vector_element_basic_type(n) != T_FLOAT &&
             Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst (MaxV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmax $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmax_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -1646,10 +1616,9 @@ instruct vmin(vReg dst, vReg src1, vReg src2) %{
   predicate(Matcher::vector_element_basic_type(n) != T_FLOAT &&
             Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst (MinV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmin $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmin_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -1662,10 +1631,9 @@ instruct vmax_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) != T_FLOAT &&
             Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst_src1 (MaxV (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmax_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmax_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -1676,10 +1644,9 @@ instruct vmin_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) != T_FLOAT &&
             Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst_src1 (MinV (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmin_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmin_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -1690,11 +1657,11 @@ instruct vmin_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 instruct vmaxu(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (UMaxV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmaxu $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmaxu_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -1703,11 +1670,11 @@ instruct vmaxu(vReg dst, vReg src1, vReg src2) %{
 
 instruct vminu(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (UMinV src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vminu $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vminu_vv(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
   %}
@@ -1718,11 +1685,11 @@ instruct vminu(vReg dst, vReg src1, vReg src2) %{
 
 instruct vmaxu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (UMaxV (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmaxu_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmaxu_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -1731,11 +1698,11 @@ instruct vmaxu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 instruct vminu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (UMinV (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vminu_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     assert(is_integral_type(bt), "unsupported type");
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vminu_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -1747,6 +1714,7 @@ instruct vminu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vmax_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (MaxVHF src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vmax_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
@@ -1761,6 +1729,7 @@ instruct vmax_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
 instruct vmin_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (MinVHF src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vmin_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
@@ -1779,6 +1748,7 @@ instruct vmax_fp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vmax_fp $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -1794,6 +1764,7 @@ instruct vmin_fp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vmin_fp $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -1811,6 +1782,7 @@ instruct vmax_fp_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vRe
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst_src1 (MaxV (Binary dst_src1 src2) vmask));
   effect(TEMP_DEF dst_src1, TEMP tmp1, TEMP tmp2, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vmax_fp_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -1827,6 +1799,7 @@ instruct vmin_fp_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vRe
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst_src1 (MinV (Binary dst_src1 src2) vmask));
   effect(TEMP_DEF dst_src1, TEMP tmp1, TEMP tmp2, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vmin_fp_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -1843,12 +1816,12 @@ instruct vmin_fp_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vRe
 // dst_src1 = src2 * src3 + dst_src1 (half precision)
 instruct vhfmla(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVHF dst_src1 (Binary src2 src3)));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vhfmla $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
     assert(UseZvfh, "must");
     assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfmacc_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -1859,11 +1832,10 @@ instruct vhfmla(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfmla(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF dst_src1 (Binary src2 src3)));
   match(Set dst_src1 (FmaVD dst_src1 (Binary src2 src3)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vfmla $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfmacc_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -1876,11 +1848,10 @@ instruct vfmla(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (FmaVF (Binary dst_src1 src2) (Binary src3 v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 src2) (Binary src3 v0)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vfmadd_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfmadd_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                  as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -1893,10 +1864,10 @@ instruct vfmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
 // "(-src2) * src3 + dst_src1" has been idealized to "src3 * (-src2) + dst_src1"
 instruct vfmlsF(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF dst_src1 (Binary src2 (NegVF src3))));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
   format %{ "vfmlsF $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfnmsac_vv(as_VectorRegister($dst_src1$$reg),
                   as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -1907,10 +1878,10 @@ instruct vfmlsF(vReg dst_src1, vReg src2, vReg src3) %{
 // "(-src2) * src3 + dst_src1" has been idealized to "src3 * (-src2) + dst_src1"
 instruct vfmlsD(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVD dst_src1 (Binary src2 (NegVD src3))));
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
   format %{ "vfmlsD $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfnmsac_vv(as_VectorRegister($dst_src1$$reg),
                   as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -1923,11 +1894,10 @@ instruct vfmlsD(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfnmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (FmaVF (Binary dst_src1 (NegVF src2)) (Binary src3 v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 (NegVD src2)) (Binary src3 v0)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vfnmsub_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfnmsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                   as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -1940,10 +1910,10 @@ instruct vfnmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
 // "(-src2) * src3 - dst_src1" has been idealized to "src3 * (-src2) - dst_src1"
 instruct vfnmlaF(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF (NegVF dst_src1) (Binary src2 (NegVF src3))));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
   format %{ "vfnmlaF $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfnmacc_vv(as_VectorRegister($dst_src1$$reg),
                   as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -1954,10 +1924,10 @@ instruct vfnmlaF(vReg dst_src1, vReg src2, vReg src3) %{
 // "(-src2) * src3 - dst_src1" has been idealized to "src3 * (-src2) - dst_src1"
 instruct vfnmlaD(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVD (NegVD dst_src1) (Binary src2 (NegVD src3))));
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
   format %{ "vfnmlaD $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfnmacc_vv(as_VectorRegister($dst_src1$$reg),
                   as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -1970,11 +1940,10 @@ instruct vfnmlaD(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfnmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (FmaVF (Binary dst_src1 (NegVF src2)) (Binary (NegVF src3) v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 (NegVD src2)) (Binary (NegVD src3) v0)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vfnmadd_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfnmadd_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                   as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -1986,10 +1955,10 @@ instruct vfnmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
 // dst_src1 = src2 * src3 - dst_src1
 instruct vfnmlsF(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVF (NegVF dst_src1) (Binary src2 src3)));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
   format %{ "vfnmlsF $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -1999,10 +1968,10 @@ instruct vfnmlsF(vReg dst_src1, vReg src2, vReg src3) %{
 // dst_src1 = -dst_src1 + src2 * src3
 instruct vfnmlsD(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (FmaVD (NegVD dst_src1) (Binary src2 src3)));
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
   format %{ "vfnmlsD $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -2015,11 +1984,10 @@ instruct vfnmlsD(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (FmaVF (Binary dst_src1 src2) (Binary (NegVF src3) v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 src2) (Binary (NegVD src3) v0)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vfmsub_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfmsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                  as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -2034,10 +2002,9 @@ instruct vmla(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (AddVS dst_src1 (MulVS src2 src3)));
   match(Set dst_src1 (AddVI dst_src1 (MulVI src2 src3)));
   match(Set dst_src1 (AddVL dst_src1 (MulVL src2 src3)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmla $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmacc_vv(as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -2051,10 +2018,9 @@ instruct vmla_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVS (Binary dst_src1 (MulVS src2 src3)) v0));
   match(Set dst_src1 (AddVI (Binary dst_src1 (MulVI src2 src3)) v0));
   match(Set dst_src1 (AddVL (Binary dst_src1 (MulVL src2 src3)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmla_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmacc_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                 as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -2069,10 +2035,9 @@ instruct vmls(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (SubVS dst_src1 (MulVS src2 src3)));
   match(Set dst_src1 (SubVI dst_src1 (MulVI src2 src3)));
   match(Set dst_src1 (SubVL dst_src1 (MulVL src2 src3)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmls $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vnmsac_vv(as_VectorRegister($dst_src1$$reg),
                  as_VectorRegister($src2$$reg), as_VectorRegister($src3$$reg));
   %}
@@ -2086,10 +2051,9 @@ instruct vmls_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVS (Binary dst_src1 (MulVS src2 src3)) v0));
   match(Set dst_src1 (SubVI (Binary dst_src1 (MulVI src2 src3)) v0));
   match(Set dst_src1 (SubVL (Binary dst_src1 (MulVL src2 src3)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmls_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vnmsac_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
                  as_VectorRegister($src3$$reg), Assembler::v0_t);
   %}
@@ -2103,10 +2067,9 @@ instruct vmul(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (MulVS src1 src2));
   match(Set dst (MulVI src1 src2));
   match(Set dst (MulVL src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmul $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
   %}
@@ -2115,11 +2078,11 @@ instruct vmul(vReg dst, vReg src1, vReg src2) %{
 
 instruct vmul_hfp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (MulVHF src1 src2));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vmul_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
     assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -2129,10 +2092,9 @@ instruct vmul_hfp(vReg dst, vReg src1, vReg src2) %{
 instruct vmul_fp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (MulVF src1 src2));
   match(Set dst (MulVD src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmul_fp $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfmul_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
   %}
@@ -2146,10 +2108,9 @@ instruct vmul_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (MulVS (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVL (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmul_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmul_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -2159,10 +2120,9 @@ instruct vmul_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (MulVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVD (Binary dst_src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmul_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfmul_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
   %}
@@ -2175,10 +2135,9 @@ instruct vmul_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
   match(Set dst (MulVB src1 (Replicate src2)));
   match(Set dst (MulVS src1 (Replicate src2)));
   match(Set dst (MulVI src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmul_vx $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -2188,9 +2147,9 @@ instruct vmul_vx(vReg dst, vReg src1, iRegIorL2I src2) %{
 
 instruct vmulL_vx(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (MulVL src1 (Replicate src2)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vmulL_vx $dst, $src1, $src2" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -2204,10 +2163,9 @@ instruct vmul_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (MulVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (MulVI (Binary dst_src (Replicate src2)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmul_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -2217,9 +2175,9 @@ instruct vmul_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
 
 instruct vmulL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVL (Binary dst_src (Replicate src2)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vmulL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -2232,10 +2190,9 @@ instruct vmulL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
 instruct vneg(vReg dst, vReg src) %{
   match(Set dst (NegVI src));
   match(Set dst (NegVL src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vneg $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -2246,10 +2203,9 @@ instruct vneg(vReg dst, vReg src) %{
 instruct vneg_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (NegVI dst_src v0));
   match(Set dst_src (NegVL dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vneg_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vneg_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
               Assembler::v0_t);
   %}
@@ -2261,10 +2217,9 @@ instruct vneg_masked(vReg dst_src, vRegMask_V0 v0) %{
 instruct vfneg(vReg dst, vReg src) %{
   match(Set dst (NegVF src));
   match(Set dst (NegVD src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vfneg $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -2275,10 +2230,9 @@ instruct vfneg(vReg dst, vReg src) %{
 instruct vfneg_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (NegVF dst_src v0));
   match(Set dst_src (NegVD dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vfneg_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfneg_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                Assembler::v0_t);
   %}
@@ -2293,6 +2247,7 @@ instruct reduce_and(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AndReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_and $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2307,6 +2262,7 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AndReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_andL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2325,6 +2281,7 @@ instruct reduce_and_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AndReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_and_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2340,6 +2297,7 @@ instruct reduce_andL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AndReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_andL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2359,6 +2317,7 @@ instruct reduce_or(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (OrReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_or $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2373,6 +2332,7 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (OrReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_orL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2391,6 +2351,7 @@ instruct reduce_or_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (OrReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_or_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2406,6 +2367,7 @@ instruct reduce_orL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0,
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (OrReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_orL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2425,6 +2387,7 @@ instruct reduce_xor(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (XorReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_xor $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2439,6 +2402,7 @@ instruct reduce_xorL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (XorReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_xorL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2457,6 +2421,7 @@ instruct reduce_xor_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (XorReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_xor_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2472,6 +2437,7 @@ instruct reduce_xorL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (XorReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_xorL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2491,6 +2457,7 @@ instruct reduce_add(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_add $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2505,6 +2472,7 @@ instruct reduce_addL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AddReductionVL src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_addL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2527,9 +2495,9 @@ instruct reduce_addF_ordered(fRegF dst, fRegF src1, vReg src2, vReg tmp) %{
   predicate(n->as_Reduction()->requires_strict_order());
   match(Set dst (AddReductionVF src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "reduce_addF_ordered $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
@@ -2542,9 +2510,9 @@ instruct reduce_addF_unordered(fRegF dst, fRegF src1, vReg src2, vReg tmp) %{
   predicate(!n->as_Reduction()->requires_strict_order());
   match(Set dst (AddReductionVF src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "reduce_addF_unordered $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredusum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
@@ -2557,9 +2525,9 @@ instruct reduce_addD_ordered(fRegD dst, fRegD src1, vReg src2, vReg tmp) %{
   predicate(n->as_Reduction()->requires_strict_order());
   match(Set dst (AddReductionVD src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "reduce_addD_ordered $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
@@ -2572,9 +2540,9 @@ instruct reduce_addD_unordered(fRegD dst, fRegD src1, vReg src2, vReg tmp) %{
   predicate(!n->as_Reduction()->requires_strict_order());
   match(Set dst (AddReductionVD src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "reduce_addD_unordered $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredusum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg));
@@ -2591,6 +2559,7 @@ instruct reduce_add_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AddReductionVI (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_add_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2606,6 +2575,7 @@ instruct reduce_addL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AddReductionVL (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "reduce_addL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2620,9 +2590,9 @@ instruct reduce_addL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
 instruct reduce_addF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst (AddReductionVF (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "reduce_addF_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg), Assembler::v0_t);
@@ -2634,9 +2604,9 @@ instruct reduce_addF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, vR
 instruct reduce_addD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst (AddReductionVD (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "reduce_addD_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this, $src2));
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
     __ vfredosum_vs(as_VectorRegister($tmp$$reg), as_VectorRegister($src2$$reg),
                     as_VectorRegister($tmp$$reg), Assembler::v0_t);
@@ -2653,6 +2623,7 @@ instruct vreduce_max(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vreduce_max $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2667,6 +2638,7 @@ instruct vreduce_maxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vreduce_maxL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2685,6 +2657,7 @@ instruct vreduce_max_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vreduce_max_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2700,6 +2673,7 @@ instruct vreduce_maxL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vreduce_maxL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2719,6 +2693,7 @@ instruct vreduce_min(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MinReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vreduce_min $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2733,6 +2708,7 @@ instruct vreduce_minL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MinReductionV src1 src2));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vreduce_minL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2751,6 +2727,7 @@ instruct vreduce_min_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vreduce_min_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2766,6 +2743,7 @@ instruct vreduce_minL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vreduce_minL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
@@ -2783,6 +2761,7 @@ instruct vreduce_maxF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "vreduce_maxF $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
@@ -2797,6 +2776,7 @@ instruct vreduce_maxD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "vreduce_maxD $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
@@ -2813,6 +2793,7 @@ instruct vreduce_maxF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "vreduce_maxF_masked $dst, $src1, $src2, $v0\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
@@ -2828,6 +2809,7 @@ instruct vreduce_maxD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "vreduce_maxD_masked $dst, $src1, $src2, $v0\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
@@ -2845,6 +2827,7 @@ instruct vreduce_minF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MinReductionV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "vreduce_minF $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
@@ -2859,6 +2842,7 @@ instruct vreduce_minD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MinReductionV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "vreduce_minD $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
@@ -2875,6 +2859,7 @@ instruct vreduce_minF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "vreduce_minF_masked $dst, $src1, $src2, $v0\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
@@ -2890,6 +2875,7 @@ instruct vreduce_minD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "vreduce_minD_masked $dst, $src1, $src2, $v0\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
@@ -2908,6 +2894,7 @@ instruct reduce_mulI(iRegINoSp dst, iRegIorL2I isrc, vReg vsrc,
                      vReg tmp1, vReg tmp2) %{
   match(Set dst (MulReductionVI isrc vsrc));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "reduce_mulI $dst, $isrc, $vsrc\t" %}
 
   ins_encode %{
@@ -2922,6 +2909,7 @@ instruct reduce_mulI_masked(iRegINoSp dst, iRegIorL2I isrc, vReg vsrc,
                             vRegMask_V0 v0, vReg tmp1, vReg tmp2) %{
   match(Set dst (MulReductionVI (Binary isrc vsrc) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "reduce_mulI_masked $dst, $isrc, $vsrc, $v0\t" %}
 
   ins_encode %{
@@ -2937,6 +2925,7 @@ instruct reduce_mulL(iRegLNoSp dst, iRegL isrc, vReg vsrc,
                      vReg tmp1, vReg tmp2) %{
   match(Set dst (MulReductionVL isrc vsrc));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "reduce_mulL $dst, $isrc, $vsrc\t" %}
 
   ins_encode %{
@@ -2951,6 +2940,7 @@ instruct reduce_mulL_masked(iRegLNoSp dst, iRegL isrc, vReg vsrc,
                             vRegMask_V0 v0, vReg tmp1, vReg tmp2) %{
   match(Set dst (MulReductionVL (Binary isrc vsrc) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  ins_riscv_vset(false);
   format %{ "reduce_mulL_masked $dst, $isrc, $vsrc, $v0\t" %}
 
   ins_encode %{
@@ -2967,10 +2957,9 @@ instruct reduce_mulL_masked(iRegLNoSp dst, iRegL isrc, vReg vsrc,
 instruct replicate(vReg dst, iRegIorL2I src) %{
   predicate(Matcher::is_non_long_integral_vector(n));
   match(Set dst (Replicate src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "replicate $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -2979,9 +2968,9 @@ instruct replicate(vReg dst, iRegIorL2I src) %{
 instruct replicateL(vReg dst, iRegL src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (Replicate src));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "replicateL $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -2990,10 +2979,9 @@ instruct replicateL(vReg dst, iRegL src) %{
 instruct replicate_imm5(vReg dst, immI5 con) %{
   predicate(Matcher::is_non_long_integral_vector(n));
   match(Set dst (Replicate con));
+  ins_riscv_vset(riscv_vset_fixed(Matcher::vector_element_basic_type(this), Matcher::vector_length_in_bytes(this), req));
   format %{ "replicate_imm5 $dst, $con" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length_in_bytes(this));
     __ vmv_v_i(as_VectorRegister($dst$$reg), $con$$constant);
   %}
   ins_pipe(pipe_slow);
@@ -3002,9 +2990,9 @@ instruct replicate_imm5(vReg dst, immI5 con) %{
 instruct replicateL_imm5(vReg dst, immL5 con) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (Replicate con));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "replicateL_imm5 $dst, $con" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmv_v_i(as_VectorRegister($dst$$reg), $con$$constant);
   %}
   ins_pipe(pipe_slow);
@@ -3013,10 +3001,10 @@ instruct replicateL_imm5(vReg dst, immL5 con) %{
 instruct replicateHF(vReg dst, fRegF src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (Replicate src));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "replicateHF $dst, $src" %}
   ins_encode %{
     assert(UseZvfh, "must");
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfmv_v_f(as_VectorRegister($dst$$reg), $src$$FloatRegister);
   %}
   ins_pipe(pipe_slow);
@@ -3025,9 +3013,9 @@ instruct replicateHF(vReg dst, fRegF src) %{
 instruct replicateF(vReg dst, fRegF src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (Replicate src));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
   format %{ "replicateF $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfmv_v_f(as_VectorRegister($dst$$reg), $src$$FloatRegister);
   %}
   ins_pipe(pipe_slow);
@@ -3036,9 +3024,9 @@ instruct replicateF(vReg dst, fRegF src) %{
 instruct replicateD(vReg dst, fRegD src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (Replicate src));
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
   format %{ "replicateD $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfmv_v_f(as_VectorRegister($dst$$reg), $src$$FloatRegister);
   %}
   ins_pipe(pipe_slow);
@@ -3075,9 +3063,9 @@ instruct replicateD(vReg dst, fRegD src) %{
 instruct vasrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (RShiftVB src shift));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vasrB $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     // if shift > BitsPerByte - 1, clear the low BitsPerByte - 1 bits
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vsra_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3093,9 +3081,9 @@ instruct vasrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 instruct vasrS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (RShiftVS src shift));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vasrS $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     // if shift > BitsPerShort - 1, clear the low BitsPerShort - 1 bits
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vsra_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3110,9 +3098,9 @@ instruct vasrS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 
 instruct vasrI(vReg dst, vReg src, vReg shift) %{
   match(Set dst (RShiftVI src shift));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vasrI $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsra_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -3121,9 +3109,9 @@ instruct vasrI(vReg dst, vReg src, vReg shift) %{
 
 instruct vasrL(vReg dst, vReg src, vReg shift) %{
   match(Set dst (RShiftVL src shift));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vasrL $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsra_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -3133,9 +3121,9 @@ instruct vasrL(vReg dst, vReg src, vReg shift) %{
 instruct vasrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVB (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vasrB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     // if shift > BitsPerByte - 1, clear the low BitsPerByte - 1 bits
     __ vmerge_vim(as_VectorRegister($shift$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
@@ -3150,9 +3138,9 @@ instruct vasrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vasrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVS (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vasrS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     // if shift > BitsPerShort - 1, clear the low BitsPerShort - 1 bits
     __ vmerge_vim(as_VectorRegister($shift$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
@@ -3167,9 +3155,9 @@ instruct vasrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vasrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVI (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vasrI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsra_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3179,9 +3167,9 @@ instruct vasrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vasrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVL (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vasrL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsra_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3191,9 +3179,9 @@ instruct vasrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vlslB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (LShiftVB src shift));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vlslB $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3209,9 +3197,9 @@ instruct vlslB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 instruct vlslS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (LShiftVS src shift));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vlslS $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3226,9 +3214,9 @@ instruct vlslS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 
 instruct vlslI(vReg dst, vReg src, vReg shift) %{
   match(Set dst (LShiftVI src shift));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vlslI $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsll_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -3237,9 +3225,9 @@ instruct vlslI(vReg dst, vReg src, vReg shift) %{
 
 instruct vlslL(vReg dst, vReg src, vReg shift) %{
   match(Set dst (LShiftVL src shift));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vlslL $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsll_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -3249,9 +3237,9 @@ instruct vlslL(vReg dst, vReg src, vReg shift) %{
 instruct vlslB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVB (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vlslB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vmand_mm(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg),
@@ -3269,9 +3257,9 @@ instruct vlslB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vlslS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVS (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vlslS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vmand_mm(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg),
@@ -3289,9 +3277,9 @@ instruct vlslS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vlslI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVI (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vlslI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsll_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3301,9 +3289,9 @@ instruct vlslI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vlslL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVL (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vlslL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsll_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3313,9 +3301,9 @@ instruct vlslL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vlsrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (URShiftVB src shift));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vlsrB $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3331,9 +3319,9 @@ instruct vlsrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 instruct vlsrS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (URShiftVS src shift));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vlsrS $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -3348,9 +3336,9 @@ instruct vlsrS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 
 instruct vlsrI(vReg dst, vReg src, vReg shift) %{
   match(Set dst (URShiftVI src shift));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vlsrI $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsrl_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -3359,9 +3347,9 @@ instruct vlsrI(vReg dst, vReg src, vReg shift) %{
 
 instruct vlsrL(vReg dst, vReg src, vReg shift) %{
   match(Set dst (URShiftVL src shift));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vlsrL $dst, $src, $shift" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsrl_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -3371,9 +3359,9 @@ instruct vlsrL(vReg dst, vReg src, vReg shift) %{
 instruct vlsrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVB (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vlsrB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     // if shift > BitsPerByte - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
     __ vmand_mm(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg),
@@ -3391,9 +3379,9 @@ instruct vlsrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vlsrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVS (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vlsrS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     // if shift > BitsPerShort - 1, clear the element
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
     __ vmand_mm(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg),
@@ -3411,9 +3399,9 @@ instruct vlsrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vlsrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVI (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vlsrI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsrl_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3423,9 +3411,9 @@ instruct vlsrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vlsrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVL (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vlsrL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsrl_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3434,10 +3422,10 @@ instruct vlsrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 
 instruct vasrB_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVB src (RShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vasrB_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -3451,10 +3439,10 @@ instruct vasrB_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vasrS_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVS src (RShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vasrS_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -3468,10 +3456,10 @@ instruct vasrS_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vasrI_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RShiftVI src (RShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vasrI_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -3485,10 +3473,10 @@ instruct vasrI_vi(vReg dst, vReg src, immI shift) %{
 instruct vasrL_vi(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (RShiftVL src (RShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vasrL_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -3501,6 +3489,7 @@ instruct vasrL_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vasrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVB (Binary dst_src (RShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vasrB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3508,7 +3497,6 @@ instruct vasrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
       return;
     }
     if (con >= BitsPerByte) con = BitsPerByte - 1;
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     __ vsra_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3517,6 +3505,7 @@ instruct vasrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vasrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVS (Binary dst_src (RShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vasrS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3524,7 +3513,6 @@ instruct vasrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
       return;
     }
     if (con >= BitsPerShort) con = BitsPerShort - 1;
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vsra_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3533,13 +3521,13 @@ instruct vasrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vasrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVI (Binary dst_src (RShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vasrI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsra_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3549,13 +3537,13 @@ instruct vasrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vasrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (RShiftVL (Binary dst_src (RShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vasrL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsra_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3564,10 +3552,10 @@ instruct vasrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlsrB_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVB src (RShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vlsrB_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -3585,10 +3573,10 @@ instruct vlsrB_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vlsrS_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVS src (RShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vlsrS_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -3606,10 +3594,10 @@ instruct vlsrS_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vlsrI_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (URShiftVI src (RShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vlsrI_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -3623,10 +3611,10 @@ instruct vlsrI_vi(vReg dst, vReg src, immI shift) %{
 instruct vlsrL_vi(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (URShiftVL src (RShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vlsrL_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     if (con == 0) {
       __ vor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                 as_VectorRegister($src$$reg));
@@ -3639,13 +3627,13 @@ instruct vlsrL_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vlsrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVB (Binary dst_src (RShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vlsrB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     if (con >= BitsPerByte) {
       __ vxor_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -3659,13 +3647,13 @@ instruct vlsrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlsrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVS (Binary dst_src (RShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vlsrS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     if (con >= BitsPerShort) {
       __ vxor_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -3679,13 +3667,13 @@ instruct vlsrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlsrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVI (Binary dst_src (RShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vlsrI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsrl_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3695,13 +3683,13 @@ instruct vlsrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vlsrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (URShiftVL (Binary dst_src (RShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vlsrL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsrl_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3710,10 +3698,10 @@ instruct vlsrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlslB_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVB src (LShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vlslB_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     if (con >= BitsPerByte) {
       __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                  as_VectorRegister($src$$reg));
@@ -3726,10 +3714,10 @@ instruct vlslB_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vlslS_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVS src (LShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vlslS_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     if (con >= BitsPerShort) {
       __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                  as_VectorRegister($src$$reg));
@@ -3742,10 +3730,10 @@ instruct vlslS_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vlslI_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (LShiftVI src (LShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vlslI_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), con);
   %}
   ins_pipe(pipe_slow);
@@ -3754,10 +3742,10 @@ instruct vlslI_vi(vReg dst, vReg src, immI shift) %{
 instruct vlslL_vi(vReg dst, vReg src, immI shift) %{
   predicate((n->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst (LShiftVL src (LShiftCntV shift)));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vlslL_vi $dst, $src, $shift" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), con);
   %}
   ins_pipe(pipe_slow);
@@ -3765,10 +3753,10 @@ instruct vlslL_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vlslB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVB (Binary dst_src (LShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
   format %{ "vlslB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_BYTE, Matcher::vector_length(this));
     if (con >= BitsPerByte) {
       __ vxor_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -3782,10 +3770,10 @@ instruct vlslB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlslS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVS (Binary dst_src (LShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vlslS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     if (con >= BitsPerShort) {
       __ vxor_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                  as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -3799,10 +3787,10 @@ instruct vlslS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlslI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVI (Binary dst_src (LShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
   format %{ "vlslI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this));
     __ vsll_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3812,10 +3800,10 @@ instruct vlslI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vlslL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (LShiftVL (Binary dst_src (LShiftCntV shift)) v0));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vlslL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsll_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), con,
                Assembler::v0_t);
   %}
@@ -3827,10 +3815,9 @@ instruct vlslL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vshiftcnt(vReg dst, iRegIorL2I cnt) %{
   match(Set dst (LShiftCntV cnt));
   match(Set dst (RShiftCntV cnt));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vshiftcnt $dst, $cnt" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($cnt$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3841,10 +3828,9 @@ instruct vshiftcnt(vReg dst, iRegIorL2I cnt) %{
 
 instruct vrotate_right(vReg dst, vReg src, vReg shift) %{
   match(Set dst (RotateRightV src shift));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_right $dst, $src, $shift\t" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vror_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -3854,10 +3840,9 @@ instruct vrotate_right(vReg dst, vReg src, vReg shift) %{
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_right_vx(vReg dst, vReg src, iRegIorL2I shift) %{
   match(Set dst (RotateRightV src (Replicate shift)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_right_vx $dst, $src, $shift\t" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vror_vx(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_Register($shift$$reg));
   %}
@@ -3866,6 +3851,7 @@ instruct vrotate_right_vx(vReg dst, vReg src, iRegIorL2I shift) %{
 
 instruct vrotate_right_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RotateRightV src shift));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_right_vi $dst, $src, $shift\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -3874,7 +3860,6 @@ instruct vrotate_right_vi(vReg dst, vReg src, immI shift) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vror_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), con);
   %}
   ins_pipe(pipe_slow);
@@ -3884,10 +3869,9 @@ instruct vrotate_right_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vrotate_right_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src shift) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_right_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vror_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3897,10 +3881,9 @@ instruct vrotate_right_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_right_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src (Replicate shift)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_right_vx_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vror_vx(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_Register($shift$$reg), Assembler::v0_t);
   %}
@@ -3909,6 +3892,7 @@ instruct vrotate_right_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0)
 
 instruct vrotate_right_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src shift) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_right_vi_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -3917,7 +3901,6 @@ instruct vrotate_right_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vror_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                con, Assembler::v0_t);
   %}
@@ -3928,10 +3911,9 @@ instruct vrotate_right_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vrotate_left(vReg dst, vReg src, vReg shift) %{
   match(Set dst (RotateLeftV src shift));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_left $dst, $src, $shift\t" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vrol_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_VectorRegister($shift$$reg));
   %}
@@ -3941,10 +3923,9 @@ instruct vrotate_left(vReg dst, vReg src, vReg shift) %{
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_left_vx(vReg dst, vReg src, iRegIorL2I shift) %{
   match(Set dst (RotateLeftV src (Replicate shift)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_left_vx $dst, $src, $shift\t" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vrol_vx(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                as_Register($shift$$reg));
   %}
@@ -3953,6 +3934,7 @@ instruct vrotate_left_vx(vReg dst, vReg src, iRegIorL2I shift) %{
 
 instruct vrotate_left_vi(vReg dst, vReg src, immI shift) %{
   match(Set dst (RotateLeftV src shift));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_left_vi $dst, $src, $shift\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -3961,7 +3943,6 @@ instruct vrotate_left_vi(vReg dst, vReg src, immI shift) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     con = bits - con;
     __ vror_vi(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), con);
   %}
@@ -3972,10 +3953,9 @@ instruct vrotate_left_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vrotate_left_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src shift) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_left_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vrol_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_VectorRegister($shift$$reg), Assembler::v0_t);
   %}
@@ -3985,10 +3965,9 @@ instruct vrotate_left_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_left_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src (Replicate shift)) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_left_vx_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vrol_vx(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                as_Register($shift$$reg), Assembler::v0_t);
   %}
@@ -3997,6 +3976,7 @@ instruct vrotate_left_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) 
 
 instruct vrotate_left_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src shift) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vrotate_left_vi_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4005,7 +3985,6 @@ instruct vrotate_left_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
     if (con == 0) {
       return;
     }
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     con = bits - con;
     __ vror_vi(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                con, Assembler::v0_t);
@@ -4017,11 +3996,11 @@ instruct vrotate_left_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vsqrt_hfp(vReg dst, vReg src) %{
   match(Set dst (SqrtVHF src));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
   format %{ "vsqrt_hfp $dst, $src" %}
   ins_encode %{
     assert(UseZvfh, "must");
     assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
-    __ vsetvli_helper(T_SHORT, Matcher::vector_length(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4030,10 +4009,9 @@ instruct vsqrt_hfp(vReg dst, vReg src) %{
 instruct vsqrt_fp(vReg dst, vReg src) %{
   match(Set dst (SqrtVF src));
   match(Set dst (SqrtVD src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsqrt_fp $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfsqrt_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4044,10 +4022,9 @@ instruct vsqrt_fp(vReg dst, vReg src) %{
 instruct vsqrt_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (SqrtVF dst_src v0));
   match(Set dst_src (SqrtVD dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vsqrt_fp_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfsqrt_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
                 Assembler::v0_t);
   %}
@@ -4113,6 +4090,7 @@ instruct varrays_hashcode(iRegP_R11 ary, iRegI_R12 cnt, iRegI_R10 result, immI b
   effect(USE_KILL ary, USE_KILL cnt, USE basic_type,
          TEMP v2, TEMP v3, TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9,
          TEMP tmp1, TEMP tmp2, TEMP tmp3, KILL cr);
+  ins_riscv_vset(false);
 
   format %{ "Array HashCode array[] $ary,$cnt,$result,$basic_type -> $result   // KILL all" %}
   ins_encode %{
@@ -4133,6 +4111,7 @@ instruct vstring_compareU_128b(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, i
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
         TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
+  ins_riscv_vset(false);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
   ins_encode %{
@@ -4154,6 +4133,7 @@ instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
         TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+  ins_riscv_vset(false);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
   ins_encode %{
@@ -4174,6 +4154,7 @@ instruct vstring_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
         TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+  ins_riscv_vset(false);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareL" %}
   ins_encode %{
@@ -4194,6 +4175,7 @@ instruct vstring_compareUL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
          TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
+  ins_riscv_vset(false);
 
   format %{"String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareUL" %}
   ins_encode %{
@@ -4213,6 +4195,7 @@ instruct vstring_compareLU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
          TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
+  ins_riscv_vset(false);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareLU" %}
   ins_encode %{
@@ -4231,6 +4214,7 @@ instruct vstring_inflate(Universe dummy, iRegP_R10 src, iRegP_R11 dst, iRegI_R12
   predicate(UseRVV);
   match(Set dummy (StrInflatedCopy src (Binary dst len)));
   effect(TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP tmp, USE_KILL src, USE_KILL dst, USE_KILL len);
+  ins_riscv_vset(false);
 
   format %{ "String Inflate $src,$dst" %}
   ins_encode %{
@@ -4247,6 +4231,7 @@ instruct vencode_iso_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R1
   match(Set result (EncodeISOArray src (Binary dst len)));
   effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
          TEMP v0, TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
+  ins_riscv_vset(false);
 
   format %{ "Encode ISO array $src, $dst, $len -> $result # KILL $src, $dst, $len, $tmp, V0-V3" %}
   ins_encode %{
@@ -4263,6 +4248,7 @@ instruct vencode_ascii_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_
   match(Set result (EncodeISOArray src (Binary dst len)));
   effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
          TEMP v0, TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
+  ins_riscv_vset(false);
 
   format %{ "Encode ASCII array $src, $dst, $len -> $result # KILL $src, $dst, $len, $tmp, V0-V3" %}
   ins_encode %{
@@ -4295,6 +4281,7 @@ instruct vcount_positives(iRegP_R11 ary, iRegI_R12 len, iRegI_R10 result,
   predicate(UseRVV);
   match(Set result (CountPositives ary len));
   effect(TEMP_DEF result, USE_KILL ary, USE_KILL len, TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP tmp);
+  ins_riscv_vset(false);
 
   format %{ "count positives byte[] $ary, $len -> $result" %}
   ins_encode %{
@@ -4312,6 +4299,7 @@ instruct vstringU_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
   effect(TEMP_DEF result, USE_KILL str1, USE_KILL cnt1, USE_KILL ch,
          TEMP tmp1, TEMP tmp2, TEMP v4, TEMP v5, TEMP v6, TEMP v7);
+  ins_riscv_vset(false);
 
   format %{ "StringUTF16 IndexOf char[] $str1, $cnt1, $ch -> $result" %}
 
@@ -4332,6 +4320,7 @@ instruct vstringL_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
   effect(TEMP_DEF result, USE_KILL str1, USE_KILL cnt1, USE_KILL ch,
          TEMP tmp1, TEMP tmp2, TEMP v4, TEMP v5, TEMP v6, TEMP v7);
+  ins_riscv_vset(false);
 
   format %{ "StringLatin1 IndexOf char[] $str1, $cnt1, $ch -> $result" %}
 
@@ -4351,6 +4340,7 @@ instruct vclearArray_reg_reg(iRegL_R29 cnt, iRegP_R28 base, Universe dummy,
   predicate(!UseBlockZeroing && UseRVV);
   match(Set dummy (ClearArray cnt base));
   effect(USE_KILL cnt, USE_KILL base, TEMP v4, TEMP v5, TEMP v6, TEMP v7);
+  ins_riscv_vset(false);
 
   format %{ "ClearArray $cnt, $base\t#@clearArray_reg_reg" %}
 
@@ -4364,10 +4354,10 @@ instruct vclearArray_reg_reg(iRegL_R29 cnt, iRegP_R28 base, Universe dummy,
 // Vector Load Const
 instruct vloadcon(vReg dst, immI0 src) %{
   match(Set dst (VectorLoadConst src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vloadcon $dst\t# generate iota indices" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($dst$$reg));
     if (is_floating_point_type(bt)) {
       __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
@@ -4378,10 +4368,9 @@ instruct vloadcon(vReg dst, immI0 src) %{
 
 instruct vmask_gen_I(vRegMask dst, iRegI src) %{
   match(Set dst (VectorMaskGen (ConvI2L src)));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmask_gen_I $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($dst$$reg));
     __ vmsltu_vx(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), $src$$Register);
   %}
@@ -4390,10 +4379,9 @@ instruct vmask_gen_I(vRegMask dst, iRegI src) %{
 
 instruct vmask_gen_L(vRegMask dst, iRegL src) %{
   match(Set dst (VectorMaskGen src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmask_gen_L $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($dst$$reg));
     __ vmsltu_vx(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), $src$$Register);
   %}
@@ -4404,10 +4392,9 @@ instruct vmask_gen_imm(vRegMask dst, immL con) %{
   predicate(n->in(1)->get_long() <= 16 ||
             n->in(1)->get_long() == Matcher::vector_length(n));
   match(Set dst (VectorMaskGen con));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmask_gen_imm $dst, $con" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     if ((uint)($con$$constant) == 0) {
       __ vmclr_m(as_VectorRegister($dst$$reg));
     } else if ((uint)($con$$constant) == Matcher::vector_length(this)) {
@@ -4423,10 +4410,9 @@ instruct vmask_gen_imm(vRegMask dst, immL con) %{
 
 instruct vmaskAll_immI(vRegMask dst, immI src) %{
   match(Set dst (MaskAll src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmaskAll_immI $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     int con = (int)$src$$constant;
     if (con == 0) {
       __ vmclr_m(as_VectorRegister($dst$$reg));
@@ -4440,10 +4426,9 @@ instruct vmaskAll_immI(vRegMask dst, immI src) %{
 
 instruct vmaskAllI(vRegMask dst, iRegIorL2I src) %{
   match(Set dst (MaskAll src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmaskAllI $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
     __ vmsne_vx(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), zr);
   %}
@@ -4452,10 +4437,9 @@ instruct vmaskAllI(vRegMask dst, iRegIorL2I src) %{
 
 instruct vmaskAll_immL(vRegMask dst, immL src) %{
   match(Set dst (MaskAll src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmaskAll_immL $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     long con = (long)$src$$constant;
     if (con == 0) {
       __ vmclr_m(as_VectorRegister($dst$$reg));
@@ -4469,10 +4453,9 @@ instruct vmaskAll_immL(vRegMask dst, immL src) %{
 
 instruct vmaskAllL(vRegMask dst, iRegL src) %{
   match(Set dst (MaskAll src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmaskAllL $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src$$reg));
     __ vmsne_vx(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), zr);
   %}
@@ -4485,10 +4468,9 @@ instruct vmaskAllL(vRegMask dst, iRegL src) %{
 
 instruct vmask_and(vRegMask dst, vRegMask src1, vRegMask src2) %{
   match(Set dst (AndVMask src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmask_and $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmand_mm(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -4498,10 +4480,9 @@ instruct vmask_and(vRegMask dst, vRegMask src1, vRegMask src2) %{
 
 instruct vmask_or(vRegMask dst, vRegMask src1, vRegMask src2) %{
   match(Set dst (OrVMask src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmask_or $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmor_mm(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_VectorRegister($src2$$reg));
@@ -4511,10 +4492,9 @@ instruct vmask_or(vRegMask dst, vRegMask src1, vRegMask src2) %{
 
 instruct vmask_xor(vRegMask dst, vRegMask src1, vRegMask src2) %{
   match(Set dst (XorVMask src1 src2));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vmask_xor $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmxor_mm(as_VectorRegister($dst$$reg),
                 as_VectorRegister($src1$$reg),
                 as_VectorRegister($src2$$reg));
@@ -4534,24 +4514,26 @@ instruct vmaskcast(vRegMask dst_src) %{
 
 instruct loadV_masked(vReg dst, vmemA mem, vRegMask_V0 v0) %{
   match(Set dst (LoadVectorMasked mem v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "loadV_masked $dst, $mem, $v0" %}
   ins_encode %{
     VectorRegister dst_reg = as_VectorRegister($dst$$reg);
     loadStore(masm, false, dst_reg,
               Matcher::vector_element_basic_type(this), as_Register($mem$$base),
-              Matcher::vector_length(this), Assembler::v0_t);
+              Matcher::vector_length(this), Assembler::v0_t, false);
   %}
   ins_pipe(pipe_slow);
 %}
 
 instruct storeV_masked(vReg src, vmemA mem, vRegMask_V0 v0) %{
   match(Set mem (StoreVectorMasked mem (Binary src v0)));
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "storeV_masked $mem, $src, $v0" %}
   ins_encode %{
     VectorRegister src_reg = as_VectorRegister($src$$reg);
     loadStore(masm, true, src_reg,
               Matcher::vector_element_basic_type(this, $src), as_Register($mem$$base),
-              Matcher::vector_length(this, $src), Assembler::v0_t);
+              Matcher::vector_length(this, $src), Assembler::v0_t, false);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4560,10 +4542,9 @@ instruct storeV_masked(vReg src, vmemA mem, vRegMask_V0 v0) %{
 
 instruct vblend(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (VectorBlend (Binary src1 src2) v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vblend $dst, $src1, $src2, v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmerge_vvm(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                   as_VectorRegister($src2$$reg));
   %}
@@ -4577,6 +4558,7 @@ instruct vblend(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
 instruct vcvtBtoX(vReg dst, vReg src) %{
   match(Set dst (VectorCastB2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vcvtBtoX $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4600,6 +4582,7 @@ instruct vcvtUBtoX(vReg dst, vReg src) %{
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorUCastB2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vcvtUBtoX $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4615,6 +4598,7 @@ instruct vcvtUBtoX(vReg dst, vReg src) %{
 instruct vcvtStoB(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorCastS2X src));
+  ins_riscv_vset(false);
   format %{ "vcvtStoB $dst, $src" %}
   ins_encode %{
     __ integer_narrow_v(as_VectorRegister($dst$$reg), T_BYTE, Matcher::vector_length(this),
@@ -4628,6 +4612,7 @@ instruct vcvtStoX(vReg dst, vReg src) %{
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorCastS2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vcvtStoX $dst, $src" %}
   ins_encode %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), Matcher::vector_element_basic_type(this),
@@ -4642,6 +4627,7 @@ instruct vcvtStoX_fp(vReg dst, vReg src) %{
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorCastS2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vcvtStoX_fp $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4660,6 +4646,7 @@ instruct vcvtUStoX(vReg dst, vReg src) %{
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorUCastS2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vcvtUStoX $dst, $src" %}
   ins_encode %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), Matcher::vector_element_basic_type(this),
@@ -4675,6 +4662,7 @@ instruct vcvtItoX_narrow(vReg dst, vReg src) %{
   predicate((Matcher::vector_element_basic_type(n) == T_BYTE ||
              Matcher::vector_element_basic_type(n) == T_SHORT));
   match(Set dst (VectorCastI2X src));
+  ins_riscv_vset(false);
   format %{ "vcvtItoX_narrow $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4688,6 +4676,7 @@ instruct vcvtItoL(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorCastI2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vcvtItoL $dst, $src" %}
   ins_encode %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), T_LONG,
@@ -4701,6 +4690,7 @@ instruct vcvtUItoL(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorUCastI2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "vcvtUItoL $dst, $src" %}
   ins_encode %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), T_LONG,
@@ -4713,9 +4703,9 @@ instruct vcvtUItoL(vReg dst, vReg src) %{
 instruct vcvtItoF(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (VectorCastI2X src));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
   format %{ "vcvtItoF $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4725,9 +4715,9 @@ instruct vcvtItoD(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorCastI2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::mf2));
   format %{ "vcvtItoD $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mf2);
     __ vfwcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4740,6 +4730,7 @@ instruct vcvtLtoI(vReg dst, vReg src) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (VectorCastL2X src));
+  ins_riscv_vset(false);
   format %{ "vcvtLtoI $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4752,9 +4743,9 @@ instruct vcvtLtoI(vReg dst, vReg src) %{
 instruct vcvtLtoF(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (VectorCastL2X src));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req, Assembler::mf2));
   format %{ "vcvtLtoF $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
     __ vfncvt_f_x_w(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4763,9 +4754,9 @@ instruct vcvtLtoF(vReg dst, vReg src) %{
 instruct vcvtLtoD(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorCastL2X src));
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
   format %{ "vcvtLtoD $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4778,6 +4769,7 @@ instruct vcvtFtoX_narrow(vReg dst, vReg src, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (VectorCastF2X src));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vcvtFtoX_narrow $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
@@ -4793,9 +4785,9 @@ instruct vcvtFtoI(vReg dst, vReg src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (VectorCastF2X src));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
   format %{ "vcvtFtoI $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4805,6 +4797,7 @@ instruct vcvtFtoL(vReg dst, vReg src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorCastF2X src));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vcvtFtoL $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
@@ -4820,9 +4813,9 @@ instruct vcvtFtoD(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorCastF2X src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req, Assembler::mf2));
   format %{ "vcvtFtoD $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
     __ vfwcvt_f_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4836,6 +4829,7 @@ instruct vcvtDtoX_narrow(vReg dst, vReg src, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (VectorCastD2X src));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vcvtDtoX_narrow $dst, $src" %}
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
@@ -4856,9 +4850,9 @@ instruct vcvtDtoL(vReg dst, vReg src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorCastD2X src));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "vcvtDtoL $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4867,9 +4861,9 @@ instruct vcvtDtoL(vReg dst, vReg src, vRegMask_V0 v0) %{
 instruct vcvtDtoF(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (VectorCastD2X src));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req, Assembler::mf2));
   format %{ "vcvtDtoF $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
     __ vfncvt_f_f_w(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -4892,6 +4886,7 @@ instruct reinterpretResize(vReg dst, vReg src) %{
   predicate(Matcher::vector_length_in_bytes(n) != Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst (VectorReinterpret src));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(false);
   format %{ "reinterpretResize $dst, $src" %}
   ins_encode %{
     uint length_in_bytes_src = Matcher::vector_length_in_bytes(this, $src);
@@ -4926,6 +4921,7 @@ instruct vmask_reinterpret_diff_esize(vRegMask dst, vRegMask_V0 src, vReg tmp) %
             Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1)));
   match(Set dst (VectorReinterpret src));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vmask_reinterpret_diff_esize $dst, $src\t# KILL $tmp" %}
   ins_encode %{
     BasicType from_bt = Matcher::vector_element_basic_type(this, $src);
@@ -4944,10 +4940,9 @@ instruct vmask_reinterpret_diff_esize(vRegMask dst, vRegMask_V0 src, vReg tmp) %
 instruct select_from_two_vectors(vReg dst, vReg src1, vReg src2, vReg index, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst (SelectFromTwoVector (Binary index src1) src2));
   effect(TEMP_DEF dst, TEMP v0, TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "select_from_two_vectors $dst, $src1, $src2, $index" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
                    as_VectorRegister($index$$reg));
     bool use_imm = __ is_simm5(Matcher::vector_length(this) - 1);
@@ -4972,10 +4967,9 @@ instruct select_from_two_vectors(vReg dst, vReg src1, vReg src2, vReg index, vRe
 instruct rearrange(vReg dst, vReg src, vReg shuffle) %{
   match(Set dst (VectorRearrange src shuffle));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "rearrange $dst, $src, $shuffle" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
                    as_VectorRegister($shuffle$$reg));
   %}
@@ -4985,10 +4979,9 @@ instruct rearrange(vReg dst, vReg src, vReg shuffle) %{
 instruct rearrange_masked(vReg dst, vReg src, vReg shuffle, vRegMask_V0 v0) %{
   match(Set dst (VectorRearrange (Binary src shuffle) v0));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "rearrange_masked $dst, $src, $shuffle, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
     __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -5005,6 +4998,7 @@ instruct extract(iRegINoSp dst, vReg src, immI idx, vReg tmp)
   match(Set dst (ExtractS src idx));
   match(Set dst (ExtractI src idx));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "extract $dst, $src, $idx\t# KILL $tmp" %}
   ins_encode %{
     __ extract_v($dst$$Register, as_VectorRegister($src$$reg),
@@ -5018,6 +5012,7 @@ instruct extractL(iRegLNoSp dst, vReg src, immI idx, vReg tmp)
 %{
   match(Set dst (ExtractL src idx));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "extractL $dst, $src, $idx\t# KILL $tmp" %}
   ins_encode %{
     __ extract_v($dst$$Register, as_VectorRegister($src$$reg), T_LONG,
@@ -5031,6 +5026,7 @@ instruct extractF(fRegF dst, vReg src, immI idx, vReg tmp)
 %{
   match(Set dst (ExtractF src idx));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "extractF $dst, $src, $idx\t# KILL $tmp" %}
   ins_encode %{
     __ extract_fp_v($dst$$FloatRegister, as_VectorRegister($src$$reg), T_FLOAT,
@@ -5043,6 +5039,7 @@ instruct extractD(fRegD dst, vReg src, immI idx, vReg tmp)
 %{
   match(Set dst (ExtractD src idx));
   effect(TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "extractD $dst, $src, $idx\t# KILL $tmp" %}
   ins_encode %{
     __ extract_fp_v($dst$$FloatRegister, as_VectorRegister($src$$reg), T_DOUBLE,
@@ -5086,10 +5083,9 @@ instruct extractUB_index_reg(iRegINoSp dst, vReg src, iRegI idx, vReg tmp)
 instruct mcompress(vRegMask dst, vRegMask src, vReg tmp) %{
   match(Set dst (CompressM src));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "mcompress $dst, $src\t# KILL $tmp" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($tmp$$reg));
     __ vcpop_m(t0, as_VectorRegister($src$$reg));
     __ vmsltu_vx(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), t0);
@@ -5100,10 +5096,9 @@ instruct mcompress(vRegMask dst, vRegMask src, vReg tmp) %{
 instruct vcompress(vReg dst, vReg src, vRegMask_V0 v0) %{
   match(Set dst (CompressV src v0));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vcompress $dst, $src, $v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
     __ vcompress_vm(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -5115,10 +5110,9 @@ instruct vcompress(vReg dst, vReg src, vRegMask_V0 v0) %{
 instruct vexpand(vReg dst, vReg src, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst (ExpandV src v0));
   effect(TEMP_DEF dst, TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vexpand $dst, $src, $v0\t# KILL $tmp" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ viota_m(as_VectorRegister($tmp$$reg), as_VectorRegister($v0$$reg));
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
@@ -5136,6 +5130,7 @@ instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
   match(Set dst (SignumVF dst (Binary zero one)));
   match(Set dst (SignumVD dst (Binary zero one)));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vsignum $dst, $dst\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -5150,6 +5145,7 @@ instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
 instruct vround_f(vReg dst, vReg src, fRegF tmp, vRegMask_V0 v0) %{
   match(Set dst (RoundVF src));
   effect(TEMP_DEF dst, TEMP tmp, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "java_round_float_v $dst, $src\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -5163,6 +5159,7 @@ instruct vround_f(vReg dst, vReg src, fRegF tmp, vRegMask_V0 v0) %{
 instruct vround_d(vReg dst, vReg src, fRegD tmp, vRegMask_V0 v0) %{
   match(Set dst (RoundVD src));
   effect(TEMP_DEF dst, TEMP tmp, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "java_round_double_v $dst, $src\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -5177,11 +5174,9 @@ instruct vround_d(vReg dst, vReg src, fRegD tmp, vRegMask_V0 v0) %{
 
 instruct vreverse_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (ReverseV dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vreverse_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vbrev_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5189,11 +5184,9 @@ instruct vreverse_masked(vReg dst_src, vRegMask_V0 v0) %{
 
 instruct vreverse(vReg dst, vReg src) %{
   match(Set dst (ReverseV src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vreverse $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vbrev_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5203,11 +5196,9 @@ instruct vreverse(vReg dst, vReg src) %{
 
 instruct vreverse_bytes_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (ReverseBytesV dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vreverse_bytes_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vrev8_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5215,11 +5206,9 @@ instruct vreverse_bytes_masked(vReg dst_src, vRegMask_V0 v0) %{
 
 instruct vreverse_bytes(vReg dst, vReg src) %{
   match(Set dst (ReverseBytesV src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vreverse_bytes $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vrev8_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5233,6 +5222,7 @@ instruct vconvHF2F(vReg dst, vReg src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (VectorCastHF2F src));
   effect(TEMP_DEF dst, TEMP v0);
+  ins_riscv_vset(false);
   format %{ "vfwcvt.f.f.v $dst, $src\t# convert half to single precision" %}
   ins_encode %{
     __ float16_to_float_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -5247,6 +5237,7 @@ instruct vconvF2HF(vReg dst, vReg src, vReg vtmp, vRegMask_V0 v0, iRegINoSp tmp)
   predicate(Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst (VectorCastF2HF src));
   effect(TEMP_DEF dst, TEMP v0, TEMP vtmp, TEMP tmp);
+  ins_riscv_vset(false);
   format %{ "vfncvt.f.f.w $dst, $src\t# convert single to half precision" %}
   ins_encode %{
     __ float_to_float16_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -5262,11 +5253,9 @@ instruct vconvF2HF(vReg dst, vReg src, vReg vtmp, vRegMask_V0 v0, iRegINoSp tmp)
 instruct vpopcount_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (PopCountVI dst_src v0));
   match(Set dst_src (PopCountVL dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vcpop_v $dst_src, $dst_src, $v0\t# vcpop_v with mask" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vcpop_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5275,11 +5264,9 @@ instruct vpopcount_masked(vReg dst_src, vRegMask_V0 v0) %{
 instruct vpopcount(vReg dst, vReg src) %{
   match(Set dst (PopCountVI src));
   match(Set dst (PopCountVL src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vcpop_v $dst, $src\t# vcpop_v without mask" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vcpop_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5289,11 +5276,9 @@ instruct vpopcount(vReg dst, vReg src) %{
 
 instruct vcountLeadingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (CountLeadingZerosV dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vcount_leading_zeros_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vclz_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5301,11 +5286,9 @@ instruct vcountLeadingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
 
 instruct vcountLeadingZeros(vReg dst, vReg src) %{
   match(Set dst (CountLeadingZerosV src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vcount_leading_zeros $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vclz_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5315,11 +5298,9 @@ instruct vcountLeadingZeros(vReg dst, vReg src) %{
 
 instruct vcountTrailingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (CountTrailingZerosV dst_src v0));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vcount_trailing_zeros_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vctz_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
@@ -5327,11 +5308,9 @@ instruct vcountTrailingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
 
 instruct vcountTrailingZeros(vReg dst, vReg src) %{
   match(Set dst (CountTrailingZerosV src));
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "vcount_trailing_zeros $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    uint vlen = Matcher::vector_length(this);
-    __ vsetvli_helper(bt, vlen);
     __ vctz_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5343,11 +5322,11 @@ instruct gather_loadS(vReg dst, indirect mem, vReg idx) %{
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n)) == 4);
   match(Set dst (LoadVectorGather mem idx));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "gather_loadS $dst, $mem, $idx" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vluxei32_v(as_VectorRegister($dst$$reg), as_Register($mem$$base),
                   as_VectorRegister($dst$$reg));
@@ -5359,11 +5338,11 @@ instruct gather_loadD(vReg dst, indirect mem, vReg idx) %{
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n)) == 8);
   match(Set dst (LoadVectorGather mem idx));
   effect(TEMP_DEF dst);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "gather_loadD $dst, $mem, $idx" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vzext_vf2(as_VectorRegister($dst$$reg), as_VectorRegister($idx$$reg));
     __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), (int)sew);
     __ vluxei64_v(as_VectorRegister($dst$$reg), as_Register($mem$$base),
@@ -5376,11 +5355,11 @@ instruct gather_loadS_masked(vReg dst, indirect mem, vReg idx, vRegMask_V0 v0, v
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n)) == 4);
   match(Set dst (LoadVectorGatherMasked mem (Binary idx v0)));
   effect(TEMP_DEF dst, TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "gather_loadS_masked $dst, $mem, $idx, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
@@ -5394,11 +5373,11 @@ instruct gather_loadD_masked(vReg dst, indirect mem, vReg idx, vRegMask_V0 v0, v
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n)) == 8);
   match(Set dst (LoadVectorGatherMasked mem (Binary idx v0)));
   effect(TEMP_DEF dst, TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "gather_loadD_masked $dst, $mem, $idx, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
@@ -5415,11 +5394,11 @@ instruct scatter_storeS(indirect mem, vReg src, vReg idx, vReg tmp) %{
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n->in(3)->in(1))) == 4);
   match(Set mem (StoreVectorScatter mem (Binary src idx)));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "scatter_storeS $mem, $idx, $src\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vsuxei32_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
                   as_VectorRegister($tmp$$reg));
@@ -5431,11 +5410,11 @@ instruct scatter_storeD(indirect mem, vReg src, vReg idx, vReg tmp) %{
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n->in(3)->in(1))) == 8);
   match(Set mem (StoreVectorScatter mem (Binary src idx)));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "scatter_storeD $mem, $idx, $src\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
     __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
     __ vsuxei64_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
@@ -5448,11 +5427,11 @@ instruct scatter_storeS_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n->in(3)->in(1))) == 4);
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx v0))));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "scatter_storeS_masked $mem, $idx, $src, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vsuxei32_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
                   as_VectorRegister($tmp$$reg), Assembler::v0_t);
@@ -5464,11 +5443,11 @@ instruct scatter_storeD_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n->in(3)->in(1))) == 8);
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx v0))));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "scatter_storeD_masked $mem, $idx, $src, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
     __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
     __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
     __ vsuxei64_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
@@ -5482,11 +5461,11 @@ instruct scatter_storeD_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
 instruct populateindex(vReg dst, iRegIorL2I src1, iRegIorL2I src2, vReg tmp) %{
   match(Set dst (PopulateIndex src1 src2));
   effect(TEMP_DEF dst, TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "populateindex $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmv_v_x(as_VectorRegister($dst$$reg), as_Register($src1$$reg));
     __ vid_v(as_VectorRegister($tmp$$reg));
     __ vmacc_vx(as_VectorRegister($dst$$reg), as_Register($src2$$reg), as_VectorRegister($tmp$$reg));
@@ -5505,10 +5484,9 @@ instruct insert_index_lt32(vReg dst, vReg src, iRegIorL2I val, immI idx, vRegMas
              Matcher::vector_element_basic_type(n) == T_INT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "insert_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vadd_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), -16);
     __ vmseq_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), (int)($idx$$constant) - 16);
@@ -5524,10 +5502,9 @@ instruct insert_index(vReg dst, vReg src, iRegIorL2I val, iRegIorL2I idx, vReg t
              Matcher::vector_element_basic_type(n) == T_INT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
+  ins_riscv_vset(riscv_vset_from_vect(this, req));
   format %{ "insert_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vmv_v_x(as_VectorRegister($tmp$$reg), $idx$$Register);
     __ vmseq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), as_VectorRegister($tmp$$reg));
@@ -5543,10 +5520,9 @@ instruct insertL_index_lt32(vReg dst, vReg src, iRegL val, immI idx, vRegMask_V0
             (Matcher::vector_element_basic_type(n) == T_LONG));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "insertL_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vadd_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), -16);
     __ vmseq_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), (int)($idx$$constant) - 16);
@@ -5560,10 +5536,9 @@ instruct insertL_index(vReg dst, vReg src, iRegL val, iRegIorL2I idx, vReg tmp, 
             (Matcher::vector_element_basic_type(n) == T_LONG));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
   format %{ "insertL_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vmv_v_x(as_VectorRegister($tmp$$reg), $idx$$Register);
     __ vmseq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), as_VectorRegister($tmp$$reg));
@@ -5579,9 +5554,9 @@ instruct insertF_index_lt32(vReg dst, vReg src, fRegF val, immI idx, vRegMask_V0
             (Matcher::vector_element_basic_type(n) == T_FLOAT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
   format %{ "insertF_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vadd_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), -16);
     __ vmseq_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), (int)($idx$$constant) - 16);
@@ -5595,9 +5570,9 @@ instruct insertF_index(vReg dst, vReg src, fRegF val, iRegIorL2I idx, vReg tmp, 
             (Matcher::vector_element_basic_type(n) == T_FLOAT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
   format %{ "insertF_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vmv_v_x(as_VectorRegister($tmp$$reg), $idx$$Register);
     __ vmseq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), as_VectorRegister($tmp$$reg));
@@ -5613,9 +5588,9 @@ instruct insertD_index_lt32(vReg dst, vReg src, fRegD val, immI idx, vRegMask_V0
             (Matcher::vector_element_basic_type(n) == T_DOUBLE));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
   format %{ "insertD_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vadd_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), -16);
     __ vmseq_vi(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), (int)($idx$$constant) - 16);
@@ -5629,9 +5604,9 @@ instruct insertD_index(vReg dst, vReg src, fRegD val, iRegIorL2I idx, vReg tmp, 
             (Matcher::vector_element_basic_type(n) == T_DOUBLE));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
   format %{ "insertD_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
-    __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vid_v(as_VectorRegister($v0$$reg));
     __ vmv_v_x(as_VectorRegister($tmp$$reg), $idx$$Register);
     __ vmseq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($v0$$reg), as_VectorRegister($tmp$$reg));
@@ -5646,10 +5621,9 @@ instruct insertD_index(vReg dst, vReg src, fRegD val, iRegIorL2I idx, vReg tmp, 
 
 instruct vmask_truecount(iRegINoSp dst, vRegMask src) %{
   match(Set dst (VectorMaskTrueCount src));
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "vmask_truecount $dst, $src" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
     __ vcpop_m($dst$$Register, as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5663,10 +5637,9 @@ instruct vmask_truecount(iRegINoSp dst, vRegMask src) %{
 instruct vmask_firsttrue(iRegINoSp dst, vRegMask src, vRegMask tmp) %{
   match(Set dst (VectorMaskFirstTrue src));
   effect(TEMP tmp);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "vmask_firsttrue $dst, $src\t# KILL $tmp" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
     __ vmsbf_m(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
     __ vcpop_m($dst$$Register, as_VectorRegister($tmp$$reg));
   %}
@@ -5680,11 +5653,11 @@ instruct vmask_firsttrue(iRegINoSp dst, vRegMask src, vRegMask tmp) %{
 
 instruct vmask_lasttrue(iRegINoSp dst, vRegMask src) %{
   match(Set dst (VectorMaskLastTrue src));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, 1, req));
   format %{ "vmask_lasttrue $dst, $src" %}
   ins_encode %{
     uint vector_length = Matcher::vector_length(this, $src);
     assert(UseZbb && vector_length <= XLEN, "precondition");
-    __ vsetvli_helper(T_LONG, 1);
     __ vmv_x_s($dst$$Register, as_VectorRegister($src$$reg));
     if (XLEN != vector_length) {
       __ slli($dst$$Register, $dst$$Register, XLEN - vector_length);
@@ -5701,11 +5674,11 @@ instruct vmask_lasttrue(iRegINoSp dst, vRegMask src) %{
 
 instruct vmask_tolong(iRegLNoSp dst, vRegMask src) %{
   match(Set dst (VectorMaskToLong src));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, 1, req));
   format %{ "vmask_tolong $dst, $src" %}
   ins_encode %{
     uint vector_length = Matcher::vector_length(this, $src);
     assert(vector_length <= XLEN, "precondition");
-    __ vsetvli_helper(T_LONG, 1);
     __ vmv_x_s($dst$$Register, as_VectorRegister($src$$reg));
     if (XLEN != vector_length) {
       __ slli($dst$$Register, $dst$$Register, XLEN - vector_length);
@@ -5719,10 +5692,10 @@ instruct vmask_tolong(iRegLNoSp dst, vRegMask src) %{
 
 instruct vmask_fromlong(vRegMask dst, iRegL src) %{
   match(Set dst (VectorLongToMask src));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, 1, req));
   format %{ "vmask_fromlong $dst, $src" %}
   ins_encode %{
     assert(Matcher::vector_length(this) <= XLEN, "precondition");
-    __ vsetvli_helper(T_LONG, 1);
     __ vmv_s_x(as_VectorRegister($dst$$reg), $src$$Register);
   %}
   ins_pipe(pipe_slow);
@@ -5753,11 +5726,9 @@ instruct cmovI_vtest_anytrue_negate(iRegINoSp dst, cmpOp cop, vRegMask op1, vReg
   predicate(n->in(1)->in(1)->as_Bool()->_test._test == BoolTest::eq &&
             static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::ne);
   match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary one zero)));
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "CMove $dst, (vectortest $cop $op1 $op2), zero, one\t#@cmovI_vtest_anytrue_negate"  %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $op1);
-    uint vector_length = Matcher::vector_length(this, $op1);
-    __ vsetvli_helper(bt, vector_length);
     __ vcpop_m($dst$$Register, as_VectorRegister($op1$$reg));
     __ snez($dst$$Register, $dst$$Register);
   %}
@@ -5788,11 +5759,10 @@ instruct cmovI_vtest_alltrue_negate(iRegINoSp dst, cmpOp cop, vRegMask op1, vReg
   predicate(n->in(1)->in(1)->as_Bool()->_test._test == BoolTest::ne &&
             static_cast<const VectorTestNode*>(n->in(1)->in(2))->get_predicate() == BoolTest::overflow);
   match(Set dst (CMoveI (Binary cop (VectorTest op1 op2)) (Binary one zero)));
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "CMove $dst, (vectortest $cop $op1 $op2), zero, one\t#@cmovI_vtest_alltrue_negate"  %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $op1);
     uint vector_length = Matcher::vector_length(this, $op1);
-    __ vsetvli_helper(bt, vector_length);
     __ vcpop_m($dst$$Register, as_VectorRegister($op1$$reg));
     __ sub($dst$$Register, $dst$$Register, vector_length);
     __ seqz($dst$$Register, $dst$$Register);
@@ -5806,11 +5776,9 @@ instruct vtest_anytrue_branch(cmpOpEqNe cop, vRegMask op1, vRegMask op2, label l
   predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::ne);
   match(If cop (VectorTest op1 op2));
   effect(USE lbl);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "b$cop (vectortest ne $op1, $op2) $lbl\t#@vtest_anytrue_branch" %}
   ins_encode %{
-    uint vector_length = Matcher::vector_length(this, $op1);
-    BasicType bt = Matcher::vector_element_basic_type(this, $op1);
-    __ vsetvli_helper(bt, vector_length);
     __ vcpop_m(t0, as_VectorRegister($op1$$reg));
     __ enc_cmpEqNe_imm0_branch($cop$$cmpcode, t0, *($lbl$$label), /* is_far */ true);
   %}
@@ -5823,11 +5791,10 @@ instruct vtest_alltrue_branch(cmpOpEqNe cop, vRegMask op1, vRegMask op2, label l
   predicate(static_cast<const VectorTestNode*>(n->in(2))->get_predicate() == BoolTest::overflow);
   match(If cop (VectorTest op1 op2));
   effect(USE lbl);
+  ins_riscv_vset(riscv_vset_from_node(this, req));
   format %{ "b$cop (vectortest overflow $op1, $op2) $lbl\t#@vtest_alltrue_branch" %}
   ins_encode %{
     uint vector_length = Matcher::vector_length(this, $op1);
-    BasicType bt = Matcher::vector_element_basic_type(this, $op1);
-    __ vsetvli_helper(bt, vector_length);
     __ vcpop_m(t0, as_VectorRegister($op1$$reg));
     __ sub(t0, t0, vector_length);
     __ enc_cmpEqNe_imm0_branch($cop$$cmpcode, t0, *($lbl$$label), /* is_far */ true);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -37,7 +37,7 @@ source %{
                         bool set_vtype = true) {
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     if (set_vtype) {
-      __ vsetvli_helper(bt, vector_length);
+      __ vsetvli_helper(bt, vector_length, vm == Assembler::v0_t ? Assembler::mu : Assembler::ma);
     }
 
     if (is_store) {
@@ -233,7 +233,7 @@ instruct vloadmask(vRegMask dst, vReg src) %{
 
 instruct vloadmask_masked(vRegMask dst, vReg src, vRegMask_V0 v0) %{
   match(Set dst (VectorLoadMask src v0));
-  ins_riscv_vset(riscv_vset_fixed(T_BOOLEAN, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BOOLEAN, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vloadmask_masked $dst, $src, $v0" %}
   ins_encode %{
     __ vmsne_vx(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), zr, Assembler::v0_t);
@@ -245,7 +245,7 @@ instruct vloadmask_masked(vRegMask dst, vReg src, vRegMask_V0 v0) %{
 
 instruct vstoremask(vReg dst, vRegMask_V0 v0, immI size) %{
   match(Set dst (VectorStoreMask v0 size));
-  ins_riscv_vset(riscv_vset_fixed(T_BOOLEAN, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BOOLEAN, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vstoremask $dst, V0 # elem size is $size byte[s]" %}
   ins_encode %{
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
@@ -364,7 +364,7 @@ instruct vabs_masked(vReg dst_src, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst_src (AbsVI dst_src v0));
   match(Set dst_src (AbsVL dst_src v0));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vabs_masked $dst_src, $dst_src, $v0\t# KILL $tmp" %}
   ins_encode %{
     __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($dst_src$$reg), 0,
@@ -378,7 +378,7 @@ instruct vabs_masked(vReg dst_src, vRegMask_V0 v0, vReg tmp) %{
 instruct vabs_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (AbsVF dst_src v0));
   match(Set dst_src (AbsVD dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vabs_fp_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     __ vfabs_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -437,7 +437,7 @@ instruct vadd_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVS (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVL (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vadd_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vadd_vv(as_VectorRegister($dst_src1$$reg),
@@ -450,7 +450,7 @@ instruct vadd_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (AddVD (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vadd_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vfadd_vv(as_VectorRegister($dst_src1$$reg),
@@ -522,7 +522,7 @@ instruct vadd_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVB (Binary dst_src (Replicate con)) v0));
   match(Set dst_src (AddVS (Binary dst_src (Replicate con)) v0));
   match(Set dst_src (AddVI (Binary dst_src (Replicate con)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vadd_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vadd_vi(as_VectorRegister($dst_src$$reg),
@@ -534,7 +534,7 @@ instruct vadd_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
 
 instruct vaddL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate con)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vaddL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vadd_vi(as_VectorRegister($dst_src$$reg),
@@ -550,7 +550,7 @@ instruct vadd_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (AddVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (AddVI (Binary dst_src (Replicate src2)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vadd_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
@@ -562,7 +562,7 @@ instruct vadd_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
 
 instruct vaddL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate src2)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vaddL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
@@ -620,7 +620,7 @@ instruct vsub_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVS (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVL (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vsub_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
@@ -632,7 +632,7 @@ instruct vsub_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (SubVD (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vsub_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vfsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
@@ -675,7 +675,7 @@ instruct vsub_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (SubVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (SubVI (Binary dst_src (Replicate src2)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vsub_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
@@ -687,7 +687,7 @@ instruct vsub_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
 
 instruct vsubL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVL (Binary dst_src (Replicate src2)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vsubL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
@@ -736,7 +736,7 @@ instruct vsaddu(vReg dst, vReg src1, vReg src2) %{
 instruct vsadd_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   predicate(n->is_SaturatingVector() && !n->as_SaturatingVector()->is_unsigned());
   match(Set dst_src (SaturatingAddV (Binary dst_src src1) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vsadd_masked $dst_src, $dst_src, $src1, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -752,7 +752,7 @@ instruct vsadd_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
 instruct vsaddu_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   predicate(n->is_SaturatingVector() && n->as_SaturatingVector()->is_unsigned());
   match(Set dst_src (SaturatingAddV (Binary dst_src src1) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vsaddu_masked $dst_src, $dst_src, $src1, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -800,7 +800,7 @@ instruct vssubu(vReg dst, vReg src1, vReg src2) %{
 instruct vssub_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   predicate(n->is_SaturatingVector() && !n->as_SaturatingVector()->is_unsigned());
   match(Set dst_src (SaturatingSubV (Binary dst_src src1) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vssub_masked $dst_src, $dst_src, $src1, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -816,7 +816,7 @@ instruct vssub_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
 instruct vssubu_masked(vReg dst_src, vReg src1, vRegMask_V0 v0) %{
   predicate(n->is_SaturatingVector() && n->as_SaturatingVector()->is_unsigned());
   match(Set dst_src (SaturatingSubV (Binary dst_src src1) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vssubu_masked $dst_src, $dst_src, $src1, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -845,7 +845,7 @@ instruct vand(vReg dst, vReg src1, vReg src2) %{
 
 instruct vand_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (AndV (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vand_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vand_vv(as_VectorRegister($dst_src1$$reg),
@@ -922,7 +922,7 @@ instruct vand_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (AndV (Binary dst_src (Replicate con)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vand_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vand_vi(as_VectorRegister($dst_src$$reg),
@@ -935,7 +935,7 @@ instruct vand_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
 instruct vandL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (AndV (Binary dst_src (Replicate con)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vandL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vand_vi(as_VectorRegister($dst_src$$reg),
@@ -952,7 +952,7 @@ instruct vand_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (AndV (Binary dst_src (Replicate src)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vand_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vand_vx(as_VectorRegister($dst_src$$reg),
@@ -965,7 +965,7 @@ instruct vand_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
 instruct vandL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (AndV (Binary dst_src (Replicate src)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vandL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vand_vx(as_VectorRegister($dst_src$$reg),
@@ -993,7 +993,7 @@ instruct vor(vReg dst, vReg src1, vReg src2) %{
 
 instruct vor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (OrV (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vor_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vor_vv(as_VectorRegister($dst_src1$$reg),
@@ -1070,7 +1070,7 @@ instruct vor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (OrV (Binary dst_src (Replicate con)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vor_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vor_vi(as_VectorRegister($dst_src$$reg),
@@ -1083,7 +1083,7 @@ instruct vor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
 instruct vorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (OrV (Binary dst_src (Replicate con)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vorL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vor_vi(as_VectorRegister($dst_src$$reg),
@@ -1100,7 +1100,7 @@ instruct vor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (OrV (Binary dst_src (Replicate src)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vor_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vor_vx(as_VectorRegister($dst_src$$reg),
@@ -1113,7 +1113,7 @@ instruct vor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
 instruct vorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (OrV (Binary dst_src (Replicate src)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vorL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vor_vx(as_VectorRegister($dst_src$$reg),
@@ -1141,7 +1141,7 @@ instruct vxor(vReg dst, vReg src1, vReg src2) %{
 
 instruct vxor_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (XorV (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vxor_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vxor_vv(as_VectorRegister($dst_src1$$reg),
@@ -1218,7 +1218,7 @@ instruct vxor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (XorV (Binary dst_src (Replicate con)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vxor_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
@@ -1231,7 +1231,7 @@ instruct vxor_vi_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
 instruct vxorL_vi_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV (Binary dst_src (Replicate con)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vxorL_vi_masked $dst_src, $dst_src, $con, $v0" %}
   ins_encode %{
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
@@ -1248,7 +1248,7 @@ instruct vxor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (XorV (Binary dst_src (Replicate src)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vxor_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vxor_vx(as_VectorRegister($dst_src$$reg),
@@ -1261,7 +1261,7 @@ instruct vxor_vx_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
 instruct vxorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV (Binary dst_src (Replicate src)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vxorL_vx_masked $dst_src, $dst_src, $src, $v0" %}
   ins_encode %{
     __ vxor_vx(as_VectorRegister($dst_src$$reg),
@@ -1278,7 +1278,7 @@ instruct vxorL_vx_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
 instruct vand_notB(vReg dst, vReg src1, vReg src2, immI_M1 m1) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (AndV src1 (XorV src2 (Replicate m1))));
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notB $dst, $src1, $src2" %}
   ins_encode %{
     __ vandn_vv(as_VectorRegister($dst$$reg),
@@ -1330,7 +1330,7 @@ instruct vand_notL(vReg dst, vReg src1, vReg src2, immL_M1 m1) %{
 instruct vand_notB_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notB_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
@@ -1344,7 +1344,7 @@ instruct vand_notB_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
 instruct vand_notS_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notS_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
@@ -1358,7 +1358,7 @@ instruct vand_notS_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
 instruct vand_notI_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notI_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
@@ -1372,7 +1372,7 @@ instruct vand_notI_masked(vReg dst_src1, vReg src2, immI_M1 m1, vRegMask_V0 v0) 
 instruct vand_notL_masked(vReg dst_src1, vReg src2, immL_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src1 (AndV (Binary dst_src1 (XorV src2 (Replicate m1))) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notL_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vandn_vv(as_VectorRegister($dst_src1$$reg),
@@ -1438,7 +1438,7 @@ instruct vand_notL_vx(vReg dst, vReg src1, iRegL src2, immL_M1 m1) %{
 instruct vand_notB_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notB_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
@@ -1452,7 +1452,7 @@ instruct vand_notB_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
 instruct vand_notS_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_SHORT);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notS_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
@@ -1466,7 +1466,7 @@ instruct vand_notS_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
 instruct vand_notI_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorI src2 m1))) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notI_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
@@ -1480,7 +1480,7 @@ instruct vand_notI_vx_masked(vReg dst_src1, iRegIorL2I src2, immI_M1 m1, vRegMas
 instruct vand_notL_vx_masked(vReg dst_src1, iRegL src2, immL_M1 m1, vRegMask_V0 v0) %{
   predicate(UseZvbb && Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src1 (AndV (Binary dst_src1 (Replicate (XorL src2 m1))) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vand_notL_vx_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vandn_vx(as_VectorRegister($dst_src1$$reg),
@@ -1500,7 +1500,7 @@ instruct vnot(vReg dst, vReg src, immI_M1 m1) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (XorV src (Replicate m1)));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vnot $dst, $src" %}
   ins_encode %{
     __ vxor_vi(as_VectorRegister($dst$$reg),
@@ -1530,7 +1530,7 @@ instruct vnot_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_SHORT ||
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst_src (XorV (Binary dst_src (Replicate m1)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vnot_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
@@ -1543,7 +1543,7 @@ instruct vnot_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
 instruct vnotL_masked(vReg dst_src, immI_M1 m1, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst_src (XorV (Binary dst_src (Replicate m1)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vnotL_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     __ vxor_vi(as_VectorRegister($dst_src$$reg),
@@ -1587,7 +1587,7 @@ instruct vdiv_fp(vReg dst, vReg src1, vReg src2) %{
 instruct vdiv_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (DivVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (DivVD (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vdiv_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vfdiv_vv(as_VectorRegister($dst_src1$$reg),
@@ -1631,7 +1631,7 @@ instruct vmax_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) != T_FLOAT &&
             Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst_src1 (MaxV (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmax_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vmax_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
@@ -1644,7 +1644,7 @@ instruct vmin_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) != T_FLOAT &&
             Matcher::vector_element_basic_type(n) != T_DOUBLE);
   match(Set dst_src1 (MinV (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmin_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vmin_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
@@ -1685,7 +1685,7 @@ instruct vminu(vReg dst, vReg src1, vReg src2) %{
 
 instruct vmaxu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (UMaxV (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmaxu_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -1698,7 +1698,7 @@ instruct vmaxu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 instruct vminu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (UMinV (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vminu_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -1848,7 +1848,7 @@ instruct vfmla(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (FmaVF (Binary dst_src1 src2) (Binary src3 v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 src2) (Binary src3 v0)));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vfmadd_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
@@ -1894,7 +1894,7 @@ instruct vfmlsD(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfnmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (FmaVF (Binary dst_src1 (NegVF src2)) (Binary src3 v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 (NegVD src2)) (Binary src3 v0)));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vfnmsub_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
@@ -1940,7 +1940,7 @@ instruct vfnmlaD(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfnmadd_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (FmaVF (Binary dst_src1 (NegVF src2)) (Binary (NegVF src3) v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 (NegVD src2)) (Binary (NegVD src3) v0)));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vfnmadd_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
@@ -1984,7 +1984,7 @@ instruct vfnmlsD(vReg dst_src1, vReg src2, vReg src3) %{
 instruct vfmsub_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (FmaVF (Binary dst_src1 src2) (Binary (NegVF src3) v0)));
   match(Set dst_src1 (FmaVD (Binary dst_src1 src2) (Binary (NegVD src3) v0)));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vfmsub_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     assert(UseFMA, "Needs FMA instructions support.");
@@ -2018,7 +2018,7 @@ instruct vmla_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (AddVS (Binary dst_src1 (MulVS src2 src3)) v0));
   match(Set dst_src1 (AddVI (Binary dst_src1 (MulVI src2 src3)) v0));
   match(Set dst_src1 (AddVL (Binary dst_src1 (MulVL src2 src3)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmla_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     __ vmacc_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
@@ -2051,7 +2051,7 @@ instruct vmls_masked(vReg dst_src1, vReg src2, vReg src3, vRegMask_V0 v0) %{
   match(Set dst_src1 (SubVS (Binary dst_src1 (MulVS src2 src3)) v0));
   match(Set dst_src1 (SubVI (Binary dst_src1 (MulVI src2 src3)) v0));
   match(Set dst_src1 (SubVL (Binary dst_src1 (MulVL src2 src3)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmls_masked $dst_src1, $dst_src1, $src2, $src3, $v0" %}
   ins_encode %{
     __ vnmsac_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($src2$$reg),
@@ -2108,7 +2108,7 @@ instruct vmul_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (MulVS (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVI (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVL (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmul_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vmul_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
@@ -2120,7 +2120,7 @@ instruct vmul_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst_src1 (MulVF (Binary dst_src1 src2) v0));
   match(Set dst_src1 (MulVD (Binary dst_src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmul_fp_masked $dst_src1, $dst_src1, $src2, $v0" %}
   ins_encode %{
     __ vfmul_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
@@ -2163,7 +2163,7 @@ instruct vmul_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVB (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (MulVS (Binary dst_src (Replicate src2)) v0));
   match(Set dst_src (MulVI (Binary dst_src (Replicate src2)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmul_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
@@ -2175,7 +2175,7 @@ instruct vmul_vx_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
 
 instruct vmulL_vx_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVL (Binary dst_src (Replicate src2)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vmulL_vx_masked $dst_src, $dst_src, $src2, $v0" %}
   ins_encode %{
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
@@ -2203,7 +2203,7 @@ instruct vneg(vReg dst, vReg src) %{
 instruct vneg_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (NegVI dst_src v0));
   match(Set dst_src (NegVL dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vneg_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     __ vneg_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -2230,7 +2230,7 @@ instruct vfneg(vReg dst, vReg src) %{
 instruct vfneg_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (NegVF dst_src v0));
   match(Set dst_src (NegVD dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vfneg_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     __ vfneg_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -2590,7 +2590,7 @@ instruct reduce_addL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
 instruct reduce_addF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst (AddReductionVF (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_addF_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
@@ -2604,7 +2604,7 @@ instruct reduce_addF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, vR
 instruct reduce_addD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst (AddReductionVD (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_addD_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
@@ -3063,7 +3063,7 @@ instruct replicateD(vReg dst, fRegD src) %{
 instruct vasrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (RShiftVB src shift));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrB $dst, $src, $shift" %}
   ins_encode %{
     // if shift > BitsPerByte - 1, clear the low BitsPerByte - 1 bits
@@ -3081,7 +3081,7 @@ instruct vasrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 instruct vasrS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (RShiftVS src shift));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrS $dst, $src, $shift" %}
   ins_encode %{
     // if shift > BitsPerShort - 1, clear the low BitsPerShort - 1 bits
@@ -3121,7 +3121,7 @@ instruct vasrL(vReg dst, vReg src, vReg shift) %{
 instruct vasrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVB (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerByte - 1);
@@ -3138,7 +3138,7 @@ instruct vasrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vasrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVS (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
     __ vmsgtu_vi(as_VectorRegister($v0$$reg), as_VectorRegister($shift$$reg), BitsPerShort - 1);
@@ -3155,7 +3155,7 @@ instruct vasrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vasrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVI (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
-  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     __ vsra_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3167,7 +3167,7 @@ instruct vasrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vasrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVL (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     __ vsra_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3179,7 +3179,7 @@ instruct vasrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vlslB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (LShiftVB src shift));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslB $dst, $src, $shift" %}
   ins_encode %{
     // if shift > BitsPerByte - 1, clear the element
@@ -3197,7 +3197,7 @@ instruct vlslB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 instruct vlslS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (LShiftVS src shift));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslS $dst, $src, $shift" %}
   ins_encode %{
     // if shift > BitsPerShort - 1, clear the element
@@ -3237,7 +3237,7 @@ instruct vlslL(vReg dst, vReg src, vReg shift) %{
 instruct vlslB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVB (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
     // if shift > BitsPerByte - 1, clear the element
@@ -3257,7 +3257,7 @@ instruct vlslB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vlslS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVS (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
     // if shift > BitsPerShort - 1, clear the element
@@ -3277,7 +3277,7 @@ instruct vlslS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vlslI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVI (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
-  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     __ vsll_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3289,7 +3289,7 @@ instruct vlslI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vlslL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVL (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     __ vsll_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3301,7 +3301,7 @@ instruct vlslL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vlsrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (URShiftVB src shift));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrB $dst, $src, $shift" %}
   ins_encode %{
     // if shift > BitsPerByte - 1, clear the element
@@ -3319,7 +3319,7 @@ instruct vlsrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
 instruct vlsrS(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (URShiftVS src shift));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrS $dst, $src, $shift" %}
   ins_encode %{
     // if shift > BitsPerShort - 1, clear the element
@@ -3359,7 +3359,7 @@ instruct vlsrL(vReg dst, vReg src, vReg shift) %{
 instruct vlsrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVB (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrB_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
     // if shift > BitsPerByte - 1, clear the element
@@ -3379,7 +3379,7 @@ instruct vlsrB_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vlsrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVS (Binary dst_src shift) vmask));
   effect(TEMP_DEF dst_src, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrS_masked $dst_src, $dst_src, $shift, $vmask\t# KILL $v0" %}
   ins_encode %{
     // if shift > BitsPerShort - 1, clear the element
@@ -3399,7 +3399,7 @@ instruct vlsrS_masked(vReg dst_src, vReg shift, vRegMask vmask, vRegMask_V0 v0) 
 instruct vlsrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVI (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
-  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrI_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     __ vsrl_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3411,7 +3411,7 @@ instruct vlsrI_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 instruct vlsrL_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVL (Binary dst_src shift) v0));
   effect(TEMP_DEF dst_src);
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrL_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     __ vsrl_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3489,7 +3489,7 @@ instruct vasrL_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vasrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVB (Binary dst_src (RShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3505,7 +3505,7 @@ instruct vasrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vasrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVS (Binary dst_src (RShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3521,7 +3521,7 @@ instruct vasrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vasrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RShiftVI (Binary dst_src (RShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3537,7 +3537,7 @@ instruct vasrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vasrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (RShiftVL (Binary dst_src (RShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vasrL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3627,7 +3627,7 @@ instruct vlsrL_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vlsrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVB (Binary dst_src (RShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3647,7 +3647,7 @@ instruct vlsrB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlsrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVS (Binary dst_src (RShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3667,7 +3667,7 @@ instruct vlsrS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlsrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (URShiftVI (Binary dst_src (RShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3683,7 +3683,7 @@ instruct vlsrI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vlsrL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (URShiftVL (Binary dst_src (RShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlsrL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3753,7 +3753,7 @@ instruct vlslL_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vlslB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVB (Binary dst_src (LShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_BYTE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslB_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3770,7 +3770,7 @@ instruct vlslB_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlslS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVS (Binary dst_src (LShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslS_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3787,7 +3787,7 @@ instruct vlslS_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 
 instruct vlslI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (LShiftVI (Binary dst_src (LShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_INT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslI_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3800,7 +3800,7 @@ instruct vlslI_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
 instruct vlslL_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   predicate((n->in(1)->in(2)->in(1)->get_int() & 0x3f) < 32);
   match(Set dst_src (LShiftVL (Binary dst_src (LShiftCntV shift)) v0));
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vlslL_vi_masked $dst_src, $dst_src, $shift, $v0" %}
   ins_encode %{
     uint32_t con = (unsigned)$shift$$constant & 0x1f;
@@ -3869,7 +3869,7 @@ instruct vrotate_right_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vrotate_right_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src shift) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vrotate_right_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     __ vror_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3881,7 +3881,7 @@ instruct vrotate_right_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_right_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src (Replicate shift)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vrotate_right_vx_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     __ vror_vx(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3892,7 +3892,7 @@ instruct vrotate_right_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0)
 
 instruct vrotate_right_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateRightV (Binary dst_src shift) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vrotate_right_vi_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -3953,7 +3953,7 @@ instruct vrotate_left_vi(vReg dst, vReg src, immI shift) %{
 
 instruct vrotate_left_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src shift) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vrotate_left_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     __ vrol_vv(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3965,7 +3965,7 @@ instruct vrotate_left_masked(vReg dst_src, vReg shift, vRegMask_V0 v0) %{
 // Only the low log2(SEW) bits of shift value are used, all other bits are ignored.
 instruct vrotate_left_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src (Replicate shift)) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vrotate_left_vx_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     __ vrol_vx(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -3976,7 +3976,7 @@ instruct vrotate_left_vx_masked(vReg dst_src, iRegIorL2I shift, vRegMask_V0 v0) 
 
 instruct vrotate_left_vi_masked(vReg dst_src, immI shift, vRegMask_V0 v0) %{
   match(Set dst_src (RotateLeftV (Binary dst_src shift) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vrotate_left_vi_masked $dst_src, $dst_src, $shift, $v0\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4022,7 +4022,7 @@ instruct vsqrt_fp(vReg dst, vReg src) %{
 instruct vsqrt_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (SqrtVF dst_src v0));
   match(Set dst_src (SqrtVD dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vsqrt_fp_masked $dst_src, $dst_src, $v0" %}
   ins_encode %{
     __ vfsqrt_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg),
@@ -4514,7 +4514,7 @@ instruct vmaskcast(vRegMask dst_src) %{
 
 instruct loadV_masked(vReg dst, vmemA mem, vRegMask_V0 v0) %{
   match(Set dst (LoadVectorMasked mem v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "loadV_masked $dst, $mem, $v0" %}
   ins_encode %{
     VectorRegister dst_reg = as_VectorRegister($dst$$reg);
@@ -4527,7 +4527,7 @@ instruct loadV_masked(vReg dst, vmemA mem, vRegMask_V0 v0) %{
 
 instruct storeV_masked(vReg src, vmemA mem, vRegMask_V0 v0) %{
   match(Set mem (StoreVectorMasked mem (Binary src v0)));
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "storeV_masked $mem, $src, $v0" %}
   ins_encode %{
     VectorRegister src_reg = as_VectorRegister($src$$reg);
@@ -4542,7 +4542,7 @@ instruct storeV_masked(vReg src, vmemA mem, vRegMask_V0 v0) %{
 
 instruct vblend(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (VectorBlend (Binary src1 src2) v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vblend $dst, $src1, $src2, v0" %}
   ins_encode %{
     __ vmerge_vvm(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
@@ -4772,7 +4772,7 @@ instruct vcvtFtoX_narrow(vReg dst, vReg src, vRegMask_V0 v0) %{
   ins_riscv_vset(false);
   format %{ "vcvtFtoX_narrow $dst, $src" %}
   ins_encode %{
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this));
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mu);
     __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ integer_narrow_v(as_VectorRegister($dst$$reg), bt, Matcher::vector_length(this),
@@ -4785,7 +4785,7 @@ instruct vcvtFtoI(vReg dst, vReg src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (VectorCastF2X src));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vcvtFtoI $dst, $src" %}
   ins_encode %{
     __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
@@ -4802,7 +4802,7 @@ instruct vcvtFtoL(vReg dst, vReg src, vRegMask_V0 v0) %{
   ins_encode %{
     __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
-    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2);
+    __ vsetvli_helper(T_FLOAT, Matcher::vector_length(this), Assembler::mf2, Assembler::mu);
     __ vmfeq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($src$$reg), as_VectorRegister($src$$reg));
     __ vfwcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
   %}
@@ -4834,7 +4834,7 @@ instruct vcvtDtoX_narrow(vReg dst, vReg src, vRegMask_V0 v0) %{
   ins_encode %{
     __ vsetvli_helper(T_DOUBLE, Matcher::vector_length(this));
     __ vmfeq_vv(as_VectorRegister($v0$$reg), as_VectorRegister($src$$reg), as_VectorRegister($src$$reg));
-    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mf2);
+    __ vsetvli_helper(T_INT, Matcher::vector_length(this), Assembler::mf2, Assembler::mu);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
     __ vfncvt_rtz_x_f_w(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -4850,7 +4850,7 @@ instruct vcvtDtoL(vReg dst, vReg src, vRegMask_V0 v0) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorCastD2X src));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vcvtDtoL $dst, $src" %}
   ins_encode %{
     __ vfcvt_rtz_x_f_v_safe(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
@@ -4940,7 +4940,7 @@ instruct vmask_reinterpret_diff_esize(vRegMask dst, vRegMask_V0 src, vReg tmp) %
 instruct select_from_two_vectors(vReg dst, vReg src1, vReg src2, vReg index, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst (SelectFromTwoVector (Binary index src1) src2));
   effect(TEMP_DEF dst, TEMP v0, TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "select_from_two_vectors $dst, $src1, $src2, $index" %}
   ins_encode %{
     __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
@@ -4967,7 +4967,7 @@ instruct select_from_two_vectors(vReg dst, vReg src1, vReg src2, vReg index, vRe
 instruct rearrange(vReg dst, vReg src, vReg shuffle) %{
   match(Set dst (VectorRearrange src shuffle));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "rearrange $dst, $src, $shuffle" %}
   ins_encode %{
     __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
@@ -4979,7 +4979,7 @@ instruct rearrange(vReg dst, vReg src, vReg shuffle) %{
 instruct rearrange_masked(vReg dst, vReg src, vReg shuffle, vRegMask_V0 v0) %{
   match(Set dst (VectorRearrange (Binary src shuffle) v0));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu, Assembler::tu));
   format %{ "rearrange_masked $dst, $src, $shuffle, $v0" %}
   ins_encode %{
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
@@ -5083,7 +5083,7 @@ instruct extractUB_index_reg(iRegINoSp dst, vReg src, iRegI idx, vReg tmp)
 instruct mcompress(vRegMask dst, vRegMask src, vReg tmp) %{
   match(Set dst (CompressM src));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "mcompress $dst, $src\t# KILL $tmp" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($tmp$$reg));
@@ -5096,7 +5096,7 @@ instruct mcompress(vRegMask dst, vRegMask src, vReg tmp) %{
 instruct vcompress(vReg dst, vReg src, vRegMask_V0 v0) %{
   match(Set dst (CompressV src v0));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu, Assembler::tu));
   format %{ "vcompress $dst, $src, $v0" %}
   ins_encode %{
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
@@ -5110,7 +5110,7 @@ instruct vcompress(vReg dst, vReg src, vRegMask_V0 v0) %{
 instruct vexpand(vReg dst, vReg src, vRegMask_V0 v0, vReg tmp) %{
   match(Set dst (ExpandV src v0));
   effect(TEMP_DEF dst, TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu, Assembler::tu));
   format %{ "vexpand $dst, $src, $v0\t# KILL $tmp" %}
   ins_encode %{
     __ viota_m(as_VectorRegister($tmp$$reg), as_VectorRegister($v0$$reg));
@@ -5174,7 +5174,7 @@ instruct vround_d(vReg dst, vReg src, fRegD tmp, vRegMask_V0 v0) %{
 
 instruct vreverse_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (ReverseV dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreverse_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
     __ vbrev_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -5196,7 +5196,7 @@ instruct vreverse(vReg dst, vReg src) %{
 
 instruct vreverse_bytes_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (ReverseBytesV dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreverse_bytes_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
     __ vrev8_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -5253,7 +5253,7 @@ instruct vconvF2HF(vReg dst, vReg src, vReg vtmp, vRegMask_V0 v0, iRegINoSp tmp)
 instruct vpopcount_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (PopCountVI dst_src v0));
   match(Set dst_src (PopCountVL dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vcpop_v $dst_src, $dst_src, $v0\t# vcpop_v with mask" %}
   ins_encode %{
     __ vcpop_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -5276,7 +5276,7 @@ instruct vpopcount(vReg dst, vReg src) %{
 
 instruct vcountLeadingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (CountLeadingZerosV dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vcount_leading_zeros_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
     __ vclz_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -5298,7 +5298,7 @@ instruct vcountLeadingZeros(vReg dst, vReg src) %{
 
 instruct vcountTrailingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
   match(Set dst_src (CountTrailingZerosV dst_src v0));
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vcount_trailing_zeros_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
     __ vctz_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
@@ -5355,7 +5355,7 @@ instruct gather_loadS_masked(vReg dst, indirect mem, vReg idx, vRegMask_V0 v0, v
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n)) == 4);
   match(Set dst (LoadVectorGatherMasked mem (Binary idx v0)));
   effect(TEMP_DEF dst, TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "gather_loadS_masked $dst, $mem, $idx, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -5373,7 +5373,7 @@ instruct gather_loadD_masked(vReg dst, indirect mem, vReg idx, vRegMask_V0 v0, v
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n)) == 8);
   match(Set dst (LoadVectorGatherMasked mem (Binary idx v0)));
   effect(TEMP_DEF dst, TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "gather_loadD_masked $dst, $mem, $idx, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -5427,7 +5427,7 @@ instruct scatter_storeS_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n->in(3)->in(1))) == 4);
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx v0))));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "scatter_storeS_masked $mem, $idx, $src, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
@@ -5443,7 +5443,7 @@ instruct scatter_storeD_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
   predicate(type2aelembytes(Matcher::vector_element_basic_type(n->in(3)->in(1))) == 8);
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx v0))));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "scatter_storeD_masked $mem, $idx, $src, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
@@ -5484,7 +5484,7 @@ instruct insert_index_lt32(vReg dst, vReg src, iRegIorL2I val, immI idx, vRegMas
              Matcher::vector_element_basic_type(n) == T_INT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "insert_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($v0$$reg));
@@ -5502,7 +5502,7 @@ instruct insert_index(vReg dst, vReg src, iRegIorL2I val, iRegIorL2I idx, vReg t
              Matcher::vector_element_basic_type(n) == T_INT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
-  ins_riscv_vset(riscv_vset_from_vect(this, req));
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "insert_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($v0$$reg));
@@ -5520,7 +5520,7 @@ instruct insertL_index_lt32(vReg dst, vReg src, iRegL val, immI idx, vRegMask_V0
             (Matcher::vector_element_basic_type(n) == T_LONG));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "insertL_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($v0$$reg));
@@ -5536,7 +5536,7 @@ instruct insertL_index(vReg dst, vReg src, iRegL val, iRegIorL2I idx, vReg tmp, 
             (Matcher::vector_element_basic_type(n) == T_LONG));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "insertL_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($v0$$reg));
@@ -5554,7 +5554,7 @@ instruct insertF_index_lt32(vReg dst, vReg src, fRegF val, immI idx, vRegMask_V0
             (Matcher::vector_element_basic_type(n) == T_FLOAT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "insertF_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($v0$$reg));
@@ -5570,7 +5570,7 @@ instruct insertF_index(vReg dst, vReg src, fRegF val, iRegIorL2I idx, vReg tmp, 
             (Matcher::vector_element_basic_type(n) == T_FLOAT));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_FLOAT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "insertF_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($v0$$reg));
@@ -5588,7 +5588,7 @@ instruct insertD_index_lt32(vReg dst, vReg src, fRegD val, immI idx, vRegMask_V0
             (Matcher::vector_element_basic_type(n) == T_DOUBLE));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "insertD_index_lt32 $dst, $src, $val, $idx" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($v0$$reg));
@@ -5604,7 +5604,7 @@ instruct insertD_index(vReg dst, vReg src, fRegD val, iRegIorL2I idx, vReg tmp, 
             (Matcher::vector_element_basic_type(n) == T_DOUBLE));
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP v0);
-  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req));
+  ins_riscv_vset(riscv_vset_fixed(T_DOUBLE, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "insertD_index $dst, $src, $val, $idx\t# KILL $tmp" %}
   ins_encode %{
     __ vid_v(as_VectorRegister($v0$$reg));

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -262,14 +262,15 @@ instruct vmaskcmp(vRegMask dst, vReg src1, vReg src2, immI cond) %{
             Matcher::vector_element_basic_type(n) == T_INT ||
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(Matcher::vector_element_basic_type(this), Matcher::vector_length(this), req, Assembler::m1, Assembler::ma));
   format %{ "vmaskcmp $dst, $src1, $src2, $cond" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vector_length = Matcher::vector_length(this);
     __ compare_integral_v(as_VectorRegister($dst$$reg),
                           as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                          (int)($cond$$constant), bt, vector_length);
+                          (int)($cond$$constant), bt, vector_length, Assembler::unmasked,
+                          false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -281,14 +282,15 @@ instruct vmaskcmp_masked(vRegMask dst, vReg src1, vReg src2, immI cond, vRegMask
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond v0)));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(Matcher::vector_element_basic_type(this), Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vmaskcmp_masked $dst, $src1, $src2, $cond, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vector_length = Matcher::vector_length(this);
     __ compare_integral_v(as_VectorRegister($dst$$reg),
                           as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                          (int)($cond$$constant), bt, vector_length, Assembler::v0_t);
+                          (int)($cond$$constant), bt, vector_length, Assembler::v0_t,
+                          false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -299,14 +301,15 @@ instruct vmaskcmp_fp(vRegMask dst, vReg src1, vReg src2, immI cond) %{
   predicate(Matcher::vector_element_basic_type(n) == T_FLOAT ||
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(Matcher::vector_element_basic_type(this), Matcher::vector_length(this), req, Assembler::m1, Assembler::ma));
   format %{ "vmaskcmp_fp $dst, $src1, $src2, $cond" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vector_length = Matcher::vector_length(this);
     __ compare_fp_v(as_VectorRegister($dst$$reg),
                     as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                    (int)($cond$$constant), bt, vector_length);
+                    (int)($cond$$constant), bt, vector_length, Assembler::unmasked,
+                          false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -316,14 +319,15 @@ instruct vmaskcmp_fp_masked(vRegMask dst, vReg src1, vReg src2, immI cond, vRegM
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond v0)));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(Matcher::vector_element_basic_type(this), Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vmaskcmp_fp_masked $dst, $src1, $src2, $cond, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vector_length = Matcher::vector_length(this);
     __ compare_fp_v(as_VectorRegister($dst$$reg),
                     as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                    (int)($cond$$constant), bt, vector_length, Assembler::v0_t);
+                    (int)($cond$$constant), bt, vector_length, Assembler::v0_t,
+                          false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1714,14 +1718,15 @@ instruct vminu_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 instruct vmax_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (MaxVHF src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vmax_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
     assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   T_SHORT, false /* is_min */, Matcher::vector_length(this));
+                   T_SHORT, false /* is_min */, Matcher::vector_length(this),
+                   false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1729,14 +1734,15 @@ instruct vmax_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
 instruct vmin_hfp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
   match(Set dst (MinVHF src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(T_SHORT, Matcher::vector_length(this), req, Assembler::m1, Assembler::mu));
   format %{ "vmin_hfp $dst, $src1, $src2" %}
   ins_encode %{
     assert(UseZvfh, "must");
     assert(Matcher::vector_element_basic_type(this) == T_SHORT, "must");
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   T_SHORT, true /* is_min */, Matcher::vector_length(this));
+                   T_SHORT, true /* is_min */, Matcher::vector_length(this),
+                   false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1748,13 +1754,14 @@ instruct vmax_fp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MaxV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmax_fp $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   bt, false /* is_min */, Matcher::vector_length(this));
+                   bt, false /* is_min */, Matcher::vector_length(this),
+                   false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1764,13 +1771,14 @@ instruct vmin_fp(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (MinV src1 src2));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmin_fp $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ minmax_fp_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
-                   bt, true /* is_min */, Matcher::vector_length(this));
+                   bt, true /* is_min */, Matcher::vector_length(this),
+                   false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1782,14 +1790,15 @@ instruct vmax_fp_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vRe
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst_src1 (MaxV (Binary dst_src1 src2) vmask));
   effect(TEMP_DEF dst_src1, TEMP tmp1, TEMP tmp2, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmax_fp_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ minmax_fp_masked_v(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                           as_VectorRegister($src2$$reg), as_VectorRegister($vmask$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          bt, false /* is_min */, Matcher::vector_length(this));
+                          bt, false /* is_min */, Matcher::vector_length(this),
+                          false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1799,14 +1808,15 @@ instruct vmin_fp_masked(vReg dst_src1, vReg src2, vRegMask vmask, vReg tmp1, vRe
             Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst_src1 (MinV (Binary dst_src1 src2) vmask));
   effect(TEMP_DEF dst_src1, TEMP tmp1, TEMP tmp2, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vmin_fp_masked $dst_src1, $dst_src1, $src2, $vmask\t# KILL $tmp1, $tmp2, $v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ minmax_fp_masked_v(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                           as_VectorRegister($src2$$reg), as_VectorRegister($vmask$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          bt, true /* is_min */, Matcher::vector_length(this));
+                          bt, true /* is_min */, Matcher::vector_length(this),
+                          false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2247,13 +2257,14 @@ instruct reduce_and(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AndReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_and $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2262,13 +2273,14 @@ instruct reduce_andL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AndReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_andL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2281,14 +2293,14 @@ instruct reduce_and_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AndReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_and_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2297,14 +2309,14 @@ instruct reduce_andL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AndReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_andL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2317,13 +2329,14 @@ instruct reduce_or(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (OrReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_or $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2332,13 +2345,14 @@ instruct reduce_orL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (OrReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_orL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2351,14 +2365,14 @@ instruct reduce_or_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (OrReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_or_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2367,14 +2381,14 @@ instruct reduce_orL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0,
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (OrReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_orL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2387,13 +2401,14 @@ instruct reduce_xor(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (XorReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_xor $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2402,13 +2417,14 @@ instruct reduce_xorL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (XorReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_xorL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2421,14 +2437,14 @@ instruct reduce_xor_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (XorReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_xor_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2437,14 +2453,14 @@ instruct reduce_xorL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (XorReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_xorL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2457,13 +2473,14 @@ instruct reduce_add(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_add $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2472,13 +2489,14 @@ instruct reduce_addL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AddReductionVL src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_addL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2495,7 +2513,7 @@ instruct reduce_addF_ordered(fRegF dst, fRegF src1, vReg src2, vReg tmp) %{
   predicate(n->as_Reduction()->requires_strict_order());
   match(Set dst (AddReductionVF src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_addF_ordered $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
@@ -2510,7 +2528,7 @@ instruct reduce_addF_unordered(fRegF dst, fRegF src1, vReg src2, vReg tmp) %{
   predicate(!n->as_Reduction()->requires_strict_order());
   match(Set dst (AddReductionVF src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_addF_unordered $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
@@ -2525,7 +2543,7 @@ instruct reduce_addD_ordered(fRegD dst, fRegD src1, vReg src2, vReg tmp) %{
   predicate(n->as_Reduction()->requires_strict_order());
   match(Set dst (AddReductionVD src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_addD_ordered $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
@@ -2540,7 +2558,7 @@ instruct reduce_addD_unordered(fRegD dst, fRegD src1, vReg src2, vReg tmp) %{
   predicate(!n->as_Reduction()->requires_strict_order());
   match(Set dst (AddReductionVD src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(riscv_vset_from_node(this, req));
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "reduce_addD_unordered $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     __ vfmv_s_f(as_VectorRegister($tmp$$reg), $src1$$FloatRegister);
@@ -2559,14 +2577,14 @@ instruct reduce_add_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (AddReductionVI (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_add_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2575,14 +2593,14 @@ instruct reduce_addL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (AddReductionVL (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "reduce_addL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2623,13 +2641,14 @@ instruct vreduce_max(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "vreduce_max $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2638,13 +2657,14 @@ instruct vreduce_maxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "vreduce_maxL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2657,14 +2677,14 @@ instruct vreduce_max_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreduce_max_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2673,14 +2693,14 @@ instruct vreduce_maxL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreduce_maxL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2693,13 +2713,14 @@ instruct vreduce_min(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MinReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "vreduce_min $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2708,13 +2729,14 @@ instruct vreduce_minL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MinReductionV src1 src2));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "vreduce_minL $dst, $src1, $src2\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
-                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2727,14 +2749,14 @@ instruct vreduce_min_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_
             Matcher::vector_element_basic_type(n->in(2)) == T_INT);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreduce_min_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2743,14 +2765,14 @@ instruct vreduce_minL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP tmp);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreduce_minL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     __ reduce_integral_v($dst$$Register, $src1$$Register,
                          as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
                          this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
-                         Assembler::v0_t);
+                         Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2761,13 +2783,14 @@ instruct vreduce_maxF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "vreduce_maxF $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          false /* is_double */, false /* is_min */, Matcher::vector_length(this, $src2));
+                          false /* is_double */, false /* is_min */, Matcher::vector_length(this, $src2),
+                          Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2776,13 +2799,14 @@ instruct vreduce_maxD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "vreduce_maxD $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          true /* is_double */, false /* is_min */, Matcher::vector_length(this, $src2));
+                          true /* is_double */, false /* is_min */, Matcher::vector_length(this, $src2),
+                          Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2793,14 +2817,14 @@ instruct vreduce_maxF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreduce_maxF_masked $dst, $src1, $src2, $v0\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
                           false /* is_double */, false /* is_min */,
-                          Matcher::vector_length(this, $src2), Assembler::v0_t);
+                          Matcher::vector_length(this, $src2), Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2809,14 +2833,14 @@ instruct vreduce_maxD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MaxReductionV (Binary src1 src2) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreduce_maxD_masked $dst, $src1, $src2, $v0\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
                           true /* is_double */, false /* is_min */,
-                          Matcher::vector_length(this, $src2), Assembler::v0_t);
+                          Matcher::vector_length(this, $src2), Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2827,13 +2851,14 @@ instruct vreduce_minF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MinReductionV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "vreduce_minF $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          false /* is_double */, true /* is_min */, Matcher::vector_length(this, $src2));
+                          false /* is_double */, true /* is_min */, Matcher::vector_length(this, $src2),
+                          Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2842,13 +2867,14 @@ instruct vreduce_minD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MinReductionV src1 src2));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::ma));
   format %{ "vreduce_minD $dst, $src1, $src2, $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          true /* is_double */, true /* is_min */, Matcher::vector_length(this, $src2));
+                          true /* is_double */, true /* is_min */, Matcher::vector_length(this, $src2),
+                          Assembler::unmasked, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2859,14 +2885,14 @@ instruct vreduce_minF_masked(fRegF dst, fRegF src1, vReg src2, vRegMask_V0 v0, v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreduce_minF_masked $dst, $src1, $src2, $v0\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
                           false /* is_double */, true /* is_min */,
-                          Matcher::vector_length(this, $src2), Assembler::v0_t);
+                          Matcher::vector_length(this, $src2), Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2875,14 +2901,14 @@ instruct vreduce_minD_masked(fRegD dst, fRegD src1, vReg src2, vRegMask_V0 v0, v
   predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE);
   match(Set dst (MinReductionV (Binary src1 src2) v0));
   effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_node(this, req, Assembler::m1, Assembler::mu));
   format %{ "vreduce_minD_masked $dst, $src1, $src2, $v0\t# KILL $tmp1, $tmp2" %}
   ins_encode %{
     __ reduce_minmax_fp_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
                           true /* is_double */, true /* is_min */,
-                          Matcher::vector_length(this, $src2), Assembler::v0_t);
+                          Matcher::vector_length(this, $src2), Assembler::v0_t, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4558,19 +4584,22 @@ instruct vblend(vReg dst, vReg src1, vReg src2, vRegMask_V0 v0) %{
 instruct vcvtBtoX(vReg dst, vReg src) %{
   match(Set dst (VectorCastB2X src));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(is_floating_point_type(Matcher::vector_element_basic_type(this)) ?
+                                  (Matcher::vector_element_basic_type(this) == T_FLOAT ? T_INT : T_LONG) :
+                                  Matcher::vector_element_basic_type(this),
+                                  Matcher::vector_length(this), req, Assembler::m1, Assembler::ma));
   format %{ "vcvtBtoX $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     if (is_floating_point_type(bt)) {
       __ integer_extend_v(as_VectorRegister($dst$$reg), bt == T_FLOAT ? T_INT : T_LONG,
                           Matcher::vector_length(this), as_VectorRegister($src$$reg), T_BYTE,
-                          true /* is_signed */);
+                          true /* is_signed */, false /* set_vtype */);
       __ vfcvt_f_x_v(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg));
     } else {
       __ integer_extend_v(as_VectorRegister($dst$$reg), bt,
                           Matcher::vector_length(this), as_VectorRegister($src$$reg), T_BYTE,
-                          true /* is_signed */);
+                          true /* is_signed */, false /* set_vtype */);
     }
   %}
   ins_pipe(pipe_slow);
@@ -4582,13 +4611,13 @@ instruct vcvtUBtoX(vReg dst, vReg src) %{
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorUCastB2X src));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::ma));
   format %{ "vcvtUBtoX $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ integer_extend_v(as_VectorRegister($dst$$reg), bt,
                         Matcher::vector_length(this), as_VectorRegister($src$$reg), T_BYTE,
-                        false /* is_signed */);
+                        false /* is_signed */, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4612,12 +4641,12 @@ instruct vcvtStoX(vReg dst, vReg src) %{
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorCastS2X src));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::ma));
   format %{ "vcvtStoX $dst, $src" %}
   ins_encode %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), Matcher::vector_element_basic_type(this),
                         Matcher::vector_length(this), as_VectorRegister($src$$reg), T_SHORT,
-                        true /* is_signed */);
+                        true /* is_signed */, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4646,12 +4675,12 @@ instruct vcvtUStoX(vReg dst, vReg src) %{
             Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorUCastS2X src));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::ma));
   format %{ "vcvtUStoX $dst, $src" %}
   ins_encode %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), Matcher::vector_element_basic_type(this),
                         Matcher::vector_length(this), as_VectorRegister($src$$reg), T_SHORT,
-                        false /* is_signed */);
+                        false /* is_signed */, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4676,12 +4705,12 @@ instruct vcvtItoL(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorCastI2X src));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::ma));
   format %{ "vcvtItoL $dst, $src" %}
   ins_encode %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), T_LONG,
                         Matcher::vector_length(this), as_VectorRegister($src$$reg), T_INT,
-                        true /* is_signed */);
+                        true /* is_signed */, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -4690,12 +4719,12 @@ instruct vcvtUItoL(vReg dst, vReg src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorUCastI2X src));
   effect(TEMP_DEF dst);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_fixed(T_LONG, Matcher::vector_length(this), req, Assembler::m1, Assembler::ma));
   format %{ "vcvtUItoL $dst, $src" %}
   ins_encode %{
     __ integer_extend_v(as_VectorRegister($dst$$reg), T_LONG,
                         Matcher::vector_length(this), as_VectorRegister($src$$reg), T_INT,
-                        false /* is_signed */);
+                        false /* is_signed */, false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5130,12 +5159,12 @@ instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
   match(Set dst (SignumVF dst (Binary zero one)));
   match(Set dst (SignumVD dst (Binary zero one)));
   effect(TEMP_DEF dst, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "vsignum $dst, $dst\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ signum_fp_v(as_VectorRegister($dst$$reg), as_VectorRegister($one$$reg),
-                   bt, Matcher::vector_length(this));
+                   bt, Matcher::vector_length(this), false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5145,13 +5174,14 @@ instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
 instruct vround_f(vReg dst, vReg src, fRegF tmp, vRegMask_V0 v0) %{
   match(Set dst (RoundVF src));
   effect(TEMP_DEF dst, TEMP tmp, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "java_round_float_v $dst, $src\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vector_length = Matcher::vector_length(this);
     __ java_round_float_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
-                          as_FloatRegister($tmp$$reg), bt, vector_length);
+                          as_FloatRegister($tmp$$reg), bt, vector_length,
+                          false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5159,13 +5189,14 @@ instruct vround_f(vReg dst, vReg src, fRegF tmp, vRegMask_V0 v0) %{
 instruct vround_d(vReg dst, vReg src, fRegD tmp, vRegMask_V0 v0) %{
   match(Set dst (RoundVD src));
   effect(TEMP_DEF dst, TEMP tmp, TEMP v0);
-  ins_riscv_vset(false);
+  ins_riscv_vset(riscv_vset_from_vect(this, req, Assembler::m1, Assembler::mu));
   format %{ "java_round_double_v $dst, $src\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vector_length = Matcher::vector_length(this);
     __ java_round_double_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg),
-                           as_FloatRegister($tmp$$reg), bt, vector_length);
+                           as_FloatRegister($tmp$$reg), bt, vector_length,
+                           false /* set_vtype */);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_vset_machnode.cpp
+++ b/src/hotspot/cpu/riscv/riscv_vset_machnode.cpp
@@ -32,7 +32,8 @@
 #include "utilities/globalDefinitions.hpp"
 
 static bool set_riscv_vset_requirement(const TypeVect* vt, RiscVVSetRequirement* req,
-                                       Assembler::LMUL vlmul) {
+                                       Assembler::LMUL vlmul,
+                                       Assembler::VMA vma, Assembler::VTA vta) {
   if (vt == nullptr) {
     return false;
   }
@@ -43,18 +44,22 @@ static bool set_riscv_vset_requirement(const TypeVect* vt, RiscVVSetRequirement*
   req->_bt = bt;
   req->_vector_length = vt->length();
   req->_vlmul = vlmul;
+  req->_vma = vma;
+  req->_vta = vta;
   req->_valid = true;
   return true;
 }
 
 bool riscv_vset_from_vect(const MachNode* node, RiscVVSetRequirement* req,
-                          Assembler::LMUL vlmul) {
+                          Assembler::LMUL vlmul,
+                          Assembler::VMA vma, Assembler::VTA vta) {
   const Type* type = node->bottom_type();
-  return type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul);
+  return type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul, vma, vta);
 }
 
 bool riscv_vset_from_node(BasicType bt, const MachNode* node, RiscVVSetRequirement* req,
-                          Assembler::LMUL vlmul) {
+                          Assembler::LMUL vlmul,
+                          Assembler::VMA vma, Assembler::VTA vta) {
   const Type* type = node->bottom_type();
   const TypeVect* vt = type != nullptr ? type->isa_vect() : nullptr;
   for (uint i = node->oper_input_base(); vt == nullptr && i < node->req(); i++) {
@@ -62,18 +67,19 @@ bool riscv_vset_from_node(BasicType bt, const MachNode* node, RiscVVSetRequireme
     type = input != nullptr ? input->bottom_type() : nullptr;
     vt = type != nullptr ? type->isa_vect() : nullptr;
   }
-  return vt != nullptr && riscv_vset_fixed(bt, vt->length(), req, vlmul);
+  return vt != nullptr && riscv_vset_fixed(bt, vt->length(), req, vlmul, vma, vta);
 }
 
 bool riscv_vset_from_node(const MachNode* node, RiscVVSetRequirement* req,
-                          Assembler::LMUL vlmul) {
-  if (riscv_vset_from_vect(node, req, vlmul)) {
+                          Assembler::LMUL vlmul,
+                          Assembler::VMA vma, Assembler::VTA vta) {
+  if (riscv_vset_from_vect(node, req, vlmul, vma, vta)) {
     return true;
   }
   for (uint i = node->oper_input_base(); i < node->req(); i++) {
     Node* input = node->in(i);
     const Type* type = input != nullptr ? input->bottom_type() : nullptr;
-    if (type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul)) {
+    if (type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul, vma, vta)) {
       return true;
     }
   }
@@ -81,31 +87,35 @@ bool riscv_vset_from_node(const MachNode* node, RiscVVSetRequirement* req,
 }
 
 bool riscv_vset_from_operand(const MachNode* node, const MachOper* opnd,
-                             RiscVVSetRequirement* req, Assembler::LMUL vlmul) {
+                             RiscVVSetRequirement* req, Assembler::LMUL vlmul,
+                             Assembler::VMA vma, Assembler::VTA vta) {
   int def_idx = node->operand_index(opnd);
   if (def_idx < 0) {
     return false;
   }
   Node* input = node->in(def_idx);
   const Type* type = input != nullptr ? input->bottom_type() : nullptr;
-  return type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul);
+  return type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul, vma, vta);
 }
 
 bool riscv_vset_fixed(BasicType bt, uint vector_length, RiscVVSetRequirement* req,
-                      Assembler::LMUL vlmul) {
+                      Assembler::LMUL vlmul,
+                      Assembler::VMA vma, Assembler::VTA vta) {
   req->_bt = bt;
   req->_vector_length = vector_length;
   req->_vlmul = vlmul;
+  req->_vma = vma;
+  req->_vta = vta;
   req->_valid = true;
   return true;
 }
 
 RiscVVSetState MachRiscVVSetNode::state() const {
-  return { _bt, Assembler::elemtype_to_sew(_bt), _vector_length, _vlmul, true };
+  return { _bt, Assembler::elemtype_to_sew(_bt), _vector_length, _vlmul, _vma, _vta, true };
 }
 
 void MachRiscVVSetNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc*) const {
-  masm->vsetvli_helper(_bt, _vector_length, _vlmul);
+  masm->vsetvli_helper(_bt, _vector_length, _vlmul, _vma, _vta);
 }
 
 uint MachRiscVVSetNode::size(PhaseRegAlloc*) const {
@@ -118,7 +128,7 @@ uint MachRiscVVSetNode::size(PhaseRegAlloc*) const {
 
 #ifndef PRODUCT
 void MachRiscVVSetNode::format(PhaseRegAlloc*, outputStream* st) const {
-  st->print("vset %s, length=%u, lmul=%d",
-            type2name(_bt), _vector_length, (int)_vlmul);
+  st->print("vset %s, length=%u, lmul=%d, vma=%d, vta=%d",
+            type2name(_bt), _vector_length, (int)_vlmul, (int)_vma, (int)_vta);
 }
 #endif

--- a/src/hotspot/cpu/riscv/riscv_vset_machnode.cpp
+++ b/src/hotspot/cpu/riscv/riscv_vset_machnode.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "nativeInst_riscv.hpp"
+#include "opto/c2_MacroAssembler.hpp"
+#include "opto/compile.hpp"
+#include "opto/matcher.hpp"
+#include "opto/output.hpp"
+#include "opto/regalloc.hpp"
+#include "riscv_vset_machnode.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+static bool set_riscv_vset_requirement(const TypeVect* vt, RiscVVSetRequirement* req,
+                                       Assembler::LMUL vlmul) {
+  if (vt == nullptr) {
+    return false;
+  }
+  BasicType bt = vt->element_basic_type();
+  if (bt == T_BOOLEAN) {
+    return false;
+  }
+  req->_bt = bt;
+  req->_vector_length = vt->length();
+  req->_vlmul = vlmul;
+  req->_valid = true;
+  return true;
+}
+
+bool riscv_vset_from_vect(const MachNode* node, RiscVVSetRequirement* req,
+                          Assembler::LMUL vlmul) {
+  const Type* type = node->bottom_type();
+  return type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul);
+}
+
+bool riscv_vset_from_node(BasicType bt, const MachNode* node, RiscVVSetRequirement* req,
+                          Assembler::LMUL vlmul) {
+  const Type* type = node->bottom_type();
+  const TypeVect* vt = type != nullptr ? type->isa_vect() : nullptr;
+  for (uint i = node->oper_input_base(); vt == nullptr && i < node->req(); i++) {
+    Node* input = node->in(i);
+    type = input != nullptr ? input->bottom_type() : nullptr;
+    vt = type != nullptr ? type->isa_vect() : nullptr;
+  }
+  return vt != nullptr && riscv_vset_fixed(bt, vt->length(), req, vlmul);
+}
+
+bool riscv_vset_from_node(const MachNode* node, RiscVVSetRequirement* req,
+                          Assembler::LMUL vlmul) {
+  if (riscv_vset_from_vect(node, req, vlmul)) {
+    return true;
+  }
+  for (uint i = node->oper_input_base(); i < node->req(); i++) {
+    Node* input = node->in(i);
+    const Type* type = input != nullptr ? input->bottom_type() : nullptr;
+    if (type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool riscv_vset_from_operand(const MachNode* node, const MachOper* opnd,
+                             RiscVVSetRequirement* req, Assembler::LMUL vlmul) {
+  int def_idx = node->operand_index(opnd);
+  if (def_idx < 0) {
+    return false;
+  }
+  Node* input = node->in(def_idx);
+  const Type* type = input != nullptr ? input->bottom_type() : nullptr;
+  return type != nullptr && set_riscv_vset_requirement(type->isa_vect(), req, vlmul);
+}
+
+bool riscv_vset_fixed(BasicType bt, uint vector_length, RiscVVSetRequirement* req,
+                      Assembler::LMUL vlmul) {
+  req->_bt = bt;
+  req->_vector_length = vector_length;
+  req->_vlmul = vlmul;
+  req->_valid = true;
+  return true;
+}
+
+RiscVVSetState MachRiscVVSetNode::state() const {
+  return { _bt, Assembler::elemtype_to_sew(_bt), _vector_length, _vlmul, true };
+}
+
+void MachRiscVVSetNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc*) const {
+  masm->vsetvli_helper(_bt, _vector_length, _vlmul);
+}
+
+uint MachRiscVVSetNode::size(PhaseRegAlloc*) const {
+  if (_vector_length <= 31 ||
+      _vector_length == (MaxVectorSize / type2aelembytes(_bt))) {
+    return NativeInstruction::instruction_size;
+  }
+  return 2 * NativeInstruction::instruction_size;
+}
+
+#ifndef PRODUCT
+void MachRiscVVSetNode::format(PhaseRegAlloc*, outputStream* st) const {
+  st->print("vset %s, length=%u, lmul=%d",
+            type2name(_bt), _vector_length, (int)_vlmul);
+}
+#endif

--- a/src/hotspot/cpu/riscv/riscv_vset_machnode.cpp
+++ b/src/hotspot/cpu/riscv/riscv_vset_machnode.cpp
@@ -110,6 +110,69 @@ bool riscv_vset_fixed(BasicType bt, uint vector_length, RiscVVSetRequirement* re
   return true;
 }
 
+bool riscv_vset_state_same(const RiscVVSetState& a, const RiscVVSetState& b) {
+  return a._valid == b._valid &&
+         (!a._valid ||
+          (a._sew == b._sew &&
+           a._vector_length == b._vector_length &&
+           a._vlmul == b._vlmul &&
+           a._vma == b._vma &&
+           a._vta == b._vta));
+}
+
+bool riscv_vset_state_equal_valid(const RiscVVSetState& a, const RiscVVSetState& b) {
+  return a._valid && b._valid &&
+         a._sew == b._sew &&
+         a._vector_length == b._vector_length &&
+         a._vlmul == b._vlmul &&
+         a._vma == b._vma &&
+         a._vta == b._vta;
+}
+
+RiscVVSetState riscv_vset_invalid_state() {
+  return { T_BYTE, Assembler::e8, 0, Assembler::m1, Assembler::ma, Assembler::ta, false };
+}
+
+bool riscv_mach_node_vset_requirement(const MachNode* mach, RiscVVSetState* state) {
+  if (mach->is_MachCall() || mach->is_MachSafePoint()) {
+    return false;
+  }
+  if (mach->is_MachRiscVVSet()) {
+    return false;
+  }
+
+  RiscVVSetRequirement req = { T_BYTE, 0, Assembler::m1, Assembler::ma, Assembler::ta, false };
+  if (mach->has_riscv_vset_requirement()) {
+    if (!mach->riscv_vset_requirement(&req)) {
+      return false;
+    }
+    *state = { req._bt, Assembler::elemtype_to_sew(req._bt), req._vector_length, req._vlmul,
+               req._vma, req._vta, true };
+    return true;
+  }
+  return false;
+}
+
+bool riscv_mach_node_kills_vset(const MachNode* mach) {
+  if (mach->is_MachCall() || mach->is_MachSafePoint()) {
+    return true;
+  }
+  if (mach->is_MachRiscVVSet()) {
+    return false;
+  }
+  if (mach->is_MachSpillCopy()) {
+    const Type* type = mach->bottom_type();
+    if (type != nullptr && (type->isa_vect() != nullptr || type->isa_pvectmask() != nullptr)) {
+      return true;
+    }
+  }
+  RiscVVSetRequirement req = { T_BYTE, 0, Assembler::m1, Assembler::ma, Assembler::ta, false };
+  if (mach->has_riscv_vset_requirement()) {
+    return !mach->riscv_vset_requirement(&req);
+  }
+  return riscv_vset_from_node(mach, &req);
+}
+
 RiscVVSetState MachRiscVVSetNode::state() const {
   return { _bt, Assembler::elemtype_to_sew(_bt), _vector_length, _vlmul, _vma, _vta, true };
 }

--- a/src/hotspot/cpu/riscv/riscv_vset_machnode.hpp
+++ b/src/hotspot/cpu/riscv/riscv_vset_machnode.hpp
@@ -33,6 +33,8 @@ struct RiscVVSetState {
   Assembler::SEW _sew;
   uint _vector_length;
   Assembler::LMUL _vlmul;
+  Assembler::VMA _vma;
+  Assembler::VTA _vta;
   bool _valid;
 };
 
@@ -40,14 +42,19 @@ class MachRiscVVSetNode : public MachIdealNode {
   BasicType _bt;
   uint _vector_length;
   Assembler::LMUL _vlmul;
+  Assembler::VMA _vma;
+  Assembler::VTA _vta;
 
  public:
-  MachRiscVVSetNode(BasicType bt, uint vector_length, Assembler::LMUL vlmul) :
-    _bt(bt), _vector_length(vector_length), _vlmul(vlmul) {}
+  MachRiscVVSetNode(BasicType bt, uint vector_length, Assembler::LMUL vlmul,
+                    Assembler::VMA vma = Assembler::ma, Assembler::VTA vta = Assembler::ta) :
+    _bt(bt), _vector_length(vector_length), _vlmul(vlmul), _vma(vma), _vta(vta) {}
 
   BasicType element_basic_type() const { return _bt; }
   uint vector_length() const { return _vector_length; }
   Assembler::LMUL vlmul() const { return _vlmul; }
+  Assembler::VMA vma() const { return _vma; }
+  Assembler::VTA vta() const { return _vta; }
 
   RiscVVSetState state() const;
 

--- a/src/hotspot/cpu/riscv/riscv_vset_machnode.hpp
+++ b/src/hotspot/cpu/riscv/riscv_vset_machnode.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV_RISCV_VSET_MACHNODE_HPP
+#define CPU_RISCV_RISCV_VSET_MACHNODE_HPP
+
+#include "opto/machnode.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+struct RiscVVSetState {
+  BasicType _bt;
+  Assembler::SEW _sew;
+  uint _vector_length;
+  Assembler::LMUL _vlmul;
+  bool _valid;
+};
+
+class MachRiscVVSetNode : public MachIdealNode {
+  BasicType _bt;
+  uint _vector_length;
+  Assembler::LMUL _vlmul;
+
+ public:
+  MachRiscVVSetNode(BasicType bt, uint vector_length, Assembler::LMUL vlmul) :
+    _bt(bt), _vector_length(vector_length), _vlmul(vlmul) {}
+
+  BasicType element_basic_type() const { return _bt; }
+  uint vector_length() const { return _vector_length; }
+  Assembler::LMUL vlmul() const { return _vlmul; }
+
+  RiscVVSetState state() const;
+
+  virtual void emit(C2_MacroAssembler* masm, PhaseRegAlloc* ra_) const;
+  virtual uint size(PhaseRegAlloc* ra_) const;
+  virtual const class Type* bottom_type() const { return Type::CONTROL; }
+  virtual int ideal_Opcode() const { return Op_Con; }
+  virtual uint size_of() const { return sizeof(MachRiscVVSetNode); }
+  virtual bool is_MachRiscVVSet() const { return true; }
+  virtual MachRiscVVSetNode* as_MachRiscVVSet() { return this; }
+
+#ifndef PRODUCT
+  virtual const char* Name() const { return "RiscVVSet"; }
+  virtual void format(PhaseRegAlloc*, outputStream* st) const;
+  virtual void dump_spec(outputStream* st) const {}
+#endif
+};
+
+#endif // CPU_RISCV_RISCV_VSET_MACHNODE_HPP

--- a/src/hotspot/cpu/riscv/riscv_vset_machnode.hpp
+++ b/src/hotspot/cpu/riscv/riscv_vset_machnode.hpp
@@ -38,6 +38,12 @@ struct RiscVVSetState {
   bool _valid;
 };
 
+bool riscv_vset_state_same(const RiscVVSetState& a, const RiscVVSetState& b);
+bool riscv_vset_state_equal_valid(const RiscVVSetState& a, const RiscVVSetState& b);
+RiscVVSetState riscv_vset_invalid_state();
+bool riscv_mach_node_vset_requirement(const MachNode* mach, RiscVVSetState* state);
+bool riscv_mach_node_kills_vset(const MachNode* mach);
+
 class MachRiscVVSetNode : public MachIdealNode {
   BasicType _bt;
   uint _vector_length;

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -2717,6 +2717,27 @@ void ArchDesc::defineEmit(FILE* fp, InstructForm& inst) {
   fprintf(fp, "}\n\n");
 }
 
+static const char* ins_riscv_vset_attr(InstructForm& inst) {
+  Attribute* attr = inst._attribs;
+  while (attr != nullptr) {
+    if (strcmp(attr->_ident, "ins_riscv_vset") == 0) {
+      return attr->_val;
+    }
+    attr = (Attribute*)attr->_next;
+  }
+  return nullptr;
+}
+
+static void define_riscv_vset_requirement(FILE* fp, InstructForm& inst) {
+  const char* attr = ins_riscv_vset_attr(inst);
+  if (attr == nullptr) {
+    return;
+  }
+  fprintf(fp, "bool %sNode::riscv_vset_requirement(RiscVVSetRequirement* req) const {\n", inst._ident);
+  fprintf(fp, "  return %s;\n", attr);
+  fprintf(fp, "}\n\n");
+}
+
 // defineEvalConstant ---------------------------------------------------------
 void ArchDesc::defineEvalConstant(FILE* fp, InstructForm& inst) {
   InsEncode* encode = inst._constant;
@@ -3205,6 +3226,12 @@ void ArchDesc::defineClasses(FILE *fp) {
       fprintf(fp,"  *block_num = oper->_block_num;\n");
       fprintf(fp,"}\n");
     }
+  }
+
+  _instructions.reset();
+  while ((instr = (InstructForm*)_instructions.iter()) != nullptr) {
+    if (instr->ideal_only()) continue;
+    define_riscv_vset_requirement(fp, *instr);
   }
 
   // Output the definitions for methods

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -1580,11 +1580,15 @@ void ArchDesc::declareClasses(FILE *fp) {
         fprintf(fp, "  virtual bool           is_TrapBasedCheckNode() const { return %s; }\n", attr->_val);
       } else if (strcmp (attr->_ident, "ins_is_late_expanded_null_check_candidate") == 0) {
         fprintf(fp, "  virtual bool           is_late_expanded_null_check_candidate() const { return %s; }\n", attr->_val);
+      } else if (strcmp (attr->_ident, "ins_riscv_vset") == 0) {
+        fprintf(fp, "  virtual bool           has_riscv_vset_requirement() const { return true; }\n");
+        fprintf(fp, "  virtual bool           riscv_vset_requirement(RiscVVSetRequirement* req) const;\n");
       } else if (strcmp (attr->_ident, "ins_cost") != 0 &&
           strncmp(attr->_ident, "ins_field_", 10) != 0 &&
           // Must match function in node.hpp: return type bool, no prefix "ins_".
           strcmp (attr->_ident, "ins_is_TrapBasedCheckNode") != 0 &&
-          strcmp (attr->_ident, "ins_short_branch") != 0) {
+          strcmp (attr->_ident, "ins_short_branch") != 0 &&
+          strcmp (attr->_ident, "ins_riscv_vset") != 0) {
         fprintf(fp, "  virtual int            %s() const { return %s; }\n", attr->_ident, attr->_val);
       }
       if (strcmp(attr->_ident, "ins_avoid_back_to_back") == 0) {

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -36,6 +36,9 @@
 #include "opto/rootnode.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/powerOfTwo.hpp"
+#ifdef RISCV
+#include "riscv_vset_machnode.hpp"
+#endif
 
 void Block_Array::grow(uint i) {
   assert(i >= Max(), "Should have been checked before, use maybe_grow?");
@@ -510,24 +513,48 @@ uint PhaseCFG::build_cfg() {
 
 // Inserts a goto & corresponding basic block between
 // block[block_no] and its succ_no'th successor block
-void PhaseCFG::insert_goto_at(uint block_no, uint succ_no) {
+Block* PhaseCFG::insert_goto_at(uint block_no, uint succ_no) {
   // get block with block_no
   assert(block_no < number_of_blocks(), "illegal block number");
   Block* in  = get_block(block_no);
   // get successor block succ_no
   assert(succ_no < in->_num_succs, "illegal successor number");
   Block* out = in->_succs[succ_no];
+  // Get the control corresponding to the succ_no'th successor of the in block.
+  // Most successor slots are projections, but a fall-through edge can be
+  // represented directly by the block-ending branch node before fixup_flow().
+  Node* slot_ctrl = in->get_node(in->number_of_nodes() - in->_num_succs + succ_no);
+  Node* edge_ctrl = slot_ctrl;
+  assert(edge_ctrl->is_Proj() || edge_ctrl == in->end(),
+         "successor control must be a projection or the block end");
+  bool found_edge_ctrl = false;
+  for (uint i = 1; i < out->num_preds(); i++) {
+    if (out->pred(i) == edge_ctrl) {
+      found_edge_ctrl = true;
+      break;
+    }
+  }
+  if (!found_edge_ctrl) {
+    for (uint i = 1; i < out->num_preds(); i++) {
+      Node* pred = out->pred(i);
+      if (get_block_for_node(pred) == in) {
+        edge_ctrl = pred;
+        found_edge_ctrl = true;
+        break;
+      }
+    }
+  }
+  assert(found_edge_ctrl, "successor predecessor must match the split edge");
   // Compute frequency of the new block. Do this before inserting
   // new block in case succ_prob() needs to infer the probability from
   // surrounding blocks.
-  float freq = in->_freq * in->succ_prob(succ_no);
-  // get ProjNode corresponding to the succ_no'th successor of the in block
-  ProjNode* proj = in->get_node(in->number_of_nodes() - in->_num_succs + succ_no)->as_Proj();
+  float freq = slot_ctrl->is_Proj() ? in->_freq * in->succ_prob(succ_no) : in->_freq;
   // create region for basic block
   RegionNode* region = new RegionNode(2);
-  region->init_req(1, proj);
+  region->init_req(1, edge_ctrl);
   // setup corresponding basic block
   Block* block = new (_block_arena) Block(_block_arena, region);
+  block->_loop = in->_loop;
   map_node_to_block(region, block);
   C->regalloc()->set_bad(region->_idx);
   // add a goto node
@@ -540,9 +567,14 @@ void PhaseCFG::insert_goto_at(uint block_no, uint succ_no) {
   // hook up successor block
   block->_succs.map(block->_num_succs++, out);
   // remap successor's predecessors if necessary
+  DEBUG_ONLY(bool remapped = false;)
   for (uint i = 1; i < out->num_preds(); i++) {
-    if (out->pred(i) == proj) out->head()->set_req(i, gto);
+    if (out->pred(i) == edge_ctrl) {
+      out->head()->set_req(i, gto);
+      DEBUG_ONLY(remapped = true;)
+    }
   }
+  assert(remapped, "successor predecessor must match the split edge");
   // remap predecessor's successor to new block
   in->_succs.map(succ_no, block);
   // Set the frequency of the new block
@@ -555,7 +587,7 @@ void PhaseCFG::insert_goto_at(uint block_no, uint succ_no) {
   if (out->_idom != in) {
     // The successor block was not immediately dominated by the predecessor
     // block, so there is no dominator subtree to update.
-    return;
+    return block;
   }
   // Update immediate dominator of the successor block.
   out->_idom = block;
@@ -591,7 +623,168 @@ void PhaseCFG::insert_goto_at(uint block_no, uint succ_no) {
       }
     }
   }
+  return block;
 }
+
+#ifdef RISCV
+static bool riscv_block_is_in_loop_nest(CFGLoop* loop, Block* block) {
+  return loop != nullptr && block != nullptr && block->_loop != nullptr && loop->in_loop_nest(block);
+}
+
+static bool riscv_is_loop_header(Block* block) {
+  return block != nullptr && block->head()->is_Loop() &&
+         block->_loop != nullptr && block->_loop->head() == block;
+}
+
+static bool riscv_analyze_loop_vset_requirements(PhaseCFG* cfg, CFGLoop* loop, RiscVVSetState* state) {
+  bool found = false;
+  RiscVVSetState only = riscv_vset_invalid_state();
+
+  for (uint i = 0; i < cfg->number_of_blocks(); i++) {
+    Block* block = cfg->get_block(i);
+    if (!riscv_block_is_in_loop_nest(loop, block)) {
+      continue;
+    }
+    // Keep the first version conservative: do not hoist across nested loops.
+    if (block->_loop != loop) {
+      return false;
+    }
+    for (uint j = 0; j < block->number_of_nodes(); j++) {
+      Node* n = block->get_node(j);
+      if (!n->is_Mach()) {
+        continue;
+      }
+      MachNode* mach = n->as_Mach();
+      RiscVVSetState required = riscv_vset_invalid_state();
+      if (riscv_mach_node_vset_requirement(mach, &required)) {
+        if (!found) {
+          only = required;
+          found = true;
+        } else if (!riscv_vset_state_equal_valid(only, required)) {
+          return false;
+        }
+      } else if (riscv_mach_node_kills_vset(mach)) {
+        return false;
+      }
+    }
+  }
+
+  if (!found) {
+    return false;
+  }
+  *state = only;
+  return true;
+}
+
+static bool riscv_find_block_no(PhaseCFG* cfg, Block* block, uint* block_no) {
+  for (uint i = 0; i < cfg->number_of_blocks(); i++) {
+    if (cfg->get_block(i) == block) {
+      *block_no = i;
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool riscv_find_loop_entry_edges(PhaseCFG* cfg, CFGLoop* loop,
+                                        GrowableArray<Block*>* entries,
+                                        GrowableArray<uint>* succs) {
+  Block* head = loop->head();
+  uint entry_count = 0;
+  uint backedge_count = 0;
+
+  for (uint p = 1; p < head->num_preds(); p++) {
+    Block* pred_block = cfg->get_block_for_node(head->pred(p));
+    if (pred_block == nullptr) {
+      return false;
+    }
+    if (riscv_block_is_in_loop_nest(loop, pred_block)) {
+      backedge_count++;
+    } else {
+      uint succ_no = 0;
+      bool found_succ = false;
+      for (uint s = 0; s < pred_block->_num_succs; s++) {
+        if (pred_block->_succs[s] == head) {
+          succ_no = s;
+          found_succ = true;
+          break;
+        }
+      }
+      if (!found_succ) {
+        return false;
+      }
+
+      Node* entry_ctrl = head->pred(p);
+      if (!pred_block->contains(entry_ctrl)) {
+        return false;
+      }
+      Node* entry_succ = pred_block->get_node(pred_block->number_of_nodes() -
+                                              pred_block->_num_succs + succ_no);
+      if (!entry_succ->is_Proj() && entry_succ != pred_block->end() &&
+          !entry_ctrl->is_Proj() && entry_ctrl != pred_block->end()) {
+        return false;
+      }
+
+      entries->append(pred_block);
+      succs->append(succ_no);
+      entry_count++;
+    }
+  }
+
+  return entry_count != 0 && backedge_count != 0;
+}
+
+static MachRiscVVSetNode* riscv_insert_vset_in_edge_block(PhaseCFG* cfg, Block* block, const RiscVVSetState& state) {
+  MachRiscVVSetNode* vset = new MachRiscVVSetNode(state._bt, state._vector_length, state._vlmul,
+                                                  state._vma, state._vta);
+  uint insert_pos = block->number_of_nodes() - block->_num_succs;
+  assert(insert_pos > 0, "must insert after block head");
+  block->insert_node(vset, insert_pos);
+  cfg->map_node_to_block(vset, block);
+  Compile::current()->regalloc()->set_bad(vset->_idx);
+  return vset;
+}
+
+void PhaseCFG::hoist_riscv_vset_before_fixup() {
+  if (!UseRiscVVSetLICM) {
+    return;
+  }
+
+  for (uint i = 0; i < number_of_blocks(); i++) {
+    Block* head = get_block(i);
+    if (!riscv_is_loop_header(head)) {
+      continue;
+    }
+
+    RiscVVSetState state = riscv_vset_invalid_state();
+    if (!riscv_analyze_loop_vset_requirements(this, head->_loop, &state)) {
+      continue;
+    }
+
+    GrowableArray<Block*> entries;
+    GrowableArray<uint> succs;
+    if (!riscv_find_loop_entry_edges(this, head->_loop, &entries, &succs)) {
+      continue;
+    }
+
+    for (int e = 0; e < entries.length(); e++) {
+      Block* entry = entries.at(e);
+      uint succ_no = succs.at(e);
+      uint pred_block_no = 0;
+      if (!riscv_find_block_no(this, entry, &pred_block_no)) {
+        continue;
+      }
+      Block* edge_block = insert_goto_at(pred_block_no, succ_no);
+      riscv_insert_vset_in_edge_block(this, edge_block, state);
+
+      // Skip the newly inserted block in this scan.
+      if (pred_block_no <= i) {
+        i++;
+      }
+    }
+  }
+}
+#endif
 
 // Does this block end in a multiway branch that cannot have the default case
 // flipped for another case?

--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -510,7 +510,7 @@ class PhaseCFG : public Phase {
   bool move_to_next(Block* bx, uint b_index);
   void move_to_end(Block* bx, uint b_index);
 
-  void insert_goto_at(uint block_no, uint succ_no);
+  Block* insert_goto_at(uint block_no, uint succ_no);
 
   // Check for NeverBranch at block end.  This needs to become a GOTO to the
   // true target.  NeverBranch are treated as a conditional branch that always
@@ -638,6 +638,10 @@ class PhaseCFG : public Phase {
 
   // Check all nodes and postalloc_expand them if necessary.
   void postalloc_expand(PhaseRegAlloc* _ra);
+
+#ifdef RISCV
+  void hoist_riscv_vset_before_fixup();
+#endif
 
 #ifndef PRODUCT
   bool trace_opto_pipelining() const { return _trace_opto_pipelining; }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3133,6 +3133,9 @@ void Compile::Code_Gen() {
     } else {
       cfg.set_loop_alignment();
     }
+#ifdef RISCV
+    cfg.hoist_riscv_vset_before_fixup();
+#endif
     cfg.fixup_flow();
     cfg.remove_unreachable_blocks();
     cfg.verify_dominator_tree();

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -63,20 +63,32 @@ struct RiscVVSetRequirement {
   BasicType _bt;
   uint _vector_length;
   Assembler::LMUL _vlmul;
+  Assembler::VMA _vma;
+  Assembler::VTA _vta;
   bool _valid;
 };
 
 bool riscv_vset_from_vect(const MachNode* node, RiscVVSetRequirement* req,
-                          Assembler::LMUL vlmul = Assembler::m1);
+                          Assembler::LMUL vlmul = Assembler::m1,
+                          Assembler::VMA vma = Assembler::ma,
+                          Assembler::VTA vta = Assembler::ta);
 bool riscv_vset_from_node(BasicType bt, const MachNode* node, RiscVVSetRequirement* req,
-                          Assembler::LMUL vlmul = Assembler::m1);
+                          Assembler::LMUL vlmul = Assembler::m1,
+                          Assembler::VMA vma = Assembler::ma,
+                          Assembler::VTA vta = Assembler::ta);
 bool riscv_vset_from_node(const MachNode* node, RiscVVSetRequirement* req,
-                          Assembler::LMUL vlmul = Assembler::m1);
+                          Assembler::LMUL vlmul = Assembler::m1,
+                          Assembler::VMA vma = Assembler::ma,
+                          Assembler::VTA vta = Assembler::ta);
 bool riscv_vset_from_operand(const MachNode* node, const MachOper* opnd,
                              RiscVVSetRequirement* req,
-                             Assembler::LMUL vlmul = Assembler::m1);
+                             Assembler::LMUL vlmul = Assembler::m1,
+                             Assembler::VMA vma = Assembler::ma,
+                             Assembler::VTA vta = Assembler::ta);
 bool riscv_vset_fixed(BasicType bt, uint vector_length, RiscVVSetRequirement* req,
-                      Assembler::LMUL vlmul = Assembler::m1);
+                      Assembler::LMUL vlmul = Assembler::m1,
+                      Assembler::VMA vma = Assembler::ma,
+                      Assembler::VTA vta = Assembler::ta);
 #endif
 
 //---------------------------MachOper------------------------------------------

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -44,17 +44,40 @@ class MachCallRuntimeNode;
 class MachCallStaticJavaNode;
 class MachEpilogNode;
 class MachIfNode;
+class MachNode;
 class MachNullCheckNode;
 class MachOper;
 class MachProjNode;
 class MachPrologNode;
 class MachReturnNode;
+class MachRiscVVSetNode;
 class MachSafePointNode;
 class MachSpillCopyNode;
 class Matcher;
 class PhaseRegAlloc;
 class RegMask;
 class State;
+
+#ifdef RISCV
+struct RiscVVSetRequirement {
+  BasicType _bt;
+  uint _vector_length;
+  Assembler::LMUL _vlmul;
+  bool _valid;
+};
+
+bool riscv_vset_from_vect(const MachNode* node, RiscVVSetRequirement* req,
+                          Assembler::LMUL vlmul = Assembler::m1);
+bool riscv_vset_from_node(BasicType bt, const MachNode* node, RiscVVSetRequirement* req,
+                          Assembler::LMUL vlmul = Assembler::m1);
+bool riscv_vset_from_node(const MachNode* node, RiscVVSetRequirement* req,
+                          Assembler::LMUL vlmul = Assembler::m1);
+bool riscv_vset_from_operand(const MachNode* node, const MachOper* opnd,
+                             RiscVVSetRequirement* req,
+                             Assembler::LMUL vlmul = Assembler::m1);
+bool riscv_vset_fixed(BasicType bt, uint vector_length, RiscVVSetRequirement* req,
+                      Assembler::LMUL vlmul = Assembler::m1);
+#endif
 
 //---------------------------MachOper------------------------------------------
 class MachOper : public ResourceObj {
@@ -248,6 +271,13 @@ public:
 
   // Support for short branches
   bool may_be_short_branch() const { return (flags() & Flag_may_be_short_branch) != 0; }
+
+  virtual bool is_MachRiscVVSet() const { return false; }
+  virtual MachRiscVVSetNode* as_MachRiscVVSet() { return nullptr; }
+#ifdef RISCV
+  virtual bool has_riscv_vset_requirement() const { return false; }
+  virtual bool riscv_vset_requirement(RiscVVSetRequirement* req) const { return false; }
+#endif
 
   // Avoid back to back some instructions on some CPUs.
   enum AvoidBackToBackFlag { AVOID_NONE = 0,

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -51,11 +51,61 @@
 #include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
 #include "utilities/xmlstream.hpp"
+#ifdef RISCV
+#include "riscv_vset_machnode.hpp"
+#endif
 
 #ifndef PRODUCT
 #define DEBUG_ARG(x) , x
 #else
 #define DEBUG_ARG(x)
+#endif
+
+#ifdef RISCV
+static RiscVVSetState invalid_vset_state() {
+  return { T_BYTE, Assembler::e8, 0, Assembler::m1, false };
+}
+
+static bool mach_node_vset_requirement(const MachNode* mach,
+                                       RiscVVSetState* state) {
+  if (mach->is_MachCall() || mach->is_MachSafePoint()) {
+    return false;
+  }
+  if (mach->is_MachRiscVVSet()) {
+    return false;
+  }
+#ifdef RISCV
+  RiscVVSetRequirement req = { T_BYTE, 0, Assembler::m1, false };
+  if (mach->has_riscv_vset_requirement()) {
+    if (!mach->riscv_vset_requirement(&req)) {
+      return false;
+    }
+    *state = { req._bt, Assembler::elemtype_to_sew(req._bt), req._vector_length, req._vlmul, true };
+    return true;
+  }
+#endif
+  return false;
+}
+
+static void insert_explicit_vset_nodes(Compile* C) {
+  for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
+    Block* block = C->cfg()->get_block(i);
+    for (uint j = 0; j < block->number_of_nodes(); j++) {
+      Node* n = block->get_node(j);
+      if (!n->is_Mach()) {
+        continue;
+      }
+      RiscVVSetState required = invalid_vset_state();
+      if (!mach_node_vset_requirement(n->as_Mach(), &required)) {
+        continue;
+      }
+      MachRiscVVSetNode* vset = new MachRiscVVSetNode(required._bt, required._vector_length, required._vlmul);
+      block->insert_node(vset, j);
+      C->cfg()->map_node_to_block(vset, block);
+      j++;
+    }
+  }
+}
 #endif
 
 //------------------------------Scheduling----------------------------------
@@ -319,6 +369,13 @@ void PhaseOutput::Output() {
   // Initialize code buffer
   estimate_buffer_size(_buf_sizes._const);
   if (C->failing()) return;
+
+#ifdef RISCV
+  insert_explicit_vset_nodes(C);
+  if (C->failing()) {
+    return;
+  }
+#endif
 
   // Pre-compute the length of blocks and replace
   // long branches with short if machine supports it.

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -88,6 +88,26 @@ static bool mach_node_vset_requirement(const MachNode* mach,
   return false;
 }
 
+static bool mach_node_kills_vset(const MachNode* mach) {
+  if (mach->is_MachCall() || mach->is_MachSafePoint()) {
+    return true;
+  }
+  if (mach->is_MachRiscVVSet()) {
+    return false;
+  }
+  if (mach->is_MachSpillCopy()) {
+    const Type* type = mach->bottom_type();
+    if (type != nullptr && (type->isa_vect() != nullptr || type->isa_pvectmask() != nullptr)) {
+      return true;
+    }
+  }
+  RiscVVSetRequirement req = { T_BYTE, 0, Assembler::m1, false };
+  if (mach->has_riscv_vset_requirement()) {
+    return !mach->riscv_vset_requirement(&req);
+  }
+  return riscv_vset_from_node(mach, &req);
+}
+
 static void insert_explicit_vset_nodes(Compile* C) {
   for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
     Block* block = C->cfg()->get_block(i);
@@ -105,6 +125,33 @@ static void insert_explicit_vset_nodes(Compile* C) {
       block->insert_node(vset, j);
       C->cfg()->map_node_to_block(vset, block);
       j++;
+    }
+  }
+}
+
+static void remove_redundant_vset_nodes_in_blocks(Compile* C) {
+  for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
+    Block* block = C->cfg()->get_block(i);
+    RiscVVSetState state = invalid_vset_state();
+    for (uint j = 0; j < block->number_of_nodes(); j++) {
+      Node* n = block->get_node(j);
+      if (!n->is_Mach()) {
+        continue;
+      }
+      MachNode* mach = n->as_Mach();
+      if (mach->is_MachRiscVVSet()) {
+        MachRiscVVSetNode* vset = mach->as_MachRiscVVSet();
+        RiscVVSetState vset_state = vset->state();
+        if (riscv_vset_state_equal_valid(state, vset_state)) {
+          block->remove_node(j);
+          C->cfg()->unmap_node_from_block(vset);
+          j--;
+        } else {
+          state = vset_state;
+        }
+      } else if (mach_node_kills_vset(mach)) {
+        state = invalid_vset_state();
+      }
     }
   }
 }
@@ -374,6 +421,7 @@ void PhaseOutput::Output() {
 
 #ifdef RISCV
   insert_explicit_vset_nodes(C);
+  remove_redundant_vset_nodes_in_blocks(C);
   if (C->failing()) {
     return;
   }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -63,7 +63,7 @@
 
 #ifdef RISCV
 static RiscVVSetState invalid_vset_state() {
-  return { T_BYTE, Assembler::e8, 0, Assembler::m1, false };
+  return { T_BYTE, Assembler::e8, 0, Assembler::m1, Assembler::ma, Assembler::ta, false };
 }
 
 static bool mach_node_vset_requirement(const MachNode* mach,
@@ -75,12 +75,13 @@ static bool mach_node_vset_requirement(const MachNode* mach,
     return false;
   }
 #ifdef RISCV
-  RiscVVSetRequirement req = { T_BYTE, 0, Assembler::m1, false };
+  RiscVVSetRequirement req = { T_BYTE, 0, Assembler::m1, Assembler::ma, Assembler::ta, false };
   if (mach->has_riscv_vset_requirement()) {
     if (!mach->riscv_vset_requirement(&req)) {
       return false;
     }
-    *state = { req._bt, Assembler::elemtype_to_sew(req._bt), req._vector_length, req._vlmul, true };
+    *state = { req._bt, Assembler::elemtype_to_sew(req._bt), req._vector_length, req._vlmul,
+               req._vma, req._vta, true };
     return true;
   }
 #endif
@@ -99,7 +100,8 @@ static void insert_explicit_vset_nodes(Compile* C) {
       if (!mach_node_vset_requirement(n->as_Mach(), &required)) {
         continue;
       }
-      MachRiscVVSetNode* vset = new MachRiscVVSetNode(required._bt, required._vector_length, required._vlmul);
+      MachRiscVVSetNode* vset = new MachRiscVVSetNode(required._bt, required._vector_length, required._vlmul,
+                                                      required._vma, required._vta);
       block->insert_node(vset, j);
       C->cfg()->map_node_to_block(vset, block);
       j++;

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -62,74 +62,28 @@
 #endif
 
 #ifdef RISCV
-static RiscVVSetState invalid_vset_state() {
-  return { T_BYTE, Assembler::e8, 0, Assembler::m1, Assembler::ma, Assembler::ta, false };
-}
-
-static bool mach_node_vset_requirement(const MachNode* mach,
-                                       RiscVVSetState* state) {
-  if (mach->is_MachCall() || mach->is_MachSafePoint()) {
-    return false;
-  }
-  if (mach->is_MachRiscVVSet()) {
-    return false;
-  }
-#ifdef RISCV
-  RiscVVSetRequirement req = { T_BYTE, 0, Assembler::m1, Assembler::ma, Assembler::ta, false };
-  if (mach->has_riscv_vset_requirement()) {
-    if (!mach->riscv_vset_requirement(&req)) {
-      return false;
-    }
-    *state = { req._bt, Assembler::elemtype_to_sew(req._bt), req._vector_length, req._vlmul,
-               req._vma, req._vta, true };
-    return true;
-  }
-#endif
-  return false;
-}
-
-static bool mach_node_kills_vset(const MachNode* mach) {
-  if (mach->is_MachCall() || mach->is_MachSafePoint()) {
-    return true;
-  }
-  if (mach->is_MachRiscVVSet()) {
-    return false;
-  }
-  if (mach->is_MachSpillCopy()) {
-    const Type* type = mach->bottom_type();
-    if (type != nullptr && (type->isa_vect() != nullptr || type->isa_pvectmask() != nullptr)) {
-      return true;
-    }
-  }
-  RiscVVSetRequirement req = { T_BYTE, 0, Assembler::m1, false };
-  if (mach->has_riscv_vset_requirement()) {
-    return !mach->riscv_vset_requirement(&req);
-  }
-  return riscv_vset_from_node(mach, &req);
-}
-
 static RiscVVSetState meet_vset_preds(Compile* C,
                                       Block* block,
                                       RiscVVSetState* out_states) {
-  RiscVVSetState result = invalid_vset_state();
+  RiscVVSetState result = riscv_vset_invalid_state();
   bool has_state = false;
   for (uint p = 1; p < block->num_preds(); p++) {
     Block* pred_block = C->cfg()->get_block_for_node(block->pred(p));
     if (pred_block == nullptr) {
-      return invalid_vset_state();
+      return riscv_vset_invalid_state();
     }
     const RiscVVSetState& pred_state = out_states[pred_block->_pre_order];
     if (!pred_state._valid) {
-      return invalid_vset_state();
+      return riscv_vset_invalid_state();
     }
     if (!has_state) {
       result = pred_state;
       has_state = true;
     } else if (!riscv_vset_state_equal_valid(result, pred_state)) {
-      return invalid_vset_state();
+      return riscv_vset_invalid_state();
     }
   }
-  return has_state ? result : invalid_vset_state();
+  return has_state ? result : riscv_vset_invalid_state();
 }
 
 static RiscVVSetState transfer_vset_state(Block* block,
@@ -143,8 +97,8 @@ static RiscVVSetState transfer_vset_state(Block* block,
     if (mach->is_MachRiscVVSet()) {
       MachRiscVVSetNode* vset = mach->as_MachRiscVVSet();
       state = vset->state();
-    } else if (mach_node_kills_vset(mach)) {
-      state = invalid_vset_state();
+    } else if (riscv_mach_node_kills_vset(mach)) {
+      state = riscv_vset_invalid_state();
     }
   }
   return state;
@@ -155,8 +109,8 @@ static void compute_vset_states(Compile* C,
                                 RiscVVSetState* out_states) {
   uint nblocks = C->cfg()->number_of_blocks();
   for (uint i = 0; i < nblocks; i++) {
-    in_states[i] = invalid_vset_state();
-    out_states[i] = invalid_vset_state();
+    in_states[i] = riscv_vset_invalid_state();
+    out_states[i] = riscv_vset_invalid_state();
   }
 
   bool changed = true;
@@ -186,8 +140,8 @@ static void insert_explicit_vset_nodes(Compile* C) {
       if (!n->is_Mach()) {
         continue;
       }
-      RiscVVSetState required = invalid_vset_state();
-      if (!mach_node_vset_requirement(n->as_Mach(), &required)) {
+      RiscVVSetState required = riscv_vset_invalid_state();
+      if (!riscv_mach_node_vset_requirement(n->as_Mach(), &required)) {
         continue;
       }
       MachRiscVVSetNode* vset = new MachRiscVVSetNode(required._bt, required._vector_length, required._vlmul,
@@ -202,7 +156,7 @@ static void insert_explicit_vset_nodes(Compile* C) {
 static void remove_redundant_vset_nodes_in_blocks(Compile* C) {
   for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
     Block* block = C->cfg()->get_block(i);
-    RiscVVSetState state = invalid_vset_state();
+    RiscVVSetState state = riscv_vset_invalid_state();
     for (uint j = 0; j < block->number_of_nodes(); j++) {
       Node* n = block->get_node(j);
       if (!n->is_Mach()) {
@@ -219,8 +173,8 @@ static void remove_redundant_vset_nodes_in_blocks(Compile* C) {
         } else {
           state = vset_state;
         }
-      } else if (mach_node_kills_vset(mach)) {
-        state = invalid_vset_state();
+      } else if (riscv_mach_node_kills_vset(mach)) {
+        state = riscv_vset_invalid_state();
       }
     }
   }
@@ -253,8 +207,8 @@ static void remove_redundant_vset_nodes(Compile* C) {
         } else {
           state = vset_state;
         }
-      } else if (mach_node_kills_vset(mach)) {
-        state = invalid_vset_state();
+      } else if (riscv_mach_node_kills_vset(mach)) {
+        state = riscv_vset_invalid_state();
       }
     }
   }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -108,6 +108,76 @@ static bool mach_node_kills_vset(const MachNode* mach) {
   return riscv_vset_from_node(mach, &req);
 }
 
+static RiscVVSetState meet_vset_preds(Compile* C,
+                                      Block* block,
+                                      RiscVVSetState* out_states) {
+  RiscVVSetState result = invalid_vset_state();
+  bool has_state = false;
+  for (uint p = 1; p < block->num_preds(); p++) {
+    Block* pred_block = C->cfg()->get_block_for_node(block->pred(p));
+    if (pred_block == nullptr) {
+      return invalid_vset_state();
+    }
+    const RiscVVSetState& pred_state = out_states[pred_block->_pre_order];
+    if (!pred_state._valid) {
+      return invalid_vset_state();
+    }
+    if (!has_state) {
+      result = pred_state;
+      has_state = true;
+    } else if (!riscv_vset_state_equal_valid(result, pred_state)) {
+      return invalid_vset_state();
+    }
+  }
+  return has_state ? result : invalid_vset_state();
+}
+
+static RiscVVSetState transfer_vset_state(Block* block,
+                                          RiscVVSetState state) {
+  for (uint j = 0; j < block->number_of_nodes(); j++) {
+    Node* n = block->get_node(j);
+    if (!n->is_Mach()) {
+      continue;
+    }
+    MachNode* mach = n->as_Mach();
+    if (mach->is_MachRiscVVSet()) {
+      MachRiscVVSetNode* vset = mach->as_MachRiscVVSet();
+      state = vset->state();
+    } else if (mach_node_kills_vset(mach)) {
+      state = invalid_vset_state();
+    }
+  }
+  return state;
+}
+
+static void compute_vset_states(Compile* C,
+                                RiscVVSetState* in_states,
+                                RiscVVSetState* out_states) {
+  uint nblocks = C->cfg()->number_of_blocks();
+  for (uint i = 0; i < nblocks; i++) {
+    in_states[i] = invalid_vset_state();
+    out_states[i] = invalid_vset_state();
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (uint i = 0; i < nblocks; i++) {
+      Block* block = C->cfg()->get_block(i);
+      RiscVVSetState new_in = meet_vset_preds(C, block, out_states);
+      RiscVVSetState new_out = transfer_vset_state(block, new_in);
+      if (!riscv_vset_state_same(in_states[block->_pre_order], new_in)) {
+        in_states[block->_pre_order] = new_in;
+        changed = true;
+      }
+      if (!riscv_vset_state_same(out_states[block->_pre_order], new_out)) {
+        out_states[block->_pre_order] = new_out;
+        changed = true;
+      }
+    }
+  }
+}
+
 static void insert_explicit_vset_nodes(Compile* C) {
   for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
     Block* block = C->cfg()->get_block(i);
@@ -133,6 +203,40 @@ static void remove_redundant_vset_nodes_in_blocks(Compile* C) {
   for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
     Block* block = C->cfg()->get_block(i);
     RiscVVSetState state = invalid_vset_state();
+    for (uint j = 0; j < block->number_of_nodes(); j++) {
+      Node* n = block->get_node(j);
+      if (!n->is_Mach()) {
+        continue;
+      }
+      MachNode* mach = n->as_Mach();
+      if (mach->is_MachRiscVVSet()) {
+        MachRiscVVSetNode* vset = mach->as_MachRiscVVSet();
+        RiscVVSetState vset_state = vset->state();
+        if (riscv_vset_state_equal_valid(state, vset_state)) {
+          block->remove_node(j);
+          C->cfg()->unmap_node_from_block(vset);
+          j--;
+        } else {
+          state = vset_state;
+        }
+      } else if (mach_node_kills_vset(mach)) {
+        state = invalid_vset_state();
+      }
+    }
+  }
+}
+
+static void remove_redundant_vset_nodes(Compile* C) {
+  uint nblocks = C->cfg()->number_of_blocks();
+  RiscVVSetState* in_states =
+      NEW_RESOURCE_ARRAY(RiscVVSetState, nblocks);
+  RiscVVSetState* out_states =
+      NEW_RESOURCE_ARRAY(RiscVVSetState, nblocks);
+  compute_vset_states(C, in_states, out_states);
+
+  for (uint i = 0; i < nblocks; i++) {
+    Block* block = C->cfg()->get_block(i);
+    RiscVVSetState state = in_states[block->_pre_order];
     for (uint j = 0; j < block->number_of_nodes(); j++) {
       Node* n = block->get_node(j);
       if (!n->is_Mach()) {
@@ -422,6 +526,7 @@ void PhaseOutput::Output() {
 #ifdef RISCV
   insert_explicit_vset_nodes(C);
   remove_redundant_vset_nodes_in_blocks(C);
+  remove_redundant_vset_nodes(C);
   if (C->failing()) {
     return;
   }


### PR DESCRIPTION
This pull request improves RVV vset instruction generation in the RISC-V
C2 backend.

The current implementation may emit multiple RVV vset instructions when
the required vector configuration is already active. This is especially
common across basic blocks and inside vectorized loops.

This change introduces explicit RVV vset nodes in the C2 instruction
pipeline and tracks the associated vector configuration and policy,
including:

- SEW
- VL
- LMUL
- tail policy
- mask policy

Based on this state, redundant RVV vset instructions are removed within
basic blocks and across control-flow edges. The implementation also
handles state propagation at control-flow joins and invalidates the
tracked state when encountering calls, safepoints, vector spill copies,
or instructions with incompatible RVV requirements.

In addition, loop-invariant RVV vset instructions can be hoisted out of
loops when the required state is consistent and the transformation is
safe. This optimization is controlled by the diagnostic
`UseRiscVVSetLICM` flag.

The existing RVV code generation behavior is preserved when the
optimization cannot prove that a vset instruction is redundant or
loop-invariant.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8390039](https://bugs.openjdk.org/browse/JDK-8390039): RISC-V: Optimize RVV vset instruction generation in C2 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32079/head:pull/32079` \
`$ git checkout pull/32079`

Update a local copy of the PR: \
`$ git checkout pull/32079` \
`$ git pull https://git.openjdk.org/jdk.git pull/32079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32079`

View PR using the GUI difftool: \
`$ git pr show -t 32079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32079.diff">https://git.openjdk.org/jdk/pull/32079.diff</a>

</details>
