### PR TITLE
8389453: [unix] Avoid unused variables warnings in libj2pkcs11 and adjust malloc rv handling

### DIFF
--- a/make/modules/jdk.crypto.cryptoki/Lib.gmk
+++ b/make/modules/jdk.crypto.cryptoki/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJ2PKCS11, \
     NAME := j2pkcs11, \
     OPTIMIZATION := LOW, \
     EXTRA_HEADER_DIRS := java.base:libjava, \
-    DISABLED_WARNINGS_gcc_p11_md.c := unused-variable, \
-    DISABLED_WARNINGS_clang_p11_md.c := unused-variable, \
     DISABLED_WARNINGS_clang_p11_util.c := format-nonliteral, \
     LIBS_unix := $(LIBDL), \
 ))

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -79,10 +79,6 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     jstring jGetFunctionList) {
 
     void *hModule;
-    int i;
-    CK_ULONG ulCount = 0;
-    CK_C_GetInterfaceList C_GetInterfaceList = NULL;
-    CK_INTERFACE_PTR iList = NULL;
     CK_C_GetInterface C_GetInterface = NULL;
     CK_INTERFACE_PTR interface = NULL;
     CK_C_GetFunctionList C_GetFunctionList = NULL;
@@ -124,27 +120,31 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     }
 
 #ifdef DEBUG
-    C_GetInterfaceList = (CK_C_GetInterfaceList) dlsym(hModule,
-            "C_GetInterfaceList");
+    CK_C_GetInterfaceList C_GetInterfaceList = (CK_C_GetInterfaceList) dlsym(hModule, "C_GetInterfaceList");
     if (C_GetInterfaceList != NULL) {
+        CK_ULONG ulCount = 0;
         TRACE0("Connect: Found C_GetInterfaceList func\n");
         rv = (C_GetInterfaceList)(NULL, &ulCount);
         if (rv == CKR_OK) {
             TRACE1("Connect: interface list size %ld \n", ulCount);
             // retrieve available interfaces and report their info
-            iList = (CK_INTERFACE_PTR)
-                malloc(ulCount*sizeof(CK_INTERFACE));
-            rv = C_GetInterfaceList(iList, &ulCount);
-            if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) {
-                TRACE0("Connect: error polling interface list\n");
-                goto cleanup;
-            }
-            for (i=0; i < (int)ulCount; i++) {
-                TRACE4("Connect: name %s, version %d.%d, flags 0x%lX\n",
-                        iList[i].pInterfaceName,
-                        ((CK_VERSION *)iList[i].pFunctionList)->major,
-                        ((CK_VERSION *)iList[i].pFunctionList)->minor,
-                        iList[i].flags);
+            CK_INTERFACE_PTR iList = (CK_INTERFACE_PTR) malloc(ulCount*sizeof(CK_INTERFACE));
+            if (iList == NULL) {
+                TRACE0("Connect: error allocating interface list\n");
+            } else {
+                rv = C_GetInterfaceList(iList, &ulCount);
+                if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) {
+                    TRACE0("Connect: error polling interface list\n");
+                    goto cleanup;
+                }
+                for (int i=0; i < (int)ulCount; i++) {
+                    TRACE4("Connect: name %s, version %d.%d, flags 0x%lX\n",
+                            iList[i].pInterfaceName,
+                            ((CK_VERSION *)iList[i].pFunctionList)->major,
+                            ((CK_VERSION *)iList[i].pFunctionList)->minor,
+                            iList[i].flags);
+                }
+                free(iList);
             }
         } else {
             TRACE0("Connect: error polling interface list size\n");


### PR DESCRIPTION
[JDK-8388872](https://bugs.openjdk.org/browse/JDK-8388872) fixed some issues in the windows pkcs11 native coding, but seems they are also present in the separate unix coding.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389453](https://bugs.openjdk.org/browse/JDK-8389453): [unix] Avoid unused variables warnings in libj2pkcs11 and adjust malloc rv handling (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32103/head:pull/32103` \
`$ git checkout pull/32103`

Update a local copy of the PR: \
`$ git checkout pull/32103` \
`$ git pull https://git.openjdk.org/jdk.git pull/32103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32103`

View PR using the GUI difftool: \
`$ git pr show -t 32103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32103.diff">https://git.openjdk.org/jdk/pull/32103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32103#issuecomment-5131100704)
</details>
