### PR TITLE
8390038: RISC-V: Optimize CRC32 and CRC32C with slicing-by-8

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2247,6 +2247,7 @@ enum VectorMask {
   INSN(vrsub_vx, 0b1010111, 0b100, 0b000011);
 
   // Vector Slide Instructions
+  INSN(vslide1up_vx, 0b1010111, 0b110, 0b001110);
   INSN(vslidedown_vx, 0b1010111, 0b100, 0b001111);
 
 #undef INSN

--- a/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
@@ -856,7 +856,80 @@ void LIRGenerator::do_update_CRC32(Intrinsic* x) {
 }
 
 void LIRGenerator::do_update_CRC32C(Intrinsic* x) {
-  ShouldNotReachHere();
+  assert(UseCRC32CIntrinsics, "why are we here?");
+  // Make all state_for calls early since they can emit code
+  LIR_Opr result = rlock_result(x);
+  switch (x->id()) {
+    case vmIntrinsics::_updateBytesCRC32C:
+    case vmIntrinsics::_updateDirectByteBufferCRC32C: {
+      bool is_updateBytes = (x->id() == vmIntrinsics::_updateBytesCRC32C);
+      int offset = is_updateBytes ? arrayOopDesc::base_offset_in_bytes(T_BYTE) : 0;
+
+      LIRItem crc(x->argument_at(0), this);
+      LIRItem buf(x->argument_at(1), this);
+      LIRItem off(x->argument_at(2), this);
+      LIRItem end(x->argument_at(3), this);
+
+      buf.load_item();
+      off.load_nonconstant();
+      end.load_nonconstant();
+
+      // len = end - off
+      LIR_Opr len  = end.result();
+      LIR_Opr tmpA = new_register(T_INT);
+      LIR_Opr tmpB = new_register(T_INT);
+      __ move(end.result(), tmpA);
+      __ move(off.result(), tmpB);
+      __ sub(tmpA, tmpB, tmpA);
+      len = tmpA;
+
+      LIR_Opr index = off.result();
+      if(off.result()->is_constant()) {
+        index = LIR_OprFact::illegalOpr;
+        offset += off.result()->as_jint();
+      }
+      LIR_Opr base_op = buf.result();
+
+      if (index->is_valid()) {
+        LIR_Opr tmp = new_register(T_LONG);
+        __ convert(Bytecodes::_i2l, index, tmp);
+        index = tmp;
+      }
+
+      if (offset) {
+        LIR_Opr tmp = new_pointer_register();
+        __ add(base_op, LIR_OprFact::intConst(offset), tmp);
+        base_op = tmp;
+        offset = 0;
+      }
+
+      LIR_Address* a = new LIR_Address(base_op,
+                                       index,
+                                       offset,
+                                       T_BYTE);
+      BasicTypeList signature(3);
+      signature.append(T_INT);
+      signature.append(T_ADDRESS);
+      signature.append(T_INT);
+      CallingConvention* cc = frame_map()->c_calling_convention(&signature);
+      const LIR_Opr result_reg = result_register_for(x->type());
+
+      LIR_Opr addr = new_register(T_ADDRESS);
+      __ leal(LIR_OprFact::address(a), addr);
+
+      crc.load_item_force(cc->at(0));
+      __ move(addr, cc->at(1));
+      __ move(len, cc->at(2));
+
+      __ call_runtime_leaf(StubRoutines::updateBytesCRC32C(), getThreadTemp(), result_reg, cc->args());
+      __ move(result_reg, result);
+
+      break;
+    }
+    default: {
+      ShouldNotReachHere();
+    }
+  }
 }
 
 void LIRGenerator::do_FmaIntrinsic(Intrinsic* x) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2144,6 +2144,65 @@ void MacroAssembler::update_word_crc32(Register crc, Register v, Register tmp1, 
   xorr(crc, crc, tmp2);
 }
 
+/**
+ * Emits code to update CRC-32 with a 64-bit value according to tables 0 to 7
+ * (slicing-by-8).
+ */
+void MacroAssembler::update_dword_crc32(Register crc, Register v,
+        Register table0, Register table1, Register table2, Register table3,
+        Register table4, Register table5, Register table6, Register table7) {
+  const Register tmp = t1;
+  assert_different_registers(crc, v, table0, table1, table2, table3, table4, table5, table6, table7, tmp);
+
+  xorr(v, v, crc);
+  mv(crc, zr);
+
+  zext(tmp, v, 8);
+  shadd(tmp, tmp, table7, tmp, 2);
+  lwu(tmp, Address(tmp));
+  xorr(crc, crc, tmp);
+
+  slli(tmp, v, 16);
+  srliw(tmp, tmp, 24);
+  shadd(tmp, tmp, table6, tmp, 2);
+  lwu(tmp, Address(tmp));
+  xorr(crc, crc, tmp);
+
+  slli(tmp, v, 8);
+  srliw(tmp, tmp, 24);
+  shadd(tmp, tmp, table5, tmp, 2);
+  lwu(tmp, Address(tmp));
+  xorr(crc, crc, tmp);
+
+  srliw(tmp, v, 24);
+  shadd(tmp, tmp, table4, tmp, 2);
+  lwu(tmp, Address(tmp));
+  xorr(crc, crc, tmp);
+
+  srli(tmp, v, 32);
+  zext(tmp, tmp, 8);
+  shadd(tmp, tmp, table3, tmp, 2);
+  lwu(tmp, Address(tmp));
+  xorr(crc, crc, tmp);
+
+  srli(tmp, v, 40);
+  zext(tmp, tmp, 8);
+  shadd(tmp, tmp, table2, tmp, 2);
+  lwu(tmp, Address(tmp));
+  xorr(crc, crc, tmp);
+
+  srli(tmp, v, 48);
+  zext(tmp, tmp, 8);
+  shadd(tmp, tmp, table1, tmp, 2);
+  lwu(tmp, Address(tmp));
+  xorr(crc, crc, tmp);
+
+  srli(tmp, v, 56);
+  shadd(tmp, tmp, table0, tmp, 2);
+  lwu(tmp, Address(tmp));
+  xorr(crc, crc, tmp);
+}
+
 
 #ifdef COMPILER2
 // This improvement (vectorization) is based on java.base/share/native/libzip/zlib/zcrc32.c.
@@ -2606,83 +2665,124 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
   assert_different_registers(crc, buf, len, table0, table1, table2, table3, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6);
   Label L_vector_entry,
         L_unroll_loop,
+        L_by8_loop_entry, L_by8_loop,
         L_by4_loop_entry, L_by4_loop,
-        L_by1_loop, L_exit, L_skip1, L_skip2;
+        L_by1_loop, L_exit, L_skip1, L_skip2, L_skip4;
 
   const int64_t single_table_size = 256;
   const int64_t unroll = 16;
-  const int64_t unroll_words = unroll*wordSize;
+  const int64_t unroll_dwords = unroll * sizeof(julong);
 
-  // tmp5 = 0xffffffff
-  notr(tmp5, zr);
-  srli(tmp5, tmp5, 32);
+  const Register table4 = tmp1;  // input: table4 base (passed from caller)
+  const Register table5 = tmp3;
+  const Register table6 = tmp4;
+  const Register table7 = tmp5;
 
-  andn(crc, tmp5, crc);
+  add(table1, table0, 1 * single_table_size * sizeof(juint), t0);
+  add(table2, table0, 2 * single_table_size * sizeof(juint), t0);
+  add(table3, table0, 3 * single_table_size * sizeof(juint), t0);
+  add(table5, table4, 1 * single_table_size * sizeof(juint), t0);
+  add(table6, table4, 2 * single_table_size * sizeof(juint), t0);
+  add(table7, table4, 3 * single_table_size * sizeof(juint), t0);
 
-  add(table1, table0, 1 * single_table_size * sizeof(juint), tmp1);
-  add(table2, table0, 2 * single_table_size * sizeof(juint), tmp1);
-  add(table3, table2, 1 * single_table_size * sizeof(juint), tmp1);
+  notr(tmp6, zr);
+  srli(tmp6, tmp6, 32);
+  andn(crc, tmp6, crc);
+  // len is a Java int. Canonicalize to signed 32-bit semantics to avoid
+  // bogus loop bounds when callers leave non-canonical high bits.
+  sext(len, len, 32);
 
-  // Ensure basic 4-byte alignment of input byte buffer
-  mv(tmp1, 4);
-  blt(len, tmp1, L_by1_loop);
-  test_bit(tmp1, buf, 0);
-  beqz(tmp1, L_skip1);
+  // Ensure at least 4-byte alignment before any lwu.
+  // Optional 8-byte alignment is only attempted when len >= 8.
+  mv(tmp6, 4);
+  blt(len, tmp6, L_by1_loop);
+  test_bit(tmp6, buf, 0);
+  beqz(tmp6, L_skip1);
     subiw(len, len, 1);
-    lbu(tmp1, Address(buf));
+    lbu(tmp2, Address(buf));
     addi(buf, buf, 1);
-    update_byte_crc32(crc, tmp1, table0);
+    update_byte_crc32(crc, tmp2, table0);
   bind(L_skip1);
-    test_bit(tmp1, buf, 1);
-    beqz(tmp1, L_skip2);
+    test_bit(tmp6, buf, 1);
+    beqz(tmp6, L_skip2);
     subiw(len, len, 2);
-    lhu(tmp1, Address(buf));
+    lhu(tmp2, Address(buf));
     addi(buf, buf, 2);
-    zext(tmp2, tmp1, 8);
-    update_byte_crc32(crc, tmp2, table0);
-    srli(tmp2, tmp1, 8);
-    update_byte_crc32(crc, tmp2, table0);
+    zext(tmp6, tmp2, 8);
+    update_byte_crc32(crc, tmp6, table0);
+    srli(tmp6, tmp2, 8);
+    update_byte_crc32(crc, tmp6, table0);
   bind(L_skip2);
+    // Only spend one 4-byte step to reach 8-byte alignment when we will
+    // actually enter by8 loops.
+    mv(tmp6, 8);
+    blt(len, tmp6, L_skip4);
+    test_bit(tmp6, buf, 2);
+    beqz(tmp6, L_skip4);
+    subiw(len, len, 4);
+    lwu(tmp2, Address(buf));
+    addi(buf, buf, 4);
+    update_word_crc32(crc, tmp2, t0, t1, tmp6, table0, table1, table2, table3, false);
+  bind(L_skip4);
 
 #ifdef COMPILER2
   if (UseRVV) {
     const int64_t tmp_limit =
             UseZvbc ? 128 * 3 // 3 rounds of folding with carry-less multiplication
-                    : MaxVectorSize >= 32 ? unroll_words*3 : unroll_words*5;
-    mv(tmp1, tmp_limit);
-    bge(len, tmp1, L_vector_entry);
+                    : MaxVectorSize >= 32 ? unroll_dwords * 3 : unroll_dwords * 5;
+    mv(tmp6, tmp_limit);
+    bge(len, tmp6, L_vector_entry);
   }
 #endif // COMPILER2
 
-  mv(tmp1, unroll_words);
-  blt(len, tmp1, L_by4_loop_entry);
+  mv(tmp6, unroll_dwords);
+  blt(len, tmp6, L_by8_loop_entry);
 
-  const Register loop_buf_end = tmp3;
+  const Register loop_buf_end = tmp6;
 
   align(CodeEntryAlignment);
   // Entry for L_unroll_loop
     add(loop_buf_end, buf, len); // loop_buf_end will be used as endpoint for loop below
-    andi(len, len, unroll_words - 1); // len = (len % unroll_words)
+    andi(len, len, unroll_dwords - 1); // len = (len % unroll_dwords)
     sub(loop_buf_end, loop_buf_end, len);
   bind(L_unroll_loop);
     for (int i = 0; i < unroll; i++) {
-      ld(tmp1, Address(buf, i*wordSize));
-      update_word_crc32(crc, tmp1, tmp2, tmp4, tmp6, table0, table1, table2, table3, false);
-      update_word_crc32(crc, tmp1, tmp2, tmp4, tmp6, table0, table1, table2, table3, true);
+      ld(tmp2, Address(buf, i * sizeof(julong)));
+      update_dword_crc32(crc, tmp2, table0, table1, table2, table3, table4, table5, table6, table7);
     }
 
-    addi(buf, buf, unroll_words);
+    addi(buf, buf, unroll_dwords);
     blt(buf, loop_buf_end, L_unroll_loop);
 
+  bind(L_by8_loop_entry);
+    mv(tmp6, 8);
+    blt(len, tmp6, L_by4_loop_entry);
+    add(loop_buf_end, buf, len); // loop_buf_end will be used as endpoint for loop below
+    andi(len, len, 7);
+    sub(loop_buf_end, loop_buf_end, len);
+  bind(L_by8_loop);
+    ld(tmp2, Address(buf));
+    update_dword_crc32(crc, tmp2, table0, table1, table2, table3, table4, table5, table6, table7);
+    addi(buf, buf, 8);
+    blt(buf, loop_buf_end, L_by8_loop);
+
   bind(L_by4_loop_entry);
-    mv(tmp1, 4);
-    blt(len, tmp1, L_by1_loop);
+    mv(tmp6, 4);
+    blt(len, tmp6, L_by1_loop);
+    // Safety net: only enter lwu loop when buf is 4-byte aligned.
+    // This prevents accidental unaligned lwu if any control-flow path
+    // reaches here without passing through the front alignment peel.
+    test_bit(tmp6, buf, 0);
+    bnez(tmp6, L_by1_loop);
+    test_bit(tmp6, buf, 1);
+    bnez(tmp6, L_by1_loop);
     add(loop_buf_end, buf, len); // loop_buf_end will be used as endpoint for loop below
     andi(len, len, 3);
     sub(loop_buf_end, loop_buf_end, len);
   bind(L_by4_loop);
-    lwu(tmp1, Address(buf));
-    update_word_crc32(crc, tmp1, tmp2, tmp4, tmp6, table0, table1, table2, table3, false);
+    lwu(tmp2, Address(buf));
+    // Do not use tmp6 here: tmp6 holds loop_buf_end for this loop.
+    update_word_crc32(crc, tmp2, t0, t1, tmp3, table0, table1, table2, table3, false);
     addi(buf, buf, 4);
     blt(buf, loop_buf_end, L_by4_loop);
 
@@ -2690,18 +2790,18 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
     beqz(len, L_exit);
 
     subiw(len, len, 1);
-    lbu(tmp1, Address(buf));
-    update_byte_crc32(crc, tmp1, table0);
+    lbu(tmp2, Address(buf));
+    update_byte_crc32(crc, tmp2, table0);
     beqz(len, L_exit);
 
     subiw(len, len, 1);
-    lbu(tmp1, Address(buf, 1));
-    update_byte_crc32(crc, tmp1, table0);
+    lbu(tmp2, Address(buf, 1));
+    update_byte_crc32(crc, tmp2, table0);
     beqz(len, L_exit);
 
     subiw(len, len, 1);
-    lbu(tmp1, Address(buf, 2));
-    update_byte_crc32(crc, tmp1, table0);
+    lbu(tmp2, Address(buf, 2));
+    update_byte_crc32(crc, tmp2, table0);
 
 #ifdef COMPILER2
   // put vector code here, otherwise "offset is too large" error occurs.
@@ -2713,9 +2813,9 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
     if (UseZvbc) { // carry-less multiplication
       kernel_crc32_vclmul_fold(crc, buf, len,
                                table0, table1, table2, table3,
-                               tmp1, tmp2, tmp3, tmp4, tmp6);
+                               tmp1, tmp2, tmp3, tmp4, tmp5);
     } else { // plain vector instructions
-      vector_update_crc32(crc, buf, len, tmp1, tmp2, tmp3, tmp4, tmp6, table0, table3);
+      vector_update_crc32(crc, buf, len, tmp1, tmp2, tmp3, tmp4, tmp5, table0, table3);
     }
 
     bgtz(len, L_by4_loop_entry);
