### PR TITLE
8390037: Optimize DES S-box table layout in DESCrypt

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DESCrypt.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESCrypt.java
@@ -40,7 +40,8 @@ import java.security.InvalidKeyException;
  */
 
 class DESCrypt extends SymmetricCipher implements DESConstants {
-    private static final int[] s0p = {
+    private static final int[] sp = {
+        // s0p (offset 0)
         0x00410100, 0x00010000, 0x40400000, 0x40410100, 0x00400000,
         0x40010100, 0x40010000, 0x40400000, 0x40010100, 0x00410100,
         0x00410000, 0x40000100, 0x40400100, 0x00400000, 0x00000000,
@@ -54,9 +55,7 @@ class DESCrypt extends SymmetricCipher implements DESConstants {
         0x00410000, 0x40400100, 0x00400000, 0x40000100, 0x40010000,
         0x00000000, 0x00010000, 0x00400000, 0x40400100, 0x00410100,
         0x40000000, 0x40410000, 0x00000100, 0x40010100,
-    };
-
-    private static final int[] s1p = {
+        // s1p (offset 64)
         0x08021002, 0x00000000, 0x00021000, 0x08020000, 0x08000002,
         0x00001002, 0x08001000, 0x00021000, 0x00001000, 0x08020002,
         0x00000002, 0x08001000, 0x00020002, 0x08021000, 0x08020000,
@@ -70,9 +69,7 @@ class DESCrypt extends SymmetricCipher implements DESConstants {
         0x00000000, 0x08000002, 0x00000002, 0x08021002, 0x00021000,
         0x08020000, 0x08020002, 0x00020000, 0x00001002, 0x08001000,
         0x08001002, 0x00000002, 0x08020000, 0x00021000,
-    };
-
-    private static final int[] s2p = {
+        // s2p (offset 128)
         0x20800000, 0x00808020, 0x00000020, 0x20800020, 0x20008000,
         0x00800000, 0x20800020, 0x00008020, 0x00800020, 0x00008000,
         0x00808000, 0x20000000, 0x20808020, 0x20000020, 0x20000000,
@@ -86,9 +83,7 @@ class DESCrypt extends SymmetricCipher implements DESConstants {
         0x00800000, 0x20808020, 0x00008000, 0x00800020, 0x20800020,
         0x00008020, 0x00800020, 0x00000000, 0x20808000, 0x20000020,
         0x20800000, 0x20008020, 0x00000020, 0x00808000,
-    };
-
-    private static final int[] s3p = {
+        // s3p (offset 192)
         0x00080201, 0x02000200, 0x00000001, 0x02080201, 0x00000000,
         0x02080000, 0x02000201, 0x00080001, 0x02080200, 0x02000001,
         0x02000000, 0x00000201, 0x02000001, 0x00080201, 0x00080000,
@@ -102,9 +97,7 @@ class DESCrypt extends SymmetricCipher implements DESConstants {
         0x00080201, 0x00080000, 0x02080201, 0x00000001, 0x02000200,
         0x00080201, 0x00080001, 0x00080200, 0x02080000, 0x02000201,
         0x00000201, 0x02000000, 0x02000001, 0x02080200,
-    };
-
-    private static final int[] s4p = {
+        // s4p (offset 256)
         0x01000000, 0x00002000, 0x00000080, 0x01002084, 0x01002004,
         0x01000080, 0x00002084, 0x01002000, 0x00002000, 0x00000004,
         0x01000004, 0x00002080, 0x01000084, 0x01002004, 0x01002080,
@@ -118,9 +111,7 @@ class DESCrypt extends SymmetricCipher implements DESConstants {
         0x00000000, 0x01002084, 0x01002004, 0x01002080, 0x00000084,
         0x00002000, 0x00002080, 0x01002004, 0x01000080, 0x00000084,
         0x00000004, 0x00002084, 0x01002000, 0x01000004,
-    };
-
-    private static final int[] s5p = {
+        // s5p (offset 320)
         0x10000008, 0x00040008, 0x00000000, 0x10040400, 0x00040008,
         0x00000400, 0x10000408, 0x00040000, 0x00000408, 0x10040408,
         0x00040400, 0x10000000, 0x10000400, 0x10000008, 0x10040000,
@@ -134,9 +125,7 @@ class DESCrypt extends SymmetricCipher implements DESConstants {
         0x00040000, 0x10000408, 0x10000008, 0x10040000, 0x00040408,
         0x00000000, 0x00000400, 0x10000008, 0x10000408, 0x10040400,
         0x10040000, 0x00000408, 0x00000008, 0x10040008,
-    };
-
-    private static final int[] s6p = {
+        // s6p (offset 384)
         0x00000800, 0x00000040, 0x00200040, 0x80200000, 0x80200840,
         0x80000800, 0x00000840, 0x00000000, 0x00200000, 0x80200040,
         0x80000040, 0x00200800, 0x80000000, 0x00200840, 0x00200800,
@@ -150,9 +139,7 @@ class DESCrypt extends SymmetricCipher implements DESConstants {
         0x00200040, 0x00000840, 0x80000040, 0x00000800, 0x80200840,
         0x00200000, 0x00200840, 0x80000000, 0x80000800, 0x80200840,
         0x80200000, 0x00200840, 0x00200800, 0x80000800,
-    };
-
-    private static final int[] s7p = {
+        // s7p (offset 448)
         0x04100010, 0x04104000, 0x00004010, 0x00000000, 0x04004000,
         0x00100010, 0x04100000, 0x04104010, 0x00000010, 0x04000000,
         0x00104000, 0x00004010, 0x00104010, 0x04004010, 0x04000010,
@@ -614,17 +601,17 @@ class DESCrypt extends SymmetricCipher implements DESConstants {
             // mangler function:
             // every 6 bit is fed into the sbox, which
             // produces 4-bit output
-            left ^= s0p[(temp & 0x3f) ^ key[j+0]]
-                ^ s1p[((temp >>  4) & 0x3f) ^ key[j+1]]
-                ^ s2p[((temp >>  8) & 0x3f) ^ key[j+2]]
-                ^ s3p[((temp >> 12) & 0x3f) ^ key[j+3]]
-                ^ s4p[((temp >> 16) & 0x3f) ^ key[j+4]]
-                ^ s5p[((temp >> 20) & 0x3f) ^ key[j+5]]
-                ^ s6p[((temp >> 24) & 0x3f) ^ key[j+6]];
+            left ^= sp[(temp & 0x3f) ^ key[j+0]]
+                ^ sp[64 | (((temp >>  4) & 0x3f) ^ key[j+1])]
+                ^ sp[128 | (((temp >>  8) & 0x3f) ^ key[j+2])]
+                ^ sp[192 | (((temp >> 12) & 0x3f) ^ key[j+3])]
+                ^ sp[256 | (((temp >> 16) & 0x3f) ^ key[j+4])]
+                ^ sp[320 | (((temp >> 20) & 0x3f) ^ key[j+5])]
+                ^ sp[384 | (((temp >> 24) & 0x3f) ^ key[j+6])];
 
             // make the last sbox input the last bit from right[0]
             temp = ((right & 1) << 5) | ((right >> 27) & 0x1f);
-            left ^= s7p[temp ^ key[j+7]];
+            left ^= sp[448 | (temp ^ key[j+7])];
             temp = left;
             left = right;
             right = temp;


### PR DESCRIPTION
This pull request simplifies the DES S-box table representation in
`DESCrypt`.

The eight separate S-box tables, `s0p` through `s7p`, are consolidated
into a single contiguous table. Each S-box is identified by a fixed
offset within the shared table, and the DES round function is updated to
use the corresponding offset when accessing the S-box entries.

This reduces the number of separate table objects and provides a simpler
and more uniform table layout while preserving the existing DES
transformation logic and lookup results.

No algorithmic behavior is changed.

### Performance
Performance was measured with `specjvm.crypto.aes`:

| Platform | Without this patch | With this patch |
| --- | ---: | ---: |
| riscv-k1 | 2.55 ops/m | 4.06 ops/m |
| arm-N2 | 23.56 ops/m | 27.45 ops/m |

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8390037](https://bugs.openjdk.org/browse/JDK-8390037): Optimize DES S-box table layout in DESCrypt (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32082/head:pull/32082` \
`$ git checkout pull/32082`

Update a local copy of the PR: \
`$ git checkout pull/32082` \
`$ git pull https://git.openjdk.org/jdk.git pull/32082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32082`

View PR using the GUI difftool: \
`$ git pr show -t 32082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32082.diff">https://git.openjdk.org/jdk/pull/32082.diff</a>

</details>
