### PR TITLE
8385593: Clarify the wording of UnsupportedClassVersionError

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -159,6 +159,8 @@
 
 #define JAVA_28_VERSION                   72
 
+#define JDK_VERSION                       (7 + (JVM_CLASSFILE_MAJOR_VERSION - JAVA_7_VERSION))
+
 void ClassFileParser::set_class_bad_constant_seen(short bad_constant) {
   assert((bad_constant == JVM_CONSTANT_Module ||
           bad_constant == JVM_CONSTANT_Package) && _major_version >= JAVA_9_VERSION,
@@ -4576,9 +4578,10 @@ void ClassFileParser::verify_class_version(u2 major, u2 minor, Symbol* class_nam
     Exceptions::fthrow(
       THREAD_AND_LOCATION,
       vmSymbols::java_lang_UnsupportedClassVersionError(),
-      "%s has been compiled by a more recent version of the Java Runtime (class file version %u.%u), "
-      "this version of the Java Runtime only recognizes class file versions up to %u.0",
-      class_name->as_C_string(), major, minor, JVM_CLASSFILE_MAJOR_VERSION);
+      "%s requires a newer Java runtime. The runtime in use, Java %u, supports class file versions up "
+      "to %u.0, but the class file version of %s is %u.%u.",
+      class_name->as_C_string(), JDK_VERSION, JVM_CLASSFILE_MAJOR_VERSION,
+      class_name->as_C_string(), major, minor);
     return;
   }
 

--- a/test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java
@@ -89,6 +89,21 @@ public class PreviewVersion {
             }
         }
 
+        // Add 1 to class's major version.  The class should fail to load
+        // because it's major version is too new for this VM.
+        int next_major_version = prev_major_version + 2;
+        klassbuf[6] = (byte)((next_major_version >> 8) & 0xff);
+        klassbuf[7] = (byte)(next_major_version & 0xff);
+        try {
+            ByteCodeLoader.load("PVTest", klassbuf);
+            throw new RuntimeException("UnsupportedClassVersionError exception not thrown");
+        } catch (java.lang.UnsupportedClassVersionError e) {
+            if (!e.getMessage().contains("requires a newer Java runtime")) {
+              throw new RuntimeException(
+                  "Wrong UnsupportedClassVersionError exception: " + e.getMessage());
+            }
+        }
+
         // Set class's major version to 45.  The class should load because class
         // version 45.65535 is valid.
         klassbuf[6] = 0;

--- a/test/hotspot/jtreg/runtime/ClassFile/UnsupportedClassFileVersion.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/UnsupportedClassFileVersion.java
@@ -43,8 +43,9 @@ public class UnsupportedClassFileVersion implements Opcodes {
         writeClassFile();
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-cp", ".",  "ClassFile");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldMatch("ClassFile requires a newer Java runtime. The runtime in use, Java .*, " +
-                           "supports class file versions up to " + System.getProperty("java.class.version") +
+        output.shouldMatch("ClassFile requires a newer Java runtime. The runtime in use, Java " +
+                           Runtime.getRuntime().version().feature() + ", supports class file versions up to " +
+                           System.getProperty("java.class.version") +
                            ", but the class file version of ClassFile is 99.0");
 
         output.shouldHaveExitValue(1);

--- a/test/hotspot/jtreg/runtime/ClassFile/UnsupportedClassFileVersion.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/UnsupportedClassFileVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,10 +43,9 @@ public class UnsupportedClassFileVersion implements Opcodes {
         writeClassFile();
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-cp", ".",  "ClassFile");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldContain("ClassFile has been compiled by a more recent version of the " +
-                            "Java Runtime (class file version 99.0), this version of " +
-                            "the Java Runtime only recognizes class file versions up to " +
-                            System.getProperty("java.class.version"));
+        output.shouldMatch("ClassFile requires a newer Java runtime. The runtime in use, Java .*, " +
+                           "supports class file versions up to " + System.getProperty("java.class.version") +
+                           ", but the class file version of ClassFile is 99.0");
 
         output.shouldHaveExitValue(1);
     }

--- a/test/jdk/java/lang/System/Versions.java
+++ b/test/jdk/java/lang/System/Versions.java
@@ -60,6 +60,7 @@ public class Versions {
         try {
             Class.forName(className, false, cl);
         } catch (UnsupportedClassVersionError e) {
+            System.out.println(e);
             supported = false;
         } catch (Throwable t) {
             // We expect an Exception indicating invalid class file

--- a/test/jdk/java/lang/System/Versions.java
+++ b/test/jdk/java/lang/System/Versions.java
@@ -60,7 +60,6 @@ public class Versions {
         try {
             Class.forName(className, false, cl);
         } catch (UnsupportedClassVersionError e) {
-            System.out.println(e);
             supported = false;
         } catch (Throwable t) {
             // We expect an Exception indicating invalid class file


### PR DESCRIPTION
Please review this simple change to give a more informative error message for `UnsupportedClassVersionError` when trying to load a recent classfile on an older VM. The wording used has already been finalized - see JBS.

Testing:

- Updated test runtime/ClassFile/UnsupportedClassFileVersion.java. 
- Added a new test case to `test/hotspot/jtreg/runtime/ClassFile/PreviewVersion.java` to show preview classfiles are also handled as expected

Tier 1 sanity testing.

Thanks

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385593](https://bugs.openjdk.org/browse/JDK-8385593): Clarify the wording of UnsupportedClassVersionError (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [8689091a](https://git.openjdk.org/jdk/pull/32117/files/8689091aba966fbaab1264ffc58c60f2fa102309)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32117/head:pull/32117` \
`$ git checkout pull/32117`

Update a local copy of the PR: \
`$ git checkout pull/32117` \
`$ git pull https://git.openjdk.org/jdk.git pull/32117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32117`

View PR using the GUI difftool: \
`$ git pr show -t 32117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32117.diff">https://git.openjdk.org/jdk/pull/32117.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32117#issuecomment-5139318634)
</details>