@@ -2723,7 +2823,9 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
 #endif // COMPILER2
 
   bind(L_exit);
-    andn(crc, tmp5, crc);
+    notr(tmp6, zr);
+    srli(tmp6, tmp6, 32);
+    andn(crc, tmp6, crc);
 }
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2236,7 +2236,8 @@ void MacroAssembler::vector_update_crc32(Register crc, Register buf, Register le
     }
 
     vmv_v_x(vcrc, zr);
-    vmv_s_x(vcrc, crc);
+    vmv_v_x(vtmp, zr);
+    vslide1up_vx(vcrc, vtmp, crc);
 
     // multiple of 64
     srli(blks, len, 6);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2574,12 +2574,9 @@ void MacroAssembler::kernel_crc32_vclmul_fold(Register crc, Register buf, Regist
                         Register tmp1, Register tmp2, Register tmp3, Register tmp4, Register tmp5) {
   const int64_t single_table_size = 256;
   const int64_t table_num = 8;   // 4 for scalar, 4 for plain vector
-  const ExternalAddress table_addr = StubRoutines::crc_table_addr();
   Register vclmul_table = tmp3;
 
-  la(vclmul_table, table_addr);
-  add(vclmul_table, vclmul_table, table_num * single_table_size * sizeof(juint), tmp1);
-  la(table0, table_addr);
+  add(vclmul_table, table0, table_num * single_table_size * sizeof(juint), tmp1);
 
   if (MaxVectorSize == 16) {
     kernel_crc32_vclmul_fold_vectorsize_16(crc, buf, len, vclmul_table, tmp1, tmp2);
@@ -2622,8 +2619,6 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
 
   andn(crc, tmp5, crc);
 
-  const ExternalAddress table_addr = StubRoutines::crc_table_addr();
-  la(table0, table_addr);
   add(table1, table0, 1 * single_table_size * sizeof(juint), tmp1);
   add(table2, table0, 2 * single_table_size * sizeof(juint), tmp1);
   add(table3, table2, 1 * single_table_size * sizeof(juint), tmp1);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1362,6 +1362,9 @@ public:
   void kernel_crc32(Register crc, Register buf, Register len,
         Register table0, Register table1, Register table2, Register table3,
         Register tmp1, Register tmp2, Register tmp3, Register tmp4, Register tmp5, Register tmp6);
+  void update_dword_crc32(Register crc, Register v,
+        Register table0, Register table1, Register table2, Register table3,
+        Register table4, Register table5, Register table6, Register table7);
   void update_word_crc32(Register crc, Register v, Register tmp1, Register tmp2, Register tmp3,
         Register table0, Register table1, Register table2, Register table3,
         bool upper);

--- a/src/hotspot/cpu/riscv/stubDeclarations_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubDeclarations_riscv.hpp
@@ -39,7 +39,7 @@
                                       do_arch_entry,                    \
                                       do_arch_entry_init,               \
                                       do_arch_entry_array)              \
-  do_arch_blob(initial, 10000)                                          \
+  do_arch_blob(initial, 12000)                                          \
 
 
 #define STUBGEN_CONTINUATION_BLOBS_ARCH_DO(do_stub,                     \

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -7252,11 +7252,47 @@ static const int64_t right_3_bits = right_n_bits(3);
     BLOCK_COMMENT("Entry:");
     __ enter(); // required for proper stackwalking of RuntimeStub frame
 
+    const ExternalAddress table_addr = StubRoutines::crc_table_addr();
+    __ la(c_rarg3, table_addr);
+
     __ kernel_crc32(crc, buf, len,
                     c_rarg3, c_rarg4, c_rarg5, c_rarg6, // tmp's for tables
                     c_rarg7, t2, t3, t4, t5, t6);       // misc tmps
 
     __ leave(); // required for proper stackwalking of RuntimeStub frame
+    __ ret();
+
+    return start;
+  }
+
+  address generate_updateBytesCRC32C() {
+    assert(UseCRC32CIntrinsics, "what are we doing here?");
+
+    __ align(CodeEntryAlignment);
+    StubId stub_id = StubId::stubgen_updateBytesCRC32C_id;
+    StubCodeMark mark(this, stub_id);
+
+    address start = __ pc();
+
+    const Register crc = c_rarg0;
+    const Register buf = c_rarg1;
+    const Register len = c_rarg2;
+
+    BLOCK_COMMENT("Entry:");
+    __ enter();
+
+    const ExternalAddress table_addr = StubRoutines::crc32c_table_addr();
+    __ la(c_rarg3, table_addr);
+
+    // Initial CRC inversion
+    __ notr(crc, crc);  // crc = ~crc
+    __ kernel_crc32(crc, buf, len,
+                    c_rarg3, c_rarg4, c_rarg5, c_rarg6,  // table0-3
+                    c_rarg7, t2, t3, t4, t5, t6);        // tmp1-6
+    // Final CRC inversion
+    __ notr(crc, crc);  // crc = ~crc
+
+    __ leave();
     __ ret();
 
     return start;
@@ -7331,6 +7367,10 @@ static const int64_t right_3_bits = right_n_bits(3);
 
     if (UseCRC32Intrinsics) {
       StubRoutines::_updateBytesCRC32 = generate_updateBytesCRC32();
+    }
+
+    if (UseCRC32CIntrinsics) {
+      StubRoutines::_updateBytesCRC32C = generate_updateBytesCRC32C();
     }
 
     if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_float16ToFloat) &&

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -7253,7 +7253,9 @@ static const int64_t right_3_bits = right_n_bits(3);
     __ enter(); // required for proper stackwalking of RuntimeStub frame
 
     const ExternalAddress table_addr = StubRoutines::crc_table_addr();
