### PR TITLE
8389088: [lworld] C2: assert(false) failed: empty program detected during loop optimization

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -3115,6 +3115,7 @@ private:
     _clones.map(phi->_idx, vt);
     Node_List casts;
     for (uint i = 1; i < phi->req(); ++i) {
+      assert(casts.size() == 0, "must be cleared");
       Node* n = phi->in(i);
       if (n == nullptr) {
         continue;
@@ -3142,6 +3143,10 @@ private:
         n->as_InlineType()->set_oop(*_phase, _phase->transform(cast));
         n = _phase->transform(n);
         if (n->is_top()) {
+          if (casts.size() > 0) {
+            // We could be skipping some unprocessed casts that are also dead. Clear the list for the next phi input.
+            casts.clear();
+          }
           break;
         }
       }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushInlineTypeDownDeadBranch.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestPushInlineTypeDownDeadBranch.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389088
+ * @summary Test that PushInlineTypeDown correctly handles dying branches in do_transform().
+ * @library /test/lib
+ * @enablePreview
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:+DeoptimizeALot -XX:+AlwaysIncrementalInline -XX:CompileOnly=${test.main.class}::test
+ *                   ${test.main.class}
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -Xcomp -XX:+StressIGVN -XX:+AlwaysIncrementalInline -XX:CompileOnly=${test.main.class}::test
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.test.lib.Asserts;
+
+public class TestPushInlineTypeDownDeadBranch {
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            Asserts.assertEQ(test(), null);
+        }
+    }
+
+    static V test() {
+        //                                                                                         null
+        //                                                                                           |
+        //                                                                                           v
+        // Before Incremental Inlining: CallStaticJava   -> OpaqueParse -> CastPP -> CheckCastPP -> Phi -> InlineType -> Return
+        // After  Incremental Inlining: InlineType(null) -> OpaqueParse -> CastPP -> CheckCastPP -> Phi -> InlineType -> Return
+        // During IGVN:                 InlineType(null)                -> CastPP -> CheckCastPP -> Phi -> InlineType -> Return
+        //                              InlineType(null)                -> CastPP -> CheckCastPP -> Phi -> InlineType -> Return
+        //                              InlineType(null)                                                -> InlineType -> Return
+        // Before Patch:                InlineType(TOP /* wrong! */)                                    -> InlineType -> Return
+        //                              <empty>
+        // After Patch:                 InlineType(null)                                                -> InlineType -> Return
+        Object obj = foo(null);
+        return (V)obj;
+    }
+
+    static Object foo(Object obj) {
+        return (V)obj;
+    }
+
+    static value class V {
+        int i = 34;
+    }
+}


### PR DESCRIPTION
Was already reviewed by @marc-chevalier and @TobiHartmann here:
https://github.com/openjdk/valhalla/pull/2678

Rebased cleanly to mainline after the Valhalla integration:
https://github.com/openjdk/jdk/commit/cc278dbb8a1ca0754d5842708b9029441055d361

Testing: 
t1-6 + valhalla-comp-stress, with and without `--enable-preview`

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389088](https://bugs.openjdk.org/browse/JDK-8389088): [lworld] C2: assert(false) failed: empty program detected during loop optimization (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32122/head:pull/32122` \
`$ git checkout pull/32122`

Update a local copy of the PR: \
`$ git checkout pull/32122` \
`$ git pull https://git.openjdk.org/jdk.git pull/32122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32122`

View PR using the GUI difftool: \
`$ git pr show -t 32122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32122.diff">https://git.openjdk.org/jdk/pull/32122.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32122#issuecomment-5142925147)
</details>
