### PR TITLE
8388755: Use floating point argument for fillVertex in MTLRenderer

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,7 +191,7 @@ void MTLRenderer_DrawRect(MTLContext *mtlc, BMTLSDOps * dstOps, jint x, jint y, 
 
 const int POLYLINE_BUF_SIZE = 64;
 
-NS_INLINE void fillVertex(struct Vertex * vertex, int x, int y) {
+NS_INLINE void fillVertex(struct Vertex * vertex, jfloat x, jfloat y) {
     vertex->position[0] = x;
     vertex->position[1] = y;
 }


### PR DESCRIPTION
We are doing float->int conversion while populating vertex data for drawPoly and drawParallelogram in MTLRenderer.fillVertex(). The final Vertex position which is passed to shader also supports storing float data, so we should not be doing this intermediate float to int conversion. This was noticed while reviewing another PR: https://github.com/openjdk/jdk/pull/31981#issuecomment-5045302871

This also deviates from what we do in OpenGL, where we directly store these float values. We also add 0.5f values to these vertex position to hit pixel centers for drawPoly, doing float->int conversion overrides this logic.

Fix is to use float arguments for fillVertex. There are no regressions seen in clientlibs testing.
Its is very difficult to write a reliable pass & fail regression test for this fix. So i have added noreg-hard label in the bug.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388755](https://bugs.openjdk.org/browse/JDK-8388755): Use floating point argument for fillVertex in MTLRenderer (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32083/head:pull/32083` \
`$ git checkout pull/32083`

Update a local copy of the PR: \
`$ git checkout pull/32083` \
`$ git pull https://git.openjdk.org/jdk.git pull/32083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32083`

View PR using the GUI difftool: \
`$ git pr show -t 32083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32083.diff">https://git.openjdk.org/jdk/pull/32083.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32083#issuecomment-5114872463)
</details>
