### PR TITLE
8388448: VarHandle can set @NullRestricted static field to null

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -533,6 +533,9 @@ final class VarHandle$InputType$s {
 #if[Object]
         @ForceInline
         static Object checkCast(FieldStaticReadWrite handle, $type$ value) {
+            if (handle.nullRestricted && value == null) {
+                throw new NullPointerException();
+            }
             return handle.fieldType.cast(value);
         }
 #end[Object]

--- a/test/jdk/java/lang/invoke/VarHandles/NullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/NullRestrictedValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+value record NullRestrictedValue(byte a, short b) {
+    static NullRestrictedValue of(byte a, short b) {
+        return new NullRestrictedValue(a, b);
+    }
+}

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
     static final boolean static_final_v = true;
 
-    static boolean static_v;
+    static boolean static_v = true;
 
-    final boolean final_v = true;
+    final boolean final_v;
 
     boolean v;
 
     static final boolean static_final_v2 = true;
 
-    static boolean static_v2;
+    static boolean static_v2 = true;
 
-    final boolean final_v2 = true;
+    final boolean final_v2;
 
     boolean v2;
 
@@ -76,6 +76,13 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
+    public VarHandleTestAccessBoolean() {
+        final_v = true;
+        v = true;
+        final_v2 = true;
+        v2 = true;
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -1415,6 +1422,5 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             });
         }
     }
-
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessByte extends VarHandleBaseTest {
     static final byte static_final_v = (byte)0x01;
 
-    static byte static_v;
+    static byte static_v = (byte)0x01;
 
-    final byte final_v = (byte)0x01;
+    final byte final_v;
 
     byte v;
 
     static final byte static_final_v2 = (byte)0x01;
 
-    static byte static_v2;
+    static byte static_v2 = (byte)0x01;
 
-    final byte final_v2 = (byte)0x01;
+    final byte final_v2;
 
     byte v2;
 
@@ -76,6 +76,13 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
+    public VarHandleTestAccessByte() {
+        final_v = (byte)0x01;
+        v = (byte)0x01;
+        final_v2 = (byte)0x01;
+        v2 = (byte)0x01;
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -1452,6 +1459,5 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             });
         }
     }
-
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessChar extends VarHandleBaseTest {
     static final char static_final_v = '\u0123';
 
-    static char static_v;
+    static char static_v = '\u0123';
 
-    final char final_v = '\u0123';
+    final char final_v;
 
     char v;
 
     static final char static_final_v2 = '\u0123';
 
-    static char static_v2;
+    static char static_v2 = '\u0123';
 
-    final char final_v2 = '\u0123';
+    final char final_v2;
 
     char v2;
 
@@ -76,6 +76,13 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
+    public VarHandleTestAccessChar() {
+        final_v = '\u0123';
+        v = '\u0123';
+        final_v2 = '\u0123';
+        v2 = '\u0123';
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -1452,6 +1459,5 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             });
         }
     }
-
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessDouble extends VarHandleBaseTest {
     static final double static_final_v = 1.0d;
 
-    static double static_v;
+    static double static_v = 1.0d;
 
-    final double final_v = 1.0d;
+    final double final_v;
 
     double v;
 
     static final double static_final_v2 = 1.0d;
 
-    static double static_v2;
+    static double static_v2 = 1.0d;
 
-    final double final_v2 = 1.0d;
+    final double final_v2;
 
     double v2;
 
@@ -76,6 +76,13 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
+    public VarHandleTestAccessDouble() {
+        final_v = 1.0d;
+        v = 1.0d;
+        final_v2 = 1.0d;
+        v2 = 1.0d;
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -1343,6 +1350,5 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
 
         }
     }
-
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessFloat extends VarHandleBaseTest {
     static final float static_final_v = 1.0f;
 
-    static float static_v;
+    static float static_v = 1.0f;
 
-    final float final_v = 1.0f;
+    final float final_v;
 
     float v;
 
     static final float static_final_v2 = 1.0f;
 
-    static float static_v2;
+    static float static_v2 = 1.0f;
 
-    final float final_v2 = 1.0f;
+    final float final_v2;
 
     float v2;
 
@@ -76,6 +76,13 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
+    public VarHandleTestAccessFloat() {
+        final_v = 1.0f;
+        v = 1.0f;
+        final_v2 = 1.0f;
+        v2 = 1.0f;
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -1343,6 +1350,5 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
 
         }
     }
-
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessInt extends VarHandleBaseTest {
     static final int static_final_v = 0x01234567;
 
-    static int static_v;
+    static int static_v = 0x01234567;
 
-    final int final_v = 0x01234567;
+    final int final_v;
 
     int v;
 
     static final int static_final_v2 = 0x01234567;
 
-    static int static_v2;
+    static int static_v2 = 0x01234567;
 
-    final int final_v2 = 0x01234567;
+    final int final_v2;
 
     int v2;
 
@@ -76,6 +76,13 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
+    public VarHandleTestAccessInt() {
+        final_v = 0x01234567;
+        v = 0x01234567;
+        final_v2 = 0x01234567;
+        v2 = 0x01234567;
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -1452,6 +1459,5 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             });
         }
     }
-
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessLong extends VarHandleBaseTest {
     static final long static_final_v = 0x0123456789ABCDEFL;
 
-    static long static_v;
+    static long static_v = 0x0123456789ABCDEFL;
 
-    final long final_v = 0x0123456789ABCDEFL;
+    final long final_v;
 
     long v;
 
     static final long static_final_v2 = 0x0123456789ABCDEFL;
 
-    static long static_v2;
+    static long static_v2 = 0x0123456789ABCDEFL;
 
-    final long final_v2 = 0x0123456789ABCDEFL;
+    final long final_v2;
 
     long v2;
 
@@ -76,6 +76,13 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
+    public VarHandleTestAccessLong() {
+        final_v = 0x0123456789ABCDEFL;
+        v = 0x0123456789ABCDEFL;
+        final_v2 = 0x0123456789ABCDEFL;
+        v2 = 0x0123456789ABCDEFL;
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -1452,6 +1459,5 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             });
         }
     }
