### PR TITLE
8388698: Typo "docllint" instead of "doclint" in jdk.compiler  module-summary.html

### DIFF
--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -204,7 +204,7 @@ import javax.tools.StandardLocation;
  * </tbody>
  * </table>
  *
- * All of the non-{@code docllint:} strings listed above may also be used with the {@code -Xlint} command line flag.
+ * All of the non-{@code doclint:} strings listed above may also be used with the {@code -Xlint} command line flag.
  * The {@code -Xlint} flag also supports these strings not supported by {@code @SuppressWarnings}:
  *
  * <table class="striped">


### PR DESCRIPTION
Please review this change. Thanks!

Fix typo in module-info.java documentation.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388698](https://bugs.openjdk.org/browse/JDK-8388698): Typo "docllint" instead of "doclint" in jdk.compiler  module-summary.html (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32085/head:pull/32085` \
`$ git checkout pull/32085`

Update a local copy of the PR: \
`$ git checkout pull/32085` \
`$ git pull https://git.openjdk.org/jdk.git pull/32085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32085`

View PR using the GUI difftool: \
`$ git pr show -t 32085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32085.diff">https://git.openjdk.org/jdk/pull/32085.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32085#issuecomment-5125499599)
</details>
