### PR TITLE
8382276: Update nsk/jdwp to use ThreadWrapper

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/BREAKPOINT/breakpoint001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/BREAKPOINT/breakpoint001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.BREAKPOINT;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,7 +37,7 @@ import java.io.*;
  */
 public class breakpoint001a {
 
-    static final int BREAKPOINT_LINE = 91;
+    static final int BREAKPOINT_LINE = 92;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -53,7 +54,7 @@ public class breakpoint001a {
 
         // create tested thread
         log.display("Creating tested thread");
-        TestedClass.thread = new TestedClass(breakpoint001.TESTED_THREAD_NAME);
+        TestedClass.thread = new TestedClass(breakpoint001.TESTED_THREAD_NAME).getThread();
         log.display("  ... thread created");
 
         // start tested thread
@@ -77,8 +78,8 @@ public class breakpoint001a {
     }
 
     // tested class
-    public static class TestedClass extends Thread {
-        public static volatile TestedClass thread = null;
+    public static class TestedClass extends ThreadWrapper {
+        public static volatile Thread thread = null;
 
         public TestedClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/EXCEPTION/exception001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/EXCEPTION/exception001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.EXCEPTION;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,9 +37,9 @@ import java.io.*;
  */
 public class exception001a {
 
-    static final int BREAKPOINT_LINE = 102;
-    static final int EXCEPTION_THROW_LINE = 114;
-    static final int EXCEPTION_CATCH_LINE = 121; // line number was changed due to 4740123
+    static final int BREAKPOINT_LINE = 103;
+    static final int EXCEPTION_THROW_LINE = 115;
+    static final int EXCEPTION_CATCH_LINE = 122; // line number was changed due to 4740123
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -84,7 +85,7 @@ public class exception001a {
     }
 
     // tested class
-    public static class TestedThreadClass extends Thread {
+    public static class TestedThreadClass extends ThreadWrapper {
 
         // static field with tested exception object
         public static volatile TestedExceptionClass exception = null;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_ACCESS/fldaccess001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_ACCESS/fldaccess001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.FIELD_ACCESS;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,8 +37,8 @@ import java.io.*;
  */
 public class fldaccess001a {
 
-    static final int BREAKPOINT_LINE = 114;
-    static final int FIELD_ACCESS_LINE = 125;
+    static final int BREAKPOINT_LINE = 115;
+    static final int FIELD_ACCESS_LINE = 126;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -82,7 +83,7 @@ public class fldaccess001a {
     }
 
     // tested thread class
-    public static class TestedThreadClass extends Thread {
+    public static class TestedThreadClass extends ThreadWrapper {
 
         public TestedThreadClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_MODIFICATION/fldmodification001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_MODIFICATION/fldmodification001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.FIELD_MODIFICATION;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,8 +37,8 @@ import java.io.*;
  */
 public class fldmodification001a {
 
-    static final int BREAKPOINT_LINE = 114;
-    static final int FIELD_MODIFICATION_LINE = 126;
+    static final int BREAKPOINT_LINE = 115;
+    static final int FIELD_MODIFICATION_LINE = 127;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -82,7 +83,7 @@ public class fldmodification001a {
     }
 
     // tested thread class
-    public static class TestedThreadClass extends Thread {
+    public static class TestedThreadClass extends ThreadWrapper {
 
         public TestedThreadClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_ENTRY/methentry001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_ENTRY/methentry001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.METHOD_ENTRY;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,8 +37,8 @@ import java.io.*;
  */
 public class methentry001a {
 
-    static final int BREAKPOINT_LINE = 91;
-    static final int METHOD_ENTRY_LINE = 103;
+    static final int BREAKPOINT_LINE = 92;
+    static final int METHOD_ENTRY_LINE = 104;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -78,7 +79,7 @@ public class methentry001a {
     }
 
     // tested class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
         public TestedClass(String name) {
             super(name);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_EXIT/methexit001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_EXIT/methexit001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.METHOD_EXIT;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,8 +37,8 @@ import java.io.*;
  */
 public class methexit001a {
 
-    static final int BREAKPOINT_LINE = 91;
-    static final int METHOD_EXIT_LINE = 105;
+    static final int BREAKPOINT_LINE = 92;
+    static final int METHOD_EXIT_LINE = 106;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -78,7 +79,7 @@ public class methexit001a {
     }
 
     // tested class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
         public TestedClass(String name) {
             super(name);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.SINGLE_STEP;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,8 +37,8 @@ import java.io.*;
  */
 public class singlestep001a {
 
-    static final int BREAKPOINT_LINE = 91;
-    static final int SINGLE_STEP_LINE = 94;
+    static final int BREAKPOINT_LINE = 92;
+    static final int SINGLE_STEP_LINE = 95;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -78,7 +79,7 @@ public class singlestep001a {
     }
 
     // tested class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
         public TestedClass(String name) {
             super(name);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.SINGLE_STEP;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,8 +37,8 @@ import java.io.*;
  */
 public class singlestep002a {
 
-    static final int BREAKPOINT_LINE = 91;
-    static final int SINGLE_STEP_LINE = 101;
+    static final int BREAKPOINT_LINE = 92;
+    static final int SINGLE_STEP_LINE = 102;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -78,7 +79,7 @@ public class singlestep002a {
     }
 
     // tested class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
         public TestedClass(String name) {
             super(name);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.SINGLE_STEP;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,8 +37,8 @@ import java.io.*;
  */
 public class singlestep003a {
 
-    static final int BREAKPOINT_LINE = 101;
-    static final int SINGLE_STEP_LINE = 92;
+    static final int BREAKPOINT_LINE = 102;
+    static final int SINGLE_STEP_LINE = 93;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -78,7 +79,7 @@ public class singlestep003a {
     }
 
     // tested class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
         public TestedClass(String name) {
             super(name);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_DEATH/thrdeath001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_DEATH/thrdeath001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.THREAD_DEATH;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,7 +37,7 @@ import java.io.*;
  */
 public class thrdeath001a {
 
-    static final int BREAKPOINT_LINE = 93;
+    static final int BREAKPOINT_LINE = 94;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -53,7 +54,7 @@ public class thrdeath001a {
 
         // create tested thread
         log.display("Creating tested thread");
-        TestedClass.thread = new TestedClass(thrdeath001.TESTED_THREAD_NAME);
+        TestedClass.thread = new TestedClass(thrdeath001.TESTED_THREAD_NAME).getThread();
         log.display("  ... thread created");
 
         // reach breakpoint
@@ -80,8 +81,8 @@ public class thrdeath001a {
     }
 
     // tested class
-    public static class TestedClass extends Thread {
-        public static volatile TestedClass thread = null;
+    public static class TestedClass extends ThreadWrapper {
+        public static volatile Thread thread = null;
 
         public TestedClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_START/thrstart001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_START/thrstart001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.Event.THREAD_START;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -36,7 +37,7 @@ import java.io.*;
  */
 public class thrstart001a {
 
-    static final int BREAKPOINT_LINE = 93;
+    static final int BREAKPOINT_LINE = 94;
 
     static ArgumentHandler argumentHandler = null;
     static Log log = null;
@@ -53,7 +54,7 @@ public class thrstart001a {
 
         // create tested thread
         log.display("Creating tested thread");
-        TestedClass.thread = new TestedClass(thrstart001.TESTED_THREAD_NAME);
+        TestedClass.thread = new TestedClass(thrstart001.TESTED_THREAD_NAME).getThread();
         log.display("  ... thread created");
 
         // reach breakpoint
@@ -80,8 +81,8 @@ public class thrstart001a {
     }
 
     // tested class
-    public static class TestedClass extends Thread {
-        public static volatile TestedClass thread = null;
+    public static class TestedClass extends ThreadWrapper {
+        public static volatile Thread thread = null;
 
         public TestedClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/MonitorInfo/monitorinfo001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/MonitorInfo/monitorinfo001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,6 +215,9 @@ public class monitorinfo001a {
     } // TestedClass class
 
     // thread which will owns monitor of the tested object
+    // Note: the monitor threads must extend Thread, not ThreadWrapper. JDWP
+    // ObjectReference.MonitorInfo reports no owner and no waiters when virtual
+    // threads own or wait on the monitor. See JDK-8382276.
     public static class MonitorOwnerThread extends Thread {
 
         public Object ready = new Object();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/GetValues/getvalues001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/GetValues/getvalues001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.StackFrame.GetValues;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -74,7 +75,7 @@ public class getvalues001a {
             log.display("Creating object of tested class");
             TestedObjectClass.object = new TestedObjectClass();
             log.display("Creating tested thread");
-            TestedObjectClass.thread = new TestedThreadClass(THREAD_NAME);
+            TestedObjectClass.thread = new TestedThreadClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadReady) {
@@ -123,7 +124,7 @@ public class getvalues001a {
     }
 
     // tested thread class
-    public static class TestedThreadClass extends Thread {
+    public static class TestedThreadClass extends ThreadWrapper {
 
         TestedThreadClass(String name) {
             super(name);
@@ -144,7 +145,7 @@ public class getvalues001a {
     public static class TestedObjectClass {
 
         // field with the tested thread and object values
-        public static volatile TestedThreadClass thread = null;
+        public static volatile Thread thread = null;
         public static volatile TestedObjectClass object = null;
 
         public void testedMethod() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/PopFrames/popframes001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/PopFrames/popframes001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package nsk.jdwp.StackFrame.PopFrames;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -40,7 +41,7 @@ public class popframes001a {
     public static final String THREAD_NAME = "testedThread";
 
     // line nunber for breakpoint
-    public static final int BREAKPOINT_LINE_NUMBER = 113;
+    public static final int BREAKPOINT_LINE_NUMBER = 114;
 
     // scaffold objects
     private static volatile ArgumentHandler argumentHandler = null;
@@ -82,7 +83,7 @@ public class popframes001a {
     }
 
     // tested thread class
-    public static class TestedThreadClass extends Thread {
+    public static class TestedThreadClass extends ThreadWrapper {
 
         // number of invokations of tested method
         public static volatile int invokations = 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/SetValues/setvalues001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/SetValues/setvalues001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,6 +158,9 @@ public class setvalues001a {
     }
 
     // tested thread class
+    // Note: TestedThreadClass must extend Thread, not ThreadWrapper. JDWP
+    // StackFrame.SetValues returns OPAQUE_FRAME for a virtual thread suspended
+    // with ThreadReference.Suspend rather than at an event. See JDK-8382276.
     public static class TestedThreadClass extends Thread {
 
         public TestedThreadClass(String name) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/ThisObject/thisobject001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/ThisObject/thisobject001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.StackFrame.ThisObject;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -73,7 +74,7 @@ public class thisobject001a {
             log.display("Creating object of tested class");
             TestedObjectClass.object = new TestedObjectClass();
             log.display("Creating tested thread");
-            TestedObjectClass.thread = new TestedThreadClass(THREAD_NAME);
+            TestedObjectClass.thread = new TestedThreadClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadReady) {
@@ -122,7 +123,7 @@ public class thisobject001a {
     }
 
     // tested thread class
-    public static class TestedThreadClass extends Thread {
+    public static class TestedThreadClass extends ThreadWrapper {
 
         TestedThreadClass(String name) {
             super(name);
@@ -144,7 +145,7 @@ public class thisobject001a {
     public static class TestedObjectClass {
 
         // field with the tested thread and object values
-        public static volatile TestedThreadClass thread = null;
+        public static volatile Thread thread = null;
         public static volatile TestedObjectClass object = null;
 
         public void testedMethod(int foo) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/CurrentContendedMonitor/curcontmonitor001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/CurrentContendedMonitor/curcontmonitor001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.CurrentContendedMonitor;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -69,7 +70,7 @@ public class curcontmonitor001a {
 
         // load tested class and create tested thread
         log.display("Creating object of tested class");
-        TestedClass.thread = new TestedClass(THREAD_NAME);
+        TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
         // start the thread and wait for notification from it
         synchronized (threadStarting) {
@@ -84,8 +85,8 @@ public class curcontmonitor001a {
             }
 
             // ensure that tested thread is waiting for monitor object
-            synchronized (TestedClass.thread.monitor) {
-                TestedClass.thread.monitor.notifyAll();
+            synchronized (TestedClass.monitor) {
+                TestedClass.monitor.notifyAll();
 
                 // send debugger signal READY
                 log.display("Sending signal to debugger: " + curcontmonitor001.READY);
@@ -112,10 +113,10 @@ public class curcontmonitor001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
         // field with monitor object which thread will infinitively wait for
         public static volatile Object monitor = new Object();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/FrameCount/framecnt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/FrameCount/framecnt001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,9 @@ public class framecnt001a {
     }
 
     // tested thread class
+    // Note: TestedClass must extend Thread, not ThreadWrapper. This test
+    // asserts an exact frame count, which the wrapper's extra frames change.
+    // See JDK-8382276.
     public static class TestedClass extends Thread {
 
         // field with the tested Thread value

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Frames/frames001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Frames/frames001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.Frames;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -70,7 +71,7 @@ public class frames001a {
 
             // load tested class and create tested thread
             log.display("Creating object of tested class");
-            TestedClass.thread = new TestedClass(THREAD_NAME);
+            TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadReady) {
@@ -108,10 +109,10 @@ public class frames001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
 
         int frames = 0;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Interrupt/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Interrupt/interrupt001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.Interrupt;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -66,7 +67,7 @@ public class interrupt001a {
 
         // load tested class and create tested thread
         log.display("Creating object of tested class");
-        TestedClass.thread = new TestedClass(THREAD_NAME);
+        TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
         // start the thread and wait for notification from it
         synchronized (threadStarting) {
@@ -139,10 +140,10 @@ public class interrupt001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
 
         TestedClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Name/name001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Name/name001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.Name;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -66,7 +67,7 @@ public class name001a {
 
             // load tested class and create tested thread
             log.display("Creating object of tested class");
-            TestedClass.thread = new TestedClass(THREAD_NAME);
+            TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadStarted) {
@@ -104,10 +105,10 @@ public class name001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
 
         TestedClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitors/ownmonitors001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitors/ownmonitors001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.OwnedMonitors;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -68,7 +69,7 @@ public class ownmonitors001a {
 
             // load tested class and create tested thread
             log.display("Creating object of tested class");
-            TestedClass.thread = new TestedClass(THREAD_NAME);
+            TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadReady) {
@@ -106,10 +107,10 @@ public class ownmonitors001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
 
         // field with object whose monitor the tested thread owns
         public static Object ownedMonitor = new Object();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Resume/resume001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Resume/resume001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.Resume;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -66,7 +67,7 @@ public class resume001a {
 
             // load tested class and create tested thread
             log.display("Creating object of tested class");
-            TestedClass.thread = new TestedClass(THREAD_NAME);
+            TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadStarted) {
@@ -104,10 +105,10 @@ public class resume001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
 
         TestedClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Status/status001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Status/status001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.Status;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -66,7 +67,7 @@ public class status001a {
 
             // load tested class and create tested thread
             log.display("Creating object of tested class");
-            TestedClass.thread = new TestedClass(THREAD_NAME);
+            TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadStarted) {
@@ -104,10 +105,10 @@ public class status001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
 
         TestedClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Stop/stop001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Stop/stop001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,6 +144,9 @@ public class stop001a {
     }
 
     // tested thread class
+    // Note: TestedClass must extend Thread, not ThreadWrapper. JDWP
+    // ThreadReference.Stop returns THREAD_NOT_SUSPENDED for a virtual thread
+    // that is not suspended at an event. See JDK-8382276.
     public static class TestedClass extends Thread {
 
         // field with the tested Thread value

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Suspend/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Suspend/suspend001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.Suspend;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -66,7 +67,7 @@ public class suspend001a {
 
             // load tested class and create tested thread
             log.display("Creating object of tested class");
-            TestedClass.thread = new TestedClass(THREAD_NAME);
+            TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadStarted) {
@@ -104,10 +105,10 @@ public class suspend001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
 
         TestedClass(String name) {
             super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/SuspendCount/suspendcnt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/SuspendCount/suspendcnt001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdwp.ThreadReference.SuspendCount;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdwp.*;
@@ -66,7 +67,7 @@ public class suspendcnt001a {
 
             // load tested class and create tested thread
             log.display("Creating object of tested class");
-            TestedClass.thread = new TestedClass(THREAD_NAME);
+            TestedClass.thread = new TestedClass(THREAD_NAME).getThread();
 
             // start the thread and wait for notification from it
             synchronized (threadStarted) {
@@ -104,10 +105,10 @@ public class suspendcnt001a {
     }
 
     // tested thread class
-    public static class TestedClass extends Thread {
+    public static class TestedClass extends ThreadWrapper {
 
         // field with the tested Thread value
-        public static volatile TestedClass thread = null;
+        public static volatile Thread thread = null;
 
         TestedClass(String name) {
             super(name);


### PR DESCRIPTION
Converts the tested threads in nsk/jdwp to jdk.test.lib.thread.ThreadWrapper so they can run under JTREG_TEST_THREAD_FACTORY=Virtual. Per JDK-8381657, the conversion targets spawned threads that make actual work in the tests.

23 tests converted. These debuggers obtain the tested thread by reading a debuggee static field over JDWP (Debugee.queryThreadID, or queryObjectID with JDWP.Tag.THREAD), so the field itself must remain a Thread - where a field is exposed that way it is retyped to Thread and assigned from getThread().

Four tests are left on platform threads, each with a comment giving the reason: 
ThreadReference/Stop - Stop returns THREAD_NOT_SUSPENDED for a virtual thread that is not suspended at an event
StackFrame/SetValues - returns OPAQUE_FRAME for a virtual thread suspended via ThreadReference.Suspend rather than at an event
ObjectReference/MonitorInfo - reports no owner and no waiters for virtual threads
ThreadReference/FrameCount  - asserts an exact frame count, which the wrapper's extra frames change

Reverting these rather than problem listing them keeps the tests running as platform threads in both configurations.

The ThreadWrapper import adds a line to each debuggee, so the hard-coded BREAKPOINT_LINE / *_LINE constants in those files are bumped by one (21 constants across 12 files).

VirtualMachine/Resume/resume001.java is unchanged - its extends Thread is a debugger-side timeout watchdog, not a thread doing test work.

Testing: nsk/jdwp on linux-x64-OL-9, with the default factory and with JTREG_TEST_THREAD_FACTORY=Virtual - all pass in both


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382276](https://bugs.openjdk.org/browse/JDK-8382276): Update nsk/jdwp to use ThreadWrapper (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32100/head:pull/32100` \
`$ git checkout pull/32100`

Update a local copy of the PR: \
`$ git checkout pull/32100` \
`$ git pull https://git.openjdk.org/jdk.git pull/32100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32100`

View PR using the GUI difftool: \
`$ git pr show -t 32100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32100.diff">https://git.openjdk.org/jdk/pull/32100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32100#issuecomment-5134348315)
</details>