-
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessNullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessNullRestrictedValue.java
@@ -1,0 +1,1659 @@
+/*
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// -- This file was mechanically generated: Do not edit! -- //
+
+/*
+ * @test
+ * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessNullRestrictedValue
+ *
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
+ *          to hit compilation thresholds
+ *
+ * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessNullRestrictedValue
+ * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessNullRestrictedValue
+ * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:-TieredCompilation  VarHandleTestAccessNullRestrictedValue
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.NullRestricted;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class VarHandleTestAccessNullRestrictedValue extends VarHandleBaseTest {
+    static final @NullRestricted NullRestrictedValue static_final_v = NullRestrictedValue.of((byte)20,(short)1854);
+
+    static @NullRestricted NullRestrictedValue static_v = NullRestrictedValue.of((byte)20,(short)1854);
+
+    final @NullRestricted NullRestrictedValue final_v;
+
+    @NullRestricted NullRestrictedValue v;
+
+    static final @NullRestricted NullRestrictedValue static_final_v2 = NullRestrictedValue.of((byte)20,(short)1854);
+
+    static @NullRestricted NullRestrictedValue static_v2 = NullRestrictedValue.of((byte)20,(short)1854);
+
+    final @NullRestricted NullRestrictedValue final_v2;
+
+    @NullRestricted NullRestrictedValue v2;
+
+    VarHandle vhFinalField;
+
+    VarHandle vhField;
+
+    VarHandle vhStaticField;
+
+    VarHandle vhStaticFinalField;
+
+    VarHandle vhArray;
+
+    VarHandle vhArrayObject;
+
+    public VarHandleTestAccessNullRestrictedValue() {
+        final_v = NullRestrictedValue.of((byte)20,(short)1854);
+        v = NullRestrictedValue.of((byte)20,(short)1854);
+        final_v2 = NullRestrictedValue.of((byte)20,(short)1854);
+        v2 = NullRestrictedValue.of((byte)20,(short)1854);
+        super();
+    }
+
+    VarHandle[] allocate(boolean same) {
+        List<VarHandle> vhs = new ArrayList<>();
+
+        String postfix = same ? "" : "2";
+        VarHandle vh;
+        try {
+            vh = MethodHandles.lookup().findVarHandle(
+                    VarHandleTestAccessNullRestrictedValue.class, "final_v" + postfix, NullRestrictedValue.class);
+            vhs.add(vh);
+
+            vh = MethodHandles.lookup().findVarHandle(
+                    VarHandleTestAccessNullRestrictedValue.class, "v" + postfix, NullRestrictedValue.class);
+            vhs.add(vh);
+
+            vh = MethodHandles.lookup().findStaticVarHandle(
+                VarHandleTestAccessNullRestrictedValue.class, "static_final_v" + postfix, NullRestrictedValue.class);
+            vhs.add(vh);
+
+            vh = MethodHandles.lookup().findStaticVarHandle(
+                VarHandleTestAccessNullRestrictedValue.class, "static_v" + postfix, NullRestrictedValue.class);
+            vhs.add(vh);
+
+            if (same) {
+                vh = MethodHandles.arrayElementVarHandle(NullRestrictedValue[].class);
+            }
+            else {
+                vh = MethodHandles.arrayElementVarHandle(String[].class);
+            }
+            vhs.add(vh);
+        } catch (Exception e) {
+            throw new InternalError(e);
+        }
+        return vhs.toArray(new VarHandle[0]);
+    }
+
+    @BeforeAll
+    public void setup() throws Exception {
+        vhFinalField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestAccessNullRestrictedValue.class, "final_v", NullRestrictedValue.class);
+
+        vhField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestAccessNullRestrictedValue.class, "v", NullRestrictedValue.class);
+
+        vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestAccessNullRestrictedValue.class, "static_final_v", NullRestrictedValue.class);
+
+        vhStaticField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestAccessNullRestrictedValue.class, "static_v", NullRestrictedValue.class);
+
+        vhArray = MethodHandles.arrayElementVarHandle(NullRestrictedValue[].class);
+        vhArrayObject = MethodHandles.arrayElementVarHandle(Object[].class);
+    }
+
+    public Object[][] varHandlesProvider() throws Exception {
+        List<VarHandle> vhs = new ArrayList<>();
+        vhs.add(vhField);
+        vhs.add(vhStaticField);
+        vhs.add(vhArray);
+
+        return vhs.stream().map(tc -> new Object[]{tc}).toArray(Object[][]::new);
+    }
+
+    @Test
+    public void testEquals() {
+        VarHandle[] vhs1 = allocate(true);
+        VarHandle[] vhs2 = allocate(true);
+
+        for (int i = 0; i < vhs1.length; i++) {
+            for (int j = 0; j < vhs1.length; j++) {
+                if (i != j) {
+                    assertNotEquals(vhs1[i], vhs1[j]);
+                    assertNotEquals(vhs1[i], vhs2[j]);
+                }
+            }
+        }
+
+        VarHandle[] vhs3 = allocate(false);
+        for (int i = 0; i < vhs1.length; i++) {
+            assertNotEquals(vhs1[i], vhs3[i]);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("varHandlesProvider")
+    public void testIsAccessModeSupported(VarHandle vh) {
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.SET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_VOLATILE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.SET_VOLATILE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_ACQUIRE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.SET_RELEASE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_OPAQUE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.SET_OPAQUE));
+
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.COMPARE_AND_SET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.COMPARE_AND_EXCHANGE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.COMPARE_AND_EXCHANGE_ACQUIRE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.COMPARE_AND_EXCHANGE_RELEASE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.WEAK_COMPARE_AND_SET_PLAIN));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.WEAK_COMPARE_AND_SET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.WEAK_COMPARE_AND_SET_ACQUIRE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.WEAK_COMPARE_AND_SET_RELEASE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_SET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_SET_ACQUIRE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_SET_RELEASE));
+
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_ADD));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_ADD_ACQUIRE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_ADD_RELEASE));
+
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_OR));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_OR_ACQUIRE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_OR_RELEASE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_AND));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_AND_ACQUIRE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_AND_RELEASE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_XOR));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_XOR_ACQUIRE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_XOR_RELEASE));
+    }
+
+    public Object[][] typesProvider() throws Exception {
+        List<Object[]> types = new ArrayList<>();
+        types.add(new Object[] {vhField, Arrays.asList(VarHandleTestAccessNullRestrictedValue.class)});
+        types.add(new Object[] {vhStaticField, Arrays.asList()});
+        types.add(new Object[] {vhArray, Arrays.asList(NullRestrictedValue[].class, int.class)});
+
+        return types.stream().toArray(Object[][]::new);
+    }
+
+    @ParameterizedTest
+    @MethodSource("typesProvider")
+    public void testTypes(VarHandle vh, List<Class<?>> pts) {
+        assertEquals(NullRestrictedValue.class, vh.varType());
+
+        assertEquals(pts, vh.coordinateTypes());
+
+        testTypes(vh);
+    }
+
+    @Test
+    public void testLookupInstanceToStatic() {
+        checkIAE("Lookup of static final field to instance final field", () -> {
+            MethodHandles.lookup().findStaticVarHandle(
+                    VarHandleTestAccessNullRestrictedValue.class, "final_v", NullRestrictedValue.class);
+        });
+
+        checkIAE("Lookup of static field to instance field", () -> {
+            MethodHandles.lookup().findStaticVarHandle(
+                    VarHandleTestAccessNullRestrictedValue.class, "v", NullRestrictedValue.class);
+        });
+    }
+
+    @Test
+    public void testLookupStaticToInstance() {
+        checkIAE("Lookup of instance final field to static final field", () -> {
+            MethodHandles.lookup().findVarHandle(
+                VarHandleTestAccessNullRestrictedValue.class, "static_final_v", NullRestrictedValue.class);
+        });
+
+        checkIAE("Lookup of instance field to static field", () -> {
+            vhStaticField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestAccessNullRestrictedValue.class, "static_v", NullRestrictedValue.class);
+        });
+    }
+
+    public Object[][] accessTestCaseProvider() throws Exception {
+        List<AccessTestCase<?>> cases = new ArrayList<>();
+
+        cases.add(new VarHandleAccessTestCase("Instance final field",
+                                              vhFinalField, vh -> testInstanceFinalField(this, vh)));
+        cases.add(new VarHandleAccessTestCase("Instance final field unsupported",
+                                              vhFinalField, vh -> testInstanceFinalFieldUnsupported(this, vh),
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Static final field",
+                                              vhStaticFinalField, VarHandleTestAccessNullRestrictedValue::testStaticFinalField));
+        cases.add(new VarHandleAccessTestCase("Static final field unsupported",
+                                              vhStaticFinalField, VarHandleTestAccessNullRestrictedValue::testStaticFinalFieldUnsupported,
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Instance field",
+                                              vhField, vh -> testInstanceField(this, vh)));
+        cases.add(new VarHandleAccessTestCase("Instance field unsupported",
+                                              vhField, vh -> testInstanceFieldUnsupported(this, vh),
+                                              false));
+        cases.add(new VarHandleAccessTestCase("Instance field null pointer exception",
+                                              vhField, vh -> testInstanceFieldNullPointerException(this, vh),
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Static field",
+                                              vhStaticField, VarHandleTestAccessNullRestrictedValue::testStaticField));
+        cases.add(new VarHandleAccessTestCase("Static field unsupported",
+                                              vhStaticField, VarHandleTestAccessNullRestrictedValue::testStaticFieldUnsupported,
+                                              false));
+        cases.add(new VarHandleAccessTestCase("Static field null pointer exception",
+                                              vhStaticField, VarHandleTestAccessNullRestrictedValue::testStaticFieldNullPointerException,
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Array",
+                                              vhArray, VarHandleTestAccessNullRestrictedValue::testArray));
+        cases.add(new VarHandleAccessTestCase("Array Object[]",
+                                              vhArrayObject, VarHandleTestAccessNullRestrictedValue::testArray));
+        cases.add(new VarHandleAccessTestCase("Array unsupported",
+                                              vhArray, VarHandleTestAccessNullRestrictedValue::testArrayUnsupported,
+                                              false));
+        cases.add(new VarHandleAccessTestCase("Array index out of bounds",
+                                              vhArray, VarHandleTestAccessNullRestrictedValue::testArrayIndexOutOfBounds,
+                                              false));
+        cases.add(new VarHandleAccessTestCase("Array store exception",
+                                              vhArrayObject, VarHandleTestAccessNullRestrictedValue::testArrayStoreException,
+                                              false));
+        cases.add(new VarHandleAccessTestCase("Array null pointer exception",
+                                              vhArrayObject, VarHandleTestAccessNullRestrictedValue::testArrayNullPointerException,
+                                              false));
+        // Work around issue with jtreg summary reporting which truncates
+        // the String result of Object.toString to 30 characters, hence
+        // the first dummy argument
+        return cases.stream().map(tc -> new Object[]{tc.toString(), tc}).toArray(Object[][]::new);
+    }
+
+    @ParameterizedTest
+    @MethodSource("accessTestCaseProvider")
+    public <T> void testAccess(String desc, AccessTestCase<T> atc) throws Throwable {
+        T t = atc.get();
+        int iters = atc.requiresLoop() ? ITERS : 1;
+        for (int c = 0; c < iters; c++) {
+            atc.testAccess(t);
+        }
+    }
+
+    static void testInstanceFinalField(VarHandleTestAccessNullRestrictedValue recv, VarHandle vh) {
+        // Plain
+        {
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "get NullRestrictedValue value");
+        }
+
+
+        // Volatile
+        {
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getVolatile NullRestrictedValue value");
+        }
+
+        // Lazy
+        {
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getRelease NullRestrictedValue value");
+        }
+
+        // Opaque
+        {
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getOpaque NullRestrictedValue value");
+        }
+    }
+
+    static void testInstanceFinalFieldUnsupported(VarHandleTestAccessNullRestrictedValue recv, VarHandle vh) {
+        checkUOE(() -> {
+            vh.set(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+        });
+
+        checkUOE(() -> {
+            vh.setVolatile(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+        });
+
+        checkUOE(() -> {
+            vh.setRelease(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+        });
+
+        checkUOE(() -> {
+            vh.setOpaque(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+        });
+
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAdd(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOr(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAnd(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXor(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+    }
+
+
+    static void testStaticFinalField(VarHandle vh) {
+        // Plain
+        {
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "get NullRestrictedValue value");
+        }
+
+
+        // Volatile
+        {
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getVolatile NullRestrictedValue value");
+        }
+
+        // Lazy
+        {
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getRelease NullRestrictedValue value");
+        }
+
+        // Opaque
+        {
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getOpaque NullRestrictedValue value");
+        }
+    }
+
+    static void testStaticFinalFieldUnsupported(VarHandle vh) {
+        checkUOE(() -> {
+            vh.set(NullRestrictedValue.of((byte)-42,(short)1854));
+        });
+
+        checkUOE(() -> {
+            vh.setVolatile(NullRestrictedValue.of((byte)-42,(short)1854));
+        });
+
+        checkUOE(() -> {
+            vh.setRelease(NullRestrictedValue.of((byte)-42,(short)1854));
+        });
+
+        checkUOE(() -> {
+            vh.setOpaque(NullRestrictedValue.of((byte)-42,(short)1854));
+        });
+
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAdd(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOr(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAnd(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXor(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+    }
+
+
+    static void testInstanceField(VarHandleTestAccessNullRestrictedValue recv, VarHandle vh) {
+        // Plain
+        {
+            vh.set(recv, NullRestrictedValue.of((byte)20,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "set NullRestrictedValue value");
+        }
+
+
+        // Volatile
+        {
+            vh.setVolatile(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setVolatile NullRestrictedValue value");
+        }
+
+        // Lazy
+        {
+            vh.setRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "setRelease NullRestrictedValue value");
+        }
+
+        // Opaque
+        {
+            vh.setOpaque(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setOpaque NullRestrictedValue value");
+        }
+
+        vh.set(recv, NullRestrictedValue.of((byte)20,(short)1854));
+
+        // Compare
+        {
+            boolean r = vh.compareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(r, true, "success compareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndSet NullRestrictedValue value");
+        }
+
+        {
+            boolean r = vh.compareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, false, "failing compareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndSet NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchange NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchange NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchange NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchange NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "success compareAndExchangeAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndExchangeAcquire NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "failing compareAndExchangeAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndExchangeAcquire NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchangeRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchangeRelease NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchangeRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchangeRelease NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetPlain(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetPlain NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetPlain NullRestrictedValue value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetPlain NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetPlain NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetAcquire(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSetAcquire NullRestrictedValue");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSetAcquire NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetRelease NullRestrictedValue");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetRelease NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSet(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSet NullRestrictedValue value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSet NullRestrictedValue value");
+        }
+
+        // Compare set and get
+        {
+            vh.set(recv, NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndSet(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSet NullRestrictedValue value");
+        }
+
+        {
+            vh.set(recv, NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndSetAcquire(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetAcquire NullRestrictedValue value");
+        }
+
+        {
+            vh.set(recv, NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndSetRelease(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetRelease NullRestrictedValue value");
+        }
+
+
+    }
+
+    static void testInstanceFieldUnsupported(VarHandleTestAccessNullRestrictedValue recv, VarHandle vh) {
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAdd(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOr(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAnd(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXor(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+    }
+
+
+    static void testStaticField(VarHandle vh) {
+        // Plain
+        {
+            vh.set(NullRestrictedValue.of((byte)20,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "set NullRestrictedValue value");
+        }
+
+
+        // Volatile
+        {
+            vh.setVolatile(NullRestrictedValue.of((byte)-42,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setVolatile NullRestrictedValue value");
+        }
+
+        // Lazy
+        {
+            vh.setRelease(NullRestrictedValue.of((byte)20,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "setRelease NullRestrictedValue value");
+        }
+
+        // Opaque
+        {
+            vh.setOpaque(NullRestrictedValue.of((byte)-42,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setOpaque NullRestrictedValue value");
+        }
+
+        vh.set(NullRestrictedValue.of((byte)20,(short)1854));
+
+        // Compare
+        {
+            boolean r = vh.compareAndSet(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(r, true, "success compareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndSet NullRestrictedValue value");
+        }
+
+        {
+            boolean r = vh.compareAndSet(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, false, "failing compareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndSet NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchange(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchange NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchange NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchange(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchange NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchange NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeAcquire(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "success compareAndExchangeAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndExchangeAcquire NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeAcquire(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "failing compareAndExchangeAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndExchangeAcquire NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeRelease(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchangeRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchangeRelease NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeRelease(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchangeRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchangeRelease NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetPlain(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetPlain NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetPlain NullRestrictedValue value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetPlain NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetPlain NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetAcquire(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSetAcquire NullRestrictedValue");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSetAcquire NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetRelease NullRestrictedValue");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetRelease NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSet(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSet NullRestrictedValue");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSet NullRestrictedValue value");
+        }
+
+        // Compare set and get
+        {
+            vh.set(NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndSet(NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSet NullRestrictedValue value");
+        }
+
+        {
+            vh.set(NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndSetAcquire(NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetAcquire NullRestrictedValue value");
+        }
+
+        {
+            vh.set(NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndSetRelease(NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetRelease NullRestrictedValue value");
+        }
+
+
+    }
+
+    static void testStaticFieldUnsupported(VarHandle vh) {
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAdd(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOr(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAnd(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXor(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+    }
+
+
+    static void testArray(VarHandle vh) {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+
+        for (int i = 0; i < array.length; i++) {
+            // Plain
+            {
+                vh.set(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "get NullRestrictedValue value");
+            }
+
+
+            // Volatile
+            {
+                vh.setVolatile(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setVolatile NullRestrictedValue value");
+            }
+
+            // Lazy
+            {
+                vh.setRelease(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+                NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "setRelease NullRestrictedValue value");
+            }
+
+            // Opaque
+            {
+                vh.setOpaque(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setOpaque NullRestrictedValue value");
+            }
+
+            vh.set(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+
+            // Compare
+            {
+                boolean r = vh.compareAndSet(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(r, true, "success compareAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndSet NullRestrictedValue value");
+            }
+
+            {
+                boolean r = vh.compareAndSet(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(r, false, "failing compareAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndSet NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchange(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchange NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchange NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchange(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchange NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchange NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "success compareAndExchangeAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndExchangeAcquire NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "failing compareAndExchangeAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndExchangeAcquire NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeRelease(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchangeRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchangeRelease NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeRelease(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchangeRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchangeRelease NullRestrictedValue value");
+            }
+
+            {
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = vh.weakCompareAndSetPlain(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetPlain NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetPlain NullRestrictedValue value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSetPlain NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetPlain NullRestrictedValue value");
+            }
+
+            {
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = vh.weakCompareAndSetAcquire(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSetAcquire NullRestrictedValue");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSetAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSetAcquire NullRestrictedValue value");
+            }
+
+            {
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = vh.weakCompareAndSetRelease(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetRelease NullRestrictedValue");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSetRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetRelease NullRestrictedValue value");
+            }
+
+            {
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = vh.weakCompareAndSet(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSet NullRestrictedValue");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSet NullRestrictedValue value");
+            }
+
+            // Compare set and get
+            {
+                vh.set(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+
+                NullRestrictedValue o = (NullRestrictedValue) vh.getAndSet(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSet NullRestrictedValue value");
+            }
+
+            {
+                vh.set(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+
+                NullRestrictedValue o = (NullRestrictedValue) vh.getAndSetAcquire(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetAcquire NullRestrictedValue value");
+            }
+
+            {
+                vh.set(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+
+                NullRestrictedValue o = (NullRestrictedValue) vh.getAndSetRelease(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetRelease NullRestrictedValue value");
+            }
+
+
+        }
+    }
+
+    static void testArrayUnsupported(VarHandle vh) {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+
+        int i = 0;
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAdd(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddAcquire(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndAddRelease(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOr(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrAcquire(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseOrRelease(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAnd(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndAcquire(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseAndRelease(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXor(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorAcquire(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+
+        checkUOE(() -> {
+            NullRestrictedValue o = (NullRestrictedValue) vh.getAndBitwiseXorRelease(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+    }
+
+    static void testArrayIndexOutOfBounds(VarHandle vh) throws Throwable {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+
+        for (int i : new int[]{-1, Integer.MIN_VALUE, 10, 11, Integer.MAX_VALUE}) {
+            final int ci = i;
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue x = (NullRestrictedValue) vh.get(array, ci);
+            });
+
+            checkAIOOBE(() -> {
+                vh.set(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(array, ci);
+            });
+
+            checkAIOOBE(() -> {
+                vh.setVolatile(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(array, ci);
+            });
+
+            checkAIOOBE(() -> {
+                vh.setRelease(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(array, ci);
+            });
+
+            checkAIOOBE(() -> {
+                vh.setOpaque(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.compareAndSet(array, ci, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchange(array, ci, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, ci, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue r = (NullRestrictedValue) vh.compareAndExchangeRelease(array, ci, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.weakCompareAndSetPlain(array, ci, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.weakCompareAndSet(array, ci, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.weakCompareAndSetAcquire(array, ci, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.weakCompareAndSetRelease(array, ci, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue o = (NullRestrictedValue) vh.getAndSet(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue o = (NullRestrictedValue) vh.getAndSetAcquire(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+            checkAIOOBE(() -> {
+                NullRestrictedValue o = (NullRestrictedValue) vh.getAndSetRelease(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+
+
+        }
+    }
+
+    static void testArrayStoreException(VarHandle vh) throws Throwable {
+        Object[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+        Arrays.fill(array, NullRestrictedValue.of((byte)20,(short)1854));
+        Object value = new Object();
+
+        // Set
+        checkASE(() -> {
+            vh.set(array, 0, value);
+        });
+
+        // SetVolatile
+        checkASE(() -> {
+            vh.setVolatile(array, 0, value);
+        });
+
+        // SetOpaque
+        checkASE(() -> {
+            vh.setOpaque(array, 0, value);
+        });
+
+        // SetRelease
+        checkASE(() -> {
+            vh.setRelease(array, 0, value);
+        });
+
+        // CompareAndSet
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSet
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetVolatile
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetAcquire
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetRelease
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchange
+        checkASE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchangeAcquire
+        checkASE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchangeRelease
+        checkASE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // GetAndSet
+        checkASE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(array, 0, value);
+        });
+
+        // GetAndSetAcquire
+        checkASE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(array, 0, value);
+        });
+
+        // GetAndSetRelease
+        checkASE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(array, 0, value);
+        });
+    }
+
+    static void testInstanceFieldNullPointerException(VarHandleTestAccessNullRestrictedValue recv, VarHandle vh) throws Throwable {
+        NullRestrictedValue value = null;
+
+        // Set
+        checkNPE(() -> {
+            vh.set(recv, value);
+        });
+
+        // SetVolatile
+        checkNPE(() -> {
+            vh.setVolatile(recv, value);
+        });
+
+        // SetOpaque
+        checkNPE(() -> {
+            vh.setOpaque(recv, value);
+        });
+
+        // SetRelease
+        checkNPE(() -> {
+            vh.setRelease(recv, value);
+        });
+
+        // CompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetVolatile
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchange
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchangeAcquire
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchangeRelease
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // GetAndSet
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(recv, value);
+        });
+
+        // GetAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(recv, value);
+        });
+
+        // GetAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(recv, value);
+        });
+    }
+
+    static void testStaticFieldNullPointerException(VarHandle vh) throws Throwable {
+        NullRestrictedValue value = null;
+
+        // Set
+        checkNPE(() -> {
+            vh.set(value);
+        });
+
+        // SetVolatile
+        checkNPE(() -> {
+            vh.setVolatile(value);
+        });
+
+        // SetOpaque
+        checkNPE(() -> {
+            vh.setOpaque(value);
+        });
+
+        // SetRelease
+        checkNPE(() -> {
+            vh.setRelease(value);
+        });
+
+        // CompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetVolatile
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchange
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchangeAcquire
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchangeRelease
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // GetAndSet
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(value);
+        });
+
+        // GetAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(value);
+        });
+
+        // GetAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(value);
+        });
+    }
+
+    static void testArrayNullPointerException(VarHandle vh) throws Throwable {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+        NullRestrictedValue value = null;
+
+        // Set
+        checkNPE(() -> {
+            vh.set(array, 0, value);
+        });
+
+        // SetVolatile
+        checkNPE(() -> {
+            vh.setVolatile(array, 0, value);
+        });
+
+        // SetOpaque
+        checkNPE(() -> {
+            vh.setOpaque(array, 0, value);
+        });
+
+        // SetRelease
+        checkNPE(() -> {
+            vh.setRelease(array, 0, value);
+        });
+
+        // CompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetVolatile
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // WeakCompareAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchange
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchangeAcquire
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // CompareAndExchangeRelease
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
+        });
+
+        // GetAndSet
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(array, 0, value);
+        });
+
+        // GetAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(array, 0, value);
+        });
+
+        // GetAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(array, 0, value);
+        });
+    }
+}
+

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessShort extends VarHandleBaseTest {
     static final short static_final_v = (short)0x0123;
 
-    static short static_v;
+    static short static_v = (short)0x0123;
 
-    final short final_v = (short)0x0123;
+    final short final_v;
 
     short v;
 
     static final short static_final_v2 = (short)0x0123;
 
-    static short static_v2;
+    static short static_v2 = (short)0x0123;
 
-    final short final_v2 = (short)0x0123;
+    final short final_v2;
 
     short v2;
 
@@ -76,6 +76,13 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
+    public VarHandleTestAccessShort() {
+        final_v = (short)0x0123;
+        v = (short)0x0123;
+        final_v2 = (short)0x0123;
+        v2 = (short)0x0123;
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -1452,6 +1459,5 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             });
         }
     }
-
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessString extends VarHandleBaseTest {
     static final String static_final_v = "foo";
 
-    static String static_v;
+    static String static_v = "foo";
 
-    final String final_v = "foo";
+    final String final_v;
 
     String v;
 
     static final String static_final_v2 = "foo";
 
-    static String static_v2;
+    static String static_v2 = "foo";
 
-    final String final_v2 = "foo";
+    final String final_v2;
 
     String v2;
 
@@ -77,6 +77,14 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
     VarHandle vhArray;
 
     VarHandle vhArrayObject;
+
+    public VarHandleTestAccessString() {
+        final_v = "foo";
+        v = "foo";
+        final_v2 = "foo";
+        v2 = "foo";
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @test
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessValue
  *
  * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
@@ -54,17 +55,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestAccessValue extends VarHandleBaseTest {
     static final Value static_final_v = Value.getInstance(10);
 
-    static Value static_v;
+    static Value static_v = Value.getInstance(10);
 
-    final Value final_v = Value.getInstance(10);
+    final Value final_v;
 
     Value v;
 
     static final Value static_final_v2 = Value.getInstance(10);
 
-    static Value static_v2;
+    static Value static_v2 = Value.getInstance(10);
 
-    final Value final_v2 = Value.getInstance(10);
+    final Value final_v2;
 
     Value v2;
 
@@ -79,6 +80,14 @@ public class VarHandleTestAccessValue extends VarHandleBaseTest {
     VarHandle vhArray;
 
     VarHandle vhArrayObject;
+
+    public VarHandleTestAccessValue() {
+        final_v = Value.getInstance(10);
+        v = Value.getInstance(10);
+        final_v2 = Value.getInstance(10);
+        v2 = Value.getInstance(10);
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
     static final boolean static_final_v = true;
 
-    static boolean static_v;
+    static boolean static_v = true;
 
-    final boolean final_v = true;
+    final boolean final_v;
 
     boolean v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessBoolean() {
+        final_v = true;
+        v = true;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
     static final byte static_final_v = (byte)0x01;
 
-    static byte static_v;
+    static byte static_v = (byte)0x01;
 
-    final byte final_v = (byte)0x01;
+    final byte final_v;
 
     byte v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessByte() {
+        final_v = (byte)0x01;
+        v = (byte)0x01;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
     static final char static_final_v = '\u0123';
 
-    static char static_v;
+    static char static_v = '\u0123';
 
-    final char final_v = '\u0123';
+    final char final_v;
 
     char v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessChar() {
+        final_v = '\u0123';
+        v = '\u0123';
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
     static final double static_final_v = 1.0d;
 
-    static double static_v;
+    static double static_v = 1.0d;
 
-    final double final_v = 1.0d;
+    final double final_v;
 
     double v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessDouble() {
+        final_v = 1.0d;
+        v = 1.0d;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
     static final float static_final_v = 1.0f;
 
-    static float static_v;
+    static float static_v = 1.0f;
 
-    final float final_v = 1.0f;
+    final float final_v;
 
     float v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessFloat() {
+        final_v = 1.0f;
+        v = 1.0f;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
     static final int static_final_v = 0x01234567;
 
-    static int static_v;
+    static int static_v = 0x01234567;
 
-    final int final_v = 0x01234567;
+    final int final_v;
 
     int v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessInt() {
+        final_v = 0x01234567;
+        v = 0x01234567;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
     static final long static_final_v = 0x0123456789ABCDEFL;
 
-    static long static_v;
+    static long static_v = 0x0123456789ABCDEFL;
 
-    final long final_v = 0x0123456789ABCDEFL;
+    final long final_v;
 
     long v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessLong() {
+        final_v = 0x0123456789ABCDEFL;
+        v = 0x0123456789ABCDEFL;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessNullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessNullRestrictedValue.java
@@ -1,0 +1,896 @@
+/*
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// -- This file was mechanically generated: Do not edit! -- //
+
+/*
+ * @test
+ * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
+ *          to hit compilation thresholds
+ * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessNullRestrictedValue
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.NullRestricted;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class VarHandleTestMethodHandleAccessNullRestrictedValue extends VarHandleBaseTest {
+    static final @NullRestricted NullRestrictedValue static_final_v = NullRestrictedValue.of((byte)20,(short)1854);
+
+    static @NullRestricted NullRestrictedValue static_v = NullRestrictedValue.of((byte)20,(short)1854);
+
+    final @NullRestricted NullRestrictedValue final_v;
+
+    @NullRestricted NullRestrictedValue v;
+
+    VarHandle vhFinalField;
+
+    VarHandle vhField;
+
+    VarHandle vhStaticField;
+
+    VarHandle vhStaticFinalField;
+
+    VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessNullRestrictedValue() {
+        final_v = NullRestrictedValue.of((byte)20,(short)1854);
+        v = NullRestrictedValue.of((byte)20,(short)1854);
+        super();
+    }
+
+    @BeforeAll
+    public void setup() throws Exception {
+        vhFinalField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestMethodHandleAccessNullRestrictedValue.class, "final_v", NullRestrictedValue.class);
+
+        vhField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestMethodHandleAccessNullRestrictedValue.class, "v", NullRestrictedValue.class);
+
+        vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestMethodHandleAccessNullRestrictedValue.class, "static_final_v", NullRestrictedValue.class);
+
+        vhStaticField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestMethodHandleAccessNullRestrictedValue.class, "static_v", NullRestrictedValue.class);
+
+        vhArray = MethodHandles.arrayElementVarHandle(NullRestrictedValue[].class);
+    }
+
+    public Object[][] accessTestCaseProvider() throws Exception {
+        List<AccessTestCase<?>> cases = new ArrayList<>();
+
+        for (VarHandleToMethodHandle f : VarHandleToMethodHandle.values()) {
+            cases.add(new MethodHandleAccessTestCase("Instance field",
+                                                     vhField, f, hs -> testInstanceField(this, hs)));
+            cases.add(new MethodHandleAccessTestCase("Instance field unsupported",
+                                                     vhField, f, hs -> testInstanceFieldUnsupported(this, hs),
+                                                     false));
+            cases.add(new MethodHandleAccessTestCase("Instance field null pointer exception",
+                                                     vhField, f, hs -> testInstanceFieldNullPointerException(this, hs),
+                                                     false));
+
+            cases.add(new MethodHandleAccessTestCase("Static field",
+                                                     vhStaticField, f, VarHandleTestMethodHandleAccessNullRestrictedValue::testStaticField));
+            cases.add(new MethodHandleAccessTestCase("Static field unsupported",
+                                                     vhStaticField, f, VarHandleTestMethodHandleAccessNullRestrictedValue::testStaticFieldUnsupported,
+                                                     false));
+            cases.add(new MethodHandleAccessTestCase("Static field null pointer exception",
+                                                     vhStaticField, f, VarHandleTestMethodHandleAccessNullRestrictedValue::testStaticFieldNullPointerException,
+                                                     false));
+
+            cases.add(new MethodHandleAccessTestCase("Array",
+                                                     vhArray, f, VarHandleTestMethodHandleAccessNullRestrictedValue::testArray));
+            cases.add(new MethodHandleAccessTestCase("Array unsupported",
+                                                     vhArray, f, VarHandleTestMethodHandleAccessNullRestrictedValue::testArrayUnsupported,
+                                                     false));
+            cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
+                                                     vhArray, f, VarHandleTestMethodHandleAccessNullRestrictedValue::testArrayIndexOutOfBounds,
+                                                     false));
+            cases.add(new MethodHandleAccessTestCase("Array null pointer exception",
+                                                     vhArray, f, VarHandleTestMethodHandleAccessNullRestrictedValue::testArrayNullPointerException,
+                                                     false));
+        }
+
+        // Work around issue with jtreg summary reporting which truncates
+        // the String result of Object.toString to 30 characters, hence
+        // the first dummy argument
+        return cases.stream().map(tc -> new Object[]{tc.toString(), tc}).toArray(Object[][]::new);
+    }
+
+    @ParameterizedTest
+    @MethodSource("accessTestCaseProvider")
+    public <T> void testAccess(String desc, AccessTestCase<T> atc) throws Throwable {
+        T t = atc.get();
+        int iters = atc.requiresLoop() ? ITERS : 1;
+        for (int c = 0; c < iters; c++) {
+            atc.testAccess(t);
+        }
+    }
+
+    static void testInstanceField(VarHandleTestMethodHandleAccessNullRestrictedValue recv, Handles hs) throws Throwable {
+        // Plain
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "set NullRestrictedValue value");
+        }
+
+
+        // Volatile
+        {
+            hs.get(TestAccessMode.SET_VOLATILE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_VOLATILE).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setVolatile NullRestrictedValue value");
+        }
+
+        // Lazy
+        {
+            hs.get(TestAccessMode.SET_RELEASE).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_ACQUIRE).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "setRelease NullRestrictedValue value");
+        }
+
+        // Opaque
+        {
+            hs.get(TestAccessMode.SET_OPAQUE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_OPAQUE).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setOpaque NullRestrictedValue value");
+        }
+
+        hs.get(TestAccessMode.SET).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+
+        // Compare
+        {
+            boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(r, true, "success compareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndSet NullRestrictedValue value");
+        }
+
+        {
+            boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, false, "failing compareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndSet NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchange NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchange NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchange NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchange NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "success compareAndExchangeAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndExchangeAcquire NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "failing compareAndExchangeAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndExchangeAcquire NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchangeRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchangeRelease NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchangeRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchangeRelease NullRestrictedValue value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetPlain NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetPlain NullRestrictedValue value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetPlain NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetPlain NullRestrictedValue value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSetAcquire NullRestrictedValue");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSetAcquire NullRestrictedValue value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetRelease NullRestrictedValue");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetRelease NullRestrictedValue value");
+        }
+
+        {
+            boolean success = false;
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET);
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSet NullRestrictedValue");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSet NullRestrictedValue value");
+        }
+
+        // Compare set and get
+        {
+            NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSet NullRestrictedValue value");
+        }
+
+
+    }
+
+    static void testInstanceFieldUnsupported(VarHandleTestMethodHandleAccessNullRestrictedValue recv, Handles hs) throws Throwable {
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
+            checkUOE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
+            checkUOE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+        }
+    }
+
+
+    static void testStaticField(Handles hs) throws Throwable {
+        // Plain
+        {
+            hs.get(TestAccessMode.SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "set NullRestrictedValue value");
+        }
+
+
+        // Volatile
+        {
+            hs.get(TestAccessMode.SET_VOLATILE).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_VOLATILE).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setVolatile NullRestrictedValue value");
+        }
+
+        // Lazy
+        {
+            hs.get(TestAccessMode.SET_RELEASE).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_ACQUIRE).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "setRelease NullRestrictedValue value");
+        }
+
+        // Opaque
+        {
+            hs.get(TestAccessMode.SET_OPAQUE).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854));
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_OPAQUE).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setOpaque NullRestrictedValue value");
+        }
+
+        hs.get(TestAccessMode.SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+
+        // Compare
+        {
+            boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(r, true, "success compareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndSet NullRestrictedValue value");
+        }
+
+        {
+            boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, false, "failing compareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndSet NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchange NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchange NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchange NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchange NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "success compareAndExchangeAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndExchangeAcquire NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "failing compareAndExchangeAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndExchangeAcquire NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchangeRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchangeRelease NullRestrictedValue value");
+        }
+
+        {
+            NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchangeRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchangeRelease NullRestrictedValue value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetPlain NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetPlain NullRestrictedValue value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetPlain NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetPlain NullRestrictedValue value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSetAcquire NullRestrictedValue");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE);
+            boolean success = (boolean) mh.invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSetAcquire NullRestrictedValue value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetRelease NullRestrictedValue");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetRelease NullRestrictedValue value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSet NullRestrictedValue");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+            assertEquals(success, false, "failing weakCompareAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSetRe NullRestrictedValue value");
+        }
+
+        // Compare set and get
+        {
+            hs.get(TestAccessMode.SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSet NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSet NullRestrictedValue value");
+        }
+
+        // Compare set and get
+        {
+            hs.get(TestAccessMode.SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetAcquire NullRestrictedValue value");
+        }
+
+        // Compare set and get
+        {
+            hs.get(TestAccessMode.SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetRelease NullRestrictedValue value");
+        }
+
+
+    }
+
+    static void testStaticFieldUnsupported(Handles hs) throws Throwable {
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
+            checkUOE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
+            checkUOE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+            });
+        }
+    }
+
+
+    static void testArray(Handles hs) throws Throwable {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+
+        for (int i = 0; i < array.length; i++) {
+            // Plain
+            {
+                hs.get(TestAccessMode.SET).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "get NullRestrictedValue value");
+            }
+
+
+            // Volatile
+            {
+                hs.get(TestAccessMode.SET_VOLATILE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_VOLATILE).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setVolatile NullRestrictedValue value");
+            }
+
+            // Lazy
+            {
+                hs.get(TestAccessMode.SET_RELEASE).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_ACQUIRE).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "setRelease NullRestrictedValue value");
+            }
+
+            // Opaque
+            {
+                hs.get(TestAccessMode.SET_OPAQUE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET_OPAQUE).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "setOpaque NullRestrictedValue value");
+            }
+
+            hs.get(TestAccessMode.SET).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+
+            // Compare
+            {
+                boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(r, true, "success compareAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndSet NullRestrictedValue value");
+            }
+
+            {
+                boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(r, false, "failing compareAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndSet NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchange NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchange NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchange NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchange NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "success compareAndExchangeAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success compareAndExchangeAcquire NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "failing compareAndExchangeAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing compareAndExchangeAcquire NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                assertEquals(r, NullRestrictedValue.of((byte)-42,(short)1854), "success compareAndExchangeRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success compareAndExchangeRelease NullRestrictedValue value");
+            }
+
+            {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(r, NullRestrictedValue.of((byte)20,(short)1854), "failing compareAndExchangeRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing compareAndExchangeRelease NullRestrictedValue value");
+            }
+
+            {
+                MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN);
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = (boolean) mh.invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetPlain NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetPlain NullRestrictedValue value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSetPlain NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetPlain NullRestrictedValue value");
+            }
+
+            {
+                MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE);
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = (boolean) mh.invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSetAcquire NullRestrictedValue");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSetAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSetAcquire NullRestrictedValue value");
+            }
+
+            {
+                MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE);
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = (boolean) mh.invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "success weakCompareAndSetRelease NullRestrictedValue");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSetAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetAcquire NullRestrictedValue value");
+            }
+
+            {
+                MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET);
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = (boolean) mh.invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "success weakCompareAndSet NullRestrictedValue");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSet NullRestrictedValue value");
+            }
+
+            // Compare set and get
+            {
+                hs.get(TestAccessMode.SET).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+
+                NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSet NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSet NullRestrictedValue value");
+            }
+
+            {
+                hs.get(TestAccessMode.SET).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+
+                NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetAcquire NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetAcquire NullRestrictedValue value");
+            }
+
+            {
+                hs.get(TestAccessMode.SET).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+
+                NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(array, i, NullRestrictedValue.of((byte)-42,(short)1854));
+                assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetRelease NullRestrictedValue");
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetRelease NullRestrictedValue value");
+            }
+
+
+        }
+    }
+
+    static void testArrayUnsupported(Handles hs) throws Throwable {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+
+        final int i = 0;
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
+            checkUOE(am, () -> {
+                NullRestrictedValue o = (NullRestrictedValue) hs.get(am).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
+            checkUOE(am, () -> {
+                NullRestrictedValue o = (NullRestrictedValue) hs.get(am).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+        }
+    }
+
+    static void testArrayIndexOutOfBounds(Handles hs) throws Throwable {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+
+        for (int i : new int[]{-1, Integer.MIN_VALUE, 10, 11, Integer.MAX_VALUE}) {
+            final int ci = i;
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
+                checkAIOOBE(am, () -> {
+                    NullRestrictedValue x = (NullRestrictedValue) hs.get(am).invokeExact(array, ci);
+                });
+            }
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+                checkAIOOBE(am, () -> {
+                    hs.get(am).invokeExact(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+                });
+            }
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+                checkAIOOBE(am, () -> {
+                    boolean r = (boolean) hs.get(am).invokeExact(array, ci, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)-42,(short)1854));
+                });
+            }
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+                checkAIOOBE(am, () -> {
+                    NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(array, ci, NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+                });
+            }
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+                checkAIOOBE(am, () -> {
+                    NullRestrictedValue o = (NullRestrictedValue) hs.get(am).invokeExact(array, ci, NullRestrictedValue.of((byte)20,(short)1854));
+                });
+            }
+
+
+        }
+    }
+
+    static void testInstanceFieldNullPointerException(VarHandleTestMethodHandleAccessNullRestrictedValue recv, Handles hs) throws Throwable {
+        NullRestrictedValue value = null;
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            checkNPE(am, () -> {
+                hs.get(am).invokeExact(recv, value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            checkNPE(am, () -> {
+                boolean r = (boolean) hs.get(am).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            checkNPE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            checkNPE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(recv, value);
+            });
+        }
+    }
+
+    static void testStaticFieldNullPointerException(Handles hs) throws Throwable {
+        NullRestrictedValue value = null;
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            checkNPE(am, () -> {
+                hs.get(am).invokeExact(value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            checkNPE(am, () -> {
+                boolean r = (boolean) hs.get(am).invokeExact(NullRestrictedValue.of((byte)20,(short)1854), value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            checkNPE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(NullRestrictedValue.of((byte)20,(short)1854), value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            checkNPE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(value);
+            });
+        }
+    }
+
+    static void testArrayNullPointerException(Handles hs) throws Throwable {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+        NullRestrictedValue value = null;
+
+        final int i = 0;
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            checkNPE(am, () -> {
+                hs.get(am).invokeExact(array, i, value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            checkNPE(am, () -> {
+                boolean r = (boolean) hs.get(am).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            checkNPE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            checkNPE(am, () -> {
+                NullRestrictedValue r = (NullRestrictedValue) hs.get(am).invokeExact(array, i, value);
+            });
+        }
+    }
+}
+

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
     static final short static_final_v = (short)0x0123;
 
-    static short static_v;
+    static short static_v = (short)0x0123;
 
-    final short final_v = (short)0x0123;
+    final short final_v;
 
     short v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessShort() {
+        final_v = (short)0x0123;
+        v = (short)0x0123;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
     static final String static_final_v = "foo";
 
-    static String static_v;
+    static String static_v = "foo";
 
-    final String final_v = "foo";
+    final String final_v;
 
     String v;
 
@@ -61,6 +61,12 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessString() {
+        final_v = "foo";
+        v = "foo";
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @test
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
  * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
  *          to hit compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessValue
@@ -48,9 +49,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VarHandleTestMethodHandleAccessValue extends VarHandleBaseTest {
     static final Value static_final_v = Value.getInstance(10);
 
-    static Value static_v;
+    static Value static_v = Value.getInstance(10);
 
-    final Value final_v = Value.getInstance(10);
+    final Value final_v;
 
     Value v;
 
@@ -63,6 +64,12 @@ public class VarHandleTestMethodHandleAccessValue extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccessValue() {
+        final_v = Value.getInstance(10);
+        v = Value.getInstance(10);
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
 
     static boolean static_v = true;
 
-    final boolean final_v = true;
+    final boolean final_v;
 
-    boolean v = true;
+    boolean v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeBoolean() {
+        final_v = true;
+        v = true;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
 
     static byte static_v = (byte)0x01;
 
-    final byte final_v = (byte)0x01;
+    final byte final_v;
 
-    byte v = (byte)0x01;
+    byte v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeByte() {
+        final_v = (byte)0x01;
+        v = (byte)0x01;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
 
     static char static_v = '\u0123';
 
-    final char final_v = '\u0123';
+    final char final_v;
 
-    char v = '\u0123';
+    char v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeChar() {
+        final_v = '\u0123';
+        v = '\u0123';
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
 
     static double static_v = 1.0d;
 
-    final double final_v = 1.0d;
+    final double final_v;
 
-    double v = 1.0d;
+    double v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeDouble() {
+        final_v = 1.0d;
+        v = 1.0d;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
 
     static float static_v = 1.0f;
 
-    final float final_v = 1.0f;
+    final float final_v;
 
-    float v = 1.0f;
+    float v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeFloat() {
+        final_v = 1.0f;
+        v = 1.0f;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
 
     static int static_v = 0x01234567;
 
-    final int final_v = 0x01234567;
+    final int final_v;
 
-    int v = 0x01234567;
+    int v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeInt() {
+        final_v = 0x01234567;
+        v = 0x01234567;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
 
     static long static_v = 0x0123456789ABCDEFL;
 
-    final long final_v = 0x0123456789ABCDEFL;
+    final long final_v;
 
-    long v = 0x0123456789ABCDEFL;
+    long v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeLong() {
+        final_v = 0x0123456789ABCDEFL;
+        v = 0x0123456789ABCDEFL;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeNullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeNullRestrictedValue.java
@@ -1,0 +1,2071 @@
+/*
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// -- This file was mechanically generated: Do not edit! -- //
+
+/*
+ * @test
+ * @bug 8156486
+ * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ * @run junit/othervm VarHandleTestMethodTypeNullRestrictedValue
+ * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeNullRestrictedValue
+ * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeNullRestrictedValue
+ * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeNullRestrictedValue
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.lang.invoke.MethodType.*;
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.NullRestricted;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTest {
+    static final @NullRestricted NullRestrictedValue static_final_v = NullRestrictedValue.of((byte)20,(short)1854);
+
+    static @NullRestricted NullRestrictedValue static_v = NullRestrictedValue.of((byte)20,(short)1854);
+
+    final @NullRestricted NullRestrictedValue final_v;
+
+    @NullRestricted NullRestrictedValue v;
+
+    VarHandle vhFinalField;
+
+    VarHandle vhField;
+
+    VarHandle vhStaticField;
+
+    VarHandle vhStaticFinalField;
+
+    VarHandle vhArray;
+
+    public VarHandleTestMethodTypeNullRestrictedValue() {
+        final_v = NullRestrictedValue.of((byte)20,(short)1854);
+        v = NullRestrictedValue.of((byte)20,(short)1854);
+        super();
+    }
+
+    @BeforeAll
+    public void setup() throws Exception {
+        vhFinalField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestMethodTypeNullRestrictedValue.class, "final_v", NullRestrictedValue.class);
+
+        vhField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestMethodTypeNullRestrictedValue.class, "v", NullRestrictedValue.class);
+
+        vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestMethodTypeNullRestrictedValue.class, "static_final_v", NullRestrictedValue.class);
+
+        vhStaticField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestMethodTypeNullRestrictedValue.class, "static_v", NullRestrictedValue.class);
+
+        vhArray = MethodHandles.arrayElementVarHandle(NullRestrictedValue[].class);
+    }
+
+    public Object[][] accessTestCaseProvider() throws Exception {
+        List<AccessTestCase<?>> cases = new ArrayList<>();
+
+        cases.add(new VarHandleAccessTestCase("Instance field",
+                                              vhField, vh -> testInstanceFieldWrongMethodType(this, vh),
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Static field",
+                                              vhStaticField, VarHandleTestMethodTypeNullRestrictedValue::testStaticFieldWrongMethodType,
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Array",
+                                              vhArray, VarHandleTestMethodTypeNullRestrictedValue::testArrayWrongMethodType,
+                                              false));
+
+        for (VarHandleToMethodHandle f : VarHandleToMethodHandle.values()) {
+            cases.add(new MethodHandleAccessTestCase("Instance field",
+                                                     vhField, f, hs -> testInstanceFieldWrongMethodType(this, hs),
+                                                     false));
+
+            cases.add(new MethodHandleAccessTestCase("Static field",
+                                                     vhStaticField, f, VarHandleTestMethodTypeNullRestrictedValue::testStaticFieldWrongMethodType,
+                                                     false));
+
+            cases.add(new MethodHandleAccessTestCase("Array",
+                                                     vhArray, f, VarHandleTestMethodTypeNullRestrictedValue::testArrayWrongMethodType,
+                                                     false));
+        }
+        // Work around issue with jtreg summary reporting which truncates
+        // the String result of Object.toString to 30 characters, hence
+        // the first dummy argument
+        return cases.stream().map(tc -> new Object[]{tc.toString(), tc}).toArray(Object[][]::new);
+    }
+
+    @ParameterizedTest
+    @MethodSource("accessTestCaseProvider")
+    public <T> void testAccess(String desc, AccessTestCase<T> atc) throws Throwable {
+        T t = atc.get();
+        int iters = atc.requiresLoop() ? ITERS : 1;
+        for (int c = 0; c < iters; c++) {
+            atc.testAccess(t);
+        }
+    }
+
+    static void testInstanceFieldWrongMethodType(VarHandleTestMethodTypeNullRestrictedValue recv, VarHandle vh) throws Throwable {
+        // Get
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(null);
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(0);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.get(recv);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.get(recv);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(recv, Void.class);
+        });
+
+
+        // Set
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            vh.set(null, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            vh.set(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            vh.set(recv, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.set(0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.set();
+        });
+        checkWMTE(() -> { // >
+            vh.set(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(null);
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(0);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getVolatile(recv);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getVolatile(recv);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(recv, Void.class);
+        });
+
+
+        // SetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            vh.setVolatile(null, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            vh.setVolatile(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setVolatile(recv, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setVolatile(0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setVolatile();
+        });
+        checkWMTE(() -> { // >
+            vh.setVolatile(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetOpaque
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(null);
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(0);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getOpaque(recv);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getOpaque(recv);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(recv, Void.class);
+        });
+
+
+        // SetOpaque
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            vh.setOpaque(null, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            vh.setOpaque(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setOpaque(recv, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setOpaque(0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setOpaque();
+        });
+        checkWMTE(() -> { // >
+            vh.setOpaque(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(null);
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(0);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getAcquire(recv);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAcquire(recv);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(recv, Void.class);
+        });
+
+
+        // SetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            vh.setRelease(null, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            vh.setRelease(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setRelease(recv, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setRelease(0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setRelease();
+        });
+        checkWMTE(() -> { // >
+            vh.setRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.compareAndSet(null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.compareAndSet(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.compareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.compareAndSet(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.compareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.compareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetPlain(null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetPlain(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetPlain(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetPlain(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetPlain();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetPlain(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSet(null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSet(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSet(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetAcquire(null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetAcquire(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetAcquire(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetRelease(null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetRelease(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetRelease(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchange
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchangeAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchangeRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(null, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(recv, Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+        // GetAndSetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(null, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(recv, Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+        // GetAndSetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(null, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(recv, Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+    }
+
+    static void testInstanceFieldWrongMethodType(VarHandleTestMethodTypeNullRestrictedValue recv, Handles hs) throws Throwable {
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class)).
+                    invokeExact((VarHandleTestMethodTypeNullRestrictedValue) null);
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, Class.class)).
+                    invokeExact(Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, int.class)).
+                    invokeExact(0);
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void x = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeNullRestrictedValue.class)).
+                    invokeExact(recv);
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeNullRestrictedValue.class)).
+                    invokeExact(recv);
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, Class.class)).
+                    invokeExact(recv, Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact((VarHandleTestMethodTypeNullRestrictedValue) null, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                hs.get(am, methodType(void.class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeNullRestrictedValue.class, Class.class)).
+                    invokeExact(recv, Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                hs.get(am, methodType(void.class, int.class, NullRestrictedValue.class)).
+                    invokeExact(0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                hs.get(am, methodType(void.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact((VarHandleTestMethodTypeNullRestrictedValue) null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeNullRestrictedValue.class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                boolean r = (boolean) hs.get(am, methodType(boolean.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            checkNPE(() -> { // null receiver
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact((VarHandleTestMethodTypeNullRestrictedValue) null, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, Class.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(recv, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+            checkWMTE(() -> { // reciever primitive class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, int.class , NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeNullRestrictedValue.class , NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeNullRestrictedValue.class , NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            checkNPE(() -> { // null receiver
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact((VarHandleTestMethodTypeNullRestrictedValue) null, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, Class.class)).
+                    invokeExact(recv, Void.class);
+            });
+            checkWMTE(() -> { // reciever primitive class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, int.class, NullRestrictedValue.class)).
+                    invokeExact(0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+
+    }
+
+
+    static void testStaticFieldWrongMethodType(VarHandle vh) throws Throwable {
+        // Get
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.get();
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.get();
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(Void.class);
+        });
+
+
+        // Set
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            vh.set(Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.set();
+        });
+        checkWMTE(() -> { // >
+            vh.set(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetVolatile
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getVolatile();
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getVolatile();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(Void.class);
+        });
+
+
+        // SetVolatile
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            vh.setVolatile(Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setVolatile();
+        });
+        checkWMTE(() -> { // >
+            vh.setVolatile(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetOpaque
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getOpaque();
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getOpaque();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(Void.class);
+        });
+
+
+        // SetOpaque
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            vh.setOpaque(Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setOpaque();
+        });
+        checkWMTE(() -> { // >
+            vh.setOpaque(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAcquire
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getAcquire();
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(Void.class);
+        });
+
+
+        // SetRelease
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            vh.setRelease(Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setRelease();
+        });
+        checkWMTE(() -> { // >
+            vh.setRelease(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndSet
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.compareAndSet(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.compareAndSet(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.compareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.compareAndSet(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSet
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetPlain(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetPlain(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetPlain();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetPlain(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetVolatile
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSet(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSet(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSet(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetAcquire
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetAcquire(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetAcquire(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetAcquire(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetRelease
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetRelease(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchange
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchange(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchange(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchangeAcquire
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeAcquire(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeAcquire(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchangeRelease
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeRelease(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeRelease(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAndSet
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSet(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSet(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAndSetAcquire
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetAcquire(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAndSetRelease
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+    }
+
+    static void testStaticFieldWrongMethodType(Handles hs) throws Throwable {
+        int i = 0;
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void x = (Void) hs.get(am, methodType(Void.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                    invokeExact();
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(Class.class)).
+                    invokeExact(Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                hs.get(am, methodType(void.class, Class.class)).
+                    invokeExact(Void.class);
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                hs.get(am, methodType(void.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                hs.get(am, methodType(void.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            // Incorrect argument types
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                boolean r = (boolean) hs.get(am, methodType(boolean.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            // Incorrect argument types
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            // Incorrect argument types
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, Class.class)).
+                    invokeExact(Void.class);
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, NullRestrictedValue.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+
+    }
+
+
+    static void testArrayWrongMethodType(VarHandle vh) throws Throwable {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+        Arrays.fill(array, NullRestrictedValue.of((byte)20,(short)1854));
+
+        // Get
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(null, 0);
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(Void.class, 0);
+        });
+        checkWMTE(() -> { // array primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(0, 0);
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(array, Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.get(array, 0);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.get(array, 0);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.get();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.get(array, 0, Void.class);
+        });
+
+
+        // Set
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            vh.set(null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            vh.set(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            vh.set(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.set(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            vh.set(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.set();
+        });
+        checkWMTE(() -> { // >
+            vh.set(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(null, 0);
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(Void.class, 0);
+        });
+        checkWMTE(() -> { // array primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(0, 0);
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(array, Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getVolatile(array, 0);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getVolatile(array, 0);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getVolatile(array, 0, Void.class);
+        });
+
+
+        // SetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            vh.setVolatile(null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            vh.setVolatile(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setVolatile(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setVolatile(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            vh.setVolatile(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setVolatile();
+        });
+        checkWMTE(() -> { // >
+            vh.setVolatile(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetOpaque
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(null, 0);
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(Void.class, 0);
+        });
+        checkWMTE(() -> { // array primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(0, 0);
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(array, Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getOpaque(array, 0);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getOpaque(array, 0);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getOpaque(array, 0, Void.class);
+        });
+
+
+        // SetOpaque
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            vh.setOpaque(null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            vh.setOpaque(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setOpaque(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setOpaque(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            vh.setOpaque(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setOpaque();
+        });
+        checkWMTE(() -> { // >
+            vh.setOpaque(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(null, 0);
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(Void.class, 0);
+        });
+        checkWMTE(() -> { // array primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(0, 0);
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(array, Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getAcquire(array, 0);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAcquire(array, 0);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(array, 0, Void.class);
+        });
+
+
+        // SetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            vh.setRelease(null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            vh.setRelease(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setRelease(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setRelease(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            vh.setRelease(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setRelease();
+        });
+        checkWMTE(() -> { // >
+            vh.setRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.compareAndSet(null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.compareAndSet(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.compareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.compareAndSet(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.compareAndSet(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.compareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.compareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetPlain(null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetPlain(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetPlain(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetPlain(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.weakCompareAndSetPlain(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetPlain();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetPlain(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSet(null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSet(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSet(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.weakCompareAndSet(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetAcquire(null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetAcquire(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // WeakCompareAndSetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetRelease(null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetRelease(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetRelease(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.weakCompareAndSetRelease(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchange
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // array primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchange(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchange(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchangeAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // array primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // CompareAndExchangeRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // expected reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // actual reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+        checkWMTE(() -> { // array primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // reciarrayever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAndSetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // reciarrayever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+        // GetAndSetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // array reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkCCE(() -> { // value reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // reciarrayever primitive class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // index reference class
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+        });
+
+
+    }
+
+    static void testArrayWrongMethodType(Handles hs) throws Throwable {
+        NullRestrictedValue[] array = (NullRestrictedValue[]) ValueClass.newNullRestrictedAtomicArray(NullRestrictedValue.class, 10, NullRestrictedValue.of((byte)20,(short)1854));
+        Arrays.fill(array, NullRestrictedValue.of((byte)20,(short)1854));
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null array
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class)).
+                    invokeExact((NullRestrictedValue[]) null, 0);
+            });
+            hs.checkWMTEOrCCE(() -> { // array reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, Class.class, int.class)).
+                    invokeExact(Void.class, 0);
+            });
+            checkWMTE(() -> { // array primitive class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, int.class, int.class)).
+                    invokeExact(0, 0);
+            });
+            checkWMTE(() -> { // index reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, Class.class)).
+                    invokeExact(array, Void.class);
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void x = (Void) hs.get(am, methodType(Void.class, NullRestrictedValue[].class, int.class)).
+                    invokeExact(array, 0);
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue[].class, int.class)).
+                    invokeExact(array, 0);
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class, Class.class)).
+                    invokeExact(array, 0, Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null array
+                hs.get(am, methodType(void.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class)).
+                    invokeExact((NullRestrictedValue[]) null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // array reference class
+                hs.get(am, methodType(void.class, Class.class, int.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                hs.get(am, methodType(void.class, NullRestrictedValue[].class, int.class, Class.class)).
+                    invokeExact(array, 0, Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                hs.get(am, methodType(void.class, int.class, int.class, NullRestrictedValue.class)).
+                    invokeExact(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // index reference class
+                hs.get(am, methodType(void.class, NullRestrictedValue[].class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                hs.get(am, methodType(void.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                hs.get(am, methodType(void.class, NullRestrictedValue[].class, int.class, Class.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact((NullRestrictedValue[]) null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue[].class, int.class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // index reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue[].class, Class.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                boolean r = (boolean) hs.get(am, methodType(boolean.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact((NullRestrictedValue[]) null, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // array reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, Class.class, int.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(array, 0, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+            checkWMTE(() -> { // array primitive class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, int.class, int.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(0, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // index reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, Class.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, NullRestrictedValue.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null array
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class)).
+                    invokeExact((NullRestrictedValue[]) null, 0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // array reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, Class.class, int.class, NullRestrictedValue.class)).
+                    invokeExact(Void.class, 0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class, Class.class)).
+                    invokeExact(array, 0, Void.class);
+            });
+            checkWMTE(() -> { // array primitive class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, int.class, int.class, NullRestrictedValue.class)).
+                    invokeExact(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // index reference class
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, Class.class, NullRestrictedValue.class)).
+                    invokeExact(array, Void.class, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, NullRestrictedValue[].class, int.class, NullRestrictedValue.class, Class.class)).
+                    invokeExact(array, 0, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
+            });
+        }
+
+
+    }
+}

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
 
     static short static_v = (short)0x0123;
 
-    final short final_v = (short)0x0123;
+    final short final_v;
 
-    short v = (short)0x0123;
+    short v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeShort() {
+        final_v = (short)0x0123;
+        v = (short)0x0123;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,9 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
 
     static String static_v = "foo";
 
-    final String final_v = "foo";
+    final String final_v;
 
-    String v = "foo";
+    String v;
 
     VarHandle vhFinalField;
 
@@ -64,6 +64,12 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeString() {
+        final_v = "foo";
+        v = "foo";
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @bug 8156486
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
  * @run junit/othervm VarHandleTestMethodTypeValue
  * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeValue
  * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeValue
@@ -53,9 +54,9 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
 
     static Value static_v = Value.getInstance(10);
 
-    final Value final_v = Value.getInstance(10);
+    final Value final_v;
 
-    Value v = Value.getInstance(10);
+    Value v;
 
     VarHandle vhFinalField;
 
@@ -66,6 +67,12 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodTypeValue() {
+        final_v = Value.getInstance(10);
+        v = Value.getInstance(10);
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #if[Value]
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
 #end[Value]
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccess$Type$
  *
@@ -45,6 +46,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+#if[NullRestricted]
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.NullRestricted;
+
+#end[NullRestricted]
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -54,21 +60,21 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
-    static final $type$ static_final_v = $value1$;
+    static final {#if[NullRestricted]?@NullRestricted }$type$ static_final_v = $value1$;
 
-    static $type$ static_v;
+    static {#if[NullRestricted]?@NullRestricted }$type$ static_v = $value1$;
 
-    final $type$ final_v = $value1$;
+    final {#if[NullRestricted]?@NullRestricted }$type$ final_v;
 
-    $type$ v;
+    {#if[NullRestricted]?@NullRestricted }$type$ v;
 
-    static final $type$ static_final_v2 = $value1$;
+    static final {#if[NullRestricted]?@NullRestricted }$type$ static_final_v2 = $value1$;
 
-    static $type$ static_v2;
+    static {#if[NullRestricted]?@NullRestricted }$type$ static_v2 = $value1$;
 
-    final $type$ final_v2 = $value1$;
+    final {#if[NullRestricted]?@NullRestricted }$type$ final_v2;
 
-    $type$ v2;
+    {#if[NullRestricted]?@NullRestricted }$type$ v2;
 
     VarHandle vhFinalField;
 
@@ -82,7 +88,15 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
 
 #if[Object]
     VarHandle vhArrayObject;
+
 #end[Object]
+    public VarHandleTestAccess$Type$() {
+        final_v = $value1$;
+        v = $value1$;
+        final_v2 = $value1$;
+        v2 = $value1$;
+        super();
+    }
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -308,12 +322,22 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Instance field unsupported",
                                               vhField, vh -> testInstanceFieldUnsupported(this, vh),
                                               false));
+#if[NullRestricted]
+        cases.add(new VarHandleAccessTestCase("Instance field null pointer exception",
+                                              vhField, vh -> testInstanceFieldNullPointerException(this, vh),
+                                              false));
+#end[NullRestricted]
 
         cases.add(new VarHandleAccessTestCase("Static field",
                                               vhStaticField, VarHandleTestAccess$Type$::testStaticField));
         cases.add(new VarHandleAccessTestCase("Static field unsupported",
                                               vhStaticField, VarHandleTestAccess$Type$::testStaticFieldUnsupported,
                                               false));
+#if[NullRestricted]
+        cases.add(new VarHandleAccessTestCase("Static field null pointer exception",
+                                              vhStaticField, VarHandleTestAccess$Type$::testStaticFieldNullPointerException,
+                                              false));
+#end[NullRestricted]
 
         cases.add(new VarHandleAccessTestCase("Array",
                                               vhArray, VarHandleTestAccess$Type$::testArray));
@@ -332,6 +356,11 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
                                               vhArrayObject, VarHandleTestAccess$Type$::testArrayStoreException,
                                               false));
 #end[Object]
+#if[NullRestricted]
+        cases.add(new VarHandleAccessTestCase("Array null pointer exception",
+                                              vhArrayObject, VarHandleTestAccess$Type$::testArrayNullPointerException,
+                                              false));
+#end[NullRestricted]
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -1455,7 +1484,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
 
 
     static void testArray(VarHandle vh) {
-        $type$[] array = new $type$[10];
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
 
         for (int i = 0; i < array.length; i++) {
             // Plain
@@ -1767,7 +1796,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
     }
 
     static void testArrayUnsupported(VarHandle vh) {
-        $type$[] array = new $type$[10];
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
 
         int i = 0;
 #if[!CAS]
@@ -1870,7 +1899,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
     }
 
     static void testArrayIndexOutOfBounds(VarHandle vh) throws Throwable {
-        $type$[] array = new $type$[10];
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
 
         for (int i : new int[]{-1, Integer.MIN_VALUE, 10, 11, Integer.MAX_VALUE}) {
             final int ci = i;
@@ -2006,10 +2035,10 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
 #end[Bitwise]
         }
     }
-
 #if[Object]
+
     static void testArrayStoreException(VarHandle vh) throws Throwable {
-        Object[] array = new $type$[10];
+        Object[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
         Arrays.fill(array, $value1$);
         Object value = new Object();
 
@@ -2089,5 +2118,245 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         });
     }
 #end[Object]
+#if[NullRestricted]
+
+    static void testInstanceFieldNullPointerException(VarHandleTestAccess$Type$ recv, VarHandle vh) throws Throwable {
+        $type$ value = null;
+
+        // Set
+        checkNPE(() -> {
+            vh.set(recv, value);
+        });
+
+        // SetVolatile
+        checkNPE(() -> {
+            vh.setVolatile(recv, value);
+        });
+
+        // SetOpaque
+        checkNPE(() -> {
+            vh.setOpaque(recv, value);
+        });
+
+        // SetRelease
+        checkNPE(() -> {
+            vh.setRelease(recv, value);
+        });
+
+        // CompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(recv, $value1$, value);
+        });
+
+        // WeakCompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(recv, $value1$, value);
+        });
+
+        // WeakCompareAndSetVolatile
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(recv, $value1$, value);
+        });
+
+        // WeakCompareAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(recv, $value1$, value);
+        });
+
+        // WeakCompareAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(recv, $value1$, value);
+        });
+
+        // CompareAndExchange
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchange(recv, $value1$, value);
+        });
+
+        // CompareAndExchangeAcquire
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchangeAcquire(recv, $value1$, value);
+        });
+
+        // CompareAndExchangeRelease
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchangeRelease(recv, $value1$, value);
+        });
+
+        // GetAndSet
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSet(recv, value);
+        });
+
+        // GetAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSetAcquire(recv, value);
+        });
+
+        // GetAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSetRelease(recv, value);
+        });
+    }
+
+    static void testStaticFieldNullPointerException(VarHandle vh) throws Throwable {
+        $type$ value = null;
+
+        // Set
+        checkNPE(() -> {
+            vh.set(value);
+        });
+
+        // SetVolatile
+        checkNPE(() -> {
+            vh.setVolatile(value);
+        });
+
+        // SetOpaque
+        checkNPE(() -> {
+            vh.setOpaque(value);
+        });
+
+        // SetRelease
+        checkNPE(() -> {
+            vh.setRelease(value);
+        });
+
+        // CompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet($value1$, value);
+        });
+
+        // WeakCompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain($value1$, value);
+        });
+
+        // WeakCompareAndSetVolatile
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet($value1$, value);
+        });
+
+        // WeakCompareAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire($value1$, value);
+        });
+
+        // WeakCompareAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease($value1$, value);
+        });
+
+        // CompareAndExchange
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchange($value1$, value);
+        });
+
+        // CompareAndExchangeAcquire
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchangeAcquire($value1$, value);
+        });
+
+        // CompareAndExchangeRelease
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchangeRelease($value1$, value);
+        });
+
+        // GetAndSet
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSet(value);
+        });
+
+        // GetAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSetAcquire(value);
+        });
+
+        // GetAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSetRelease(value);
+        });
+    }
+
+    static void testArrayNullPointerException(VarHandle vh) throws Throwable {
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
+        $type$ value = null;
+
+        // Set
+        checkNPE(() -> {
+            vh.set(array, 0, value);
+        });
+
+        // SetVolatile
+        checkNPE(() -> {
+            vh.setVolatile(array, 0, value);
+        });
+
+        // SetOpaque
+        checkNPE(() -> {
+            vh.setOpaque(array, 0, value);
+        });
+
+        // SetRelease
+        checkNPE(() -> {
+            vh.setRelease(array, 0, value);
+        });
+
+        // CompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(array, 0, $value1$, value);
+        });
+
+        // WeakCompareAndSet
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(array, 0, $value1$, value);
+        });
+
+        // WeakCompareAndSetVolatile
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(array, 0, $value1$, value);
+        });
+
+        // WeakCompareAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, $value1$, value);
+        });
+
+        // WeakCompareAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(array, 0, $value1$, value);
+        });
+
+        // CompareAndExchange
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchange(array, 0, $value1$, value);
+        });
+
+        // CompareAndExchangeAcquire
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchangeAcquire(array, 0, $value1$, value);
+        });
+
+        // CompareAndExchangeRelease
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.compareAndExchangeRelease(array, 0, $value1$, value);
+        });
+
+        // GetAndSet
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSet(array, 0, value);
+        });
+
+        // GetAndSetAcquire
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSetAcquire(array, 0, value);
+        });
+
+        // GetAndSetRelease
+        checkNPE(() -> { // receiver reference class
+            $type$ x = ($type$) vh.getAndSetRelease(array, 0, value);
+        });
+    }
+#end[NullRestricted]
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #if[Value]
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
 #end[Value]
  * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
  *          to hit compilation thresholds
@@ -40,6 +41,11 @@ import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
 
+#if[NullRestricted]
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.NullRestricted;
+
+#end[NullRestricted]
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
@@ -48,13 +54,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
-    static final $type$ static_final_v = $value1$;
+    static final {#if[NullRestricted]?@NullRestricted }$type$ static_final_v = $value1$;
 
-    static $type$ static_v;
+    static {#if[NullRestricted]?@NullRestricted }$type$ static_v = $value1$;
 
-    final $type$ final_v = $value1$;
+    final {#if[NullRestricted]?@NullRestricted }$type$ final_v;
 
-    $type$ v;
+    {#if[NullRestricted]?@NullRestricted }$type$ v;
 
     VarHandle vhFinalField;
 
@@ -65,6 +71,12 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodHandleAccess$Type$() {
+        final_v = $value1$;
+        v = $value1$;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {
@@ -92,12 +104,22 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Instance field unsupported",
                                                      vhField, f, hs -> testInstanceFieldUnsupported(this, hs),
                                                      false));
+#if[NullRestricted]
+            cases.add(new MethodHandleAccessTestCase("Instance field null pointer exception",
+                                                     vhField, f, hs -> testInstanceFieldNullPointerException(this, hs),
+                                                     false));
+#end[NullRestricted]
 
             cases.add(new MethodHandleAccessTestCase("Static field",
                                                      vhStaticField, f, VarHandleTestMethodHandleAccess$Type$::testStaticField));
             cases.add(new MethodHandleAccessTestCase("Static field unsupported",
                                                      vhStaticField, f, VarHandleTestMethodHandleAccess$Type$::testStaticFieldUnsupported,
                                                      false));
+#if[NullRestricted]
+            cases.add(new MethodHandleAccessTestCase("Static field null pointer exception",
+                                                     vhStaticField, f, VarHandleTestMethodHandleAccess$Type$::testStaticFieldNullPointerException,
+                                                     false));
+#end[NullRestricted]
 
             cases.add(new MethodHandleAccessTestCase("Array",
                                                      vhArray, f, VarHandleTestMethodHandleAccess$Type$::testArray));
@@ -107,6 +129,11 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccess$Type$::testArrayIndexOutOfBounds,
                                                      false));
+#if[NullRestricted]
+            cases.add(new MethodHandleAccessTestCase("Array null pointer exception",
+                                                     vhArray, f, VarHandleTestMethodHandleAccess$Type$::testArrayNullPointerException,
+                                                     false));
+#end[NullRestricted]
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -811,7 +838,7 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
 
 
     static void testArray(Handles hs) throws Throwable {
-        $type$[] array = new $type$[10];
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
 
         for (int i = 0; i < array.length; i++) {
             // Plain
@@ -1127,7 +1154,7 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
     }
 
     static void testArrayUnsupported(Handles hs) throws Throwable {
-        $type$[] array = new $type$[10];
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
 
         final int i = 0;
 #if[!CAS]
@@ -1168,7 +1195,7 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
     }
 
     static void testArrayIndexOutOfBounds(Handles hs) throws Throwable {
-        $type$[] array = new $type$[10];
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
 
         for (int i : new int[]{-1, Integer.MIN_VALUE, 10, 11, Integer.MAX_VALUE}) {
             final int ci = i;
@@ -1222,5 +1249,99 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
 #end[Bitwise]
         }
     }
+#if[NullRestricted]
+
+    static void testInstanceFieldNullPointerException(VarHandleTestMethodHandleAccess$Type$ recv, Handles hs) throws Throwable {
+        $type$ value = null;
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            checkNPE(am, () -> {
+                hs.get(am).invokeExact(recv, value);
+            });
+        }
+#if[CAS]
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            checkNPE(am, () -> {
+                boolean r = (boolean) hs.get(am).invokeExact(recv, $value1$, value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            checkNPE(am, () -> {
+                $type$ r = ($type$) hs.get(am).invokeExact(recv, $value1$, value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            checkNPE(am, () -> {
+                $type$ r = ($type$) hs.get(am).invokeExact(recv, value);
+            });
+        }
+#end[CAS]
+    }
+
+    static void testStaticFieldNullPointerException(Handles hs) throws Throwable {
+        $type$ value = null;
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            checkNPE(am, () -> {
+                hs.get(am).invokeExact(value);
+            });
+        }
+#if[CAS]
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            checkNPE(am, () -> {
+                boolean r = (boolean) hs.get(am).invokeExact($value1$, value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            checkNPE(am, () -> {
+                $type$ r = ($type$) hs.get(am).invokeExact($value1$, value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            checkNPE(am, () -> {
+                $type$ r = ($type$) hs.get(am).invokeExact(value);
+            });
+        }
+#end[CAS]
+    }
+
+    static void testArrayNullPointerException(Handles hs) throws Throwable {
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
+        $type$ value = null;
+
+        final int i = 0;
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            checkNPE(am, () -> {
+                hs.get(am).invokeExact(array, i, value);
+            });
+        }
+#if[CAS]
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            checkNPE(am, () -> {
+                boolean r = (boolean) hs.get(am).invokeExact(array, i, $value1$, value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            checkNPE(am, () -> {
+                $type$ r = ($type$) hs.get(am).invokeExact(array, i, $value1$, value);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            checkNPE(am, () -> {
+                $type$ r = ($type$) hs.get(am).invokeExact(array, i, value);
+            });
+        }
+#end[CAS]
+    }
+#end[NullRestricted]
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 #if[Value]
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
 #end[Value]
  * @run junit/othervm VarHandleTestMethodType$Type$
  * @run junit/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodType$Type$
@@ -44,6 +45,11 @@ import java.util.List;
 
 import static java.lang.invoke.MethodType.*;
 
+#if[NullRestricted]
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.NullRestricted;
+
+#end[NullRestricted]
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,13 +57,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
-    static final $type$ static_final_v = $value1$;
+    static final {#if[NullRestricted]?@NullRestricted }$type$ static_final_v = $value1$;
 
-    static $type$ static_v = $value1$;
+    static {#if[NullRestricted]?@NullRestricted }$type$ static_v = $value1$;
 
-    final $type$ final_v = $value1$;
+    final {#if[NullRestricted]?@NullRestricted }$type$ final_v;
 
-    $type$ v = $value1$;
+    {#if[NullRestricted]?@NullRestricted }$type$ v;
 
     VarHandle vhFinalField;
 
@@ -68,6 +74,12 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
+
+    public VarHandleTestMethodType$Type$() {
+        final_v = $value1$;
+        v = $value1$;
+        super();
+    }
 
     @BeforeAll
     public void setup() throws Exception {
@@ -2026,7 +2038,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
 
 
     static void testArrayWrongMethodType(VarHandle vh) throws Throwable {
-        $type$[] array = new $type$[10];
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
         Arrays.fill(array, $value1$);
 
         // Get
@@ -3006,7 +3018,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
     }
 
     static void testArrayWrongMethodType(Handles hs) throws Throwable {
-        $type$[] array = new $type$[10];
+        $type$[] array = {#if[NullRestricted]?($type$[]) ValueClass.newNullRestrictedAtomicArray($type$.class, 10, $value1$):new $type$[10]};
         Arrays.fill(array, $value1$);
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {

--- a/test/jdk/java/lang/invoke/VarHandles/generate-vh-tests.sh
+++ b/test/jdk/java/lang/invoke/VarHandles/generate-vh-tests.sh
@@ -9,7 +9,7 @@ SPP=build.tools.spp.Spp
 # desirable to generate code using ASM which will allow more flexibility
 # in the kinds of tests that are generated.
 
-for type in boolean byte short char int long float double String Value
+for type in boolean byte short char int long float double String Value NullRestrictedValue
 do
   Type="$(tr '[:lower:]' '[:upper:]' <<< ${type:0:1})${type:1}"
   args="-K$type -Dtype=$type -DType=$Type"
@@ -36,6 +36,9 @@ do
       ;;
     Value)
       args="$args -KObject -KValue"
+      ;;
+    NullRestrictedValue)
+      args="$args -KObject -KValue -KNullRestricted"
       ;;
   esac
 
@@ -93,6 +96,10 @@ do
       value2="Value.getInstance(20)"
       value3="Value.getInstance(30)"
       ;;
+    NullRestrictedValue)
+      value1="NullRestrictedValue.of((byte)20,(short)1854)"
+      value2="NullRestrictedValue.of((byte)-42,(short)1854)"
+      value3="NullRestrictedValue.of((byte)20,(short)-31083)"
   esac
 
   args="$args -Dvalue1=$value1 -Dvalue2=$value2 -Dvalue3=$value3 -Dwrong_primitive_type=$wrong_primitive_type"


### PR DESCRIPTION
The static field VarHandle is missing null checks that blocks incoming nulls.

The fix is simple; the overwhelming changes come from these areas:
1. To introduce a null-restricted set of fields and values, we need to use early initialization and null-restricted array creation for our test templates.
2. Added `test(InstanceField|StaticField|Array)NullPointerException` to `VarHandleTest(MethodHandle|)AccessNullRestrictedValue` for the effective unit tests. Without the patch, the `testStaticFieldNullPointerException` fails.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388448](https://bugs.openjdk.org/browse/JDK-8388448): VarHandle can set @<!---->NullRestricted static field to null (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32115/head:pull/32115` \
`$ git checkout pull/32115`

Update a local copy of the PR: \
`$ git checkout pull/32115` \
`$ git pull https://git.openjdk.org/jdk.git pull/32115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32115`

View PR using the GUI difftool: \
`$ git pr show -t 32115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32115.diff">https://git.openjdk.org/jdk/pull/32115.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32115#issuecomment-5139183647)
</details>
