### PR TITLE
8253442: Bigapps SIGSEGV in DeadlockCycle::print_on_with

### DIFF
--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1025,10 +1025,10 @@ void DeadlockCycle::print_on_with(ThreadsList * t_list, outputStream* st) const 
           currentThread = JavaThread::cast(owner);
           st->print_cr("%s \"%s\"", owner_desc, currentThread->name());
         } else {
-          st->print_cr(",\n  which has now been released");
+          st->print_cr("%s non-Java thread=" PTR_FORMAT, owner_desc, p2i(owner));
         }
       } else {
-        st->print_cr("%s non-Java thread=" PTR_FORMAT, owner_desc, p2i(owner));
+        st->print_cr(",\n  which has now been released");
       }
     }
 
@@ -1049,9 +1049,9 @@ void DeadlockCycle::print_on_with(ThreadsList * t_list, outputStream* st) const 
         // blocked permanently.
         st->print_cr("%s UNKNOWN_owner_addr=" INT64_FORMAT, owner_desc,
                      waitingToLockMonitor->owner());
-        continue;
+      } else {
+        st->print_cr("%s \"%s\"", owner_desc, currentThread->name());
       }
-      st->print_cr("%s \"%s\"", owner_desc, currentThread->name());
     } else if (waitingToLockBlocker != nullptr) {
       st->print("  waiting for ownable synchronizer " INTPTR_FORMAT ", (a %s)",
                 p2i(waitingToLockBlocker),

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -517,6 +517,7 @@ DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, 
       }
       previousThread = currentThread;
       waitingToLockMonitor = (ObjectMonitor*)currentThread->current_pending_monitor();
+      waitingToLockRawMonitor = currentThread->current_pending_raw_monitor();
       if (concurrent_locks) {
         waitingToLockBlocker = currentThread->current_park_blocker();
       }
@@ -1050,7 +1051,8 @@ void DeadlockCycle::print_on_with(ThreadsList * t_list, outputStream* st) const 
                      waitingToLockMonitor->owner());
         continue;
       }
-    } else {
+      st->print_cr("%s \"%s\"", owner_desc, currentThread->name());
+    } else if (waitingToLockBlocker != nullptr) {
       st->print("  waiting for ownable synchronizer " INTPTR_FORMAT ", (a %s)",
                 p2i(waitingToLockBlocker),
                 waitingToLockBlocker->klass()->external_name());
@@ -1059,8 +1061,10 @@ void DeadlockCycle::print_on_with(ThreadsList * t_list, outputStream* st) const 
       oop ownerObj = java_util_concurrent_locks_AbstractOwnableSynchronizer::get_owner_threadObj(waitingToLockBlocker);
       currentThread = java_lang_Thread::thread(ownerObj);
       assert(currentThread != nullptr, "AbstractOwnableSynchronizer owning thread is unexpectedly null");
+      st->print_cr("%s \"%s\"", owner_desc, currentThread->name());
+    } else {
+      assert(waitingToLockRawMonitor != nullptr, "some deadlock must have been found");
     }
