### PR TITLE
8389234: [lworld] Bad cast for delayed access through abstract value class

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1092,12 +1092,15 @@ void GraphBuilder::load_indexed(BasicType type) {
       bool is_null_free = array_klass->is_elem_null_free();
       bool will_link;
       ciField* next_field = s.get_field(will_link);
-      bool next_needs_patching = !next_field->holder()->is_initialized() ||
+      ciInstanceKlass* next_holder = next_field->holder();
+      bool next_needs_patching = !next_holder->is_initialized() ||
                                  !next_field->will_link(method(), Bytecodes::_getfield) ||
                                  PatchALot;
       bool needs_atomic_access = array_klass->is_elem_atomic();
+      // Offset adjustment for delayed reads requires a concrete inline holder
+      bool next_holder_is_inlinetype = next_holder->is_inlinetype();
       can_delay_access = is_null_free && C1UseDelayedFlattenedFieldReads &&
-                         !next_needs_patching && !needs_atomic_access;
+                         !next_needs_patching && !needs_atomic_access && next_holder_is_inlinetype;
     }
     if (can_delay_access) {
       // potentially optimizable array access, storing information for delayed decision
@@ -1998,12 +2001,16 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
               s.next();
               if (s.cur_bc() == Bytecodes::_getfield && !needs_patching) {
                 ciField* next_field = s.get_field(will_link);
-                bool next_needs_patching = !next_field->holder()->is_loaded() ||
+                ciInstanceKlass* next_holder = next_field->holder();
+                bool next_needs_patching = !next_holder->is_loaded() ||
                                           !next_field->will_link(method(), Bytecodes::_getfield) ||
                                           PatchALot;
                 // We can't update the offset for atomic accesses
                 bool next_needs_atomic_access = next_field->is_flat() && next_field->is_atomic();
-                can_delay_access = C1UseDelayedFlattenedFieldReads && !next_needs_patching && !next_needs_atomic_access && next_field->is_null_free();
+                // Offset adjustment for delayed reads requires a concrete inline holder
+                bool next_holder_is_inlinetype = next_holder->is_inlinetype();
+                can_delay_access = C1UseDelayedFlattenedFieldReads && !next_needs_patching && !next_needs_atomic_access &&
+                                   next_field->is_null_free() && next_holder_is_inlinetype;
               }
             }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAbstractDelayedAccess.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAbstractDelayedAccess.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.vm.annotation.NullRestricted;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8389234
+ * @summary Test C1 delayed access with a field declared in an abstract value class.
+ * @library /test/lib
+ * @enablePreview
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1
+ *                   ${test.main.class}
+ */
+public class TestAbstractDelayedAccess {
+    static abstract value class AbstractValue {
+        @NullRestricted
+        Integer i = 42;
+    }
+
+    static value class ConcreteValue extends AbstractValue { }
+
+    static class Holder {
+        @NullRestricted
+        ConcreteValue value;
+
+        Holder() {
+            value = new ConcreteValue();
+            super();
+        }
+    }
+
+    // Loading h.value starts a delayed flat field access. Resolving AbstractValue.i
+    // while it is pending must not cast the AbstractValue holder to ciInlineKlass.
+    static int test(Holder h) {
+        return h.value.i;
+    }
+
+    public static void main(String[] args) {
+        Holder h = new Holder();
+        for (int i = 0; i < 20_000; i++) {
+            Asserts.assertEQ(test(h), 42);
+        }
+    }
+}
+


### PR DESCRIPTION
This PR replaces the Valhalla draft PR [2673](https://github.com/openjdk/valhalla/pull/2673), which was already reviewed by @merykitty but was not integrated due to the code freeze immediately before the Valhalla mainline integration.

---

C1 delays some flat field and array reads to fuse subsequent getfield operations into a single load. The code currently assumes that the next field’s holder is a `ciInlineKlass` and uses its `payload_offset()`. However, if the field holder is an abstract value class, it is represented as `ciInstanceKlass`, triggering an assert.

The fix restricts the optimization to fields whose holder is a concrete inline class. A more complete alternative would track the concrete flattened receiver class in the delayed-access state and calculate offsets relative to that layout. I quickly prototyped this but it's much more complicated and I'm therefore leaving this to future work.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389234](https://bugs.openjdk.org/browse/JDK-8389234): [lworld] Bad cast for delayed access through abstract value class (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32135/head:pull/32135` \
`$ git checkout pull/32135`

Update a local copy of the PR: \
`$ git checkout pull/32135` \
`$ git pull https://git.openjdk.org/jdk.git pull/32135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32135`

View PR using the GUI difftool: \
`$ git pr show -t 32135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32135.diff">https://git.openjdk.org/jdk/pull/32135.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32135#issuecomment-5141107807)
</details>
