### PR TITLE
8388713: CodeCache initialization asserts when rounding up boundary values for CodeHeap flags

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -286,12 +286,6 @@ void CodeCache::initialize_heaps() {
     set_size_of_unset_code_heap(&non_nmethod, cache_size, profiled.size + non_profiled.size + hot.size, non_nmethod_min_size);
   }
 
-  /*if(!can_align_up(non_nmethod.size, min_size)  ||
-     !can_align_up(profiled.size, min_size)     ||
-     !can_align_up(non_profiled.size, min_size) ||
-     !can_align_up(hot.size, min_size)) {
-    vm_exit_during_initialization("Code cache size exceeds platform limit");
-  }*/
   // Note: if large page support is enabled, min_size is at least the large
   // page size. This ensures that the code cache is covered by large pages.
   non_nmethod.size = align_up(non_nmethod.size, min_size);
@@ -1243,9 +1237,6 @@ void CodeCache::initialize() {
   // This was originally just a check of the alignment, causing failure, instead, round
   // the code cache to the page size.  In particular, Solaris is moving to a larger
   // default page size.
-  /*if(!can_align_up(CodeCacheExpansionSize, os::vm_page_size())) {
-    vm_exit_during_initialization("Code cache size exceeds platform limit");
-  }*/
   CodeCacheExpansionSize = align_up(CodeCacheExpansionSize, os::vm_page_size());
 
   if (SegmentedCodeCache) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -286,6 +286,12 @@ void CodeCache::initialize_heaps() {
     set_size_of_unset_code_heap(&non_nmethod, cache_size, profiled.size + non_profiled.size + hot.size, non_nmethod_min_size);
   }
 
+  if(!can_align_up(non_nmethod.size, min_size)  ||
+     !can_align_up(profiled.size, min_size)     ||
+     !can_align_up(non_profiled.size, min_size) ||
+     !can_align_up(hot.size, min_size)) {
+    vm_exit_during_initialization("Code cache size exceeds platform limit");
+  }
   // Note: if large page support is enabled, min_size is at least the large
   // page size. This ensures that the code cache is covered by large pages.
   non_nmethod.size = align_up(non_nmethod.size, min_size);
@@ -1237,6 +1243,9 @@ void CodeCache::initialize() {
   // This was originally just a check of the alignment, causing failure, instead, round
   // the code cache to the page size.  In particular, Solaris is moving to a larger
   // default page size.
+  if(!can_align_up(CodeCacheExpansionSize, os::vm_page_size())) {
+    vm_exit_during_initialization("Code cache size exceeds platform limit");
+  }
   CodeCacheExpansionSize = align_up(CodeCacheExpansionSize, os::vm_page_size());
 
   if (SegmentedCodeCache) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -286,12 +286,12 @@ void CodeCache::initialize_heaps() {
     set_size_of_unset_code_heap(&non_nmethod, cache_size, profiled.size + non_profiled.size + hot.size, non_nmethod_min_size);
   }
 
-  if(!can_align_up(non_nmethod.size, min_size)  ||
+  /*if(!can_align_up(non_nmethod.size, min_size)  ||
      !can_align_up(profiled.size, min_size)     ||
      !can_align_up(non_profiled.size, min_size) ||
      !can_align_up(hot.size, min_size)) {
     vm_exit_during_initialization("Code cache size exceeds platform limit");
-  }
+  }*/
   // Note: if large page support is enabled, min_size is at least the large
   // page size. This ensures that the code cache is covered by large pages.
   non_nmethod.size = align_up(non_nmethod.size, min_size);
@@ -1243,9 +1243,9 @@ void CodeCache::initialize() {
   // This was originally just a check of the alignment, causing failure, instead, round
   // the code cache to the page size.  In particular, Solaris is moving to a larger
   // default page size.
-  if(!can_align_up(CodeCacheExpansionSize, os::vm_page_size())) {
+  /*if(!can_align_up(CodeCacheExpansionSize, os::vm_page_size())) {
     vm_exit_during_initialization("Code cache size exceeds platform limit");
-  }
+  }*/
   CodeCacheExpansionSize = align_up(CodeCacheExpansionSize, os::vm_page_size());
 
   if (SegmentedCodeCache) {

--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -382,10 +382,10 @@ void JVMFlagAccess::print_range(outputStream* st, const JVMFlag* flag) {
       // Two special cases where the lower limit of the range is defined by an os:: function call
       // and cannot be initialized at compile time with constexpr.
       if (func == (void*)VMPageSizeConstraintFunc) {
-        uintx min = (uintx)os::vm_page_size();
-        uintx max = max_uintx;
+        size_t min = os::vm_page_size();
+        size_t max = align_down(SIZE_MAX, min);
 
-        JVMTypedFlagLimit<uintx> tmp(0, min, max);
+        JVMTypedFlagLimit<size_t> tmp(0, min, max);
         access_impl(flag)->print_range(st, &tmp);
       } else if (func == (void*)NUMAInterleaveGranularityConstraintFunc) {
         size_t min = os::vm_allocation_granularity();

--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -379,11 +379,17 @@ void JVMFlagAccess::print_range(outputStream* st, const JVMFlag* flag) {
     if (limit != nullptr) {
       void* func = limit->constraint_func();
 
-      // Two special cases where the lower limit of the range is defined by an os:: function call
+      // Special cases where range limits are defined by an os:: function calls
       // and cannot be initialized at compile time with constexpr.
-      if (func == (void*)VMPageSizeConstraintFunc) {
+      if (func == (void*)VMPageSizeConstraintFunc || func == (void*)CodeHeapSizeConstraintFunc) {
         size_t min = os::vm_page_size();
-        size_t max = align_down(SIZE_MAX, min);
+        size_t max = align_down(CODE_CACHE_SIZE_LIMIT, min);
+
+        JVMTypedFlagLimit<size_t> tmp(0, min, max);
+        access_impl(flag)->print_range(st, &tmp);
+      } else if (func == (void*)CodeCacheExpansionSizeConstraintFunc) {
+        size_t min = 32*K;
+        size_t max = align_down(SIZE_MAX, os::vm_page_size());
 
         JVMTypedFlagLimit<size_t> tmp(0, min, max);
         access_impl(flag)->print_range(st, &tmp);

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -110,7 +110,7 @@ JVMFlag::Error ContendedPaddingWidthConstraintFunc(int value, bool verbose) {
 
 JVMFlag::Error VMPageSizeConstraintFunc(size_t value, bool verbose) {
   size_t min = os::vm_page_size();
-  size_t max = align_down(SIZE_MAX, min);
+  size_t max = align_down(CODE_CACHE_SIZE_LIMIT, min);
   if (value < min || value > max) {
     JVMFlag::printError(verbose,
                         "%s %s=%zu is outside the allowed range [ %zu"
@@ -124,15 +124,15 @@ JVMFlag::Error VMPageSizeConstraintFunc(size_t value, bool verbose) {
   return JVMFlag::SUCCESS;
 }
 
-//For code heap size flags where 0 means heap disabled.
-//Non-zero values must be page aligned and must not overflow
-//when rounded up to a page boundary.
+// For code heap size flags where 0 means heap disabled, set internally by
+// FLAG_SET_ERGO. Non-zero values must be page aligned and must not exceed
+// the platform code cache limit.
 JVMFlag::Error CodeHeapSizeConstraintFunc(size_t value, bool verbose) {
   if (value == 0) {
     return JVMFlag::SUCCESS;
   }
   size_t min = os::vm_page_size();
-  size_t max = align_down(SIZE_MAX, min);
+  size_t max = align_down(CODE_CACHE_SIZE_LIMIT, min);
   if (value < min || value > max) {
     JVMFlag::printError(verbose,
                         "%s %s=%zu is outside the allowed range [ %zu"
@@ -140,6 +140,24 @@ JVMFlag::Error CodeHeapSizeConstraintFunc(size_t value, bool verbose) {
                         JVMFlagLimit::last_checked_flag()->type_string(),
                         JVMFlagLimit::last_checked_flag()->name(),
                         value, min, max);
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+
+  return JVMFlag::SUCCESS;
+}
+
+// CodeCacheExpansionSize is an expansion increment, not a heap capacity.
+// It must not overflow when rounded up to page boundary.
+JVMFlag::Error CodeCacheExpansionSizeConstraintFunc(size_t value, bool verbose) {
+  size_t min = 32*K;
+  size_t max = align_down(SIZE_MAX, os::vm_page_size());
+  if (value < min || value > max) {
+    JVMFlag::printError(verbose,
+                       "%s %s=%zu is outside the allowed range [ %zu"
+                       " ... %zu ]\n",
+                       JVMFlagLimit::last_checked_flag()->type_string(),
+                       JVMFlagLimit::last_checked_flag()->name(),
+                       value, min, max);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
 

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -110,13 +110,36 @@ JVMFlag::Error ContendedPaddingWidthConstraintFunc(int value, bool verbose) {
 
 JVMFlag::Error VMPageSizeConstraintFunc(size_t value, bool verbose) {
   size_t min = os::vm_page_size();
-  if (value < min) {
+  size_t max = align_down(SIZE_MAX, min);
+  if (value < min || value > max) {
     JVMFlag::printError(verbose,
                         "%s %s=%zu is outside the allowed range [ %zu"
                         " ... %zu ]\n",
                         JVMFlagLimit::last_checked_flag()->type_string(),
                         JVMFlagLimit::last_checked_flag()->name(),
-                        value, min, max_uintx);
+                        value, min, max);
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+
+  return JVMFlag::SUCCESS;
+}
+
+//For code heap size flags where 0 means heap disabled.
+//Non-zero values must be page aligned and must not overflow
+//when rounded up to a page boundary.
+JVMFlag::Error CodeHeapSizeConstraintFunc(size_t value, bool verbose) {
+  if (value == 0) {
+    return JVMFlag::SUCCESS;
+  }
+  size_t min = os::vm_page_size();
+  size_t max = align_down(SIZE_MAX, min);
+  if (value < min || value > max) {
+    JVMFlag::printError(verbose,
+                        "%s %s=%zu is outside the allowed range [ %zu"
+                        " ... %zu ]\n",
+                        JVMFlagLimit::last_checked_flag()->type_string(),
+                        JVMFlagLimit::last_checked_flag()->name(),
+                        value, min, max);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
 

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
@@ -41,6 +41,7 @@
   f(int,    ObjectAlignmentInBytesConstraintFunc)     \
   f(int,    ContendedPaddingWidthConstraintFunc)      \
   f(size_t, VMPageSizeConstraintFunc)                 \
+  f(size_t, CodeHeapSizeConstraintFunc)               \
   f(size_t, NUMAInterleaveGranularityConstraintFunc)  \
   f(size_t, LargePageSizeInBytesConstraintFunc)       \
   f(ccstr,  OnSpinWaitInstNameConstraintFunc)

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
@@ -42,6 +42,7 @@
   f(int,    ContendedPaddingWidthConstraintFunc)      \
   f(size_t, VMPageSizeConstraintFunc)                 \
   f(size_t, CodeHeapSizeConstraintFunc)               \
+  f(size_t, CodeCacheExpansionSizeConstraintFunc)     \
   f(size_t, NUMAInterleaveGranularityConstraintFunc)  \
   f(size_t, LargePageSizeInBytesConstraintFunc)       \
   f(ccstr,  OnSpinWaitInstNameConstraintFunc)

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1512,11 +1512,11 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product_pd(size_t, NonProfiledCodeHeapSize,                               \
           "Size of code heap with non-profiled methods (in bytes)")         \
-          range(0, SIZE_MAX)                                                \
+          constraint(CodeHeapSizeConstraintFunc, AtParse)                   \
                                                                             \
   product_pd(size_t, ProfiledCodeHeapSize,                                  \
           "Size of code heap with profiled methods (in bytes)")             \
-          range(0, SIZE_MAX)                                                \
+          constraint(CodeHeapSizeConstraintFunc, AtParse)                   \
                                                                             \
   product_pd(size_t, NonNMethodCodeHeapSize,                                \
           "Size of code heap with non-nmethods (in bytes)")                 \
@@ -1529,6 +1529,7 @@ const int ObjectAlignmentInBytes = 8;
   product_pd(size_t, CodeCacheExpansionSize,                                \
           "Code cache expansion size (in bytes)")                           \
           range(32*K, SIZE_MAX)                                             \
+          constraint(VMPageSizeConstraintFunc, AtParse)                     \
                                                                             \
   product_pd(size_t, CodeCacheMinBlockLength, DIAGNOSTIC,                   \
           "Minimum number of segments in a code cache block")               \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1524,12 +1524,11 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(size_t, HotCodeHeapSize, 0, EXPERIMENTAL,                         \
           "Size of code heap with predicted hot methods (in bytes)")        \
-          range(0, SIZE_MAX)                                                \
+          constraint(CodeHeapSizeConstraintFunc, AtParse)                   \
                                                                             \
   product_pd(size_t, CodeCacheExpansionSize,                                \
           "Code cache expansion size (in bytes)")                           \
-          range(32*K, SIZE_MAX)                                             \
-          constraint(VMPageSizeConstraintFunc, AtParse)                     \
+          constraint(CodeCacheExpansionSizeConstraintFunc, AtParse)         \
                                                                             \
   product_pd(size_t, CodeCacheMinBlockLength, DIAGNOSTIC,                   \
           "Minimum number of segments in a code cache block")               \

--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -82,6 +82,12 @@ public class CheckSegmentedCodeCache {
         out.shouldHaveExitValue(1);
     }
 
+    private static void failsWithPattern(ProcessBuilder pb, String message) throws Exception {
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldMatch(message);
+        out.shouldHaveExitValue(1);
+    }
+
     private static void verifyCodeHeapSize(ProcessBuilder pb, String heapName, long heapSize) throws Exception {
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
         out.shouldHaveExitValue(0);
@@ -253,6 +259,6 @@ public class CheckSegmentedCodeCache {
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+SegmentedCodeCache",
                                                               "-XX:NonNMethodCodeHeapSize=3G",
                                                               "-version");
-        failsWith(pb, "Code cache size exceeds platform limit");
+        failsWithPattern(pb, ".*NonNMethodCodeHeapSize=\\d+ is outside the allowed range.*");
     }
 }

--- a/test/hotspot/jtreg/compiler/codecache/CheckUpperLimit.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckUpperLimit.java
@@ -43,7 +43,7 @@ public class CheckUpperLimit {
 
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:ReservedCodeCacheSize=2049m", "-version");
         out = new OutputAnalyzer(pb.start());
-        out.shouldContain("Invalid ReservedCodeCacheSize=");
+        out.shouldMatch(".*ReservedCodeCacheSize=\\d+ is outside the allowed range.*");
         out.shouldHaveExitValue(1);
     }
 }


### PR DESCRIPTION
Validate code heap size flags using flag constraints to prevent assertion crash. Allows graceful exit with proper error message.

Affected flags: ProfiledCodeHeapSize, NonProfiledCodeHeapSize, NonNMethodCodeHeapSize, HotCodeHeapSize CodeCacheExpansionSize.

Before this fix, passing an extremely large value (e.g. SIZE_MAX) caused a JVM crash with assert(can_align_up(size, alignment)) failed: precondition.

After this fix, the same input is rejected at flag parse time before any initialization runs, and the JVM exits gracefully with descriptive error message:
> size_t ProfiledCodeHeapSize=18446744073709551615 is outside the allowed range [ 65536 ... 2147483648 ]
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

The allowed range for the code heap size flags (ProfiledCodeHeapSize, NonProfiledCodeHeapSize, HotCodeHeapSize) is [ os::vm_page_size() ... align_down(CODE_CACHE_SIZE_LIMIT, page_size) ] i.e no single segment can exceed the total cache limit. A value of 0 is also accepted as it is set internally by FLAG_SET_ERGO when the heap is disabled (e.g. when SegmentedCodeCache is off or tiered compilation is disabled), not as a meaningful user input.

For NonNMethodCodeHeapSize, the same range [ os::vm_page_size() ... align_down(CODE_CACHE_SIZE_LIMIT, page_size) ] applies via the existing VMPageSizeConstraintFunc, now updated with the upper bound. 0 is not valid here as this heap is always present.

For CodeCacheExpansionSize, the allowed range is [ 32K ... align_down(SIZE_MAX, page_size) ]. It is an expansion increment, not a heap capacity, so CODE_CACHE_SIZE_LIMIT is not a meaningful upper bound; only the overflow guard applies.

JBS Issue: [JDK-8388713](https://bugs.openjdk.org/browse/JDK-8388713)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388713](https://bugs.openjdk.org/browse/JDK-8388713): CodeCache initialization asserts when rounding up boundary values for CodeHeap flags (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32118/head:pull/32118` \
`$ git checkout pull/32118`

Update a local copy of the PR: \
`$ git checkout pull/32118` \
`$ git pull https://git.openjdk.org/jdk.git pull/32118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32118`

View PR using the GUI difftool: \
`$ git pr show -t 32118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32118.diff">https://git.openjdk.org/jdk/pull/32118.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32118#issuecomment-5187889751)
</details>
