### PR TITLE
8389214: [lworld] StoreFlatNode with TOP value input not correctly handled by IGVN

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -2287,10 +2287,12 @@ const Type* LoadFlatNode::Value(PhaseGVN* phase) const {
 }
 
 const Type* StoreFlatNode::Value(PhaseGVN* phase) const {
+  Node* val = in(TypeFunc::Parms + 2);
   if (phase->type(in(TypeFunc::Control)) == Type::TOP || phase->type(in(TypeFunc::Memory)) == Type::TOP ||
-      phase->type(base()) == Type::TOP || phase->type(ptr()) == Type::TOP || phase->type(value()) == Type::TOP) {
+      phase->type(base()) == Type::TOP || phase->type(ptr()) == Type::TOP || phase->type(val) == Type::TOP) {
     return Type::TOP;
   }
+  assert(val->is_InlineType(), "must be InlineTypeNode: %s", val->Name());
   return bottom_type();
 }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadStoreFlat.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadStoreFlat.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389214
+ * @summary Test that a StoreFlatNode with a TOP value input is properly handled by IGVN.
+ * @enablePreview
+ * @run main ${test.main.class}
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -Xcomp
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+AlwaysIncrementalInline
+ *                   -XX:+StressIGVN -XX:StressSeed=331205763
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestDeadStoreFlat {
+    static Integer box() {
+        throw new RuntimeException();
+    }
+
+    static Integer[] test() {
+        try {
+            Integer boxed = box();
+            return new Integer[] { boxed };
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    public static void main(String[] args) {
+        // Make sure exception class loaded
+        RuntimeException tmp = new RuntimeException();
+        test();
+    }
+}
+


### PR DESCRIPTION
This PR replaces the Valhalla draft PR [2675](https://github.com/openjdk/valhalla/pull/2675), which was already reviewed by @marc-chevalier but was not integrated due to the code freeze immediately before the Valhalla mainline integration.

---

Late inlining of `TestDeadStoreFlat::box` exposes an unconditional throw causing the returned `Integer` `InlineTypeNode` to be replaced by `TOP`. Depending on the IGVN worklist order, it might then process the dead but still reachable `StoreFlatNode` with now `TOP` value input. Calling `value()` from `StoreFlatNode::Value` then asserts because it's not an `InlineTypeNode`:
https://github.com/openjdk/jdk/blob/f181286389fad995be1e71de60f30d14eb1c9122/src/hotspot/share/opto/inlinetypenode.hpp#L229

The fix is to return `TOP` if the value input is `TOP`. I also added an assert to check the invariant that the input is always an `InlineTypeNode` otherwise.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389214](https://bugs.openjdk.org/browse/JDK-8389214): [lworld] StoreFlatNode with TOP value input not correctly handled by IGVN (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32137/head:pull/32137` \
`$ git checkout pull/32137`

Update a local copy of the PR: \
`$ git checkout pull/32137` \
`$ git pull https://git.openjdk.org/jdk.git pull/32137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32137`

View PR using the GUI difftool: \
`$ git pr show -t 32137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32137.diff">https://git.openjdk.org/jdk/pull/32137.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32137#issuecomment-5141120171)
</details>
