### PR TITLE
8388848: [lworld] ConnectionGraph::process_call_arguments does not correctly handle wide arguments

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -2152,19 +2152,28 @@ bool ConnectionGraph::add_final_edges_unsafe_access(Node* n, uint opcode) {
 // }
 // void m(Object o, MyValue v, int i)
 // produces the pairs:
-// (Object, Object), (Myvalue, int), (MyValue, float), (int, int)
+// (Object, Object), (MyValue, int), (MyValue, float), (int, int)
 class DomainIterator : public StackObj {
 private:
-  const TypeTuple* _domain;
-  const TypeTuple* _domain_cc;
-  const GrowableArray<SigEntry>* _sig_cc;
+  const TypeTuple* _domain;               // Domain of the JVM signature
+  const TypeTuple* _domain_cc;            // Domain of the scalarized calling convention
+  const GrowableArray<SigEntry>* _sig_cc; // Entries of the scalarized calling convention
 
-  uint _i_domain;
-  uint _i_domain_cc;
-  int _i_sig_cc;
-  uint _depth;
-  uint _first_field_pos;
-  const bool _is_static;
+  uint _i_domain;        // JVM signature domain index (long/double take two slots)
+  uint _i_domain_cc;     // Scalarized calling convention domain index
+  int _i_arg;            // JVM signature argument index (long/double take one argument)
+  int _i_sig_cc;         // Scalarized calling convention SigEntry index
+  uint _depth;           // Scalarized value nesting depth
+  uint _first_field_pos; // Scalarized calling convention domain index of the first non-hidden value field
+  const bool _is_static; // Whether the target method is static
+
+  void advance_domain() {
+    const BasicType bt = _domain->field_at(_i_domain)->basic_type();
+    _i_domain++;
+    if (bt != T_LONG && bt != T_DOUBLE) {
+      _i_arg++;
+    }
+  }
 
   void next_helper() {
     if (_sig_cc == nullptr) {
@@ -2183,7 +2192,7 @@ private:
       } else if (bt == T_VOID && (prev_bt != T_LONG && prev_bt != T_DOUBLE)) {
         _depth--;
         if (_depth == 0) {
-          _i_domain++;
+          advance_domain();
         }
       } else if (bt == T_OBJECT && prev_bt == T_METADATA && (_is_static || _i_domain > 0) && _sig_cc->at(_i_sig_cc)._offset == 0) {
         assert(_sig_cc->at(_i_sig_cc)._vt_oop, "buffer expected right after T_METADATA");
@@ -2212,6 +2221,7 @@ public:
     _sig_cc(call->method()->get_sig_cc()),
     _i_domain(TypeFunc::Parms),
     _i_domain_cc(TypeFunc::Parms),
+    _i_arg(0),
     _i_sig_cc(0),
     _depth(0),
     _first_field_pos(0),
@@ -2229,7 +2239,7 @@ public:
     assert(_depth != 0 || _domain->field_at(_i_domain) == _domain_cc->field_at(_i_domain_cc), "should produce same non scalarized elements");
     _i_sig_cc++;
     if (_depth == 0) {
-      _i_domain++;
+      advance_domain();
     }
     _i_domain_cc++;
     next_helper();
@@ -2241,6 +2251,10 @@ public:
 
   uint i_domain_cc() const {
     return _i_domain_cc;
+  }
+
+  int i_arg() const {
+    return _i_arg;
   }
 
   const Type* current_domain() const {
@@ -2267,18 +2281,25 @@ bool ConnectionGraph::returns_an_argument(CallNode* call) {
 
   const TypeTuple* d = call->tf()->domain_sig();
   bool ret_arg = false;
+  int arg_num = 0;
   for (uint i = TypeFunc::Parms; i < d->cnt(); i++) {
-    if (d->field_at(i)->isa_ptr() != nullptr &&
+    const Type* t = d->field_at(i);
+    if (t->isa_ptr() != nullptr &&
         call_analyzer->is_arg_returned(i - TypeFunc::Parms)) {
-      if (meth->is_scalarized_arg(i - TypeFunc::Parms) && !compatible_return(call->as_CallJava(), i)) {
+      const bool scalarized_arg = meth->is_scalarized_arg(arg_num);
+      if (scalarized_arg && !compatible_return(call->as_CallJava(), i)) {
         return false;
       }
-      if (call->tf()->returns_inline_type_as_fields() != meth->is_scalarized_arg(i - TypeFunc::Parms)) {
+      if (call->tf()->returns_inline_type_as_fields() != scalarized_arg) {
         return false;
       }
       ret_arg = true;
     }
+    if (t != Type::HALF) {
+      arg_num++;
+    }
   }
+  assert(arg_num == meth->signature()->count() + (meth->is_static() ? 0 : 1), "inconsistent argument count");
   return ret_arg;
 }
 
@@ -2611,18 +2632,19 @@ void ConnectionGraph::process_call_arguments(CallNode *call) {
         PointsToNode* call_ptn = ptnode_adr(call->_idx);
         bool ret_arg = returns_an_argument(call);
         for (DomainIterator di(call->as_CallJava()); di.has_next(); di.next()) {
-          int k = di.i_domain() - TypeFunc::Parms;
+          const int jvms_slot = di.i_domain() - TypeFunc::Parms;
+          const bool scalarized_arg = meth->is_scalarized_arg(di.i_arg());
           const Type* at = di.current_domain_cc();
           Node* arg = call->in(di.i_domain_cc());
           PointsToNode* arg_ptn = ptnode_adr(arg->_idx);
-          assert(!call_analyzer->is_arg_returned(k) || !meth->is_scalarized_arg(k) ||
+          assert(!call_analyzer->is_arg_returned(jvms_slot) || !scalarized_arg ||
                  !compatible_return(call->as_CallJava(), di.i_domain()) ||
                  call->proj_out_or_null(di.i_domain_cc() - di.first_field_pos() + TypeFunc::Parms + 1) == nullptr ||
                  _igvn->type(call->proj_out_or_null(di.i_domain_cc() - di.first_field_pos() + TypeFunc::Parms + 1)) == at,
                  "scalarized return and scalarized argument should match");
-          if (at->isa_ptr() != nullptr && call_analyzer->is_arg_returned(k) && ret_arg) {
+          if (at->isa_ptr() != nullptr && call_analyzer->is_arg_returned(jvms_slot) && ret_arg) {
             // The call returns arguments.
-            if (meth->is_scalarized_arg(k)) {
+            if (scalarized_arg) {
               ProjNode* res_proj = call->proj_out_or_null(di.i_domain_cc() - di.first_field_pos() + TypeFunc::Parms + 1);
               if (res_proj != nullptr) {
                 assert(_igvn->type(res_proj)->isa_ptr(), "scalarized return and scalarized argument should match");
@@ -2643,12 +2665,12 @@ void ConnectionGraph::process_call_arguments(CallNode *call) {
           }
           if (at->isa_oopptr() != nullptr &&
               arg_ptn->escape_state() < PointsToNode::GlobalEscape) {
-            if (!call_analyzer->is_arg_stack(k)) {
+            if (!call_analyzer->is_arg_stack(jvms_slot)) {
               // The argument global escapes
               set_escape_state(arg_ptn, PointsToNode::GlobalEscape NOT_PRODUCT(COMMA trace_arg_escape_message(call)));
             } else {
               set_escape_state(arg_ptn, PointsToNode::ArgEscape NOT_PRODUCT(COMMA trace_arg_escape_message(call)));
-              if (!call_analyzer->is_arg_local(k)) {
+              if (!call_analyzer->is_arg_local(jvms_slot)) {
                 // The argument itself doesn't escape, but any fields might
                 set_fields_escape_state(arg_ptn, PointsToNode::GlobalEscape NOT_PRODUCT(COMMA trace_arg_escape_message(call)));
               }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestEAWideArg.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestEAWideArg.java
@@ -26,7 +26,7 @@
  * @summary Test EA with wide arguments and mixed scalarized calling convention.
  * @enablePreview
  * @library /test/lib /
- * @run main/othervm TestEAWideArg
+ * @run main ${test.main.class}
  * @run main/othervm -Xbatch -XX:-TieredCompilation
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-PreloadClasses
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test*

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestEAWideArg.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestEAWideArg.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test EA with wide arguments and mixed scalarized calling convention.
+ * @enablePreview
+ * @library /test/lib /
+ * @run main/othervm TestEAWideArg
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-PreloadClasses
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   -XX:CompileCommand=dontinline,${test.main.class}*::test*
+ *                   ${test.main.class}
+ */
+
+import jdk.test.lib.Asserts;
+
+public class TestEAWideArg {
+
+    // When the test methods below are linked, 'Unloaded' is still unloaded,
+    // creating a mix of scalarized and non-scalarized value arguments.
+    static value record Unloaded(int value) { }
+
+    static Unloaded testLongCallee(long l, Integer i1, Unloaded unloaded, Integer i2) {
+        return unloaded;
+    }
+
+    static Unloaded testDoubleCallee(double l, Integer i1, Unloaded unloaded, Integer i2) {
+        return unloaded;
+    }
+
+    static Unloaded testLong(int value) {
+        return testLongCallee(value, value, new Unloaded(value), value);
+    }
+
+    static Unloaded testDouble(int value) {
+        return testDoubleCallee(value, value, new Unloaded(value), value);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; i++) {
+            Asserts.assertEquals(testLong(i).value, i);
+            Asserts.assertEquals(testDouble(i).value, i);
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestEAWideArg.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestEAWideArg.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8388848
  * @summary Test EA with wide arguments and mixed scalarized calling convention.
  * @enablePreview
  * @library /test/lib /


### PR DESCRIPTION
This PR replaces the Valhalla draft PR [2664](https://github.com/openjdk/valhalla/pull/2664), which was already reviewed by @merykitty but was not integrated due to the code freeze immediately before the Valhalla mainline integration.

---

As described by [PR 2079](https://github.com/openjdk/valhalla/pull/2079), EA processes non-inlined call arguments using BCEA information to add argument and return edges to the ConnectionGraph based on their escape state. `DomainIterator` maps scalarized `CallNode` arguments back to their corresponding Java signature arguments and return projections.

With mixed scalarized calling conventions, that code associates returned arguments with incorrect return projections and triggers an assertion. The problem is that the code confuses JVMS slot indices with Java signature indices. The JVMS contains an additional `Type::HALF` slot for `long` and `double`, while `Method::is_scalarized_arg()` expects Java signature indices.

The new test disables preloading so that `Unloaded` is still unloaded when the callee methods are linked, while the already-loaded `Integer` arguments are scalarized. In the `(long/double, Integer, Unloaded, Integer)` signature, `Unloaded` is
  signature argument 2 but JVMS slot 3. The old code therefore queried signature argument 3 - the scalarized trailing Integer - and incorrectly treated the buffered `Unloaded` argument as scalarized. The preceding scalarized `Integer` supplied a stale field offset, causing an incompatible return projection and the assertion.

The fix tracks Java signature indices separately. I also tried to add a few comments to explain the purpose of the iterator fields.

@rwestrel Since the original `DomainIterator` code is from [JDK-8377480](https://bugs.openjdk.org/browse/JDK-8377480), could you please take a look?

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388848](https://bugs.openjdk.org/browse/JDK-8388848): [lworld] ConnectionGraph::process_call_arguments does not correctly handle wide arguments (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32131/head:pull/32131` \
`$ git checkout pull/32131`

Update a local copy of the PR: \
`$ git checkout pull/32131` \
`$ git pull https://git.openjdk.org/jdk.git pull/32131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32131`

View PR using the GUI difftool: \
`$ git pr show -t 32131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32131.diff">https://git.openjdk.org/jdk/pull/32131.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32131#issuecomment-5141119141)
</details>
