### PR TITLE
8388469: Error: assert(_init_deps.contains(ktd)) failed when running TestSetupAOTTest.java with -XX:+CICountOSR

### DIFF
--- a/src/hotspot/share/oops/trainingData.cpp
+++ b/src/hotspot/share/oops/trainingData.cpp
@@ -30,6 +30,7 @@
 #include "classfile/javaClasses.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionaryShared.hpp"
+#include "compiler/compileBroker.hpp"
 #include "compiler/compileTask.hpp"
 #include "memory/metadataFactory.hpp"
 #include "memory/metaspaceClosure.hpp"
@@ -61,7 +62,7 @@ KlassTrainingData::KlassTrainingData() {
   assert(CDSConfig::is_dumping_static_archive() || UseSharedSpaces, "only for CDS");
 }
 
-CompileTrainingData::CompileTrainingData() : _level(-1), _compile_id(-1) {
+CompileTrainingData::CompileTrainingData() : _level(-1), _is_osr(false), _compile_id(-1) {
   // Used by cppVtables.cpp only
   assert(CDSConfig::is_dumping_static_archive() || UseSharedSpaces, "only for CDS");
 }
@@ -225,6 +226,7 @@ void MethodTrainingData::print_on(outputStream* st, bool name_only) const {
 
 CompileTrainingData* CompileTrainingData::make(CompileTask* task) {
   int level = task->comp_level();
+  bool is_osr = (task->osr_bci() != CompileBroker::standard_entry_bci);
   int compile_id = task->compile_id();
   Thread* thread = Thread::current();
   methodHandle m(thread, task->method());
@@ -238,16 +240,16 @@ CompileTrainingData* CompileTrainingData::make(CompileTask* task) {
   mtd->notice_compilation(level);
 
   TrainingDataLocker l;
-  CompileTrainingData* ctd = CompileTrainingData::allocate(mtd, level, compile_id);
-  if (ctd != nullptr) {
-    CompileTrainingData*& last_ctd = mtd->_last_toplevel_compiles[level - 1];
-    if (last_ctd != nullptr) {
-      assert(mtd->highest_top_level() >= level, "consistency");
-      if (last_ctd->compile_id() < compile_id) {
+  CompileTrainingData*& last_ctd = mtd->_last_toplevel_compiles[level - 1];
+  CompileTrainingData* ctd = nullptr;
+  if (last_ctd == nullptr ||                                                   // no previous CTD
+      (last_ctd->is_osr() == is_osr && last_ctd->compile_id() < compile_id) || // newer compile for same OSR status
+      (last_ctd->is_osr() && !is_osr)) {                                       // newer non-OSR compile after OSR compile
+    ctd = CompileTrainingData::allocate(mtd, level, is_osr, compile_id);
+    if (ctd != nullptr) {
+      if (last_ctd != nullptr) {
         last_ctd->clear_init_deps();
-        last_ctd = ctd;
       }
-    } else {
       last_ctd = ctd;
       mtd->notice_toplevel_compilation(level);
     }

--- a/src/hotspot/share/oops/trainingData.hpp
+++ b/src/hotspot/share/oops/trainingData.hpp
@@ -532,6 +532,7 @@ class CompileTrainingData : public TrainingData {
 
   MethodTrainingData* _method;
   const short _level;
+  const bool _is_osr;
   const int _compile_id;
 
   // classes that should be initialized before this JIT task runs
@@ -648,9 +649,10 @@ private:
   CompileTrainingData();
   CompileTrainingData(MethodTrainingData* mtd,
                       int level,
+                      bool is_osr,
                       int compile_id)
       : TrainingData(),  // empty key
-        _method(mtd), _level(level), _compile_id(compile_id), _init_deps_left(0) { }
+        _method(mtd), _level(level), _is_osr(is_osr), _compile_id(compile_id), _init_deps_left(0) { }
 public:
   ciRecords& ci_records() { return _ci_records; }
   static CompileTrainingData* make(CompileTask* task) NOT_CDS_RETURN_(nullptr);
@@ -660,7 +662,7 @@ public:
   MethodTrainingData* method() const { return _method; }
 
   int level() const { return _level; }
-
+  bool is_osr() const { return _is_osr; }
   int compile_id() const { return _compile_id; }
 
   int init_dep_count() const {
@@ -719,8 +721,8 @@ public:
 
   void verify(bool verify_dep_counter);
 
-  static CompileTrainingData* allocate(MethodTrainingData* mtd, int level, int compile_id) {
-    return TrainingData::allocate<CompileTrainingData>(mtd, level, compile_id);
+  static CompileTrainingData* allocate(MethodTrainingData* mtd, int level, bool is_osr, int compile_id) {
+    return TrainingData::allocate<CompileTrainingData>(mtd, level, is_osr, compile_id);
   }
 };
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotProfile/OptionsStability.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotProfile/OptionsStability.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8388469
+ * @summary Verify that AOT workflow works with -XX:+CICountOSR and -XX:CICountNative
+ * @requires vm.cds
+ * @requires vm.debug
+ * @library /test/lib /test/setup_aot
+ * @build OptionsStability JavacBenchApp TestSetupAOT
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller
+ *                 TestSetupAOT
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
+ *                 TestSetupAOT
+ *                 TestSetupAOT$ToolOutput
+ *                 JavacBenchApp
+ *                 JavacBenchApp$ClassFile
+ *                 JavacBenchApp$FileManager
+ *                 JavacBenchApp$SourceFile
+ * @run driver OptionsStability
+ */
+
+import jdk.test.lib.cds.SimpleCDSAppTester;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class OptionsStability {
+    public static void main(String... args) throws Exception {
+        SimpleCDSAppTester.of("TestSetupAOT")
+            .classpath("app.jar")
+            .addVmArgs("-XX:+CICountOSR", "-XX:+CICountNative")
+            .appCommandLine("TestSetupAOT", ".")
+            .runAOTWorkflow();
+    }
+}


### PR DESCRIPTION
Resolve compile_id ambiguity between OSR and normal compiles




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388469](https://bugs.openjdk.org/browse/JDK-8388469): Error: assert(_init_deps.contains(ktd)) failed when running TestSetupAOTTest.java with -XX:+CICountOSR (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32106/head:pull/32106` \
`$ git checkout pull/32106`

Update a local copy of the PR: \
`$ git checkout pull/32106` \
`$ git pull https://git.openjdk.org/jdk.git pull/32106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32106`

View PR using the GUI difftool: \
`$ git pr show -t 32106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32106.diff">https://git.openjdk.org/jdk/pull/32106.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32106#issuecomment-5133025011)
</details>
