### PR TITLE
8390036: C2: Avoid duplicate AddP base rematerialization

### DIFF
--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -912,6 +912,12 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
         JVMState* jvms = n->jvms();
         uint oopoff = jvms ? jvms->oopoff() : cnt;
         uint old_last = cnt - 1;
+
+        MachNode *addp_mach = n->is_Mach() ? n->as_Mach() : nullptr;
+        bool is_addp = (addp_mach && addp_mach->ideal_Opcode() == Op_AddP);
+        Node* addp_base_original_def = nullptr;
+        Node* addp_base_remat_def = nullptr;
+
         for( inpidx = 1; inpidx < cnt; inpidx++ ) {
           // Derived/base pairs may be added to our inputs during this loop.
           // If inpidx > old_last, then one of these new inputs is being
@@ -948,10 +954,23 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
             // Rematerializable?  Then clone def at use site instead
             // of store/load
             if( def->rematerialize() ) {
-              int old_size = b->number_of_nodes();
-              def = split_Rematerialize( def, b, insidx, maxlrg, splits, slidx, lrg2reach, Reachblock, true );
-              if( !def ) return 0; // Bail out
-              insidx += b->number_of_nodes()-old_size;
+              Node* original_def = def;
+              bool reuse_addp_base_remat = is_addp &&
+                                           inpidx == AddPNode::Address &&
+                                           addp_base_original_def != nullptr &&
+                                           addp_base_original_def == original_def;
+              if (reuse_addp_base_remat) {
+                def = addp_base_remat_def;
+              } else {
+                int old_size = b->number_of_nodes();
+                def = split_Rematerialize( def, b, insidx, maxlrg, splits, slidx, lrg2reach, Reachblock, true );
+                if( !def ) return 0; // Bail out
+                insidx += b->number_of_nodes()-old_size;
+                if (is_addp && inpidx == AddPNode::Base) {
+                  addp_base_original_def = original_def;
+                  addp_base_remat_def = def;
+                }
+              }
             }
 
             MachNode *mach = n->is_Mach() ? n->as_Mach() : nullptr;


### PR DESCRIPTION
This pull request improves C2 register splitting by avoiding duplicate
rematerialization for some AddP nodes.

During register splitting, a rematerializable definition may be cloned at
the use site instead of being spilled and reloaded. For an AddP node, the
base and address inputs can refer to the same original rematerializable
definition. The current code may rematerialize that same definition twice
while processing the inputs of a single AddP node.

This change records the rematerialized definition used for the AddP base
input. If the AddP address input refers to the same original definition,
the already rematerialized node is reused instead of cloning it again.

This avoids generating duplicate rematerialized nodes for this case while
preserving the existing register splitting behavior for other nodes.

For example, without this patch C2 may rematerialize the same constant
array pointer twice before forming the address:
```asm
092e    B19: #  out( B63 B20 ) <- in( B18 )  Freq: 16.9945
092e +  mv  R18, aryptr:int[int:64] (java/lang/Cloneable,java/io/Serializable)<ciTypeArray length=64 type=<ciTypeArrayKlass name=[I loaded=true ident=1383 address=0x0000003f38012ac8> ident=1436 address=0x0000003ef82763d8>:Constant:exact,iid=bot      # ptr, #@loadConP
0946 +  mv  R30, aryptr:int[int:64] (java/lang/Cloneable,java/io/Serializable)<ciTypeArray length=64 type=<ciTypeArrayKlass name=[I loaded=true ident=1383 address=0x0000003f38012ac8> ident=1436 address=0x0000003ef82763d8>:Constant:exact,iid=bot      # ptr, #@loadConP
095e +  shadd  R30, R28, R18, #2        # ptr, #@shaddP_reg_reg_ext_b
0962 +  andi  R28, R20, #63     #@andI_reg_imm
0966    spill R28 -> R18        # spill size = 32
0968 +  lw  R28, [R30, #16]     # int, #@loadI
096c    spill R28 -> [sp, #32]  # spill size = 32
096e +  bgeu  R29, R7, B63      #@cmpU_branch  P=0.000001 C=-1.000000
```
With this patch, the rematerialized base is reused for the AddP address
input, so only one constant pointer materialization is emitted:
```asm
087e    B19: #  out( B63 B20 ) <- in( B18 )  Freq: 16.9972
087e +  mv  R31, aryptr:int[int:64] (java/lang/Cloneable,java/io/Serializable)<ciTypeArray length=64 type=<ciTypeArrayKlass name=[I loaded=true ident=1381 address=0x0000003f5800aca8> ident=1434 address=0x0000003f584168a8>:Constant:exact,iid=bot # ptr, #@loadConP
0896 +  shadd  R31, R19, R31, #2        # ptr, #@shaddP_reg_reg_ext_b
089a +  andi  R29, R18, #63     #@andI_reg_imm
089e    spill R29 -> R19        # spill size = 32
08a0 +  lw  R29, [R31, #16]     # int, #@loadI
08a4    spill R29 -> [sp, #32]  # spill size = 32
08a6 +  bgeu  R28, R7, B63      #@cmpU_branch  P=0.000001 C=-1.000000
```
This avoids generating duplicate rematerialized nodes for this case while
preserving the existing register splitting behavior for other nodes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8390036](https://bugs.openjdk.org/browse/JDK-8390036): C2: Avoid duplicate AddP base rematerialization (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32084/head:pull/32084` \
`$ git checkout pull/32084`

Update a local copy of the PR: \
`$ git checkout pull/32084` \
`$ git pull https://git.openjdk.org/jdk.git pull/32084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32084`

View PR using the GUI difftool: \
`$ git pr show -t 32084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32084.diff">https://git.openjdk.org/jdk/pull/32084.diff</a>

</details>
