### PR TITLE
8389323: Remove unused jdk.internal.httpclient.monitorFlowDelegate property

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -34,9 +34,6 @@ import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
-import java.lang.ref.Reference;
-import java.lang.ref.ReferenceQueue;
-import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -111,9 +108,6 @@ public class SSLFlowDelegate {
     private static final ByteBuffer HS_TRIGGER = ByteBuffer.allocate(0);
     // When handshake is in progress trying to wrap may produce no bytes.
     private static final ByteBuffer NOTHING = ByteBuffer.allocate(0);
-    private static final String monProp = Utils.getProperty("jdk.internal.httpclient.monitorFlowDelegate");
-    private static final boolean isMonitored =
-            monProp != null && (monProp.isEmpty() || monProp.equalsIgnoreCase("true"));
 
     final Executor exec;
     final Reader reader;
@@ -121,7 +115,6 @@ public class SSLFlowDelegate {
     final SSLEngine engine;
     final String tubeName; // hack
     final CompletableFuture<String> alpnCF; // completes on initial handshake
-    final Monitorable monitor = isMonitored ? this::monitor : null; // prevent GC until SSLFD is stopped
     volatile boolean close_notify_received;
     final CompletableFuture<Void> readerCF;
     final CompletableFuture<Void> writerCF;
@@ -173,8 +166,6 @@ public class SSLFlowDelegate {
         // connect the Reader to the downReader and the
         // Writer to the downWriter.
         connect(downReader, downWriter);
-
-        if (isMonitored) Monitor.add(monitor);
     }
 
     /**
@@ -218,26 +209,6 @@ public class SSLFlowDelegate {
         String alpn = engine.getApplicationProtocol();
         if (debug.on()) debug.log("setALPN = %s", alpn);
         alpnCF.complete(alpn);
-    }
-
-    public String monitor() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("SSL: id ").append(id);
-        sb.append(" ").append(dbgString());
-        sb.append(" HS state: " + states(handshakeState));
-        sb.append(" Engine state: " + engine.getHandshakeStatus().toString());
-        if (stateList != null) {
-            sb.append(" LL : ");
-            for (String s : stateList) {
-                sb.append(s).append(" ");
-            }
-        }
-        sb.append("\r\n");
-        sb.append("Reader:: ").append(reader.toString());
-        sb.append("\r\n");
-        sb.append("Writer:: ").append(writer.toString());
-        sb.append("\r\n===================================");
-        return sb.toString();
     }
 
     protected SchedulingAction enterReadScheduling() {
@@ -607,104 +578,6 @@ public class SSLFlowDelegate {
         }
     }
 
-    public interface Monitorable {
-        public String getInfo();
-    }
-
-    public static class Monitor extends Thread {
-        final List<WeakReference<Monitorable>> list;
-        final List<FinalMonitorable> finalList;
-        final ReferenceQueue<Monitorable> queue = new ReferenceQueue<>();
-        static Monitor themon;
-
-        static {
-            themon = new Monitor();
-            themon.start(); // uncomment to enable Monitor
-        }
-
-        // An instance used to temporarily store the
-        // last observable state of a monitorable object.
-        // When Monitor.remove(o) is called, we replace
-        // 'o' with a FinalMonitorable whose reference
-        // will be enqueued after the last observable state
-        // has been printed.
-        final class FinalMonitorable implements Monitorable {
-            final String finalState;
-            FinalMonitorable(Monitorable o) {
-                finalState = o.getInfo();
-                finalList.add(this);
-            }
-            @Override
-            public String getInfo() {
-                finalList.remove(this);
-                return finalState;
-            }
-        }
-
-        Monitor() {
-            super("Monitor");
-            setDaemon(true);
-            list = Collections.synchronizedList(new LinkedList<>());
-            finalList = new ArrayList<>(); // access is synchronized on list above
-        }
-
-        void addTarget(Monitorable o) {
-            list.add(new WeakReference<>(o, queue));
-        }
-        void removeTarget(Monitorable o) {
-            // It can take a long time for GC to clean up references.
-            // Calling Monitor.remove() early helps removing noise from the
-            // logs/
-            synchronized (list) {
-                Iterator<WeakReference<Monitorable>> it = list.iterator();
-                while (it.hasNext()) {
-                    Monitorable m = it.next().get();
-                    if (m == null) it.remove();
-                    if (o == m) {
-                        it.remove();
-                        break;
-                    }
-                }
-                FinalMonitorable m = new FinalMonitorable(o);
-                addTarget(m);
-                Reference.reachabilityFence(m);
-            }
-        }
-
-        public static void add(Monitorable o) {
-            themon.addTarget(o);
-        }
-        public static void remove(Monitorable o) {
-            themon.removeTarget(o);
-        }
-
-        @Override
-        public void run() {
-            System.out.println("Monitor starting");
-            try {
-                while (true) {
-                    Thread.sleep(20 * 1000);
-                    synchronized (list) {
-                        Reference<? extends Monitorable> expired;
-                        while ((expired = queue.poll()) != null) list.remove(expired);
-                        for (WeakReference<Monitorable> ref : list) {
-                            Monitorable o = ref.get();
-                            if (o == null) continue;
-                            if (o instanceof FinalMonitorable) {
-                                ref.enqueue();
-                            }
-                            System.out.println(o.getInfo());
-                            System.out.println("-------------------------");
-                        }
-                    }
-                    System.out.println("--o-o-o-o-o-o-o-o-o-o-o-o-o-o-");
-                }
-            } catch (InterruptedException e) {
-                System.out.println("Monitor exiting with " + e);
-            }
-        }
-    }
-
     /**
      * Processing function for outgoing data. Pass it thru SSLEngine.wrap()
      * Any encrypted buffers generated are passed downstream to be written.
@@ -1007,7 +880,6 @@ public class SSLFlowDelegate {
                     "Connection closed before successful ALPN negotiation");
             alpnCF.completeExceptionally(alpn);
         }
-        if (isMonitored) Monitor.remove(monitor);
     }
 
     private Void stopOnError(Throwable error) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -119,8 +119,6 @@ public class SSLFlowDelegate {
     final CompletableFuture<Void> writerCF;
     final CompletableFuture<Void> stopCF;
     final Consumer<ByteBuffer> recycler;
-    static AtomicInteger scount = new AtomicInteger(1);
-    final int id;
 
     /**
      * Creates an SSLFlowDelegate fed from two Flow.Subscribers. Each
@@ -146,7 +144,6 @@ public class SSLFlowDelegate {
             Subscriber<? super List<ByteBuffer>> downReader,
             Subscriber<? super List<ByteBuffer>> downWriter)
         {
-        this.id = scount.getAndIncrement();
         this.tubeName = String.valueOf(downWriter);
         this.recycler = recycler;
         this.reader = new Reader();

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -41,7 +41,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscriber;
@@ -943,8 +942,6 @@ public class SSLFlowDelegate {
     }
 
     final AtomicInteger handshakeState;
-    final ConcurrentLinkedQueue<String> stateList =
-            debug.on() ? new ConcurrentLinkedQueue<>() : null;
 
     // Atomically executed to update task bits. Sets either DOING_TASKS or REQUESTING_TASKS
     // depending on previous value
@@ -967,10 +964,6 @@ public class SSLFlowDelegate {
     private boolean doHandshake(HandshakeStatus handshakeStatus, int caller) {
         // unconditionally sets the HANDSHAKING bit, while preserving task bits
         handshakeState.getAndAccumulate(0, (current, unused) -> HANDSHAKING | (current & TASK_BITS));
-        if (stateList != null && debug.on()) {
-            stateList.add(handshakeStatus.toString());
-            stateList.add(Integer.toString(caller));
-        }
         switch (handshakeStatus) {
             case NEED_TASK:
                 int s = handshakeState.accumulateAndGet(0, REQUEST_OR_DO_TASKS);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -414,7 +414,6 @@ public class SSLFlowDelegate {
                 int len;
                 boolean complete = false;
                 while (readBuf.remaining() > (len = minBytesRequired)) {
-                    boolean handshaking = false;
                     try {
                         EngineResult result;
                         readBufferLock.lock();
@@ -479,7 +478,6 @@ public class SSLFlowDelegate {
                             return;
                         }
                         if (result.handshaking()) {
-                            handshaking = true;
                             if (debugr.on()) debugr.log("handshaking");
                             if (doHandshake(result.handshakeStatus(), READER)) continue; // need unwrap
                             else break; // doHandshake will have triggered the write scheduler if necessary
@@ -492,10 +490,6 @@ public class SSLFlowDelegate {
                         Throwable cause = checkForHandshake(ex);
                         errorCommon(cause);
                         handleError(cause);
-                        return;
-                    }
-                    if (handshaking && !complete) {
-                        requestMoreDataIfNeeded();
                         return;
                     }
                 }
@@ -1126,12 +1120,6 @@ public class SSLFlowDelegate {
                    && s != HandshakeStatus.NOT_HANDSHAKING
                    && result.getStatus() != Status.CLOSED;
         }
-
-        boolean needUnwrap() {
-            HandshakeStatus s = result.getHandshakeStatus();
-            return s == HandshakeStatus.NEED_UNWRAP;
-        }
-
 
         int bytesConsumed() {
             return result.bytesConsumed();

--- a/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/FlowTest.java
+++ b/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/FlowTest.java
@@ -219,7 +219,6 @@ public class FlowTest extends AbstractRandomTest {
             thread3 = new Thread(this::clientReader, "clientReader");
             publisher = new SubmissionPublisher<>(exec, Flow.defaultBufferSize(),
                     this::handlePublisherException);
-            SSLFlowDelegate.Monitor.add(this::monitor);
         }
 
         public void start() {
@@ -311,11 +310,6 @@ public class FlowTest extends AbstractRandomTest {
         }
 
         private final AtomicInteger loopCount = new AtomicInteger();
-
-        public String monitor() {
-            return "serverLoopback: loopcount = " + loopCount.get()
-                    + " clientRead: count = " + readCount.get();
-        }
 
         // thread2
         private void serverLoopback() {

--- a/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/SSLTubeTest.java
+++ b/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/SSLTubeTest.java
@@ -24,7 +24,6 @@
 package jdk.internal.net.http;
 
 import jdk.internal.net.http.common.FlowTube;
-import jdk.internal.net.http.common.SSLFlowDelegate;
 import jdk.internal.net.http.common.Utils;
 
 import javax.net.ssl.SSLContext;
@@ -104,7 +103,6 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
             thread3 = new Thread(this::clientReader, "clientReader");
             publisher = new SubmissionPublisher<>(exec, Flow.defaultBufferSize(),
                     this::handlePublisherException);
-            SSLFlowDelegate.Monitor.add(this::monitor);
         }
 
         public void start() {
@@ -195,11 +193,6 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
         }
 
         private final AtomicInteger loopCount = new AtomicInteger();
-
-        public String monitor() {
-            return "serverLoopback: loopcount = " + loopCount.toString()
-                    + " clientRead: count = " + readCount.toString();
-        }
 
         // thread2
         private void serverLoopback() {


### PR DESCRIPTION
Remove the SSLTubeSubscriber#Monitor class, related system property, code, and all uses. The class provided debug information that is also available in the httpclient debug logs, and was only used by 2 tests.

No new tests. Existing tests continue to pass.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389323](https://bugs.openjdk.org/browse/JDK-8389323): Remove unused jdk.internal.httpclient.monitorFlowDelegate property (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32089/head:pull/32089` \
`$ git checkout pull/32089`

Update a local copy of the PR: \
`$ git checkout pull/32089` \
`$ git pull https://git.openjdk.org/jdk.git pull/32089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32089`

View PR using the GUI difftool: \
`$ git pr show -t 32089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32089.diff">https://git.openjdk.org/jdk/pull/32089.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32089#issuecomment-5120417278)
</details>
