### PR TITLE
8389110: java/nio/file/FileStore/Basic.java testEnumerateFileStores fails in container: FileStores should be unique

### DIFF
--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -263,7 +263,7 @@ public final class FileUtils {
      * File systems are considered to be accessible if this process completes
      * successfully before a given fixed duration has elapsed.
      *
-     * @implNote On Unix this executes the {@code df} command in a separate
+     * @implNote On Unix this executes the {@code df -a} command in a separate
      * process and on Windows always returns {@code true}.
      *
      * @return whether file systems appear to be accessible and duplicate-free
@@ -274,7 +274,7 @@ public final class FileUtils {
         final AtomicBoolean areMountPointsOK = new AtomicBoolean(true);
         Thread thr = new Thread(() -> {
             try {
-                Process proc = new ProcessBuilder("df").start();
+                Process proc = new ProcessBuilder("df", "-a").start();
                 BufferedReader reader = new BufferedReader
                     (new InputStreamReader(proc.getInputStream()));
                 // Skip the first line as it is the "df" output header.


### PR DESCRIPTION
testEnumerateFileStores enumerates FileSystems.getDefault().getFileStores(), puts them in a HashSet and asserts the sizes match. In a container run it saw 35 stores but 34 unique.

Two identical entries in /proc/mounts produce two UnixFileStore objects that compare equal (equals requires dev, mount dir and name to all match), so the HashSet collapses them.

The test already guards against this with assumeTrue(FileUtils.areMountPointsAccessibleAndUnique()), but that helper runs plain `df`, which lists only a subset of mounted file systems - in the failing run `df` reported 4 file systems while the JDK enumerated 35 - so it cannot see the duplicates the test then asserts on.

Reproduced by creating a duplicate mount in a container:
mkdir -p /mnt/dup
mount --bind /mnt/dup /mnt/dup
mount --bind /mnt/dup /mnt/dup

/proc/mounts then holds two identical entries; `df` matches neither, `df -a` matches both. With that in place, only the flag differing:
df    -> jtreg FileStore/Basic.java: failed: 1
df -a -> jtreg FileStore/Basic.java: passed: 1 (assumption fires, testEnumerateFileStores skipped, other four subtests still run)

The @implNote is updated to match.
areFileSystemsAccessible() above also uses plain `df` while documenting itself as checking "all mounted file systems"; left unchanged to keep this minimal, but it may deserve the same fix.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389110](https://bugs.openjdk.org/browse/JDK-8389110): java/nio/file/FileStore/Basic.java testEnumerateFileStores fails in container: FileStores should be unique (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Ekaterina Pavlova](https://openjdk.org/census#epavlova) (@katyapav - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32091/head:pull/32091` \
`$ git checkout pull/32091`

Update a local copy of the PR: \
`$ git checkout pull/32091` \
`$ git pull https://git.openjdk.org/jdk.git pull/32091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32091`

View PR using the GUI difftool: \
`$ git pr show -t 32091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32091.diff">https://git.openjdk.org/jdk/pull/32091.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32091#issuecomment-5122730687)
</details>
