### PR TITLE
8389259: Class::desiredAssertionStatus asserts with primitive or array class receiver

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2217,11 +2217,12 @@ JVM_ENTRY(jboolean, JVM_DesiredAssertionStatus(JNIEnv *env, jclass unused, jclas
   assert(cls != nullptr, "bad class");
 
   oop r = JNIHandles::resolve(cls);
-  if (java_lang_Class::is_primitive(r)) {
-    return JavaAssertions::systemClassDefault();
-  }
+  assert(! java_lang_Class::is_primitive(r), "primitive classes not allowed");
+  if (java_lang_Class::is_primitive(r)) return false;
 
   Klass* k = java_lang_Class::as_Klass(r);
+  assert(k->is_instance_klass(), "must be an instance klass");
+  if (!k->is_instance_klass()) return false;
 
   ResourceMark rm(THREAD);
   const char* name = k->name()->as_C_string();

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2217,12 +2217,11 @@ JVM_ENTRY(jboolean, JVM_DesiredAssertionStatus(JNIEnv *env, jclass unused, jclas
   assert(cls != nullptr, "bad class");
 
   oop r = JNIHandles::resolve(cls);
-  assert(! java_lang_Class::is_primitive(r), "primitive classes not allowed");
-  if (java_lang_Class::is_primitive(r)) return false;
+  if (java_lang_Class::is_primitive(r)) {
+    return JavaAssertions::systemClassDefault();
+  }
 
   Klass* k = java_lang_Class::as_Klass(r);
-  assert(k->is_instance_klass(), "must be an instance klass");
-  if (!k->is_instance_klass()) return false;
 
   ResourceMark rm(THREAD);
   const char* name = k->name()->as_C_string();

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3324,6 +3324,8 @@ public final class Class<T> implements java.io.Serializable,
      * @since  1.4
      */
     public boolean desiredAssertionStatus() {
+        if (isPrimitive() || isArray()) return false;
+
         ClassLoader loader = classLoader;
         // If the loader is null this is a system class, so ask the VM
         if (loader == null)

--- a/test/jdk/java/lang/Class/desiredAssertionStatus/Sanity.java
+++ b/test/jdk/java/lang/Class/desiredAssertionStatus/Sanity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8389259
+ * @summary Sanity check that Class.desiredAssertionStatus() works.
+ * @library /test/lib
+ * @run testng/othervm -esa -ea -Dsys.option=on  -Duser.option=on Sanity
+ * @run testng/othervm -dsa -ea -Dsys.option=off -Duser.option=on Sanity
+ * @run testng/othervm -esa -ea -Dsys.option=on  -Duser.option=on Sanity
+ * @run testng/othervm -esa -da -Dsys.option=on  -Duser.option=off Sanity
+ */
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class Sanity {
+
+    @Test
+    public void test() throws Exception {
+        boolean systemDefaultOn = System.getProperty("sys.option").equals("on");
+        boolean userDefaultOn = System.getProperty("user.option").equals("on");
+
+        Assert.assertTrue(Object.class.desiredAssertionStatus() == systemDefaultOn);
+        Assert.assertTrue(Object[].class.desiredAssertionStatus() == systemDefaultOn);
+        Assert.assertTrue(Sanity.class.desiredAssertionStatus() == userDefaultOn);
+    }
+}

--- a/test/jdk/java/lang/Class/desiredAssertionStatus/Sanity.java
+++ b/test/jdk/java/lang/Class/desiredAssertionStatus/Sanity.java
@@ -27,8 +27,8 @@
  * @library /test/lib
  * @run testng/othervm -esa -ea -Dsys.option=on  -Duser.option=on Sanity
  * @run testng/othervm -dsa -ea -Dsys.option=off -Duser.option=on Sanity
- * @run testng/othervm -esa -ea -Dsys.option=on  -Duser.option=on Sanity
  * @run testng/othervm -esa -da -Dsys.option=on  -Duser.option=off Sanity
+ * @run testng/othervm -dsa -da -Dsys.option=off -Duser.option=off Sanity
  */
 
 import org.testng.annotations.Test;

--- a/test/jdk/java/lang/Class/desiredAssertionStatus/Sanity.java
+++ b/test/jdk/java/lang/Class/desiredAssertionStatus/Sanity.java
@@ -44,5 +44,6 @@ public class Sanity {
         Assert.assertTrue(Object.class.desiredAssertionStatus() == systemDefaultOn);
         Assert.assertTrue(Object[].class.desiredAssertionStatus() == systemDefaultOn);
         Assert.assertTrue(Sanity.class.desiredAssertionStatus() == userDefaultOn);
+        Assert.assertTrue(Sanity[].class.desiredAssertionStatus() == userDefaultOn);
     }
 }

--- a/test/jdk/java/lang/Class/desiredAssertionStatus/Sanity.java
+++ b/test/jdk/java/lang/Class/desiredAssertionStatus/Sanity.java
@@ -41,9 +41,10 @@ public class Sanity {
         boolean systemDefaultOn = System.getProperty("sys.option").equals("on");
         boolean userDefaultOn = System.getProperty("user.option").equals("on");
 
+        Assert.assertTrue(int.class.desiredAssertionStatus() == false);
         Assert.assertTrue(Object.class.desiredAssertionStatus() == systemDefaultOn);
-        Assert.assertTrue(Object[].class.desiredAssertionStatus() == systemDefaultOn);
+        Assert.assertTrue(Object[].class.desiredAssertionStatus() == false);
         Assert.assertTrue(Sanity.class.desiredAssertionStatus() == userDefaultOn);
-        Assert.assertTrue(Sanity[].class.desiredAssertionStatus() == userDefaultOn);
+        Assert.assertTrue(Sanity[].class.desiredAssertionStatus() == false);
     }
 }


### PR DESCRIPTION
This fixes a longstanding problem with desiredAssertionStatus and adds a test.
Tested with tier1.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389259](https://bugs.openjdk.org/browse/JDK-8389259): Class::desiredAssertionStatus asserts with primitive or array class receiver (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32086/head:pull/32086` \
`$ git checkout pull/32086`

Update a local copy of the PR: \
`$ git checkout pull/32086` \
`$ git pull https://git.openjdk.org/jdk.git pull/32086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32086`

View PR using the GUI difftool: \
`$ git pr show -t 32086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32086.diff">https://git.openjdk.org/jdk/pull/32086.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32086#issuecomment-5117573935)
</details>
