### PR TITLE
Vector API can be value classes!

### DIFF
--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -59,6 +59,7 @@ JAVA_BASE_VALUE_CLASS_REPLACEMENTS := \
     java/time/chrono/HijrahDate.java \
     java/time/chrono/JapaneseDate.java \
     java/time/chrono/ThaiBuddhistDate.java \
+    jdk/internal/vm/vector/VectorSupport.java \
     #
 
 JAVA_BASE_VALUE_CLASS_SRC_PATHS := \

--- a/make/modules/jdk.incubator.vector/Gensrc.gmk
+++ b/make/modules/jdk.incubator.vector/Gensrc.gmk
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+################################################################################
+
+include GensrcCommon.gmk
+include GensrcProperties.gmk
+include GensrcStreamPreProcessing.gmk
+
+include gensrc/GensrcValueClasses.gmk
+
+################################################################################

--- a/make/modules/jdk.incubator.vector/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/jdk.incubator.vector/gensrc/GensrcValueClasses.gmk
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+################################################################################
+# Generate the value class replacements for jdk.incubator.vector source files
+# See doc/value-class-preview.md for an overview of value class generation
+
+$(eval $(call SetupTextFileProcessing, JDK_VECTOR_VALUE_CLASS_TARGETS, \
+    SOURCE_DIRS := $(TOPDIR)/src/jdk.incubator.vector/share/classes/, \
+    OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/gensrc-valueclasses/jdk.incubator.vector/, \
+    REPLACEMENTS := \
+        /\*value\*/ class => value class ; \
+        /\*value\*/ record => value record ; \
+))
+
+TARGETS += $(JDK_VECTOR_VALUE_CLASS_TARGETS)

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -161,9 +161,9 @@ public class VectorSupport {
 
     /* ============================================================================ */
 
-    public static class VectorSpecies<E> {}
+    public abstract static class VectorSpecies<E> {}
 
-    public static class VectorPayload {
+    public abstract static /*value*/ class VectorPayload {
         private final Object payload; // array of primitives
 
         public VectorPayload(Object payload) {
@@ -175,19 +175,19 @@ public class VectorSupport {
         }
     }
 
-    public static class Vector<E> extends VectorPayload {
+    public abstract static /*value*/ class Vector<E> extends VectorPayload {
         public Vector(Object payload) {
             super(payload);
         }
     }
 
-    public static class VectorShuffle<E> extends VectorPayload {
+    public abstract static /*value*/ class VectorShuffle<E> extends VectorPayload {
         public VectorShuffle(Object payload) {
             super(payload);
         }
     }
 
-    public static class VectorMask<E> extends VectorPayload {
+    public abstract static /*value*/ class VectorMask<E> extends VectorPayload {
         public VectorMask(Object payload) {
             super(payload);
         }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -30,7 +30,7 @@ import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.incubator.vector.VectorOperators.*;
 
-abstract sealed class AbstractMask<E> extends VectorMask<E>
+abstract sealed /*value*/ class AbstractMask<E> extends VectorMask<E>
         permits ByteVector64.ByteMask64, ByteVector128.ByteMask128, ByteVector256.ByteMask256, ByteVector512.ByteMask512, ByteVectorMax.ByteMaskMax,
         DoubleVector64.DoubleMask64, DoubleVector128.DoubleMask128, DoubleVector256.DoubleMask256, DoubleVector512.DoubleMask512, DoubleVectorMax.DoubleMaskMax,
         FloatVector64.FloatMask64, FloatVector128.FloatMask128, FloatVector256.FloatMask256, FloatVector512.FloatMask512, FloatVectorMax.FloatMaskMax,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
@@ -29,7 +29,7 @@ import java.util.function.IntUnaryOperator;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
 
-abstract sealed class AbstractShuffle<E> extends VectorShuffle<E>
+abstract sealed /*value*/ class AbstractShuffle<E> extends VectorShuffle<E>
         permits ByteVector64.ByteShuffle64, ByteVector128.ByteShuffle128, ByteVector256.ByteShuffle256, ByteVector512.ByteShuffle512, ByteVectorMax.ByteShuffleMax,
         DoubleVector64.DoubleShuffle64, DoubleVector128.DoubleShuffle128, DoubleVector256.DoubleShuffle256, DoubleVector512.DoubleShuffle512, DoubleVectorMax.DoubleShuffleMax,
         FloatVector64.FloatShuffle64, FloatVector128.FloatShuffle128, FloatVector256.FloatShuffle256, FloatVector512.FloatShuffle512, FloatVectorMax.FloatShuffleMax,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -34,7 +34,7 @@ import jdk.internal.vm.vector.VectorSupport;
 import static jdk.incubator.vector.VectorOperators.*;
 
 @SuppressWarnings("cast")
-abstract sealed class AbstractVector<E> extends Vector<E>
+abstract sealed /*value*/ class AbstractVector<E> extends Vector<E>
         permits ByteVector, DoubleVector, FloatVector, IntVector, LongVector, ShortVector, Float16Vector {
     /**
      * The order of vector bytes when stored in natural,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -49,7 +49,7 @@ import static jdk.incubator.vector.VectorOperators.*;
  * {@code byte} values.
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract sealed class ByteVector extends AbstractVector<Byte>
+public abstract sealed /*value*/ class ByteVector extends AbstractVector<Byte>
          permits ByteVector64, ByteVector128, ByteVector256, ByteVector512, ByteVectorMax {
 
     ByteVector(byte[] vec) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector128.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector128.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ByteVector128 extends ByteVector {
+final /*value*/ class ByteVector128 extends ByteVector {
     static final ByteSpecies VSPECIES =
         (ByteSpecies) ByteVector.SPECIES_128;
 
@@ -599,7 +599,7 @@ final class ByteVector128 extends ByteVector {
 
     // Mask
     @ValueBased
-    static final class ByteMask128 extends AbstractMask<Byte> {
+    static final /*value*/ class ByteMask128 extends AbstractMask<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM
@@ -832,7 +832,7 @@ final class ByteVector128 extends ByteVector {
 
     // Shuffle
     @ValueBased
-    static final class ByteShuffle128 extends AbstractShuffle<Byte> {
+    static final /*value*/ class ByteShuffle128 extends AbstractShuffle<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector256.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector256.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ByteVector256 extends ByteVector {
+final /*value*/ class ByteVector256 extends ByteVector {
     static final ByteSpecies VSPECIES =
         (ByteSpecies) ByteVector.SPECIES_256;
 
@@ -631,7 +631,7 @@ final class ByteVector256 extends ByteVector {
 
     // Mask
     @ValueBased
-    static final class ByteMask256 extends AbstractMask<Byte> {
+    static final /*value*/ class ByteMask256 extends AbstractMask<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM
@@ -864,7 +864,7 @@ final class ByteVector256 extends ByteVector {
 
     // Shuffle
     @ValueBased
-    static final class ByteShuffle256 extends AbstractShuffle<Byte> {
+    static final /*value*/ class ByteShuffle256 extends AbstractShuffle<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector512.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector512.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ByteVector512 extends ByteVector {
+final /*value*/ class ByteVector512 extends ByteVector {
     static final ByteSpecies VSPECIES =
         (ByteSpecies) ByteVector.SPECIES_512;
 
@@ -695,7 +695,7 @@ final class ByteVector512 extends ByteVector {
 
     // Mask
     @ValueBased
-    static final class ByteMask512 extends AbstractMask<Byte> {
+    static final /*value*/ class ByteMask512 extends AbstractMask<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM
@@ -928,7 +928,7 @@ final class ByteVector512 extends ByteVector {
 
     // Shuffle
     @ValueBased
-    static final class ByteShuffle512 extends AbstractShuffle<Byte> {
+    static final /*value*/ class ByteShuffle512 extends AbstractShuffle<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector64.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector64.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ByteVector64 extends ByteVector {
+final /*value*/ class ByteVector64 extends ByteVector {
     static final ByteSpecies VSPECIES =
         (ByteSpecies) ByteVector.SPECIES_64;
 
@@ -583,7 +583,7 @@ final class ByteVector64 extends ByteVector {
 
     // Mask
     @ValueBased
-    static final class ByteMask64 extends AbstractMask<Byte> {
+    static final /*value*/ class ByteMask64 extends AbstractMask<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM
@@ -816,7 +816,7 @@ final class ByteVector64 extends ByteVector {
 
     // Shuffle
     @ValueBased
-    static final class ByteShuffle64 extends AbstractShuffle<Byte> {
+    static final /*value*/ class ByteShuffle64 extends AbstractShuffle<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVectorMax.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVectorMax.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ByteVectorMax extends ByteVector {
+final /*value*/ class ByteVectorMax extends ByteVector {
     static final ByteSpecies VSPECIES =
         (ByteSpecies) ByteVector.SPECIES_MAX;
 
@@ -569,7 +569,7 @@ final class ByteVectorMax extends ByteVector {
 
     // Mask
     @ValueBased
-    static final class ByteMaskMax extends AbstractMask<Byte> {
+    static final /*value*/ class ByteMaskMax extends AbstractMask<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM
@@ -802,7 +802,7 @@ final class ByteVectorMax extends ByteVector {
 
     // Shuffle
     @ValueBased
-    static final class ByteShuffleMax extends AbstractShuffle<Byte> {
+    static final /*value*/ class ByteShuffleMax extends AbstractShuffle<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Byte> CTYPE = byte.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -49,7 +49,7 @@ import static jdk.incubator.vector.VectorOperators.*;
  * {@code double} values.
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract sealed class DoubleVector extends AbstractVector<Double>
+public abstract sealed /*value*/ class DoubleVector extends AbstractVector<Double>
          permits DoubleVector64, DoubleVector128, DoubleVector256, DoubleVector512, DoubleVectorMax {
 
     DoubleVector(double[] vec) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector128.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector128.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class DoubleVector128 extends DoubleVector {
+final /*value*/ class DoubleVector128 extends DoubleVector {
     static final DoubleSpecies VSPECIES =
         (DoubleSpecies) DoubleVector.SPECIES_128;
 
@@ -561,7 +561,7 @@ final class DoubleVector128 extends DoubleVector {
 
     // Mask
     @ValueBased
-    static final class DoubleMask128 extends AbstractMask<Double> {
+    static final /*value*/ class DoubleMask128 extends AbstractMask<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Double> CTYPE = double.class; // used by the JVM
@@ -794,7 +794,7 @@ final class DoubleVector128 extends DoubleVector {
 
     // Shuffle
     @ValueBased
-    static final class DoubleShuffle128 extends AbstractShuffle<Double> {
+    static final /*value*/ class DoubleShuffle128 extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector256.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector256.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class DoubleVector256 extends DoubleVector {
+final /*value*/ class DoubleVector256 extends DoubleVector {
     static final DoubleSpecies VSPECIES =
         (DoubleSpecies) DoubleVector.SPECIES_256;
 
@@ -565,7 +565,7 @@ final class DoubleVector256 extends DoubleVector {
 
     // Mask
     @ValueBased
-    static final class DoubleMask256 extends AbstractMask<Double> {
+    static final /*value*/ class DoubleMask256 extends AbstractMask<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Double> CTYPE = double.class; // used by the JVM
@@ -798,7 +798,7 @@ final class DoubleVector256 extends DoubleVector {
 
     // Shuffle
     @ValueBased
-    static final class DoubleShuffle256 extends AbstractShuffle<Double> {
+    static final /*value*/ class DoubleShuffle256 extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector512.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector512.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class DoubleVector512 extends DoubleVector {
+final /*value*/ class DoubleVector512 extends DoubleVector {
     static final DoubleSpecies VSPECIES =
         (DoubleSpecies) DoubleVector.SPECIES_512;
 
@@ -573,7 +573,7 @@ final class DoubleVector512 extends DoubleVector {
 
     // Mask
     @ValueBased
-    static final class DoubleMask512 extends AbstractMask<Double> {
+    static final /*value*/ class DoubleMask512 extends AbstractMask<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Double> CTYPE = double.class; // used by the JVM
@@ -806,7 +806,7 @@ final class DoubleVector512 extends DoubleVector {
 
     // Shuffle
     @ValueBased
-    static final class DoubleShuffle512 extends AbstractShuffle<Double> {
+    static final /*value*/ class DoubleShuffle512 extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector64.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector64.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class DoubleVector64 extends DoubleVector {
+final /*value*/ class DoubleVector64 extends DoubleVector {
     static final DoubleSpecies VSPECIES =
         (DoubleSpecies) DoubleVector.SPECIES_64;
 
@@ -559,7 +559,7 @@ final class DoubleVector64 extends DoubleVector {
 
     // Mask
     @ValueBased
-    static final class DoubleMask64 extends AbstractMask<Double> {
+    static final /*value*/ class DoubleMask64 extends AbstractMask<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Double> CTYPE = double.class; // used by the JVM
@@ -792,7 +792,7 @@ final class DoubleVector64 extends DoubleVector {
 
     // Shuffle
     @ValueBased
-    static final class DoubleShuffle64 extends AbstractShuffle<Double> {
+    static final /*value*/ class DoubleShuffle64 extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVectorMax.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVectorMax.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class DoubleVectorMax extends DoubleVector {
+final /*value*/ class DoubleVectorMax extends DoubleVector {
     static final DoubleSpecies VSPECIES =
         (DoubleSpecies) DoubleVector.SPECIES_MAX;
 
@@ -558,7 +558,7 @@ final class DoubleVectorMax extends DoubleVector {
 
     // Mask
     @ValueBased
-    static final class DoubleMaskMax extends AbstractMask<Double> {
+    static final /*value*/ class DoubleMaskMax extends AbstractMask<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Double> CTYPE = double.class; // used by the JVM
@@ -791,7 +791,7 @@ final class DoubleVectorMax extends DoubleVector {
 
     // Shuffle
     @ValueBased
-    static final class DoubleShuffleMax extends AbstractShuffle<Double> {
+    static final /*value*/ class DoubleShuffleMax extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
@@ -26,6 +26,8 @@
 package jdk.incubator.vector;
 
 import java.io.IOException;
+import java.io.Serial;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -101,7 +103,7 @@ import jdk.internal.vm.vector.Float16Math;
 // expected to be aligned with Value Classes and Object as described in
 // JEP-401 (https://openjdk.org/jeps/401).
 @jdk.internal.ValueBased
-public final class Float16
+public final /*value*/ class Float16
     extends Number
     implements Comparable<Float16> {
 
@@ -1767,6 +1769,18 @@ public final class Float16
      */
     public static Float16 signum(Float16 f) {
         return (f.floatValue() == 0.0f || isNaN(f)) ? f : copySign(ONE, f);
+    }
+
+    @Serial
+    private Object writeReplace() {
+        return new SerialProxy(value);
+    }
+
+    private record SerialProxy(short value) implements Serializable {
+        @Serial
+        private Object readResolve() {
+            return Float16.shortBitsToFloat16(value);
+        }
     }
 
     // TODO: Temporary location for this functionality while Float16

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
@@ -96,7 +96,7 @@ import static java.lang.Float.*;
  * @see Float#float16ToFloat(short)
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract sealed class Float16Vector extends AbstractVector<Float16>
+public abstract sealed /*value*/ class Float16Vector extends AbstractVector<Float16>
          permits Float16Vector64, Float16Vector128, Float16Vector256, Float16Vector512, Float16VectorMax {
 
     Float16Vector(short[] vec) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector128.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector128.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class Float16Vector128 extends Float16Vector {
+final /*value*/ class Float16Vector128 extends Float16Vector {
     static final Float16Species VSPECIES =
         (Float16Species) Float16Vector.SPECIES_128;
 
@@ -584,7 +584,7 @@ final class Float16Vector128 extends Float16Vector {
 
     // Mask
     @ValueBased
-    static final class Float16Mask128 extends AbstractMask<Float16> {
+    static final /*value*/ class Float16Mask128 extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -817,7 +817,7 @@ final class Float16Vector128 extends Float16Vector {
 
     // Shuffle
     @ValueBased
-    static final class Float16Shuffle128 extends AbstractShuffle<Float16> {
+    static final /*value*/ class Float16Shuffle128 extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector256.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector256.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class Float16Vector256 extends Float16Vector {
+final /*value*/ class Float16Vector256 extends Float16Vector {
     static final Float16Species VSPECIES =
         (Float16Species) Float16Vector.SPECIES_256;
 
@@ -600,7 +600,7 @@ final class Float16Vector256 extends Float16Vector {
 
     // Mask
     @ValueBased
-    static final class Float16Mask256 extends AbstractMask<Float16> {
+    static final /*value*/ class Float16Mask256 extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -833,7 +833,7 @@ final class Float16Vector256 extends Float16Vector {
 
     // Shuffle
     @ValueBased
-    static final class Float16Shuffle256 extends AbstractShuffle<Float16> {
+    static final /*value*/ class Float16Shuffle256 extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector512.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector512.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class Float16Vector512 extends Float16Vector {
+final /*value*/ class Float16Vector512 extends Float16Vector {
     static final Float16Species VSPECIES =
         (Float16Species) Float16Vector.SPECIES_512;
 
@@ -632,7 +632,7 @@ final class Float16Vector512 extends Float16Vector {
 
     // Mask
     @ValueBased
-    static final class Float16Mask512 extends AbstractMask<Float16> {
+    static final /*value*/ class Float16Mask512 extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -865,7 +865,7 @@ final class Float16Vector512 extends Float16Vector {
 
     // Shuffle
     @ValueBased
-    static final class Float16Shuffle512 extends AbstractShuffle<Float16> {
+    static final /*value*/ class Float16Shuffle512 extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector64.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector64.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class Float16Vector64 extends Float16Vector {
+final /*value*/ class Float16Vector64 extends Float16Vector {
     static final Float16Species VSPECIES =
         (Float16Species) Float16Vector.SPECIES_64;
 
@@ -576,7 +576,7 @@ final class Float16Vector64 extends Float16Vector {
 
     // Mask
     @ValueBased
-    static final class Float16Mask64 extends AbstractMask<Float16> {
+    static final /*value*/ class Float16Mask64 extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -809,7 +809,7 @@ final class Float16Vector64 extends Float16Vector {
 
     // Shuffle
     @ValueBased
-    static final class Float16Shuffle64 extends AbstractShuffle<Float16> {
+    static final /*value*/ class Float16Shuffle64 extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16VectorMax.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16VectorMax.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class Float16VectorMax extends Float16Vector {
+final /*value*/ class Float16VectorMax extends Float16Vector {
     static final Float16Species VSPECIES =
         (Float16Species) Float16Vector.SPECIES_MAX;
 
@@ -569,7 +569,7 @@ final class Float16VectorMax extends Float16Vector {
 
     // Mask
     @ValueBased
-    static final class Float16MaskMax extends AbstractMask<Float16> {
+    static final /*value*/ class Float16MaskMax extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -802,7 +802,7 @@ final class Float16VectorMax extends Float16Vector {
 
     // Shuffle
     @ValueBased
-    static final class Float16ShuffleMax extends AbstractShuffle<Float16> {
+    static final /*value*/ class Float16ShuffleMax extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -49,7 +49,7 @@ import static jdk.incubator.vector.VectorOperators.*;
  * {@code float} values.
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract sealed class FloatVector extends AbstractVector<Float>
+public abstract sealed /*value*/ class FloatVector extends AbstractVector<Float>
          permits FloatVector64, FloatVector128, FloatVector256, FloatVector512, FloatVectorMax {
 
     FloatVector(float[] vec) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector128.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector128.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class FloatVector128 extends FloatVector {
+final /*value*/ class FloatVector128 extends FloatVector {
     static final FloatSpecies VSPECIES =
         (FloatSpecies) FloatVector.SPECIES_128;
 
@@ -564,7 +564,7 @@ final class FloatVector128 extends FloatVector {
 
     // Mask
     @ValueBased
-    static final class FloatMask128 extends AbstractMask<Float> {
+    static final /*value*/ class FloatMask128 extends AbstractMask<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Float> CTYPE = float.class; // used by the JVM
@@ -797,7 +797,7 @@ final class FloatVector128 extends FloatVector {
 
     // Shuffle
     @ValueBased
-    static final class FloatShuffle128 extends AbstractShuffle<Float> {
+    static final /*value*/ class FloatShuffle128 extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector256.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector256.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class FloatVector256 extends FloatVector {
+final /*value*/ class FloatVector256 extends FloatVector {
     static final FloatSpecies VSPECIES =
         (FloatSpecies) FloatVector.SPECIES_256;
 
@@ -572,7 +572,7 @@ final class FloatVector256 extends FloatVector {
 
     // Mask
     @ValueBased
-    static final class FloatMask256 extends AbstractMask<Float> {
+    static final /*value*/ class FloatMask256 extends AbstractMask<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Float> CTYPE = float.class; // used by the JVM
@@ -805,7 +805,7 @@ final class FloatVector256 extends FloatVector {
 
     // Shuffle
     @ValueBased
-    static final class FloatShuffle256 extends AbstractShuffle<Float> {
+    static final /*value*/ class FloatShuffle256 extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector512.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector512.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class FloatVector512 extends FloatVector {
+final /*value*/ class FloatVector512 extends FloatVector {
     static final FloatSpecies VSPECIES =
         (FloatSpecies) FloatVector.SPECIES_512;
 
@@ -588,7 +588,7 @@ final class FloatVector512 extends FloatVector {
 
     // Mask
     @ValueBased
-    static final class FloatMask512 extends AbstractMask<Float> {
+    static final /*value*/ class FloatMask512 extends AbstractMask<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Float> CTYPE = float.class; // used by the JVM
@@ -821,7 +821,7 @@ final class FloatVector512 extends FloatVector {
 
     // Shuffle
     @ValueBased
-    static final class FloatShuffle512 extends AbstractShuffle<Float> {
+    static final /*value*/ class FloatShuffle512 extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector64.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector64.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class FloatVector64 extends FloatVector {
+final /*value*/ class FloatVector64 extends FloatVector {
     static final FloatSpecies VSPECIES =
         (FloatSpecies) FloatVector.SPECIES_64;
 
@@ -560,7 +560,7 @@ final class FloatVector64 extends FloatVector {
 
     // Mask
     @ValueBased
-    static final class FloatMask64 extends AbstractMask<Float> {
+    static final /*value*/ class FloatMask64 extends AbstractMask<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Float> CTYPE = float.class; // used by the JVM
@@ -793,7 +793,7 @@ final class FloatVector64 extends FloatVector {
 
     // Shuffle
     @ValueBased
-    static final class FloatShuffle64 extends AbstractShuffle<Float> {
+    static final /*value*/ class FloatShuffle64 extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVectorMax.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVectorMax.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class FloatVectorMax extends FloatVector {
+final /*value*/ class FloatVectorMax extends FloatVector {
     static final FloatSpecies VSPECIES =
         (FloatSpecies) FloatVector.SPECIES_MAX;
 
@@ -557,7 +557,7 @@ final class FloatVectorMax extends FloatVector {
 
     // Mask
     @ValueBased
-    static final class FloatMaskMax extends AbstractMask<Float> {
+    static final /*value*/ class FloatMaskMax extends AbstractMask<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Float> CTYPE = float.class; // used by the JVM
@@ -790,7 +790,7 @@ final class FloatVectorMax extends FloatVector {
 
     // Shuffle
     @ValueBased
-    static final class FloatShuffleMax extends AbstractShuffle<Float> {
+    static final /*value*/ class FloatShuffleMax extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -49,7 +49,7 @@ import static jdk.incubator.vector.VectorOperators.*;
  * {@code int} values.
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract sealed class IntVector extends AbstractVector<Integer>
+public abstract sealed /*value*/ class IntVector extends AbstractVector<Integer>
          permits IntVector64, IntVector128, IntVector256, IntVector512, IntVectorMax {
 
     IntVector(int[] vec) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector128.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector128.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class IntVector128 extends IntVector {
+final /*value*/ class IntVector128 extends IntVector {
     static final IntSpecies VSPECIES =
         (IntSpecies) IntVector.SPECIES_128;
 
@@ -575,7 +575,7 @@ final class IntVector128 extends IntVector {
 
     // Mask
     @ValueBased
-    static final class IntMask128 extends AbstractMask<Integer> {
+    static final /*value*/ class IntMask128 extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM
@@ -808,7 +808,7 @@ final class IntVector128 extends IntVector {
 
     // Shuffle
     @ValueBased
-    static final class IntShuffle128 extends AbstractShuffle<Integer> {
+    static final /*value*/ class IntShuffle128 extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector256.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector256.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class IntVector256 extends IntVector {
+final /*value*/ class IntVector256 extends IntVector {
     static final IntSpecies VSPECIES =
         (IntSpecies) IntVector.SPECIES_256;
 
@@ -583,7 +583,7 @@ final class IntVector256 extends IntVector {
 
     // Mask
     @ValueBased
-    static final class IntMask256 extends AbstractMask<Integer> {
+    static final /*value*/ class IntMask256 extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM
@@ -816,7 +816,7 @@ final class IntVector256 extends IntVector {
 
     // Shuffle
     @ValueBased
-    static final class IntShuffle256 extends AbstractShuffle<Integer> {
+    static final /*value*/ class IntShuffle256 extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector512.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector512.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class IntVector512 extends IntVector {
+final /*value*/ class IntVector512 extends IntVector {
     static final IntSpecies VSPECIES =
         (IntSpecies) IntVector.SPECIES_512;
 
@@ -599,7 +599,7 @@ final class IntVector512 extends IntVector {
 
     // Mask
     @ValueBased
-    static final class IntMask512 extends AbstractMask<Integer> {
+    static final /*value*/ class IntMask512 extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM
@@ -832,7 +832,7 @@ final class IntVector512 extends IntVector {
 
     // Shuffle
     @ValueBased
-    static final class IntShuffle512 extends AbstractShuffle<Integer> {
+    static final /*value*/ class IntShuffle512 extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector64.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector64.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class IntVector64 extends IntVector {
+final /*value*/ class IntVector64 extends IntVector {
     static final IntSpecies VSPECIES =
         (IntSpecies) IntVector.SPECIES_64;
 
@@ -571,7 +571,7 @@ final class IntVector64 extends IntVector {
 
     // Mask
     @ValueBased
-    static final class IntMask64 extends AbstractMask<Integer> {
+    static final /*value*/ class IntMask64 extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM
@@ -804,7 +804,7 @@ final class IntVector64 extends IntVector {
 
     // Shuffle
     @ValueBased
-    static final class IntShuffle64 extends AbstractShuffle<Integer> {
+    static final /*value*/ class IntShuffle64 extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVectorMax.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVectorMax.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class IntVectorMax extends IntVector {
+final /*value*/ class IntVectorMax extends IntVector {
     static final IntSpecies VSPECIES =
         (IntSpecies) IntVector.SPECIES_MAX;
 
@@ -569,7 +569,7 @@ final class IntVectorMax extends IntVector {
 
     // Mask
     @ValueBased
-    static final class IntMaskMax extends AbstractMask<Integer> {
+    static final /*value*/ class IntMaskMax extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM
@@ -813,7 +813,7 @@ final class IntVectorMax extends IntVector {
 
     // Shuffle
     @ValueBased
-    static final class IntShuffleMax extends AbstractShuffle<Integer> {
+    static final /*value*/ class IntShuffleMax extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Integer> CTYPE = int.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -49,7 +49,7 @@ import static jdk.incubator.vector.VectorOperators.*;
  * {@code long} values.
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract sealed class LongVector extends AbstractVector<Long>
+public abstract sealed /*value*/ class LongVector extends AbstractVector<Long>
          permits LongVector64, LongVector128, LongVector256, LongVector512, LongVectorMax {
 
     LongVector(long[] vec) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector128.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector128.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class LongVector128 extends LongVector {
+final /*value*/ class LongVector128 extends LongVector {
     static final LongSpecies VSPECIES =
         (LongSpecies) LongVector.SPECIES_128;
 
@@ -562,7 +562,7 @@ final class LongVector128 extends LongVector {
 
     // Mask
     @ValueBased
-    static final class LongMask128 extends AbstractMask<Long> {
+    static final /*value*/ class LongMask128 extends AbstractMask<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM
@@ -795,7 +795,7 @@ final class LongVector128 extends LongVector {
 
     // Shuffle
     @ValueBased
-    static final class LongShuffle128 extends AbstractShuffle<Long> {
+    static final /*value*/ class LongShuffle128 extends AbstractShuffle<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector256.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector256.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class LongVector256 extends LongVector {
+final /*value*/ class LongVector256 extends LongVector {
     static final LongSpecies VSPECIES =
         (LongSpecies) LongVector.SPECIES_256;
 
@@ -566,7 +566,7 @@ final class LongVector256 extends LongVector {
 
     // Mask
     @ValueBased
-    static final class LongMask256 extends AbstractMask<Long> {
+    static final /*value*/ class LongMask256 extends AbstractMask<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM
@@ -799,7 +799,7 @@ final class LongVector256 extends LongVector {
 
     // Shuffle
     @ValueBased
-    static final class LongShuffle256 extends AbstractShuffle<Long> {
+    static final /*value*/ class LongShuffle256 extends AbstractShuffle<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector512.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector512.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class LongVector512 extends LongVector {
+final /*value*/ class LongVector512 extends LongVector {
     static final LongSpecies VSPECIES =
         (LongSpecies) LongVector.SPECIES_512;
 
@@ -574,7 +574,7 @@ final class LongVector512 extends LongVector {
 
     // Mask
     @ValueBased
-    static final class LongMask512 extends AbstractMask<Long> {
+    static final /*value*/ class LongMask512 extends AbstractMask<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM
@@ -807,7 +807,7 @@ final class LongVector512 extends LongVector {
 
     // Shuffle
     @ValueBased
-    static final class LongShuffle512 extends AbstractShuffle<Long> {
+    static final /*value*/ class LongShuffle512 extends AbstractShuffle<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector64.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector64.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class LongVector64 extends LongVector {
+final /*value*/ class LongVector64 extends LongVector {
     static final LongSpecies VSPECIES =
         (LongSpecies) LongVector.SPECIES_64;
 
@@ -560,7 +560,7 @@ final class LongVector64 extends LongVector {
 
     // Mask
     @ValueBased
-    static final class LongMask64 extends AbstractMask<Long> {
+    static final /*value*/ class LongMask64 extends AbstractMask<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM
@@ -793,7 +793,7 @@ final class LongVector64 extends LongVector {
 
     // Shuffle
     @ValueBased
-    static final class LongShuffle64 extends AbstractShuffle<Long> {
+    static final /*value*/ class LongShuffle64 extends AbstractShuffle<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVectorMax.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVectorMax.java
@@ -42,7 +42,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class LongVectorMax extends LongVector {
+final /*value*/ class LongVectorMax extends LongVector {
     static final LongSpecies VSPECIES =
         (LongSpecies) LongVector.SPECIES_MAX;
 
@@ -560,7 +560,7 @@ final class LongVectorMax extends LongVector {
 
     // Mask
     @ValueBased
-    static final class LongMaskMax extends AbstractMask<Long> {
+    static final /*value*/ class LongMaskMax extends AbstractMask<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM
@@ -793,7 +793,7 @@ final class LongVectorMax extends LongVector {
 
     // Shuffle
     @ValueBased
-    static final class LongShuffleMax extends AbstractShuffle<Long> {
+    static final /*value*/ class LongShuffleMax extends AbstractShuffle<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Long> CTYPE = long.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -49,7 +49,7 @@ import static jdk.incubator.vector.VectorOperators.*;
  * {@code short} values.
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract sealed class ShortVector extends AbstractVector<Short>
+public abstract sealed /*value*/ class ShortVector extends AbstractVector<Short>
          permits ShortVector64, ShortVector128, ShortVector256, ShortVector512, ShortVectorMax {
 
     ShortVector(short[] vec) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector128.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector128.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ShortVector128 extends ShortVector {
+final /*value*/ class ShortVector128 extends ShortVector {
     static final ShortSpecies VSPECIES =
         (ShortSpecies) ShortVector.SPECIES_128;
 
@@ -583,7 +583,7 @@ final class ShortVector128 extends ShortVector {
 
     // Mask
     @ValueBased
-    static final class ShortMask128 extends AbstractMask<Short> {
+    static final /*value*/ class ShortMask128 extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -816,7 +816,7 @@ final class ShortVector128 extends ShortVector {
 
     // Shuffle
     @ValueBased
-    static final class ShortShuffle128 extends AbstractShuffle<Short> {
+    static final /*value*/ class ShortShuffle128 extends AbstractShuffle<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector256.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector256.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ShortVector256 extends ShortVector {
+final /*value*/ class ShortVector256 extends ShortVector {
     static final ShortSpecies VSPECIES =
         (ShortSpecies) ShortVector.SPECIES_256;
 
@@ -599,7 +599,7 @@ final class ShortVector256 extends ShortVector {
 
     // Mask
     @ValueBased
-    static final class ShortMask256 extends AbstractMask<Short> {
+    static final /*value*/ class ShortMask256 extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -832,7 +832,7 @@ final class ShortVector256 extends ShortVector {
 
     // Shuffle
     @ValueBased
-    static final class ShortShuffle256 extends AbstractShuffle<Short> {
+    static final /*value*/ class ShortShuffle256 extends AbstractShuffle<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector512.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector512.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ShortVector512 extends ShortVector {
+final /*value*/ class ShortVector512 extends ShortVector {
     static final ShortSpecies VSPECIES =
         (ShortSpecies) ShortVector.SPECIES_512;
 
@@ -631,7 +631,7 @@ final class ShortVector512 extends ShortVector {
 
     // Mask
     @ValueBased
-    static final class ShortMask512 extends AbstractMask<Short> {
+    static final /*value*/ class ShortMask512 extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -864,7 +864,7 @@ final class ShortVector512 extends ShortVector {
 
     // Shuffle
     @ValueBased
-    static final class ShortShuffle512 extends AbstractShuffle<Short> {
+    static final /*value*/ class ShortShuffle512 extends AbstractShuffle<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector64.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector64.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ShortVector64 extends ShortVector {
+final /*value*/ class ShortVector64 extends ShortVector {
     static final ShortSpecies VSPECIES =
         (ShortSpecies) ShortVector.SPECIES_64;
 
@@ -575,7 +575,7 @@ final class ShortVector64 extends ShortVector {
 
     // Mask
     @ValueBased
-    static final class ShortMask64 extends AbstractMask<Short> {
+    static final /*value*/ class ShortMask64 extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -808,7 +808,7 @@ final class ShortVector64 extends ShortVector {
 
     // Shuffle
     @ValueBased
-    static final class ShortShuffle64 extends AbstractShuffle<Short> {
+    static final /*value*/ class ShortShuffle64 extends AbstractShuffle<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVectorMax.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVectorMax.java
@@ -41,7 +41,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class ShortVectorMax extends ShortVector {
+final /*value*/ class ShortVectorMax extends ShortVector {
     static final ShortSpecies VSPECIES =
         (ShortSpecies) ShortVector.SPECIES_MAX;
 
@@ -569,7 +569,7 @@ final class ShortVectorMax extends ShortVector {
 
     // Mask
     @ValueBased
-    static final class ShortMaskMax extends AbstractMask<Short> {
+    static final /*value*/ class ShortMaskMax extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM
@@ -802,7 +802,7 @@ final class ShortVectorMax extends ShortVector {
 
     // Shuffle
     @ValueBased
-    static final class ShortShuffleMax extends AbstractShuffle<Short> {
+    static final /*value*/ class ShortShuffleMax extends AbstractShuffle<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<Short> CTYPE = short.class; // used by the JVM

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
@@ -1953,7 +1953,7 @@ import java.util.Arrays;
  * @sealedGraph
  */
 @SuppressWarnings("exports")
-public abstract sealed class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vector<E> permits AbstractVector {
+public abstract sealed /*value*/ class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vector<E> permits AbstractVector {
 
     // This type is sealed within its package.
     // Users cannot roll their own vector types.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -131,7 +131,7 @@ import java.util.Objects;
  *           the element type of a vector
  */
 @SuppressWarnings("exports")
-public abstract sealed class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport.VectorMask<E> permits AbstractMask {
+public abstract sealed /*value*/ class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport.VectorMask<E> permits AbstractMask {
     VectorMask(boolean[] bits) { super(bits); }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShuffle.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShuffle.java
@@ -136,7 +136,7 @@ import java.util.function.IntUnaryOperator;
  *           the element type of a vector
  */
 @SuppressWarnings("exports")
-public abstract sealed class VectorShuffle<E> extends jdk.internal.vm.vector.VectorSupport.VectorShuffle<E> permits AbstractShuffle {
+public abstract sealed /*value*/ class VectorShuffle<E> extends jdk.internal.vm.vector.VectorSupport.VectorShuffle<E> permits AbstractShuffle {
     VectorShuffle(Object indices) {
         super(indices);
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -102,7 +102,7 @@ import static java.lang.Float.*;
 #end[FP16]
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtype$>
+public abstract sealed /*value*/ class $abstractvectortype$ extends AbstractVector<$Boxtype$>
          permits $Type$Vector64, $Type$Vector128, $Type$Vector256, $Type$Vector512, $Type$VectorMax {
 
     $abstractvectortype$($type$[] vec) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -44,7 +44,7 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings("cast")  // warning: redundant cast
 @ValueBased
-final class $vectortype$ extends $abstractvectortype$ {
+final /*value*/ class $vectortype$ extends $abstractvectortype$ {
     static final $Type$Species VSPECIES =
         ($Type$Species) $Type$Vector.SPECIES_$BITS$;
 
@@ -909,7 +909,7 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     // Mask
     @ValueBased
-    static final class $masktype$ extends AbstractMask<$Boxtype$> {
+    static final /*value*/ class $masktype$ extends AbstractMask<$Boxtype$> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<$Carriertype$> CTYPE = $carriertype$.class; // used by the JVM
@@ -1157,7 +1157,7 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     // Shuffle
     @ValueBased
-    static final class $shuffletype$ extends AbstractShuffle<$Boxtype$> {
+    static final /*value*/ class $shuffletype$ extends AbstractShuffle<$Boxtype$> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
 
         static final Class<$Boxbitstype$> CTYPE = $bitstype$.class; // used by the JVM


### PR DESCRIPTION
Testing: Build JDK, run jshell with `--add-modules jdk.incubator.vector --enable-preview`, and run this:
```
import module jdk.incubator.vector;
IntVector.class.isValue()
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32113/head:pull/32113` \
`$ git checkout pull/32113`

Update a local copy of the PR: \
`$ git checkout pull/32113` \
`$ git pull https://git.openjdk.org/jdk.git pull/32113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32113`

View PR using the GUI difftool: \
`$ git pr show -t 32113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32113.diff">https://git.openjdk.org/jdk/pull/32113.diff</a>

</details>