-    st->print_cr("%s \"%s\"", owner_desc, currentThread->name());
   }
 
   st->cr();

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
@@ -117,14 +117,13 @@ public class PrintRawMonitorLockTest {
 
         OutputAnalyzer output = executor.execute("Thread.print -l=true");
         if (!output.getOutput().contains("Found 1 deadlock")) {
-            // Execute dcmd in a loop in case the threads haven't deadlocked yet.
-            // Fail after 100 iterations.  That's all it should take unless something is wrong.
-            for (int i = 0; i < 100; i++) {
+            // Execute dcmd in a timed loop in case the threads haven't deadlocked yet.
+            while (true) {
                 try {
                     Thread.sleep(100);
                 } catch (InterruptedException ie) {
                 }
-                // try again, otherwise java thinks it's not initialized.
+                // try again, otherwise java thinks output is not initialized.
                 output = executor.execute("Thread.print -l=true");
                 if (output.getOutput().contains("Found 1 deadlock")) {
                     break;

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
@@ -21,6 +21,19 @@
  * questions.
  */
 
+/*
+ * @test
+ * @bug 8253442
+ * @summary Test of diagnostic command Thread.print prints a deadlock of only JVMTI raw monitors.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @requires vm.jvmti
+ * @run testng/othervm/native -agentlib:PrintRawMonitorLockTest PrintRawMonitorLockTest
+ */
+
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 import org.testng.Assert;
@@ -35,25 +48,13 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
-/*
- * @test
- * @bug 8253442
- * @summary Test of diagnostic command Thread.print with only JVMTI raw monitor.
- * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.compiler
- *          java.management
- *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @requires vm.jvmti
- * @run testng/othervm/native -agentlib:PrintRawMonitorLockTest PrintRawMonitorLockTest
- */
 public class PrintRawMonitorLockTest {
 
-    static private void log(String s) { System.out.println(s); }
-    static private String AGENT_LIB = "PrintRawMonitorLockTest";;
+    private static void log(String s) { System.out.println(s); }
+    private static String AGENT_LIB = "PrintRawMonitorLockTest";;
 
-    native static int createRawMonitors();
-    native static int rawMonitorEnter(int id);
+    static native int createRawMonitors();
+    static native int rawMonitorEnter(int id);
 
     static {
         try {
@@ -92,18 +93,18 @@ public class PrintRawMonitorLockTest {
                 throw new RuntimeException("error in JVMTI RawMonitorEnter: " +
                                            "retCode=" + retCode);
             }
-            log("entered lock1");
+            log("entered my lock");
 
-            /* Hold lock on "lock" to show up in thread dump */
-            /* Signal that we're ready for thread dump */
+            // Signal that we're ready for thread dump.
             waitForBarrier(readyBarrier);
 
+            log("trying to enter the other lock");
             retCode = rawMonitorEnter(otherid);
             if (retCode != 0) {
                 throw new RuntimeException("error in JVMTI RawMonitorEnter: " +
                                            "retCode=" + retCode);
             }
-            log("tried to enter lock2");
+            log("shouldn't get here since the threads are deadlocked");
         }
     }
 
@@ -113,8 +114,7 @@ public class PrintRawMonitorLockTest {
             throw new RuntimeException("error in JVMTI CreateRawMonitor: " +
                                        "retCode=" + retCode);
         }
-        log("created threadLock");
-
+        log("created JVM TI raw monitors");
     }
 
     public void run(CommandExecutor executor) {
@@ -126,15 +126,15 @@ public class PrintRawMonitorLockTest {
         RawMonitorThread bThread = new RawMonitorThread(2, 1);
         bThread.start();
 
-        /* Wait for threads to get ready */
+        // Wait for threads to get ready.
         waitForBarrier(readyBarrier);
 
         OutputAnalyzer output;
 
+        // Execute dcmd in a loop in case the threads haven't deadlocked yet.
         while (true) {
-            /* Execute */
             try {
-                Thread.sleep(200);
+                Thread.sleep(100);
             } catch (InterruptedException ie) {
             }
             output = executor.execute("Thread.print -l=true");

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+import jdk.test.lib.dcmd.CommandExecutor;
+import jdk.test.lib.dcmd.JMXExecutor;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
+
+/*
+ * @test
+ * @summary Test of diagnostic command Thread.print with only JVMTI raw monitor.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @requires vm.jvmti
+ * @run testng/othervm/native -agentlib:PrintRawMonitorLockTest PrintRawMonitorLockTest
+ */
+public class PrintRawMonitorLockTest {
+
+    static private void log(String s) { System.out.println(s); }
+    static private String AGENT_LIB = "PrintRawMonitorLockTest";;
+
+    native static int createRawMonitors();
+    native static int rawMonitorEnter(int id);
+
+    static {
+        try {
+            System.loadLibrary(AGENT_LIB);
+            log("Loaded library: " + AGENT_LIB);
+        } catch (UnsatisfiedLinkError ule) {
+            log("Failed to load library: " + AGENT_LIB);
+            log("java.library.path: " + System.getProperty("java.library.path"));
+            throw ule;
+        }
+    }
+
+    CyclicBarrier readyBarrier = new CyclicBarrier(3);
+
+    private void waitForBarrier(CyclicBarrier b) {
+        try {
+            b.await();
+        } catch (InterruptedException | BrokenBarrierException e) {
+            Assert.fail("Test error: Caught unexpected exception:", e);
+        }
+    }
+
+    class RawMonitorThread extends Thread {
+        int id;
+        int otherid;
+
+        RawMonitorThread(int id, int otherid) {
+            this.id = id;
+            this.otherid = otherid;
+            setDaemon(true);
+        }
+
+        public void run() {
+            int retCode = rawMonitorEnter(id);
+            if (retCode != 0) {
+                throw new RuntimeException("error in JVMTI RawMonitorEnter: " +
+                                           "retCode=" + retCode);
+            }
+            log("entered lock1");
+
+            /* Hold lock on "lock" to show up in thread dump */
+            /* Signal that we're ready for thread dump */
+            waitForBarrier(readyBarrier);
+
+            retCode = rawMonitorEnter(otherid);
+            if (retCode != 0) {
+                throw new RuntimeException("error in JVMTI RawMonitorEnter: " +
+                                           "retCode=" + retCode);
+            }
+            log("tried to enter lock2");
+        }
+    }
+
+    private void setupRawMonitors() {
+        int retCode = createRawMonitors();
+        if (retCode != 0) {
+            throw new RuntimeException("error in JVMTI CreateRawMonitor: " +
+                                       "retCode=" + retCode);
+        }
+        log("created threadLock");
+
+    }
+
+    public void run(CommandExecutor executor) {
+        setupRawMonitors();
+
+        RawMonitorThread aThread = new RawMonitorThread(1, 2);
+        aThread.start();
+
+        RawMonitorThread bThread = new RawMonitorThread(2, 1);
+        bThread.start();
+
+        /* Wait for threads to get ready */
+        waitForBarrier(readyBarrier);
+
+        OutputAnalyzer output;
+
+        while (true) {
+            /* Execute */
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException ie) {
+            }
+            output = executor.execute("Thread.print -l=true");
+            if (output.getOutput().contains("Found 1 deadlock")) {
+                break;
+            }
+        }
+
+        output.shouldContain("waiting to lock JVM TI raw monitor");
+    }
+
+    @Test
+    public void jmx() {
+        if (Thread.currentThread().isVirtual()) {
+            throw new SkipException("skipping test since current thread is virtual thread");
+        }
+        run(new JMXExecutor());
+    }
+}

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
@@ -56,17 +56,6 @@ public class PrintRawMonitorLockTest {
     static native int createRawMonitors();
     static native int rawMonitorEnter(int id);
 
-    static {
-        try {
-            System.loadLibrary(AGENT_LIB);
-            log("Loaded library: " + AGENT_LIB);
-        } catch (UnsatisfiedLinkError ule) {
-            log("Failed to load library: " + AGENT_LIB);
-            log("java.library.path: " + System.getProperty("java.library.path"));
-            throw ule;
-        }
-    }
-
     CyclicBarrier readyBarrier = new CyclicBarrier(3);
 
     private void waitForBarrier(CyclicBarrier b) {

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
@@ -45,8 +45,6 @@ import jdk.test.lib.dcmd.JMXExecutor;
 
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.regex.Pattern;
 
 public class PrintRawMonitorLockTest {
 
@@ -117,20 +115,22 @@ public class PrintRawMonitorLockTest {
         // Wait for threads to get ready.
         waitForBarrier(readyBarrier);
 
-        OutputAnalyzer output;
-
-        // Execute dcmd in a loop in case the threads haven't deadlocked yet.
-        while (true) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException ie) {
-            }
-            output = executor.execute("Thread.print -l=true");
-            if (output.getOutput().contains("Found 1 deadlock")) {
-                break;
+        OutputAnalyzer output = executor.execute("Thread.print -l=true");
+        if (!output.getOutput().contains("Found 1 deadlock")) {
+            // Execute dcmd in a loop in case the threads haven't deadlocked yet.
+            // Fail after 100 iterations.  That's all it should take unless something is wrong.
+            for (int i = 0; i < 100; i++) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ie) {
+                }
+                // try again, otherwise java thinks it's not initialized.
+                output = executor.execute("Thread.print -l=true");
+                if (output.getOutput().contains("Found 1 deadlock")) {
+                    break;
+                }
             }
         }
-
         output.shouldContain("waiting to lock JVM TI raw monitor");
     }
 

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 
 /*
  * @test
+ * @bug 8253442
  * @summary Test of diagnostic command Thread.print with only JVMTI raw monitor.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintRawMonitorLockTest.java
@@ -51,7 +51,6 @@ import java.util.regex.Pattern;
 public class PrintRawMonitorLockTest {
 
     private static void log(String s) { System.out.println(s); }
-    private static String AGENT_LIB = "PrintRawMonitorLockTest";;
 
     static native int createRawMonitors();
     static native int rawMonitorEnter(int id);

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/libPrintRawMonitorLockTest.cpp
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/libPrintRawMonitorLockTest.cpp
@@ -59,28 +59,13 @@ Java_PrintRawMonitorLockTest_rawMonitorEnter(JNIEnv *jni, jclass cls, int id) {
   }
 }
 
-/** Agent library initialization. */
-
 JNIEXPORT jint JNICALL
 Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   LOG("\nAgent_OnLoad started");
-
   // create JVMTI environment
   if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
     return JNI_ERR;
   }
-
-#if 0
-  // add specific capabilities for suspending thread
-  jvmtiCapabilities suspendCaps;
-  memset(&suspendCaps, 0, sizeof(suspendCaps));
-  suspendCaps.can_suspend = 1;
-
-  jvmtiError err = jvmti->AddCapabilities(&suspendCaps);
-  if (err != JVMTI_ERROR_NONE) {
-    return JNI_ERR;
-  }
-#endif
   LOG("Agent_OnLoad finished\n");
   return JNI_OK;
 }

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/libPrintRawMonitorLockTest.cpp
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/libPrintRawMonitorLockTest.cpp
@@ -21,7 +21,6 @@
  * questions.
  */
 
-#include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.hpp"
 

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/libPrintRawMonitorLockTest.cpp
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/libPrintRawMonitorLockTest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <string.h>
+#include "jvmti.h"
+
+extern "C" {
+
+static jvmtiEnv* jvmti = nullptr;
+static jrawMonitorID threadLock1 = nullptr;
+static char threadLockName1[] = "threadLock1";
+
+static jrawMonitorID threadLock2 = nullptr;
+static char threadLockName2[] = "threadLock2";
+
+#define LOG(...) \
+  do { \
+    printf(__VA_ARGS__); \
+    printf("\n"); \
+    fflush(stdout); \
+  } while (0)
+
+JNIEXPORT jint JNICALL
+Java_PrintRawMonitorLockTest_createRawMonitors(JNIEnv *jni, jclass cls) {
+  if (jvmti->CreateRawMonitor(threadLockName1, &threadLock1) != JNI_OK) {
+    return JNI_ERR;
+  }
+  return jvmti->CreateRawMonitor(threadLockName2, &threadLock2);
+}
+
+JNIEXPORT jint JNICALL
+Java_PrintRawMonitorLockTest_rawMonitorEnter(JNIEnv *jni, jclass cls, int id) {
+  if (id == 1) {
+    return jvmti->RawMonitorEnter(threadLock1);
+  } else if (id == 2) {
+    return jvmti->RawMonitorEnter(threadLock2);
+  } else {
+    return JNI_ERR;
+  }
+}
+
+/** Agent library initialization. */
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  LOG("\nAgent_OnLoad started");
+
+  // create JVMTI environment
+  if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
+    return JNI_ERR;
+  }
+
+#if 0
+  // add specific capabilities for suspending thread
+  jvmtiCapabilities suspendCaps;
+  memset(&suspendCaps, 0, sizeof(suspendCaps));
+  suspendCaps.can_suspend = 1;
+
+  jvmtiError err = jvmti->AddCapabilities(&suspendCaps);
+  if (err != JVMTI_ERROR_NONE) {
+    return JNI_ERR;
+  }
+#endif
+  LOG("Agent_OnLoad finished\n");
+  return JNI_OK;
+}
+
+}

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/libPrintRawMonitorLockTest.cpp
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/libPrintRawMonitorLockTest.cpp
@@ -23,6 +23,7 @@
 
 #include <string.h>
 #include "jvmti.h"
+#include "jvmti_common.hpp"
 
 extern "C" {
 
@@ -32,13 +33,6 @@ static char threadLockName1[] = "threadLock1";
 
 static jrawMonitorID threadLock2 = nullptr;
 static char threadLockName2[] = "threadLock2";
-
-#define LOG(...) \
-  do { \
-    printf(__VA_ARGS__); \
-    printf("\n"); \
-    fflush(stdout); \
-  } while (0)
 
 JNIEXPORT jint JNICALL
 Java_PrintRawMonitorLockTest_createRawMonitors(JNIEnv *jni, jclass cls) {


### PR DESCRIPTION
This fixes the crash when printing deadlocks when the only lock held for the thread in the deadlock is the JVMTI raw monitor lock.  This also fixes deadlock detection for only raw monitor locks and adds a test for it.

make test TEST="serviceability/dcmd/thread vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Deadlock serviceability/jvmti/SuspendWithRawMonitorEnter serviceability/jvmti/vthread/RawMonitorTest"

Tested with jvmti deadlock detection tests above, and tier 1-4 in progress.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8253442](https://bugs.openjdk.org/browse/JDK-8253442): Bigapps SIGSEGV in DeadlockCycle::print_on_with (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [bcbb3bcc](https://git.openjdk.org/jdk/pull/32092/files/bcbb3bcc92a607a758cf0615f4e505a4280dd4c8)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [bcbb3bcc](https://git.openjdk.org/jdk/pull/32092/files/bcbb3bcc92a607a758cf0615f4e505a4280dd4c8)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32092/head:pull/32092` \
`$ git checkout pull/32092`

Update a local copy of the PR: \
`$ git checkout pull/32092` \
`$ git pull https://git.openjdk.org/jdk.git pull/32092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32092`

View PR using the GUI difftool: \
`$ git pr show -t 32092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32092.diff">https://git.openjdk.org/jdk/pull/32092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32092#issuecomment-5123448460)
</details>
