### PR TITLE
8388317: [lworld] LibraryCallKit::inline_unsafe_flat_access asserts on null literal

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2782,13 +2782,17 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
       value = new_value;
     }
 
-    assert(value_type->inline_klass() == value_klass, "value is of type %s while valueType is %s", value_type->inline_klass()->name()->as_utf8(), value_klass->name()->as_utf8());
+    assert(value_type == TypePtr::NULL_PTR || value_type->inline_klass() == value_klass,
+           "value is of type %s while value klass is %s", value_type->inline_klass()->name()->as_utf8(), value_klass->name()->as_utf8());
     if (layout == LayoutKind::REFERENCE) {
       const TypePtr* ptr_type = (decorators & C2_MISMATCHED) != 0 ? TypeRawPtr::BOTTOM : _gvn.type(ptr)->is_ptr();
       access_store_at(base, ptr, ptr_type, value, value_type, T_OBJECT, decorators);
     } else {
       bool atomic = LayoutKindHelper::is_atomic_flat(layout);
       bool null_free = !LayoutKindHelper::is_nullable_flat(layout);
+      if (null_free) {
+        null_check(value);
+      }
       value->as_InlineType()->store_flat(this, base, ptr, atomic, immutable_memory, null_free, decorators);
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -149,6 +149,7 @@ public class TestIntrinsics {
 
     public TestIntrinsics() {
         test24_vt = MyValue1.createWithFieldsInline(rI, rL);
+        test31_vt = MyValue1.createDefaultInline();
         super();
     }
 
@@ -658,6 +659,7 @@ public class TestIntrinsics {
         Asserts.assertEQ(v.v1, res);
     }
 
+    @NullRestricted
     MyValue1 test31_vt;
     private static final long TEST31_VT_OFFSET;
     private static final boolean TEST31_VT_FLATTENED;
@@ -835,6 +837,54 @@ public class TestIntrinsics {
         test31_vt = MyValue1.createDefaultInline();
         test38(vt);
         Asserts.assertEQ(vt, test31_vt);
+    }
+
+    // Test put intrinsic with null
+    @Test
+    @IR(failOn = {CALL_UNSAFE})
+    public void test39(MyValue1 val) {
+        if (TEST31_VT_FLATTENED) {
+            U.putFlatValue(this, TEST31_VT_OFFSET, TEST31_VT_LAYOUT, MyValue1.class, val);
+        } else {
+            U.putReference(this, TEST31_VT_OFFSET, null);
+        }
+    }
+
+    @Run(test = "test39")
+    public void test39_verifier() {
+        test31_vt = MyValue1.createDefaultInline();
+        try {
+            test39(null);
+            if (TEST31_VT_FLATTENED) {
+                throw new RuntimeException("No NullPointerException thrown");
+            }
+        } catch (NullPointerException npe) {
+            // Expected
+        }
+    }
+
+    // Same as test39 but with a constant null
+    @Test
+    @IR(failOn = {CALL_UNSAFE})
+    public void test39Constant() {
+        if (TEST31_VT_FLATTENED) {
+            U.putFlatValue(this, TEST31_VT_OFFSET, TEST31_VT_LAYOUT, MyValue1.class, null);
+        } else {
+            U.putReference(this, TEST31_VT_OFFSET, null);
+        }
+    }
+
+    @Run(test = "test39Constant")
+    public void test39Constant_verifier() {
+        test31_vt = MyValue1.createDefaultInline();
+        try {
+            test39Constant();
+            if (TEST31_VT_FLATTENED) {
+                throw new RuntimeException("No NullPointerException thrown");
+            }
+        } catch (NullPointerException npe) {
+            // Expected
+        }
     }
 
     // Test value class array creation via reflection


### PR DESCRIPTION
This PR replaces the Valhalla draft PR [2648](https://github.com/openjdk/valhalla/pull/2648), which was already reviewed by @chhagedorn, @fparain, @merykitty but was not integrated due to the code freeze immediately before the Valhalla mainline integration.

---

We hit an assert in `value_type->inline_klass()` in the `Unsafe::putFlatValue` C2 intrinsic when `null` is passed because `TypePtr::NULL_PTR` is not a `TypeInstPtr`. I fixed the assert to account for that.

While writing the test, I noticed that `TEST31_VT_FLATTENED` is always `false` because `test31_vt` is of type `MyValue1` which is way too large to be flat because nullable implies atomic. I think this is a regression from when we migrated from Q-types. I made the field null-free to make sure it can be flattened. I then noticed that we are missing a null-check in the intrinsic and also fixed that.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388317](https://bugs.openjdk.org/browse/JDK-8388317): [lworld] LibraryCallKit::inline_unsafe_flat_access asserts on null literal (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32126/head:pull/32126` \
`$ git checkout pull/32126`

Update a local copy of the PR: \
`$ git checkout pull/32126` \
`$ git pull https://git.openjdk.org/jdk.git pull/32126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32126`

View PR using the GUI difftool: \
`$ git pr show -t 32126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32126.diff">https://git.openjdk.org/jdk/pull/32126.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32126#issuecomment-5141110905)
</details>
