### PR TITLE
8388527: Add "indistinguishable" cross-reference to Double's discussion of equality

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -169,7 +169,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * number and is not equal to any value, including itself.
  * </dd>
  *
- * <dt><dfn>{@index "bit-wise equivalence"}</dfn>:</dt>
+ * <dt><dfn>{@index "bit-wise equivalence"} (or indistinguishable)</dfn>:</dt>
  * <dd>The bits of the two floating-point values are the same. This
  * equivalence relation for {@code double} values {@code a} and {@code
  * b} is implemented by the expression
@@ -177,6 +177,8 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * Under this relation, {@code +0.0} and {@code -0.0} are
  * distinguished from each other and every bit pattern encoding a NaN
  * is distinguished from every other bit pattern encoding a NaN.
+ * Note this is the notion of equivalence used when {@linkplain
+ * Object#equals(Object) comparing value objects for equality}.
  * </dd>
  *
  * <dt><dfn><a id=repEquivalence></a>{@index "representation equivalence"}</dfn>:</dt>

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -178,7 +178,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * distinguished from each other and every bit pattern encoding a NaN
  * is distinguished from every other bit pattern encoding a NaN.
  * Note this is the notion of equivalence used when {@linkplain
- * Object#equals(Object) comparing value objects for equality}.
+ * Object##equalsIndistinguishable comparing value objects for equality}.
  * </dd>
  *
  * <dt><dfn><a id=repEquivalence></a>{@index "representation equivalence"}</dfn>:</dt>

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -171,8 +171,8 @@ public class Object {
      * that is, for any non-null reference values {@code x} and
      * {@code y}, this method returns {@code true} if and only
      * if {@code x} and {@code y} refer to the same identity object or
-     * indistinguishable value objects ({@code x == y} has the value
-     * {@code true}).
+     * <a id=equalsIndistinguishable>indistinguishable value objects ({@code x == y} has the value
+     * {@code true})</a>.
      * <p>
      * In other words, under the object equality equivalence
      * relation, each equivalence class only has a single element.


### PR DESCRIPTION
Add reference to "indistinguishable" in Object.equals.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388527](https://bugs.openjdk.org/browse/JDK-8388527): Add "indistinguishable" cross-reference to Double's discussion of equality (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32114/head:pull/32114` \
`$ git checkout pull/32114`

Update a local copy of the PR: \
`$ git checkout pull/32114` \
`$ git pull https://git.openjdk.org/jdk.git pull/32114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32114`

View PR using the GUI difftool: \
`$ git pr show -t 32114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32114.diff">https://git.openjdk.org/jdk/pull/32114.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32114#issuecomment-5138957129)
</details>
