### PR TITLE
8389378: RISC-V: Eliminate redundant sext.w by fusing ConvI2L with int producers

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8522,6 +8522,82 @@ instruct convI2L_reg_reg(iRegLNoSp dst, iRegIorL2I src)
   ins_pipe(ialu_reg);
 %}
 
+// Fused int-producer + ConvI2L rules.
+instruct convI2L_addI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (AddI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "addw  $dst, $src1, $src2\t#@convI2L_addI_reg_reg" %}
+
+  ins_encode %{
+    __ addw(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct convI2L_addI_reg_imm(iRegLNoSp dst, iRegIorL2I src1, immIAdd src2) %{
+  match(Set dst (ConvI2L (AddI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "addiw  $dst, $src1, $src2\t#@convI2L_addI_reg_imm" %}
+
+  ins_encode %{
+    __ addiw(as_Register($dst$$reg),
+             as_Register($src1$$reg),
+             $src2$$constant);
+  %}
+
+  ins_pipe(ialu_reg_imm);
+%}
+
+instruct convI2L_subI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (SubI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "subw  $dst, $src1, $src2\t#@convI2L_subI_reg_reg" %}
+
+  ins_encode %{
+    __ subw(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct convI2L_mulI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (MulI src1 src2)));
+
+  ins_cost(IMUL_COST);
+  format %{ "mulw  $dst, $src1, $src2\t#@convI2L_mulI_reg_reg" %}
+
+  ins_encode %{
+    __ mulw(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(imul_reg_reg);
+%}
+
+instruct convI2L_lShiftI_reg_imm(iRegLNoSp dst, iRegIorL2I src1, immI src2) %{
+  match(Set dst (ConvI2L (LShiftI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "slliw  $dst, $src1, ($src2 & 0x1f)\t#@convI2L_lShiftI_reg_imm" %}
+
+  ins_encode %{
+    __ slliw(as_Register($dst$$reg),
+             as_Register($src1$$reg),
+             (unsigned) $src2$$constant & 0x1f);
+  %}
+
+  ins_pipe(ialu_reg_shift);
+%}
+
 instruct convL2I_reg(iRegINoSp dst, iRegL src) %{
   match(Set dst (ConvL2I src));
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8583,6 +8583,21 @@ instruct convI2L_mulI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %
   ins_pipe(imul_reg_reg);
 %}
 
+instruct convI2L_lShiftI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (LShiftI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "sllw  $dst, $src1, $src2\t#@convI2L_lShiftI_reg_reg" %}
+
+  ins_encode %{
+    __ sllw(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg_vshift);
+%}
+
 instruct convI2L_lShiftI_reg_imm(iRegLNoSp dst, iRegIorL2I src1, immI src2) %{
   match(Set dst (ConvI2L (LShiftI src1 src2)));
 
@@ -8591,6 +8606,66 @@ instruct convI2L_lShiftI_reg_imm(iRegLNoSp dst, iRegIorL2I src1, immI src2) %{
 
   ins_encode %{
     __ slliw(as_Register($dst$$reg),
+             as_Register($src1$$reg),
+             (unsigned) $src2$$constant & 0x1f);
+  %}
+
+  ins_pipe(ialu_reg_shift);
+%}
+
+instruct convI2L_urShiftI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (URShiftI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "srlw  $dst, $src1, $src2\t#@convI2L_urShiftI_reg_reg" %}
+
+  ins_encode %{
+    __ srlw(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg_vshift);
+%}
+
+instruct convI2L_urShiftI_reg_imm(iRegLNoSp dst, iRegIorL2I src1, immI src2) %{
+  match(Set dst (ConvI2L (URShiftI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "srliw  $dst, $src1, ($src2 & 0x1f)\t#@convI2L_urShiftI_reg_imm" %}
+
+  ins_encode %{
+    __ srliw(as_Register($dst$$reg),
+             as_Register($src1$$reg),
+             (unsigned) $src2$$constant & 0x1f);
+  %}
+
+  ins_pipe(ialu_reg_shift);
+%}
+
+instruct convI2L_rShiftI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (RShiftI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "sraw  $dst, $src1, $src2\t#@convI2L_rShiftI_reg_reg" %}
+
+  ins_encode %{
+    __ sraw(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg_vshift);
+%}
+
+instruct convI2L_rShiftI_reg_imm(iRegLNoSp dst, iRegIorL2I src1, immI src2) %{
+  match(Set dst (ConvI2L (RShiftI src1 src2)));
+
+  ins_cost(ALU_COST);
+  format %{ "sraiw  $dst, $src1, ($src2 & 0x1f)\t#@convI2L_rShiftI_reg_imm" %}
+
+  ins_encode %{
+    __ sraiw(as_Register($dst$$reg),
              as_Register($src1$$reg),
              (unsigned) $src2$$constant & 0x1f);
   %}


### PR DESCRIPTION
Hi, please consider.
On RISC-V, C2 materializes `ConvI2L` as a separate `sext.w` even when its input is produced by a W-suffix instruction (`addw`, `addiw`, `subw`, `mulw`, `slliw`) whose 32-bit result is already sign-extended into bits[63:32]. The `sext.w` is redundant in that case.
This patch adds matcher rules that fuse `(ConvI2L (AddI/SubI/MulI/LShiftI))` into the single W-suffix instruction.

- [x] Run tier1-tier3 test with release on SG2044
- [x] C2 instruct Opto log:

We can print the assembly log of the JDK built-in test TestMergeStoresUnsafeArrayPointer, and the assembly log changes are as follows(We can observe that two sext.w instructions have been eliminated):
before this patch:
```
Compiled method (c2) 4984   36       4       compiler.c2.TestMergeStoresUnsafeArrayPointer::test2 (54 bytes)
...
  0x0000003f98aceb22:   lui	t2,0x38                     ;   {oop(a 'java/lang/Class'{0x000000070081fc20} = 'compiler/c2/TestMergeStoresUnsafeArrayPointer')}
  0x0000003f98aceb26:   addi	t2,t2,64 # 0x0000000000038040
  0x0000003f98aceb2a:   slli	t2,t2,0xb
  0x0000003f98aceb2e:   addi	t2,t2,2032
  0x0000003f98aceb32:   slli	t2,t2,0x6
  0x0000003f98aceb36:   addi	t2,t2,32
  0x0000003f98aceb3a:   lw	t3,144(t2)
  0x0000003f98aceb3e:   lui	t2,0x80000
  0x0000003f98aceb42:   addiw	t2,t2,-1 # 0x000000007fffffff
  0x0000003f98aceb44:   addw	t4,t3,t2
  0x0000003f98aceb48:   sext.w	t2,t4
  0x0000003f98aceb4c:   li	t4,1
  0x0000003f98aceb4e:   slli	t4,t4,0x1f
  0x0000003f98aceb50:   addi	t4,t4,212
  0x0000003f98aceb54:   beqz	a1,0x0000003f98aceb98
  0x0000003f98aceb58:   add	t2,t2,a1
  0x0000003f98aceb5a:   addiw	t3,t3,4
  0x0000003f98aceb5c:   lui	t6,0x42424
  0x0000003f98aceb60:   addiw	t6,t6,578 # 0x0000000042424242
  0x0000003f98aceb64:   add	t2,t2,t4
  0x0000003f98aceb66:   sext.w	t3,t3
  0x0000003f98aceb68:   sw	t6,0(t2)
...
```

after this patch:
```
Compiled method (c2) 3701   36       4       compiler.c2.TestMergeStoresUnsafeArrayPointer::test2 (54 bytes)
...
0x0000003f90aceb22:   lui	t2,0x38                     ;   {oop(a 'java/lang/Class'{0x0000000700811fa0} = 'compiler/c2/TestMergeStoresUnsafeArrayPointer')}
  0x0000003f90aceb26:   addi	t2,t2,64 # 0x0000000000038040
  0x0000003f90aceb2a:   slli	t2,t2,0xb
  0x0000003f90aceb2e:   addi	t2,t2,1150
  0x0000003f90aceb32:   slli	t2,t2,0x6
  0x0000003f90aceb36:   addi	t2,t2,32
  0x0000003f90aceb3a:   lw	t3,144(t2)
  0x0000003f90aceb3e:   lui	t2,0x80000
  0x0000003f90aceb42:   addiw	t2,t2,-1 # 0x000000007fffffff
  0x0000003f90aceb44:   addw	t2,t3,t2
  0x0000003f90aceb48:   li	t4,1
  0x0000003f90aceb4a:   slli	t4,t4,0x1f
  0x0000003f90aceb4c:   addi	t4,t4,212
  0x0000003f90aceb50:   beqz	a1,0x0000003f90aceb92
  0x0000003f90aceb54:   add	t2,t2,a1
  0x0000003f90aceb56:   lui	t6,0x42424
  0x0000003f90aceb5a:   addiw	t6,t6,578 # 0x0000000042424242
  0x0000003f90aceb5e:   add	t2,t2,t4
  0x0000003f90aceb60:   addiw	t3,t3,4
  0x0000003f90aceb62:   sw	t6,0(t2)
...
```

For easier verification, I constructed the following test to validate the newly added c2 instruct.
```
public class TestConvI2LFusion {

    static final int ITERS = 20_000;

    static long addRegReg(int a, int b)     { return (long)(a + b); }
    static long addRegImm(int a)            { return (long)(a + 1234); }
    static long subRegReg(int a, int b)     { return (long)(a - b); }
    static long mulRegReg(int a, int b)     { return (long)(a * b); }
    static long lShiftRegReg(int a, int b)  { return (long)(a << b); }
    static long lShiftRegImm(int a)         { return (long)(a << 7); }
    static long rShiftRegReg(int a, int b)  { return (long)(a >> b); }
    static long rShiftRegImm(int a)         { return (long)(a >> 7); }
    static long urShiftRegReg(int a, int b) { return (long)(a >>> b); }
    static long urShiftRegImm(int a)        { return (long)(a >>> 7); }

    public static void main(String[] args) {
        long sum = 0;
        for (int i = 0; i < ITERS; i++) {
            sum += addRegReg(i, i + 1);
            sum += addRegImm(i);
            sum += subRegReg(i, 2 * i);
            sum += mulRegReg(i, i + 3);
            sum += lShiftRegReg(i, i);
            sum += lShiftRegImm(i);
            sum += rShiftRegReg(-i, i);
            sum += rShiftRegImm(-i);
            sum += urShiftRegReg(-i, i);
            sum += urShiftRegImm(-i);
        }
        System.out.println(sum);
    }
}


```

Opto log result:
```
./java -Xbatch -XX:-TieredCompilation  -XX:+PrintOptoAssembly  TestConvI2LFusion | grep -oE '#@convI2L_\w+' | sort | uniq -c
      1 #@convI2L_addI_reg_imm
      1 #@convI2L_addI_reg_reg
      1 #@convI2L_lShiftI_reg_imm
      1 #@convI2L_lShiftI_reg_reg
      1 #@convI2L_mulI_reg_reg
     69 #@convI2L_reg_reg
      1 #@convI2L_rShiftI_reg_imm
      1 #@convI2L_rShiftI_reg_reg
      1 #@convI2L_subI_reg_reg
      1 #@convI2L_urShiftI_reg_imm
      1 #@convI2L_urShiftI_reg_reg
```


Opto log without this patch(taking the method TestConvI2LFusion.lShiftRegImm as an example):
```
022     slliw  R7, R11, (#7 & 0x1f)	#@lShiftI_reg_imm
026 +   addw  R10, R7, zr	#@convI2L_reg_reg
```

Opto log with this path(taking the method TestConvI2LFusion.lShiftRegImm as an example):
```
022     slliw  R10, R11, (#7 & 0x1f)	#@convI2L_lShiftI_reg_imm
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389378](https://bugs.openjdk.org/browse/JDK-8389378): RISC-V: Eliminate redundant sext.w by fusing ConvI2L with int producers (**Enhancement** - P4)


### Reviewers
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32096/head:pull/32096` \
`$ git checkout pull/32096`

Update a local copy of the PR: \
`$ git checkout pull/32096` \
`$ git pull https://git.openjdk.org/jdk.git pull/32096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32096`

View PR using the GUI difftool: \
`$ git pr show -t 32096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32096.diff">https://git.openjdk.org/jdk/pull/32096.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32096#issuecomment-5316807497)
</details>
