### PR TITLE
8388884: [macOS] Swing Aqua L&F text components enable drag by default

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaEditorPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaEditorPaneUI.java
@@ -33,17 +33,32 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicEditorPaneUI;
 import javax.swing.text.*;
 
+import sun.swing.SwingAccessor;
+
 public final class AquaEditorPaneUI extends BasicEditorPaneUI {
     public static ComponentUI createUI(final JComponent c){
         return new AquaEditorPaneUI();
     }
 
+    private boolean oldDragState;
+
     @Override
     protected void installDefaults(){
+        oldDragState = getComponent().getDragEnabled();
         super.installDefaults();
         if (!GraphicsEnvironment.isHeadless()) {
             LookAndFeel.installProperty(getComponent(), "dragEnabled", true);
         }
+    }
+
+    @Override
+    protected void uninstallDefaults() {
+        if (!SwingAccessor.getJTextComponentAccessor()
+                          .isDragEnabledSet(getComponent())) {
+            LookAndFeel.installProperty(getComponent(), "dragEnabled",
+                                        oldDragState);
+        }
+        super.uninstallDefaults();
     }
 
     FocusListener focusListener;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaEditorPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaEditorPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,21 +38,13 @@ public final class AquaEditorPaneUI extends BasicEditorPaneUI {
         return new AquaEditorPaneUI();
     }
 
-    boolean oldDragState = false;
     @Override
     protected void installDefaults(){
         super.installDefaults();
-        if(!GraphicsEnvironment.isHeadless()){
-            oldDragState = getComponent().getDragEnabled();
-            getComponent().setDragEnabled(true);
-        }
     }
 
     @Override
     protected void uninstallDefaults(){
-        if(!GraphicsEnvironment.isHeadless()){
-            getComponent().setDragEnabled(oldDragState);
-        }
         super.uninstallDefaults();
     }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaEditorPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaEditorPaneUI.java
@@ -41,11 +41,9 @@ public final class AquaEditorPaneUI extends BasicEditorPaneUI {
     @Override
     protected void installDefaults(){
         super.installDefaults();
-    }
-
-    @Override
-    protected void uninstallDefaults(){
-        super.uninstallDefaults();
+        if (!GraphicsEnvironment.isHeadless()) {
+            LookAndFeel.installProperty(getComponent(), "dragEnabled", true);
+        }
     }
 
     FocusListener focusListener;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextAreaUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextAreaUI.java
@@ -70,11 +70,9 @@ public final class AquaTextAreaUI extends BasicTextAreaUI {
     @Override
     protected void installDefaults() {
         super.installDefaults();
-    }
-
-    @Override
-    protected void uninstallDefaults() {
-        super.uninstallDefaults();
+        if (!GraphicsEnvironment.isHeadless()) {
+            LookAndFeel.installProperty(getComponent(), "dragEnabled", true);
+        }
     }
 
     // Install a default keypress action which handles Cmd and Option keys

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextAreaUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextAreaUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,21 +67,13 @@ public final class AquaTextAreaUI extends BasicTextAreaUI {
         super.uninstallListeners();
     }
 
-    boolean oldDragState = false;
     @Override
     protected void installDefaults() {
-        if (!GraphicsEnvironment.isHeadless()) {
-            oldDragState = getComponent().getDragEnabled();
-            getComponent().setDragEnabled(true);
-        }
         super.installDefaults();
     }
 
     @Override
     protected void uninstallDefaults() {
-        if (!GraphicsEnvironment.isHeadless()) {
-            getComponent().setDragEnabled(oldDragState);
-        }
         super.uninstallDefaults();
     }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextAreaUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextAreaUI.java
@@ -32,6 +32,8 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicTextAreaUI;
 import javax.swing.text.*;
 
+import sun.swing.SwingAccessor;
+
 public final class AquaTextAreaUI extends BasicTextAreaUI {
     public static ComponentUI createUI(final JComponent c) {
         return new AquaTextAreaUI();
@@ -67,12 +69,25 @@ public final class AquaTextAreaUI extends BasicTextAreaUI {
         super.uninstallListeners();
     }
 
+    private boolean oldDragState;
+
     @Override
-    protected void installDefaults() {
+    protected void installDefaults(){
+        oldDragState = getComponent().getDragEnabled();
         super.installDefaults();
         if (!GraphicsEnvironment.isHeadless()) {
             LookAndFeel.installProperty(getComponent(), "dragEnabled", true);
         }
+    }
+
+    @Override
+    protected void uninstallDefaults() {
+        if (!SwingAccessor.getJTextComponentAccessor()
+                          .isDragEnabledSet(getComponent())) {
+            LookAndFeel.installProperty(getComponent(), "dragEnabled",
+                                        oldDragState);
+        }
+        super.uninstallDefaults();
     }
 
     // Install a default keypress action which handles Cmd and Option keys

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldUI.java
@@ -84,7 +84,7 @@ public class AquaTextFieldUI extends BasicTextFieldUI {
     protected void uninstallDefaults() {
         if (!SwingAccessor.getJTextComponentAccessor()
                           .isDragEnabledSet(getComponent())) {
-            LookAndFeel.installProperty(getComponent(), "dragEnabled", 
+            LookAndFeel.installProperty(getComponent(), "dragEnabled",
                                         oldDragState);
         }
         super.uninstallDefaults();

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldUI.java
@@ -71,11 +71,9 @@ public class AquaTextFieldUI extends BasicTextFieldUI {
     @Override
     protected void installDefaults() {
         super.installDefaults();
-    }
-
-    @Override
-    protected void uninstallDefaults() {
-        super.uninstallDefaults();
+        if (!GraphicsEnvironment.isHeadless()) {
+            LookAndFeel.installProperty(getComponent(), "dragEnabled", true);
+        }
     }
 
     // Install a default keypress action which handles Cmd and Option keys

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldUI.java
@@ -32,6 +32,7 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicTextFieldUI;
 import javax.swing.text.*;
 
+import sun.swing.SwingAccessor;
 import com.apple.laf.AquaUtils.JComponentPainter;
 
 public class AquaTextFieldUI extends BasicTextFieldUI {
@@ -68,12 +69,25 @@ public class AquaTextFieldUI extends BasicTextFieldUI {
         super.uninstallListeners();
     }
 
+    private boolean oldDragState;
+
     @Override
-    protected void installDefaults() {
+    protected void installDefaults(){
+        oldDragState = getComponent().getDragEnabled();
         super.installDefaults();
         if (!GraphicsEnvironment.isHeadless()) {
             LookAndFeel.installProperty(getComponent(), "dragEnabled", true);
         }
+    }
+
+    @Override
+    protected void uninstallDefaults() {
+        if (!SwingAccessor.getJTextComponentAccessor()
+                          .isDragEnabledSet(getComponent())) {
+            LookAndFeel.installProperty(getComponent(), "dragEnabled", 
+                                        oldDragState);
+        }
+        super.uninstallDefaults();
     }
 
     // Install a default keypress action which handles Cmd and Option keys

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextFieldUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,24 +68,14 @@ public class AquaTextFieldUI extends BasicTextFieldUI {
         super.uninstallListeners();
     }
 
-    boolean oldDragState = false;
     @Override
     protected void installDefaults() {
-        if (!GraphicsEnvironment.isHeadless()) {
-            oldDragState = getComponent().getDragEnabled();
-            getComponent().setDragEnabled(true);
-        }
-
         super.installDefaults();
     }
 
     @Override
     protected void uninstallDefaults() {
         super.uninstallDefaults();
-
-        if (!GraphicsEnvironment.isHeadless()) {
-            getComponent().setDragEnabled(oldDragState);
-        }
     }
 
     // Install a default keypress action which handles Cmd and Option keys

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextPaneUI.java
@@ -67,11 +67,9 @@ public final class AquaTextPaneUI extends BasicTextPaneUI {
     @Override
     protected void installDefaults() {
         super.installDefaults();
-    }
-
-    @Override
-    protected void uninstallDefaults() {
-        super.uninstallDefaults();
+        if (!GraphicsEnvironment.isHeadless()) {
+            LookAndFeel.installProperty(getComponent(), "dragEnabled", true);
+        }
     }
 
     // Install a default keypress action which handles Cmd and Option keys

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextPaneUI.java
@@ -63,7 +63,6 @@ public final class AquaTextPaneUI extends BasicTextPaneUI {
         super.uninstallListeners();
     }
 
-    boolean oldDragState = false;
     @Override
     protected void installDefaults() {
         super.installDefaults();

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextPaneUI.java
@@ -32,6 +32,8 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicTextPaneUI;
 import javax.swing.text.*;
 
+import sun.swing.SwingAccessor;
+
 //[3663467] moved it to sublcass from BasicEditorPaneUI to BasicTextPaneUI. (vm)
 public final class AquaTextPaneUI extends BasicTextPaneUI {
     public static ComponentUI createUI(final JComponent c) {
@@ -63,13 +65,27 @@ public final class AquaTextPaneUI extends BasicTextPaneUI {
         super.uninstallListeners();
     }
 
+    private boolean oldDragState;
+
     @Override
-    protected void installDefaults() {
+    protected void installDefaults(){
+        oldDragState = getComponent().getDragEnabled();
         super.installDefaults();
         if (!GraphicsEnvironment.isHeadless()) {
             LookAndFeel.installProperty(getComponent(), "dragEnabled", true);
         }
     }
+
+    @Override
+    protected void uninstallDefaults() {
+        if (!SwingAccessor.getJTextComponentAccessor()
+                          .isDragEnabledSet(getComponent())) {
+            LookAndFeel.installProperty(getComponent(), "dragEnabled",
+                                        oldDragState);
+        }
+        super.uninstallDefaults();
+    }
+
 
     // Install a default keypress action which handles Cmd and Option keys
     // properly

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTextPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTextPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,19 +66,11 @@ public final class AquaTextPaneUI extends BasicTextPaneUI {
     boolean oldDragState = false;
     @Override
     protected void installDefaults() {
-        final JTextComponent c = getComponent();
-        if (!GraphicsEnvironment.isHeadless()) {
-            oldDragState = c.getDragEnabled();
-            c.setDragEnabled(true);
-        }
         super.installDefaults();
     }
 
     @Override
     protected void uninstallDefaults() {
-        if (!GraphicsEnvironment.isHeadless()) {
-            getComponent().setDragEnabled(oldDragState);
-        }
         super.uninstallDefaults();
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -90,6 +90,7 @@ import javax.swing.event.AncestorEvent;
 import javax.swing.event.AncestorListener;
 import javax.swing.event.EventListenerList;
 import javax.swing.plaf.ComponentUI;
+import javax.swing.text.JTextComponent;
 
 import sun.awt.AWTAccessor;
 import sun.awt.SunToolkit;
@@ -4191,6 +4192,13 @@ public abstract class JComponent extends Container implements Serializable,
                 super.setFocusTraversalKeys(KeyboardFocusManager.
                                             BACKWARD_TRAVERSAL_KEYS,
                                             strokeSet);
+            }
+        } else if ("dragEnabled".equals(propertyName)
+                && this instanceof JTextComponent textComponent) {
+            var accessor = SwingAccessor.getJTextComponentAccessor();
+            if (!accessor.isDragEnabledSet(textComponent)) {
+                accessor.setDragEnabledUIResource(textComponent,
+                                                  (Boolean) value);
             }
         } else {
             throw new IllegalArgumentException("property \""+

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -36,6 +36,7 @@ import java.awt.FocusTraversalPolicy;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
+import java.awt.GraphicsEnvironment;
 import java.awt.Insets;
 import java.awt.KeyboardFocusManager;
 import java.awt.Point;
@@ -4195,10 +4196,12 @@ public abstract class JComponent extends Container implements Serializable,
             }
         } else if ("dragEnabled".equals(propertyName)
                 && this instanceof JTextComponent textComponent) {
-            var accessor = SwingAccessor.getJTextComponentAccessor();
-            if (!accessor.isDragEnabledSet(textComponent)) {
-                accessor.setDragEnabledUIResource(textComponent,
-                                                  (Boolean) value);
+            if (!GraphicsEnvironment.isHeadless()) {
+                var accessor = SwingAccessor.getJTextComponentAccessor();
+                if (!accessor.isDragEnabledSet(textComponent)) {
+                    accessor.setDragEnabledUIResource(textComponent,
+                                                      (Boolean) value);
+                }
             }
         } else {
             throw new IllegalArgumentException("property \""+

--- a/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
@@ -274,10 +274,10 @@ public abstract class LookAndFeel
      */
     public static void installProperty(JComponent c,
                                        String propertyName, Object propertyValue) {
+        // this is a special case because the JPasswordField's ancestor hierarchy
+        // includes a class outside of javax.swing, thus we cannot call setUIProperty
+        // directly.
         if (SunToolkit.isInstanceOf(c, "javax.swing.JPasswordField")) {
-            // this is a special case because the JPasswordField's ancestor hierarchy
-            // includes a class outside of javax.swing, thus we cannot call setUIProperty
-            // directly.
             if (!((JPasswordField)c).customSetUIProperty(propertyName, propertyValue)) {
                 c.setUIProperty(propertyName, propertyValue);
             }

--- a/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
@@ -37,6 +37,7 @@ import sun.awt.SunToolkit;
 import javax.swing.text.*;
 import javax.swing.border.*;
 import javax.swing.plaf.*;
+import sun.swing.SwingAccessor;
 
 import java.net.URL;
 import sun.swing.SwingUtilities2;
@@ -274,10 +275,17 @@ public abstract class LookAndFeel
      */
     public static void installProperty(JComponent c,
                                        String propertyName, Object propertyValue) {
-        // this is a special case because the JPasswordField's ancestor hierarchy
-        // includes a class outside of javax.swing, thus we cannot call setUIProperty
-        // directly.
-        if (SunToolkit.isInstanceOf(c, "javax.swing.JPasswordField")) {
+        if ("dragEnabled".equals(propertyName)
+            && c instanceof JTextComponent textComponent) {
+            var accessor = SwingAccessor.getJTextComponentAccessor();
+            if (!accessor.isDragEnabledSet(textComponent)) {
+                accessor.setDragEnabledUIResource(textComponent,
+                                                   (Boolean) propertyValue);
+            }
+        } else if (SunToolkit.isInstanceOf(c, "javax.swing.JPasswordField")) {
+            // this is a special case because the JPasswordField's ancestor hierarchy
+            // includes a class outside of javax.swing, thus we cannot call setUIProperty
+            // directly.
             if (!((JPasswordField)c).customSetUIProperty(propertyName, propertyValue)) {
                 c.setUIProperty(propertyName, propertyValue);
             }

--- a/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
@@ -26,7 +26,6 @@
 package javax.swing;
 
 import java.awt.Font;
-import java.awt.HeadlessException;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.Color;
@@ -268,9 +267,6 @@ public abstract class LookAndFeel
      * @throws NullPointerException if {@code c} is {@code null}, or the
      *         named property has not been set by the developer and
      *         {@code propertyValue} is {@code null}
-     * @throws HeadlessException if {@code propertyName} is
-     *          {@code "dragEnabled"}, {@code propertyValue} is {@code true},
-     *          and the environment is headless
      * @param c target component to set the property on
      * @param propertyName name of the property to set
      * @param propertyValue value of the property

--- a/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
@@ -26,6 +26,7 @@
 package javax.swing;
 
 import java.awt.Font;
+import java.awt.HeadlessException;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.Color;
@@ -267,6 +268,9 @@ public abstract class LookAndFeel
      * @throws NullPointerException if {@code c} is {@code null}, or the
      *         named property has not been set by the developer and
      *         {@code propertyValue} is {@code null}
+     * @throws HeadlessException if {@code propertyName} is
+     *          {@code "dragEnabled"}, {@code propertyValue} is {@code true},
+     *          and the environment is headless
      * @param c target component to set the property on
      * @param propertyName name of the property to set
      * @param propertyValue value of the property

--- a/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
@@ -37,7 +37,6 @@ import sun.awt.SunToolkit;
 import javax.swing.text.*;
 import javax.swing.border.*;
 import javax.swing.plaf.*;
-import sun.swing.SwingAccessor;
 
 import java.net.URL;
 import sun.swing.SwingUtilities2;
@@ -275,14 +274,7 @@ public abstract class LookAndFeel
      */
     public static void installProperty(JComponent c,
                                        String propertyName, Object propertyValue) {
-        if ("dragEnabled".equals(propertyName)
-            && c instanceof JTextComponent textComponent) {
-            var accessor = SwingAccessor.getJTextComponentAccessor();
-            if (!accessor.isDragEnabledSet(textComponent)) {
-                accessor.setDragEnabledUIResource(textComponent,
-                                                   (Boolean) propertyValue);
-            }
-        } else if (SunToolkit.isInstanceOf(c, "javax.swing.JPasswordField")) {
+        if (SunToolkit.isInstanceOf(c, "javax.swing.JPasswordField")) {
             // this is a special case because the JPasswordField's ancestor hierarchy
             // includes a class outside of javax.swing, thus we cannot call setUIProperty
             // directly.

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -355,6 +355,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
             editor.setMargin(UIManager.getInsets(prefix + ".margin"));
         }
 
+        LookAndFeel.installProperty(editor, "dragEnabled", false);
         updateCursor();
     }
 

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -653,7 +653,6 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * drag handling, this property should be set to {@code true}, and the
      * component's {@code TransferHandler} needs to be {@code non-null}.
      * The default value of the {@code dragEnabled} property is {@code false}.
-     * but look and feel can override the default to match the native text component drag property.
      * <p>
      * The job of honoring this property, and recognizing a user drag gesture,
      * lies with the look and feel implementation, and in particular, the component's

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -312,6 +312,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
         addFocusListener(caretEvent);
         setEditable(true);
         setDragEnabled(false);
+        dragEnabledSet = false;
         setLayout(null); // layout is managed by View hierarchy
         updateUI();
     }
@@ -652,6 +653,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * drag handling, this property should be set to {@code true}, and the
      * component's {@code TransferHandler} needs to be {@code non-null}.
      * The default value of the {@code dragEnabled} property is {@code false}.
+     * but L&F can override the default to match the native text component drag property.
      * <p>
      * The job of honoring this property, and recognizing a user drag gesture,
      * lies with the look and feel implementation, and in particular, the component's
@@ -679,6 +681,12 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
     @BeanProperty(bound = false, description
             = "determines whether automatic drag handling is enabled")
     public void setDragEnabled(boolean b) {
+        checkDragEnabled(b);
+        dragEnabled = b;
+        dragEnabledSet = true;
+    }
+
+    private void setDragEnabledUIResource(boolean b) {
         checkDragEnabled(b);
         dragEnabled = b;
     }
@@ -767,6 +775,13 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
                                               Object state, boolean forDrop)
                 {
                     return textComp.setDropLocation(location, state, forDrop);
+                }
+                public boolean isDragEnabledSet(JTextComponent textComp) {
+                    return textComp.dragEnabledSet;
+                }
+                public void setDragEnabledUIResource(JTextComponent textComp,
+                                                     boolean value) {
+                    textComp.setDragEnabledUIResource(value);
                 }
             });
     }
@@ -3869,6 +3884,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
     private Insets margin;
     private char focusAccelerator;
     private boolean dragEnabled;
+    private boolean dragEnabledSet;
 
     /**
      * The drop mode for this component.

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -653,7 +653,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * drag handling, this property should be set to {@code true}, and the
      * component's {@code TransferHandler} needs to be {@code non-null}.
      * The default value of the {@code dragEnabled} property is {@code false}.
-     * but L&F can override the default to match the native text component drag property.
+     * but look and feel can override the default to match the native text component drag property.
      * <p>
      * The job of honoring this property, and recognizing a user drag gesture,
      * lies with the look and feel implementation, and in particular, the component's

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -3815,6 +3815,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
         boolean newDragEnabled = f.get("dragEnabled", false);
         checkDragEnabled(newDragEnabled);
         dragEnabled = newDragEnabled;
+        dragEnabledSet = f.get("dragEnabledSet", false);
         DropMode newDropMode = (DropMode) f.get("dropMode",
                 DropMode.USE_SELECTION);
         checkDropMode(newDropMode);

--- a/src/java.desktop/share/classes/sun/swing/SwingAccessor.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingAccessor.java
@@ -87,6 +87,8 @@ public final class SwingAccessor {
          */
         Object setDropLocation(JTextComponent textComp, TransferHandler.DropLocation location,
                                Object state, boolean forDrop);
+        boolean isDragEnabledSet(JTextComponent textComp);
+        void setDragEnabledUIResource(JTextComponent textComp, boolean value);
     }
 
     /**

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8388884
+ * @key headful
+ * @summary Checks dragEnabled defaults and explicit settings across installed L&Fs
+ * @run main TextComponentDragEnabledTest
+ */
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import javax.swing.JEditorPane;
+import javax.swing.JPasswordField;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import javax.swing.text.JTextComponent;
+
+public class TextComponentDragEnabledTest {
+
+    private static final List<Supplier<JTextComponent>> TEXT_COMPONENTS = List.of(
+            JTextField::new,
+            JTextArea::new,
+            JTextPane::new,
+            JEditorPane::new
+    );
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                runTest();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private static void runTest() throws Exception {
+        String originalLaf = UIManager.getLookAndFeel().getClass().getName();
+
+        try {
+            testDefaultsForAllLookAndFeels();
+            testExplicitSettingsForAllLookAndFeels();
+        } finally {
+            UIManager.setLookAndFeel(originalLaf);
+        }
+    }
+
+    private static void testDefaultsForAllLookAndFeels()
+            throws Exception {
+        for (UIManager.LookAndFeelInfo laf :
+                UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing L&F " + laf.getClassName());
+            UIManager.setLookAndFeel(laf.getClassName());
+
+            for (Supplier<JTextComponent> supplier : TEXT_COMPONENTS) {
+                JTextComponent component = supplier.get();
+                checkDragEnabled(component, false,
+                    "new component under " + laf.getClassName());
+            }
+        }
+    }
+
+    private static void testExplicitSettingsForAllLookAndFeels()
+            throws Exception {
+        for (boolean expected : new boolean[] { false, true }) {
+            for (UIManager.LookAndFeelInfo laf :
+                UIManager.getInstalledLookAndFeels()) {
+                UIManager.setLookAndFeel(new MetalLookAndFeel());
+
+                for (Supplier<JTextComponent> supplier : TEXT_COMPONENTS) {
+                    JTextComponent component = supplier.get();
+                    component.setDragEnabled(expected);
+
+                    UIManager.setLookAndFeel(laf.getClassName());
+                    component.updateUI();
+
+                    checkDragEnabled(component, expected,
+                        "after switching to " + laf.getClassName());
+                }
+            }
+        }
+    }
+
+    private static void checkDragEnabled(JTextComponent component,
+                                          boolean expected,
+                                          String msg) {
+        boolean actual = component.getDragEnabled();
+        if (actual != expected) {
+            throw new RuntimeException(component.getClass().getName()
+                    + ": " + msg
+                    + "; expected dragEnabled=" + expected
+                    + ", actual=" + actual);
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import javax.swing.JEditorPane;
+import javax.swing.JFormattedTextField;
 import javax.swing.JPasswordField;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
@@ -52,7 +53,8 @@ public class TextComponentDragEnabledTest {
             JTextArea::new,
             JTextPane::new,
             JEditorPane::new,
-            JPasswordField::new
+            JPasswordField::new,
+            JFormattedTextField::new
     );
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -45,6 +45,8 @@ import javax.swing.text.JTextComponent;
 
 public class TextComponentDragEnabledTest {
 
+    private static final String AQUA_LAF = "com.apple.laf.AquaLookAndFeel";
+
     private static final List<Supplier<JTextComponent>> TEXT_COMPONENTS = List.of(
             JTextField::new,
             JTextArea::new,
@@ -76,8 +78,9 @@ public class TextComponentDragEnabledTest {
 
             for (Supplier<JTextComponent> supplier : TEXT_COMPONENTS) {
                 JTextComponent component = supplier.get();
-                checkDragEnabled(component, false,
-                    "new component under " + laf.getClassName());
+                boolean expected = AQUA_LAF.equals(laf.getClassName());
+                checkDragEnabled(component, expected,
+                        "new component under " + laf.getClassName());
             }
         }
     }

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -53,6 +53,11 @@ import javax.swing.plaf.metal.MetalLookAndFeel;
 import javax.swing.text.JTextComponent;
 import javax.swing.UnsupportedLookAndFeelException;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 public class TextComponentDragEnabledTest {
 
     private static final String AQUA_LAF = "com.apple.laf.AquaLookAndFeel";
@@ -121,8 +126,29 @@ public class TextComponentDragEnabledTest {
 
                     checkDragEnabled(component, expected,
                         "after switching to " + laf.getClassName());
+
+                    testSerialization(component, expected);
                 }
             }
+        }
+    }
+
+    private static void testSerialization(JTextComponent component, boolean expected) throws Exception {
+        JTextComponent copy = serializeAndDeserialize(component);
+        checkDragEnabled(copy, expected, "after deserializing application value");
+    }
+
+    private static JTextComponent serializeAndDeserialize(JTextComponent component)
+                                  throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(component);
+        }
+
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (JTextComponent) in.readObject();
         }
     }
 

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -51,7 +51,8 @@ public class TextComponentDragEnabledTest {
             JTextField::new,
             JTextArea::new,
             JTextPane::new,
-            JEditorPane::new
+            JEditorPane::new,
+            JPasswordField::new
     );
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -22,15 +22,24 @@
  */
 
 /*
- * @test
+ * @test id=headful
  * @bug 8388884
  * @key headful
  * @summary Checks dragEnabled defaults and explicit settings across installed L&Fs
  * @run main TextComponentDragEnabledTest
  */
 
+/*
+ * @test id=headless
+ * @bug 8388884
+ * @summary Checks dragEnabled defaults and explicit settings across installed L&Fs
+ * @run main/othervm -Djava.awt.headless=true TextComponentDragEnabledTest
+ */
+
 import java.util.List;
 import java.util.function.Supplier;
+
+import java.awt.GraphicsEnvironment;
 
 import javax.swing.JEditorPane;
 import javax.swing.JFormattedTextField;
@@ -68,7 +77,9 @@ public class TextComponentDragEnabledTest {
 
     private static void runTest() throws Exception {
         testDefaultsForAllLookAndFeels();
-        testExplicitSettingsForAllLookAndFeels();
+        if (!GraphicsEnvironment.isHeadless()) {
+            testExplicitSettingsForAllLookAndFeels();
+        }
     }
 
     private static void testDefaultsForAllLookAndFeels()
@@ -80,7 +91,8 @@ public class TextComponentDragEnabledTest {
 
             for (Supplier<JTextComponent> supplier : TEXT_COMPONENTS) {
                 JTextComponent component = supplier.get();
-                boolean expected = AQUA_LAF.equals(laf.getClassName());
+                boolean expected = AQUA_LAF.equals(laf.getClassName())
+                                   && !GraphicsEnvironment.isHeadless();
                 checkDragEnabled(component, expected,
                         "new component under " + laf.getClassName());
             }

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -115,9 +115,9 @@ public class TextComponentDragEnabledTest {
         for (boolean expected : new boolean[] { false, true }) {
             for (UIManager.LookAndFeelInfo laf :
                 UIManager.getInstalledLookAndFeels()) {
-                UIManager.setLookAndFeel(new MetalLookAndFeel());
 
                 for (Supplier<JTextComponent> supplier : TEXT_COMPONENTS) {
+                    UIManager.setLookAndFeel(new MetalLookAndFeel());
                     JTextComponent component = supplier.get();
                     component.setDragEnabled(expected);
 

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -63,14 +63,8 @@ public class TextComponentDragEnabledTest {
     }
 
     private static void runTest() throws Exception {
-        String originalLaf = UIManager.getLookAndFeel().getClass().getName();
-
-        try {
-            testDefaultsForAllLookAndFeels();
-            testExplicitSettingsForAllLookAndFeels();
-        } finally {
-            UIManager.setLookAndFeel(originalLaf);
-        }
+        testDefaultsForAllLookAndFeels();
+        testExplicitSettingsForAllLookAndFeels();
     }
 
     private static void testDefaultsForAllLookAndFeels()

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -51,6 +51,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.plaf.metal.MetalLookAndFeel;
 import javax.swing.text.JTextComponent;
+import javax.swing.UnsupportedLookAndFeelException;
 
 public class TextComponentDragEnabledTest {
 
@@ -87,7 +88,12 @@ public class TextComponentDragEnabledTest {
         for (UIManager.LookAndFeelInfo laf :
                 UIManager.getInstalledLookAndFeels()) {
             System.out.println("Testing L&F " + laf.getClassName());
-            UIManager.setLookAndFeel(laf.getClassName());
+            try {
+                UIManager.setLookAndFeel(laf.getClassName());
+            } catch (UnsupportedLookAndFeelException e) {
+                System.out.println("Skipping unsupported L&F: " + laf.getClassName());
+                continue;
+            }
 
             for (Supplier<JTextComponent> supplier : TEXT_COMPONENTS) {
                 JTextComponent component = supplier.get();

--- a/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
+++ b/test/jdk/javax/swing/text/JTextComponent/TextComponentDragEnabledTest.java
@@ -40,7 +40,6 @@ import javax.swing.JTextField;
 import javax.swing.JTextPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.plaf.metal.MetalLookAndFeel;
 import javax.swing.text.JTextComponent;
 


### PR DESCRIPTION
Aqua classes for text components enables dragEnabled by default although setDragEnabled spec cites `"The default value of the dragEnabled property is false. "` and there is nothing in Aqua L&F that mentions otherwise as to why the default is overridden.
Other L&F dont override the mode and the code is there from macosx port days so it seems to be an oversight.

The code is deleted.
Test is added to check 
 - default value is honoured in all installed L&Fs
 - explicit application setting of drag mode is preserved on L&F change

 CI testing is ok.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388884](https://bugs.openjdk.org/browse/JDK-8388884): [macOS] Swing Aqua L&amp;F text components enable drag by default (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32101/head:pull/32101` \
`$ git checkout pull/32101`

Update a local copy of the PR: \
`$ git checkout pull/32101` \
`$ git pull https://git.openjdk.org/jdk.git pull/32101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32101`

View PR using the GUI difftool: \
`$ git pr show -t 32101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32101.diff">https://git.openjdk.org/jdk/pull/32101.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32101#issuecomment-5130154628)
</details>
