### PR TITLE
8388385: CDS dumping fails with circular JAR manifest Class-Path

### DIFF
--- a/src/hotspot/share/cds/aotClassLocation.cpp
+++ b/src/hotspot/share/cds/aotClassLocation.cpp
@@ -633,7 +633,7 @@ void AOTClassLocationConfig::add_class_location(JavaThread* current, GrowableCla
         // other via cpattr.
         bool found_duplicate = false;
         for (int i = boot_cp_start_index(); i < tmp_array.length(); i++) {
-          if (strcmp(tmp_array.at(i)->path(), libname) == 0) {
+          if (os::same_files(tmp_array.at(i)->path(), libname)) {
             found_duplicate = true;
             break;
           }

--- a/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttrCircularReference.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttrCircularReference.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Yunbo Zhang. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8388385
+ * @summary CDS dumping should not loop on circular JAR manifest Class-Path entries
+ * @requires vm.cds
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run driver/timeout=60 ClassPathAttrCircularReference
+ */
+
+import jdk.test.lib.cds.CDSOptions;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class ClassPathAttrCircularReference {
+    public static void main(String[] args) throws Exception {
+        createJar("A.jar", "./B.jar");
+        createJar("B.jar", "A.jar");
+
+        CDSOptions opts = (new CDSOptions())
+                .addPrefix("-cp", "A.jar")
+                .addSuffix("-Xlog:class+path=info");
+        CDSTestUtils.createArchiveAndCheck(opts)
+                .shouldContain("path [2] =")
+                .shouldNotContain("path [3] =");
+    }
+
+    private static void createJar(String jarName, String classPath) throws Exception {
+        String manifest = "Manifest-Version: 1.0\n" +
+                          "Class-Path: " + classPath + "\n";
+        ClassFileInstaller.writeJar(jarName,
+                                    ClassFileInstaller.Manifest.fromString(manifest));
+    }
+}


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388385](https://bugs.openjdk.org/browse/JDK-8388385): CDS dumping fails with circular JAR manifest Class-Path (**Bug** - P3)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32107/head:pull/32107` \
`$ git checkout pull/32107`

Update a local copy of the PR: \
`$ git checkout pull/32107` \
`$ git pull https://git.openjdk.org/jdk.git pull/32107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32107`

View PR using the GUI difftool: \
`$ git pr show -t 32107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32107.diff">https://git.openjdk.org/jdk/pull/32107.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32107#issuecomment-5134175103)
</details>
