### PR TITLE
8388386: Remove deprecated sun.net.www.http.HttpClient#resetProperties

### DIFF
--- a/src/java.base/share/classes/sun/net/www/http/HttpClient.java
+++ b/src/java.base/share/classes/sun/net/www/http/HttpClient.java
@@ -170,14 +170,6 @@ public class HttpClient extends NetworkClient {
         }
     }
 
-    /**
-     * A NOP method kept for backwards binary compatibility
-     * @deprecated -- system properties are no longer cached.
-     */
-    @Deprecated
-    public static synchronized void resetProperties() {
-    }
-
     int getKeepAliveTimeout() {
         return keepAliveTimeout;
     }


### PR DESCRIPTION
Please review this change. Thanks!

Remove the deprecated no-op resetProperties method from the internal HttpClient class.

No tests are added because the removed method has no behavior.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388386](https://bugs.openjdk.org/browse/JDK-8388386): Remove deprecated sun.net.www.http.HttpClient#resetProperties (**Enhancement** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32097/head:pull/32097` \
`$ git checkout pull/32097`

Update a local copy of the PR: \
`$ git checkout pull/32097` \
`$ git pull https://git.openjdk.org/jdk.git pull/32097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32097`

View PR using the GUI difftool: \
`$ git pr show -t 32097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32097.diff">https://git.openjdk.org/jdk/pull/32097.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32097#issuecomment-5127275035)
</details>