+    const ExternalAddress table_ext_addr = StubRoutines::riscv::crc_table_ext_addr();
     __ la(c_rarg3, table_addr);
+    __ la(c_rarg7, table_ext_addr);
 
     __ kernel_crc32(crc, buf, len,
                     c_rarg3, c_rarg4, c_rarg5, c_rarg6, // tmp's for tables
@@ -7282,7 +7284,9 @@ static const int64_t right_3_bits = right_n_bits(3);
     __ enter();
 
     const ExternalAddress table_addr = StubRoutines::crc32c_table_addr();
+    const ExternalAddress table_ext_addr = StubRoutines::riscv::crc32c_table_ext_addr();
     __ la(c_rarg3, table_addr);
+    __ la(c_rarg7, table_ext_addr);
 
     // Initial CRC inversion
     __ notr(crc, crc);  // crc = ~crc

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
@@ -36,6 +36,9 @@
 
 // define fields for arch-specific entries
 
+// CRC32C polynomial constant (reflected form of Castagnoli polynomial 0x1EDC6F41)
+#define CRC32C_POLY 0x82F63B78
+
 #define DEFINE_ARCH_ENTRY(arch, blob_name, stub_name, field_name, getter_name) \
   address StubRoutines:: arch :: STUB_FIELD_NAME(field_name)  = nullptr;
 
@@ -53,12 +56,126 @@ STUBGEN_ARCH_ENTRIES_DO(DEFINE_ARCH_ENTRY, DEFINE_ARCH_ENTRY_INIT, DEFINE_ARCH_E
 
 bool StubRoutines::riscv::_completed = false;
 
+// CRC32C table pointer (initialized on first use)
+juint* StubRoutines::riscv::_crc32c_table = nullptr;
+
 /**
  *  crc_table[] from jdk/src/java.base/share/native/libzip/zlib/crc32.h
  */
 
 address StubRoutines::crc_table_addr()    { return (address)StubRoutines::riscv::_crc_table; }
-address StubRoutines::crc32c_table_addr() { ShouldNotCallThis(); return nullptr; }
+address StubRoutines::crc32c_table_addr() {
+  if (StubRoutines::riscv::_crc32c_table == nullptr) {
+    StubRoutines::riscv::generate_CRC32C_table();
+  }
+  return (address)StubRoutines::riscv::_crc32c_table;
+}
+
+/**
+ * Generate CRC32C lookup table.
+ *
+ * Layout (same contract as CRC32/vector path):
+ *   - tables 0..3: scalar update tables
+ *   - tables 4..7: braid tables for RVV vector_update_crc32()
+ *   - tail: carry-less multiplication constants
+ */
+void StubRoutines::riscv::generate_CRC32C_table() {
+  constexpr int table_size = 256;
+  constexpr int scalar_tables = 4;
+  constexpr int braid_tables = 4;
+  constexpr int N = 16;
+  constexpr int W = 4;
+
+  ATTRIBUTE_ALIGNED(4096) static juint crc32c_table[(scalar_tables + braid_tables) * table_size + 20];
+
+  auto multmodp_crc32c = [](uint32_t a, uint32_t b) -> uint32_t {
+    if (a == 0) {
+      return 0;
+    }
+
+    uint32_t m = 1u << 31;
+    uint32_t p = 0;
+    while (true) {
+      if ((a & m) != 0) {
+        p ^= b;
+        if ((a & (m - 1)) == 0) {
+          break;
+        }
+      }
+      m >>= 1;
+      b = ((b & 1) != 0) ? ((b >> 1) ^ CRC32C_POLY) : (b >> 1);
+    }
+    return p;
+  };
+
+  auto x2nmodp_direct_crc32c = [](int exponent) -> uint32_t {
+    uint32_t p = 1u << 31;
+    for (int i = 0; i < exponent; i++) {
+      p = ((p & 1) != 0) ? ((p >> 1) ^ CRC32C_POLY) : (p >> 1);
+    }
+    return p;
+  };
+
+  // Table 0: Base CRC32C lookup table.
+  for (int i = 0; i < table_size; i++) {
+    uint32_t crc = static_cast<uint32_t>(i);
+    for (int j = 0; j < 8; j++) {
+      crc = ((crc & 1) != 0) ? ((crc >> 1) ^ CRC32C_POLY) : (crc >> 1);
+    }
+    crc32c_table[i] = crc;
+  }
+
+  // Tables 1..3: scalar extension tables.
+  for (int table_idx = 1; table_idx < scalar_tables; table_idx++) {
+    const int prev_base = (table_idx - 1) * table_size;
+    const int curr_base = table_idx * table_size;
+    for (int i = 0; i < table_size; i++) {
+      uint32_t crc = crc32c_table[prev_base + i];
+      crc32c_table[curr_base + i] = crc32c_table[crc & 0xFF] ^ (crc >> 8);
+    }
+  }
+
+  // Tables 4..7: braid tables for vector_update_crc32() with (N=16, W=4).
+  for (int k = 0; k < braid_tables; k++) {
+    const int exponent = (N * W + 3 - k) << 3;
+    const uint32_t p = x2nmodp_direct_crc32c(exponent);
+    const int base = (scalar_tables + k) * table_size;
+    crc32c_table[base] = 0;
+    for (int i = 1; i < table_size; i++) {
+      crc32c_table[base + i] =
+          multmodp_crc32c(static_cast<uint32_t>(i) << 24, p);
+    }
+  }
+
+  // Add CRC32C carry-less multiplication constants for Zvbc folding/reduction.
+  // Keep this sequence in sync with kernel_crc32_vclmul_fold_* table consumption.
+  int vclmul_offset = (scalar_tables + braid_tables) * table_size;
+
+  crc32c_table[vclmul_offset++] = 0x6992cea2UL;
+  crc32c_table[vclmul_offset++] = 0x00000000UL;
+  crc32c_table[vclmul_offset++] = 0x0d3b6092UL;
+  crc32c_table[vclmul_offset++] = 0x00000000UL;
+  crc32c_table[vclmul_offset++] = 0x740eef02UL;
+  crc32c_table[vclmul_offset++] = 0x00000000UL;
+  crc32c_table[vclmul_offset++] = 0x9e4addf8UL;
+  crc32c_table[vclmul_offset++] = 0x00000000UL;
+  crc32c_table[vclmul_offset++] = 0x1c291d04UL;
+  crc32c_table[vclmul_offset++] = 0x00000000UL;
+  crc32c_table[vclmul_offset++] = 0xd82c63daUL;
+  crc32c_table[vclmul_offset++] = 0x00000001UL;
+  crc32c_table[vclmul_offset++] = 0x384aa63aUL;
+  crc32c_table[vclmul_offset++] = 0x00000001UL;
+  crc32c_table[vclmul_offset++] = 0xba4fc28eUL;
+  crc32c_table[vclmul_offset++] = 0x00000000UL;
+  crc32c_table[vclmul_offset++] = 0xf20c0dfeUL;
+  crc32c_table[vclmul_offset++] = 0x00000000UL;
+  crc32c_table[vclmul_offset++] = 0x4cd00bd6UL;
+  crc32c_table[vclmul_offset++] = 0x00000001UL;
+
+  _crc32c_table = crc32c_table;
+}
+
+#undef CRC32C_POLY
 
 ATTRIBUTE_ALIGNED(4096) juint StubRoutines::riscv::_crc_table[] =
 {

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
@@ -58,6 +58,8 @@ bool StubRoutines::riscv::_completed = false;
 
 // CRC32C table pointer (initialized on first use)
 juint* StubRoutines::riscv::_crc32c_table = nullptr;
+juint* StubRoutines::riscv::_crc32c_table_ext = nullptr;
+ATTRIBUTE_ALIGNED(4096) juint StubRoutines::riscv::_crc_table_ext[4 * 256];
 
 /**
  *  crc_table[] from jdk/src/java.base/share/native/libzip/zlib/crc32.h
@@ -69,6 +71,35 @@ address StubRoutines::crc32c_table_addr() {
     StubRoutines::riscv::generate_CRC32C_table();
   }
   return (address)StubRoutines::riscv::_crc32c_table;
+}
+
+address StubRoutines::riscv::crc_table_ext_addr() {
+  static bool initialized = false;
+  if (!initialized) {
+    generate_CRC32_ext_table();
+    initialized = true;
+  }
+  return (address)_crc_table_ext;
+}
+
+address StubRoutines::riscv::crc32c_table_ext_addr() {
+  if (_crc32c_table_ext == nullptr) {
+    generate_CRC32C_table();
+  }
+  return (address)_crc32c_table_ext;
+}
+
+void StubRoutines::riscv::generate_CRC32_ext_table() {
+  const juint* table0 = _crc_table;
+  for (int index = 0; index < 256; index++) {
+    juint r = table0[index];
+    for (int k = 1; k <= 7; k++) {
+      r = table0[r & 0xFF] ^ (r >> 8);
+      if (k >= 4) {
+        _crc_table_ext[(k - 4) * 256 + index] = r;
+      }
+    }
+  }
 }
 
 /**
@@ -87,6 +118,7 @@ void StubRoutines::riscv::generate_CRC32C_table() {
   constexpr int W = 4;
 
   ATTRIBUTE_ALIGNED(4096) static juint crc32c_table[(scalar_tables + braid_tables) * table_size + 20];
+  ATTRIBUTE_ALIGNED(4096) static juint crc32c_table_ext[4 * table_size];
 
   auto multmodp_crc32c = [](uint32_t a, uint32_t b) -> uint32_t {
     if (a == 0) {
@@ -147,6 +179,18 @@ void StubRoutines::riscv::generate_CRC32C_table() {
     }
   }
 
+  // Scalar slicing-by-8 extension tables (table4..table7), stored separately
+  // from vector braid tables to preserve existing vector table layout.
+  for (int index = 0; index < table_size; index++) {
+    uint32_t r = crc32c_table[index];
+    for (int k = 1; k <= 7; k++) {
+      r = crc32c_table[r & 0xFF] ^ (r >> 8);
+      if (k >= 4) {
+        crc32c_table_ext[(k - 4) * table_size + index] = r;
+      }
+    }
+  }
+
   // Add CRC32C carry-less multiplication constants for Zvbc folding/reduction.
   // Keep this sequence in sync with kernel_crc32_vclmul_fold_* table consumption.
   int vclmul_offset = (scalar_tables + braid_tables) * table_size;
@@ -173,6 +217,7 @@ void StubRoutines::riscv::generate_CRC32C_table() {
   crc32c_table[vclmul_offset++] = 0x00000001UL;
 
   _crc32c_table = crc32c_table;
+  _crc32c_table_ext = crc32c_table_ext;
 }
 
 #undef CRC32C_POLY

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -99,11 +99,16 @@ private:
 
 private:
   static juint    _crc_table[];
+  static juint    _crc_table_ext[];
   static juint*   _crc32c_table;
+  static juint*   _crc32c_table_ext;
 
 public:
   // CRC32C table generation
   static void generate_CRC32C_table();
+  static void generate_CRC32_ext_table();
+  static address crc_table_ext_addr();
+  static address crc32c_table_ext_addr();
 };
 
 #endif // CPU_RISCV_STUBROUTINES_RISCV_HPP

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -99,6 +99,11 @@ private:
 
 private:
   static juint    _crc_table[];
+  static juint*   _crc32c_table;
+
+public:
+  // CRC32C table generation
+  static void generate_CRC32C_table();
 };
 
 #endif // CPU_RISCV_STUBROUTINES_RISCV_HPP

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -214,8 +214,14 @@ void VM_Version::common_initialize() {
     FLAG_SET_DEFAULT(UseCRC32Intrinsics, false);
   }
 
-  if (UseCRC32CIntrinsics) {
-    warning("CRC32C intrinsics are not available on this CPU.");
+  if (!AvoidUnalignedAccesses && (UseZba || UseRVV)) {
+    if (FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {
+      FLAG_SET_DEFAULT(UseCRC32CIntrinsics, true);
+    }
+  } else {
+    if (!FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {
+      warning("CRC32C intrinsic are not available on this CPU.");
+    }
     FLAG_SET_DEFAULT(UseCRC32CIntrinsics, false);
   }
 }


### PR DESCRIPTION
This pull request improves CRC32 and CRC32C support in the RISC-V backend.

The main change adds slicing-by-8 processing for the scalar CRC32 and
CRC32C paths. A new 64-bit update helper processes eight input bytes at
a time using eight lookup tables. The required extended lookup tables are
generated and exposed through RISC-V stub routines for both CRC32 and
CRC32C.

The change also implements the CRC32C intrinsic in the RISC-V
compiler path. The CRC32C byte-array and direct-byte-buffer intrinsics are
lowered to the generated CRC32C stub when `UseCRC32CIntrinsics` is
enabled.

Finally, fix the tail handling in the vector CRC32 implementation. The
initial CRC value is inserted into the vector using `vslide1up.vx` instead
of relying on scalar-to-vector insertion behavior that does not correctly
preserve the expected vector layout for the tail path.

Together, these changes improve CRC32 and CRC32C code generation while
preserving the existing vector and intrinsic entry points.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8390038](https://bugs.openjdk.org/browse/JDK-8390038): RISC-V: Optimize CRC32 and CRC32C with slicing-by-8 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32080/head:pull/32080` \
`$ git checkout pull/32080`

Update a local copy of the PR: \
`$ git checkout pull/32080` \
`$ git pull https://git.openjdk.org/jdk.git pull/32080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32080`

View PR using the GUI difftool: \
`$ git pr show -t 32080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32080.diff">https://git.openjdk.org/jdk/pull/32080.diff</a>

</details>
