### PR TITLE
8389384: JDK-6960970 broke cross compilation on slow-debug level

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -321,7 +321,7 @@ class JvmtiExport : public AllStatic {
   static JvmtiThreadState* hide_single_stepping(JavaThread *thread) NOT_JVMTI_RETURN_(nullptr);
 
   // frame pop management
-  static bool has_frame_pop_for_top_frame(JavaThread *current);
+  static bool has_frame_pop_for_top_frame(JavaThread *current) NOT_JVMTI_RETURN_(false);
 
   // Methods that notify the debugger that something interesting has happened in the VM.
   static void post_early_vm_start        () NOT_JVMTI_RETURN;


### PR DESCRIPTION
Hi all,

The compilation target `buildjdk` doesn't include the feature `jvmti`, so when cross compiling a slow-debug image, `JvmtiExport::has_frame_pop_for_top_frame` can't be found and the cross compilation fails.

The cross building of release and fast-debug images succeeded. It may be caused by compiler optimization.

Best Regards,
-- Guoxiong

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389384](https://bugs.openjdk.org/browse/JDK-8389384): JDK-6960970 broke cross compilation on slow-debug level (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32099/head:pull/32099` \
`$ git checkout pull/32099`

Update a local copy of the PR: \
`$ git checkout pull/32099` \
`$ git pull https://git.openjdk.org/jdk.git pull/32099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32099`

View PR using the GUI difftool: \
`$ git pr show -t 32099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32099.diff">https://git.openjdk.org/jdk/pull/32099.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32099#issuecomment-5127706158)
</details>
