### PR TITLE
8388544: [lworld] Bad dominance assert in C2 when late-inlining through MH calls

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -868,8 +868,8 @@ void CallGenerator::do_late_inline_helper() {
               oop->init_req(2, buffer_oop);
               mem->init_req(2, kit.merged_memory());
 
-              // Update oop input to buffer
-              kit.gvn().hash_delete(vt);
+              // Use cloned InlineTypeNode to propagate oop from now on
+              vt = vt->clone_if_required(&kit.gvn(), kit.map());
               vt->set_oop(kit.gvn(), kit.gvn().transform(oop));
               vt->set_is_buffered(kit.gvn());
               vt = kit.gvn().transform(vt)->as_InlineType();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLateInlineSharedInlineType.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLateInlineSharedInlineType.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8388544
+ * @summary Test late inlining of a method handle that returns a shared value object.
+ * @requires vm.compiler2.enabled
+ * @enablePreview
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline -Xbatch
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::test*
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public value class TestLateInlineSharedInlineType {
+    static final MethodHandle MH1;
+    static final MethodHandle MH2;
+    static volatile Object vSink;
+    static Object sink1;
+    static Object sink2;
+
+    Integer integer = 42;
+
+    public Integer getInteger() {
+        return integer;
+    }
+
+    static {
+        try {
+            MH1 = MethodHandles.lookup().findVirtual(TestLateInlineSharedInlineType.class, "getInteger", MethodType.methodType(Integer.class));
+            MH2 = MH1.asType(MethodType.methodType(Object.class, TestLateInlineSharedInlineType.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    // Below tests all trigger the same bug but with slightly different failure modes:
+    // Field 'integer' is represented by a (shared) InlineTypeNode and buffered on the
+    // first store to sink. Late MH inlining updates that node's oop input in-place to
+    // a newly created, later buffer. InlineTypeNode::Ideal() then removes the first
+    // buffer as redundant re-allocation and rewires an earlier use to the later buffer.
+
+    // We assert with "Bad immediate dominator info." when walking the dominator chain
+    // from early use towards the non-dominating later definition.
+    void test1() throws Throwable {
+        vSink = integer;
+        vSink = (Integer)MH1.invokeExact(this);
+    }
+
+    // We assert with "bad dominance" in loop verification because the definition of the
+    // second buffer does not dominate its use at the first vSink store.
+    void test2() throws Throwable {
+        vSink = integer;
+        vSink = MH2.invokeExact(this);
+    }
+
+    // The invalid dependency remains hidden in a Phi and escapes normal PhaseCFG::verify().
+    // The early sink1 store therefore reads the late buffer's register before it is
+    // defined, leading to an "object not in heap" assert in the GC.
+    void test3() throws Throwable {
+        sink1 = integer;
+        sink2 = MH2.invokeExact(this);
+    }
+
+    public static void main(String[] args) throws Throwable {
+        for (int i = 0; i < 50_000; i++) {
+            TestLateInlineSharedInlineType test = new TestLateInlineSharedInlineType();
+            test.test1();
+            test.test2();
+            test.test3();
+        }
+    }
+}


### PR DESCRIPTION
This PR replaces the Valhalla draft PR [2660](https://github.com/openjdk/valhalla/pull/2660), which was already reviewed by @marc-chevalier and @merykitty but was not integrated due to the code freeze immediately before the Valhalla mainline integration.

---

When late-inlining a method handle call that returns a value object in scalarized form, we need to ..

https://github.com/openjdk/jdk/blob/1c3301cb96d779d06bb6e2391c35ce729bc28189/src/hotspot/share/opto/callGenerator.cpp#L779-L788

We then update the oop input of the returned InlineTypeNode to the newly allocated buffer:
https://github.com/openjdk/jdk/blob/1c3301cb96d779d06bb6e2391c35ce729bc28189/src/hotspot/share/opto/callGenerator.cpp#L873-L874

This is incorrect since the returned InlineTypeNode is shared and can be used further up in the graph. The new test demonstrates where this will lead to a def-after-use dominance violation.

The fix is to clone the InlineTypeNode if required before updating the oop input, similar to what we do already in normal buffering:
https://github.com/openjdk/jdk/blob/1c3301cb96d779d06bb6e2391c35ce729bc28189/src/hotspot/share/opto/inlinetypenode.cpp#L1071-L1073

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388544](https://bugs.openjdk.org/browse/JDK-8388544): [lworld] Bad dominance assert in C2 when late-inlining through MH calls (**Bug** - P3)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32129/head:pull/32129` \
`$ git checkout pull/32129`

Update a local copy of the PR: \
`$ git checkout pull/32129` \
`$ git pull https://git.openjdk.org/jdk.git pull/32129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32129`

View PR using the GUI difftool: \
`$ git pr show -t 32129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32129.diff">https://git.openjdk.org/jdk/pull/32129.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32129#issuecomment-5141113511)
</details>
