### PR TITLE
8388192: [lworld] Some code is not guarded by Arguments::is_valhalla_enabled()

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7911,8 +7911,10 @@ void MacroAssembler::fast_lock(Register basic_lock, Register obj, Register t1, R
   // Try to lock. Transition lock bits 0b01 => 0b00
   assert(oopDesc::mark_offset_in_bytes() == 0, "required to avoid lea");
   orr(mark, mark, markWord::unlocked_value);
-  // Mask inline_type bit such that we go to the slow path if object is an inline type
-  andr(mark, mark, ~((int) markWord::inline_type_bit_in_place));
+  if (Arguments::is_valhalla_enabled()) {
+    // Mask inline_type bit such that we go to the slow path if object is an inline type
+    andr(mark, mark, ~((int) markWord::inline_type_bit_in_place));
+  }
 
   eor(t, mark, markWord::unlocked_value);
   cmpxchg(/*addr*/ obj, /*expected*/ mark, /*new*/ t, Assembler::xword, memory_order_acquire);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2623,11 +2623,13 @@ class StubGenerator: public StubCodeGenerator {
     __ eor(rscratch2, rscratch2, scratch_src_klass);
     __ cbnz(rscratch2, L_failed);
 
-    // Check for flat inline type array -> return -1
-    __ test_flat_array_oop(src, rscratch2, L_failed);
+    if (Arguments::is_valhalla_enabled()) {
+      // Check for flat inline type array -> return -1
+      __ test_flat_array_oop(src, rscratch2, L_failed);
 
-    // Check for null-free (non-flat) inline type array -> handle as object array
-    __ test_null_free_array_oop(src, rscratch2, L_objArray);
+      // Check for null-free (non-flat) inline type array -> handle as object array
+      __ test_null_free_array_oop(src, rscratch2, L_objArray);
+    }
 
     //  if (!src->is_Array()) return -1;
     __ tbz(lh, 31, L_failed);  // i.e. (lh >= 0)

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -7064,8 +7064,11 @@ void MacroAssembler::fast_lock(Register basic_lock, Register obj, Register tmp1,
   // Try to lock. Transition lock-bits 0b01 => 0b00
   assert(oopDesc::mark_offset_in_bytes() == 0, "required to avoid a la");
   ori(mark, mark, markWord::unlocked_value);
-  // Mask inline_type bit such that we go to the slow path if object is an inline type
-  andi(mark, mark, ~((int) markWord::inline_type_bit_in_place));
+  if (Arguments::is_valhalla_enabled()) {
+    // Mask inline_type bit such that we go to the slow path if object is an inline type
+    andi(mark, mark, ~((int) markWord::inline_type_bit_in_place));
+  }
+
   xori(t, mark, markWord::unlocked_value);
   cmpxchg(/*addr*/ obj, /*expected*/ mark, /*new*/ t, Assembler::int64,
           /*acquire*/ Assembler::aq, /*release*/ Assembler::relaxed, /*result*/ t);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1925,15 +1925,16 @@ class StubGenerator: public StubCodeGenerator {
     __ load_klass(t1, dst);
     __ bne(t1, scratch_src_klass, L_failed);
 
-    // Check for flat inline type array -> return -1
-    __ test_flat_array_oop(src, t1, L_failed);
+    if (Arguments::is_valhalla_enabled()) {
+      // Check for flat inline type array -> return -1
+      __ test_flat_array_oop(src, t1, L_failed);
 
-    // Check for null-free (non-flat) inline type array -> handle as object array
-    __ test_null_free_array_oop(src, t1, L_objArray);
+      // Check for null-free (non-flat) inline type array -> handle as object array
+      __ test_null_free_array_oop(src, t1, L_objArray);
+    }
 
-    // if src->is_Array() isn't null then return -1
-    // i.e. (lh >= 0)
-    __ bgez(lh, L_failed);
+    // if (!src->is_Array()) return -1;
+    __ bgez(lh, L_failed);  // i.e. (lh >= 0)
 
     // At this point, it is known to be a typeArray (array_tag 0x3).
 #ifdef ASSERT

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -10617,8 +10617,10 @@ void MacroAssembler::fast_lock(Register basic_lock, Register obj, Register reg_r
   movptr(tmp, reg_rax);
   andptr(tmp, ~(int32_t)markWord::unlocked_value);
   orptr(reg_rax, markWord::unlocked_value);
-  // Mask inline_type bit such that we go to the slow path if object is an inline type
-  andptr(reg_rax, ~((int) markWord::inline_type_bit_in_place));
+  if (Arguments::is_valhalla_enabled()) {
+    // Mask inline_type bit such that we go to the slow path if object is an inline type
+    andptr(reg_rax, ~((int) markWord::inline_type_bit_in_place));
+  }
 
   lock(); cmpxchgptr(tmp, Address(obj, oopDesc::mark_offset_in_bytes()));
   jcc(Assembler::notEqual, slow);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -3599,11 +3599,13 @@ address StubGenerator::generate_generic_copy(address byte_copy_entry, address sh
   __ cmpq(r10_src_klass, rax);
   __ jcc(Assembler::notEqual, L_failed);
 
-  // Check for flat inline type array -> return -1
-  __ test_flat_array_oop(src, rax, L_failed);
+  if (Arguments::is_valhalla_enabled()) {
+    // Check for flat inline type array -> return -1
+    __ test_flat_array_oop(src, rax, L_failed);
 
-  // Check for null-free (non-flat) inline type array -> handle as object array
-  __ test_null_free_array_oop(src, rax, L_objArray);
+    // Check for null-free (non-flat) inline type array -> handle as object array
+    __ test_null_free_array_oop(src, rax, L_objArray);
+  }
 
   const Register rax_lh = rax;  // layout helper
   __ movl(rax_lh, Address(r10_src_klass, lh_offset));

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -26,6 +26,7 @@
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "oops/objArrayKlass.hpp"
+#include "runtime/arguments.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "stubGenerator_x86_64.hpp"

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5227,11 +5227,13 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
     // should be thrown
     generate_negative_guard(length, bailout, &length);
 
-    // Handle inline type arrays
-    // TODO 8251971 This is too strong
-    generate_fair_guard(flat_array_test(load_object_klass(original)), bailout);
-    generate_fair_guard(flat_array_test(refined_klass_node), bailout);
-    generate_fair_guard(null_free_array_test(original), bailout);
+    if (Arguments::is_valhalla_enabled()) {
+      // Handle inline type arrays
+      // TODO 8251971 This is too strong
+      generate_fair_guard(flat_array_test(load_object_klass(original)), bailout);
+      generate_fair_guard(flat_array_test(refined_klass_node), bailout);
+      generate_fair_guard(null_free_array_test(original), bailout);
+    }
 
     // Bail out if start is larger than the original length
     Node* orig_tail = _gvn.transform(new SubINode(orig_length, start));
@@ -6844,32 +6846,34 @@ bool LibraryCallKit::inline_arraycopy() {
       slow_region->add_req(not_subtype_ctrl);
     }
 
-    // TODO 8251971 Improve this. What about atomicity? Make sure this is always folded for type arrays.
-    // If destination is null-restricted, source must be null-restricted as well: src_null_restricted || !dst_null_restricted
-    Node* src_klass = load_object_klass(src);
-    Node* adr_prop_src = basic_plus_adr(top(), src_klass, in_bytes(ArrayKlass::properties_offset()));
-    Node* prop_src = _gvn.transform(LoadNode::make(_gvn, control(), immutable_memory(), adr_prop_src,
-                                                   _gvn.type(adr_prop_src)->is_ptr(), TypeInt::INT, T_INT,
-                                                   MemNode::unordered));
-    Node* adr_prop_dest = basic_plus_adr(top(), refined_dest_klass, in_bytes(ArrayKlass::properties_offset()));
-    Node* prop_dest = _gvn.transform(LoadNode::make(_gvn, control(), immutable_memory(), adr_prop_dest,
-                                                    _gvn.type(adr_prop_dest)->is_ptr(), TypeInt::INT, T_INT,
-                                                    MemNode::unordered));
+    if (Arguments::is_valhalla_enabled()) {
+      // TODO 8251971 Improve this. What about atomicity? Make sure this is always folded for type arrays.
+      // If destination is null-restricted, source must be null-restricted as well: src_null_restricted || !dst_null_restricted
+      Node* src_klass = load_object_klass(src);
+      Node* adr_prop_src = basic_plus_adr(top(), src_klass, in_bytes(ArrayKlass::properties_offset()));
+      Node* prop_src = _gvn.transform(LoadNode::make(_gvn, control(), immutable_memory(), adr_prop_src,
+                                                     _gvn.type(adr_prop_src)->is_ptr(), TypeInt::INT, T_INT,
+                                                     MemNode::unordered));
+      Node* adr_prop_dest = basic_plus_adr(top(), refined_dest_klass, in_bytes(ArrayKlass::properties_offset()));
+      Node* prop_dest = _gvn.transform(LoadNode::make(_gvn, control(), immutable_memory(), adr_prop_dest,
+                                                      _gvn.type(adr_prop_dest)->is_ptr(), TypeInt::INT, T_INT,
+                                                      MemNode::unordered));
 
-    const ArrayProperties props_null_restricted = ArrayProperties::Default().with_null_restricted();
-    jint props_value = (jint)props_null_restricted.value();
+      const ArrayProperties props_null_restricted = ArrayProperties::Default().with_null_restricted();
+      jint props_value = (jint)props_null_restricted.value();
 
-    prop_dest = _gvn.transform(new XorINode(prop_dest, intcon(props_value)));
-    prop_src = _gvn.transform(new OrINode(prop_dest, prop_src));
-    prop_src = _gvn.transform(new AndINode(prop_src, intcon(props_value)));
+      prop_dest = _gvn.transform(new XorINode(prop_dest, intcon(props_value)));
+      prop_src = _gvn.transform(new OrINode(prop_dest, prop_src));
+      prop_src = _gvn.transform(new AndINode(prop_src, intcon(props_value)));
 
-    Node* chk = _gvn.transform(new CmpINode(prop_src, intcon(props_value)));
-    Node* tst = _gvn.transform(new BoolNode(chk, BoolTest::ne));
-    generate_fair_guard(tst, slow_region);
+      Node* chk = _gvn.transform(new CmpINode(prop_src, intcon(props_value)));
+      Node* tst = _gvn.transform(new BoolNode(chk, BoolTest::ne));
+      generate_fair_guard(tst, slow_region);
 
-    // TODO 8251971 This is too strong
-    generate_fair_guard(flat_array_test(src), slow_region);
-    generate_fair_guard(flat_array_test(dest), slow_region);
+      // TODO 8251971 This is too strong
+      generate_fair_guard(flat_array_test(src), slow_region);
+      generate_fair_guard(flat_array_test(dest), slow_region);
+    }
 
     {
       PreserveJVMState pjvms(this);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -64,6 +64,7 @@
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "prims/unsafe.hpp"
+#include "runtime/arguments.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/mountUnmountDisabler.hpp"

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -33,6 +33,7 @@
 #include "opto/macro.hpp"
 #include "opto/runtime.hpp"
 #include "opto/vectornode.hpp"
+#include "runtime/arguments.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/align.hpp"
 #include "utilities/powerOfTwo.hpp"
@@ -1604,7 +1605,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     // TODO 8251971 This is too strong
     // We need to be careful here because 'adjust_for_flat_array' will adjust offsets/length etc. which then does not work anymore for the slow call to SharedRuntime::slow_arraycopy_C.
     assert(top_src->is_flat() == top_dest->is_flat(), "must have bailed out before");
-    if (!flat_and_same_nullness) {
+    if (Arguments::is_valhalla_enabled() && !flat_and_same_nullness) {
       generate_flat_array_guard(&ctrl, src, merge_mem, slow_region);
       generate_flat_array_guard(&ctrl, dest, merge_mem, slow_region);
       generate_null_free_array_guard(&ctrl, dest, merge_mem, slow_region);


### PR DESCRIPTION
This PR replaces the Valhalla draft PR [2640](https://github.com/openjdk/valhalla/pull/2640), which was already reviewed by @chhagedorn but was not integrated due to the code freeze immediately before the Valhalla mainline integration.

---

Some Valhalla specific code misses an `Arguments::is_valhalla_enabled()` check.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388192](https://bugs.openjdk.org/browse/JDK-8388192): [lworld] Some code is not guarded by Arguments::is_valhalla_enabled() (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [b2684aab](https://git.openjdk.org/jdk/pull/32123/files/b2684aab1e397c886e34b16674483a908bec2bee)

### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32123/head:pull/32123` \
`$ git checkout pull/32123`

Update a local copy of the PR: \
`$ git checkout pull/32123` \
`$ git pull https://git.openjdk.org/jdk.git pull/32123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32123`

View PR using the GUI difftool: \
`$ git pr show -t 32123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32123.diff">https://git.openjdk.org/jdk/pull/32123.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32123#issuecomment-5141112597)
</details>
