### PR TITLE
8389455: Avoid local initialized unused variables in libjimage

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -108,12 +108,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJIMAGE, \
     OPTIMIZATION := LOW, \
     EXTRA_HEADER_DIRS := libjava, \
     CFLAGS_unix := -UDEBUG, \
-    DISABLED_WARNINGS_gcc_imageDecompressor.cpp := unused-variable, \
-    DISABLED_WARNINGS_gcc_imageFile.cpp := unused-const-variable \
-        unused-variable, \
-    DISABLED_WARNINGS_clang_imageDecompressor.cpp := unused-variable, \
-    DISABLED_WARNINGS_clang_imageFile.cpp := unused-private-field \
-        unused-variable, \
     LDFLAGS := $(LDFLAGS_CXX_JDK), \
     JDK_LIBS := libjvm, \
     LIBS_unix := $(LIBDL), \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -108,6 +108,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJIMAGE, \
     OPTIMIZATION := LOW, \
     EXTRA_HEADER_DIRS := libjava, \
     CFLAGS_unix := -UDEBUG, \
+    DISABLED_WARNINGS_clang_imageFile.cpp := unused-private-field \
     LDFLAGS := $(LDFLAGS_CXX_JDK), \
     JDK_LIBS := libjvm, \
     LIBS_unix := $(LIBDL), \

--- a/src/java.base/share/native/libjimage/imageDecompressor.cpp
+++ b/src/java.base/share/native/libjimage/imageDecompressor.cpp
@@ -43,15 +43,6 @@ typedef jboolean (*ZipInflateFully_t)(void *inBuf, jlong inLen,
                                       void *outBuf, jlong outLen, char **pmsg);
 static ZipInflateFully_t ZipInflateFully        = NULL;
 
-#ifndef WIN32
-    #define JNI_LIB_PREFIX "lib"
-    #ifdef __APPLE__
-        #define JNI_LIB_SUFFIX ".dylib"
-    #else
-        #define JNI_LIB_SUFFIX ".so"
-    #endif
-#endif
-
 /**
  * Return the address of the entry point named in the zip shared library.
  * @param name - the name of the entry point
@@ -179,7 +170,7 @@ void ImageDecompressor::decompress_resource(u1* compressed, u1* uncompressed,
 void ZipDecompressor::decompress_resource(u1* data, u1* uncompressed,
                 ResourceHeader* header, const ImageStrings* strings) {
     char* msg = NULL;
-    jboolean res = ZipDecompressor::decompress(data, header->_size, uncompressed,
+    [[maybe_unused]] jboolean res = ZipDecompressor::decompress(data, header->_size, uncompressed,
                     header->_uncompressed_size, &msg);
     assert(res && "decompression failed");
 }

--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -43,12 +43,6 @@
 // Map the full jimage, only with 64 bit addressing.
 bool ImageFileReader::memory_map_image = sizeof(void *) == 8;
 
-#ifdef WIN32
-const char FileSeparator = '\\';
-#else
-const char FileSeparator = '/';
-#endif
-
 // Image files are an alternate file format for storing classes and resources. The
 // goal is to supply file access which is faster and smaller than the jar format.
 //
@@ -428,7 +422,7 @@ void ImageFileReader::get_resource(ImageLocation& location, u1* uncompressed_dat
             compressed_data = new u1[(size_t)compressed_size];
             assert(compressed_data != NULL && "allocation failed");
             // Read bytes from offset beyond the image index.
-            bool is_read = read_at(compressed_data, compressed_size, _index_size + offset);
+            [[maybe_unused]] bool is_read = read_at(compressed_data, compressed_size, _index_size + offset);
             assert(is_read && "error reading from image or short read");
         } else {
             compressed_data = get_data_address() + offset;
@@ -444,7 +438,7 @@ void ImageFileReader::get_resource(ImageLocation& location, u1* uncompressed_dat
         }
     } else {
         // Read bytes from offset beyond the image index.
-        bool is_read = read_at(uncompressed_data, uncompressed_size, _index_size + offset);
+        [[maybe_unused]] bool is_read = read_at(uncompressed_data, uncompressed_size, _index_size + offset);
         assert(is_read && "error reading from image or short read");
     }
 }


### PR DESCRIPTION
We have a couple of local initialized unused variables in libjimage, those should be cleaned up.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389455](https://bugs.openjdk.org/browse/JDK-8389455): Avoid local initialized unused variables in libjimage (**Bug** - P4)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32105/head:pull/32105` \
`$ git checkout pull/32105`

Update a local copy of the PR: \
`$ git checkout pull/32105` \
`$ git pull https://git.openjdk.org/jdk.git pull/32105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32105`

View PR using the GUI difftool: \
`$ git pr show -t 32105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32105.diff">https://git.openjdk.org/jdk/pull/32105.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32105#issuecomment-5131792616)
</details>
