### PR TITLE
8389450: [lworld] Value class adapter generation leaks CodeCache BufferBlob

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2922,11 +2922,10 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(StubId id, address destination
 }
 
 BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
-  BufferBlob* buf = BufferBlob::create("inline types pack/unpack", 16 * K);
-  if (buf == nullptr) {
+  CodeBuffer buffer("inline types pack/unpack", 16 * K, 0);
+  if (buffer.blob() == nullptr) {
     return nullptr;
   }
-  CodeBuffer buffer(buf);
   short buffer_locs[20];
   buffer.insts()->initialize_shared_locs((relocInfo*)buffer_locs,
                                          sizeof(buffer_locs)/sizeof(relocInfo));

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3731,11 +3731,10 @@ void SharedRuntime::montgomery_square(jint *a_ints, jint *n_ints,
 }
 
 BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
-  BufferBlob* buf = BufferBlob::create("inline types pack/unpack", 16 * K);
-  if (buf == nullptr) {
+  CodeBuffer buffer("inline types pack/unpack", 16 * K, 0);
+  if (buffer.blob() == nullptr) {
     return nullptr;
   }
-  CodeBuffer buffer(buf);
   short buffer_locs[20];
   buffer.insts()->initialize_shared_locs((relocInfo*)buffer_locs,
                                          sizeof(buffer_locs)/sizeof(relocInfo));

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueClassCodeCacheLeak.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueClassCodeCacheLeak.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8389450
+ * @summary Test that loading and unloading value classes does not leak code cache memory.
+ * @requires vm.flagless & vm.opt.final.ClassUnloading
+ * @enablePreview
+ * @run main/othervm -XX:ReservedCodeCacheSize=32m ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.io.InputStream;
+
+public class TestValueClassCodeCacheLeak {
+    public static value class TemporaryValue { }
+
+    static final class Loader extends ClassLoader {
+        Class<?> define(byte[] bytes) {
+            return defineClass("compiler.valhalla.inlinetypes.TestValueClassCodeCacheLeak$TemporaryValue", bytes, 0, bytes.length);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        InputStream in = TestValueClassCodeCacheLeak.class.getResourceAsStream("TestValueClassCodeCacheLeak$TemporaryValue.class");
+        byte[] bytes = in.readAllBytes();
+
+        // Create a class loader, load value class and throw the class loader away
+        // to trigger class unloading. This should not leak (code cache) memory.
+        for (int i = 0; i < 5000; i++) {
+            new Loader().define(bytes);
+        }
+    }
+}
+


### PR DESCRIPTION
This PR replaces the Valhalla draft PR [2686](https://github.com/openjdk/valhalla/pull/2686) which was not integrated due to the code freeze immediately before the Valhalla mainline integration.

---

There are several constructors for a `CodeBuffer`:
https://github.com/openjdk/jdk/blob/38bb8992943bb6a5774e1c1b639cf404a7ad8f56/src/hotspot/share/asm/codeBuffer.hpp#L672-L702

Turns out that the ones that take an external `BufferBlob`, instead of allocating one themselves, would also not free it in the destructor:
https://github.com/openjdk/jdk/blob/38bb8992943bb6a5774e1c1b639cf404a7ad8f56/src/hotspot/share/asm/codeBuffer.cpp#L133-L139

Makes sense in hindsight ... :slightly_smiling_face: Now `generate_buffered_inline_type_adapter` wraps a scratch `BufferBlob` in such a "non-owning" `CodeBuffer`. While the final `BufferedInlineTypeBlob` is correctly reclaimed during class unloading, the scratch blob is never freed. As a result, the new test fails with `OutOfMemoryError: Out of space in CodeCache for adapters`.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389450](https://bugs.openjdk.org/browse/JDK-8389450): [lworld] Value class adapter generation leaks CodeCache BufferBlob (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32141/head:pull/32141` \
`$ git checkout pull/32141`

Update a local copy of the PR: \
`$ git checkout pull/32141` \
`$ git pull https://git.openjdk.org/jdk.git pull/32141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32141`

View PR using the GUI difftool: \
`$ git pr show -t 32141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32141.diff">https://git.openjdk.org/jdk/pull/32141.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32141#issuecomment-5141081260)
</details>
