### PR TITLE
8388851: [lworld] Remove obsolete array store address recomputation

### DIFF
--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -490,7 +490,7 @@ class Parse : public GraphKit {
   void do_one_bytecode();
 
   // helper function to generate array store check
-  Node* array_store_check(Node*& adr, const Type*& elemtype);
+  Node* array_store_check(const Type*& elemtype);
   // Helper function to generate array load
   void array_load(BasicType etype);
   Node* load_from_unknown_flat_array(Node* array, Node* array_index, const TypeOopPtr* element_ptr);

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -204,7 +204,7 @@ void Parse::array_store(BasicType bt) {
 
   Node* stored_value_casted = nullptr;
   if (bt == T_OBJECT) {
-    stored_value_casted = array_store_check(adr, elemtype);
+    stored_value_casted = array_store_check(elemtype);
     if (stopped()) {
       return;
     }

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -140,10 +140,9 @@ void Parse::do_instanceof() {
 
 //------------------------------array_store_check------------------------------
 // pull array from stack and check that the store is valid
-Node* Parse::array_store_check(Node*& adr, const Type*& elemtype) {
+Node* Parse::array_store_check(const Type*& elemtype) {
   // Shorthand access to array store elements without popping them.
   Node *obj = peek(0);
-  Node *idx = peek(1);
   Node *ary = peek(2);
 
   if (_gvn.type(obj) == TypePtr::NULL_PTR) {
@@ -233,11 +232,7 @@ Node* Parse::array_store_check(Node*& adr, const Type*& elemtype) {
         Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, extak->as_exact_instance_type()));
         replace_in_map(ary, cast);
         ary = cast;
-
-        // Recompute element type and address
-        const TypeAryPtr* arytype = _gvn.type(ary)->is_aryptr();
-        elemtype = arytype->elem();
-        adr = array_element_address(ary, idx, T_OBJECT, arytype->size(), control());
+        elemtype = _gvn.type(ary)->is_aryptr()->elem();
 
         CompileLog* log = C->log();
         if (log != nullptr) {


### PR DESCRIPTION
This PR replaces the Valhalla draft PR [2665](https://github.com/openjdk/valhalla/pull/2665), which was already reviewed by @marc-chevalier but was not integrated due to the code freeze immediately before the Valhalla mainline integration.

---

Since [JDK-8357474](https://bugs.openjdk.org/browse/JDK-8357474), flat-array stores now compute their address from the refined array and index. Therefore, recomputing it in `array_store_check` as introduced by [JDK-8258412](https://bugs.openjdk.org/browse/JDK-8258412) became redundant and keeps an otherwise dead `CheckCastPP` alive, contributing to a performance regression.

Thanks,
Tobias


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388851](https://bugs.openjdk.org/browse/JDK-8388851): [lworld] Remove obsolete array store address recomputation (**Enhancement** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32132/head:pull/32132` \
`$ git checkout pull/32132`

Update a local copy of the PR: \
`$ git checkout pull/32132` \
`$ git pull https://git.openjdk.org/jdk.git pull/32132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32132`

View PR using the GUI difftool: \
`$ git pr show -t 32132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32132.diff">https://git.openjdk.org/jdk/pull/32132.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32132#issuecomment-5141111757)
</details>
