### PR TITLE
8382272: Update nsk/jdb tests to use ThreadWrapper

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -129,7 +130,7 @@ public class exclude001 extends JdbTest {
 
                 if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
 
-                    threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+                    threads = jdb.getThreadIdsByName(MYTHREAD);
 
                     if (threads.length != 1) {
                         log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
@@ -66,7 +66,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001a.java
@@ -23,6 +23,7 @@
 
 package nsk.jdb.exclude.exclude001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -62,7 +63,7 @@ public class exclude001a {
         Thread holder [] = new Thread[numThreads];
 
         for (int i = 0; i < numThreads ; i++) {
-            holder[i] = new MyThread(MYTHREAD + "-" + i);
+            holder[i] = new MyThread(MYTHREAD + "-" + i).getThread();
             holder[i].start();
             try {
                 holder[i].join();
@@ -80,7 +81,7 @@ public class exclude001a {
 }
 
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
     String name;
 
     public MyThread (String s) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -54,7 +54,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -84,6 +83,7 @@ public class interrupt001 extends JdbTest {
     static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
     static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
+    static final String THREAD_STARTED_BREAK = PACKAGE_NAME + ".interrupt001a$MyThread.threadStarted";
     static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = DEBUGGEE_CLASS + "$" + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notInterrupted";
@@ -106,7 +106,39 @@ public class interrupt001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
+
+        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
+        // tested thread first hits threadStarted(); receiving that event is
+        // what makes a virtual thread visible to jdb with the default debug
+        // agent behavior, so count the hits to be sure every tested thread
+        // became visible before the lookup below.
+        int started = 0;
+        while (true) {
+            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
+            // Match the fully qualified method of the stop location as a single
+            // token: debuggee output can interleave with jdb's own output and
+            // split the "Breakpoint hit:" prefix away from the location, so do
+            // not require both in the same paragraph. The "(" suffix avoids
+            // matching jdb's "Set deferred breakpoint" messages.
+            Paragrep contGrep = new Paragrep(contReply);
+            if (contGrep.find(LAST_BREAK + "(") > 0) {
+                break;
+            }
+            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
+                started++;
+                continue;
+            }
+            failure("Stopped at unexpected location, expected " + LAST_BREAK
+                    + " or " + THREAD_STARTED_BREAK);
+            for (String line : contReply) {
+                log.complain("reply: " + line);
+            }
+            break;
+        }
+        if (started != numThreads) {
+            failure("Expected " + numThreads + " threadStarted() hits, got: " + started);
+        }
 
         threads = jdb.getThreadIdsByName(MYTHREAD);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -91,11 +92,12 @@ public class interrupt001 extends JdbTest {
 
     /*
      * Pattern for finding the thread ID in a line like the following:
-     *   (nsk.jdb.interrupt.interrupt001.interrupt001a$MyThread)651 Thread-0          cond. waiting
-     * Note we can't match on DEBUGGEE_THREAD because it includes a $, which Pattern
-     * uses to match the end of a line.
+     *   (java.lang.Thread)651 MyThread-0          cond. waiting
+     * The tested threads are created via ThreadWrapper, so the class shown is
+     * java.lang.Thread or java.lang.VirtualThread rather than the test's own class.
+     * Match on the thread name instead.
      */
-    private static Pattern tidPattern = Pattern.compile("\\(.+" + MYTHREAD + "\\)(\\S+)");
+    private static Pattern tidPattern = Pattern.compile("\\(.+Thread\\)(\\S+)\\s+" + MYTHREAD);
 
     protected void runCases() {
         String[] reply;
@@ -106,7 +108,7 @@ public class interrupt001 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        threads = jdb.getThreadIdsByName(MYTHREAD);
 
         if (threads.length != numThreads) {
             log.complain("jdb should report " + numThreads + " instance of " + DEBUGGEE_THREAD);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -75,6 +75,7 @@ public class interrupt001 extends JdbTest {
     public static void main (String argv[]) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
+        lastBreak = LAST_BREAK;
         new interrupt001().runTest(argv);
     }
 
@@ -106,39 +107,7 @@ public class interrupt001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
-
-        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
-        // tested thread first hits threadStarted(); receiving that event is
-        // what makes a virtual thread visible to jdb with the default debug
-        // agent behavior, so count the hits to be sure every tested thread
-        // became visible before the lookup below.
-        int started = 0;
-        while (true) {
-            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
-            // Match the fully qualified method of the stop location as a single
-            // token: debuggee output can interleave with jdb's own output and
-            // split the "Breakpoint hit:" prefix away from the location, so do
-            // not require both in the same paragraph. The "(" suffix avoids
-            // matching jdb's "Set deferred breakpoint" messages.
-            Paragrep contGrep = new Paragrep(contReply);
-            if (contGrep.find(LAST_BREAK + "(") > 0) {
-                break;
-            }
-            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
-                started++;
-                continue;
-            }
-            failure("Stopped at unexpected location, expected " + LAST_BREAK
-                    + " or " + THREAD_STARTED_BREAK);
-            for (String line : contReply) {
-                log.complain("reply: " + line);
-            }
-            break;
-        }
-        if (started != numThreads) {
-            failure("Expected " + numThreads + " threadStarted() hits, got: " + started);
-        }
+        waitForTestedThreadStarts(THREAD_STARTED_BREAK, numThreads);
 
         threads = jdb.getThreadIdsByName(MYTHREAD);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.interrupt.interrupt001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jdb.*;
 
@@ -32,12 +33,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /* This is debuggee aplication */
 public class interrupt001a {
-    private class MyThread extends Thread {
+    private class MyThread extends ThreadWrapper {
         final Object lock;
         int ind;
         String name;
 
         public MyThread (Object l, int i, String n) {
+            super(n);
             lock = l;
             ind = i;
             name = n;
@@ -96,7 +98,7 @@ public class interrupt001a {
 
         for (i = 0; i < numThreads ; i++) {
             locks[i] = new Object();
-            holder[i] = new MyThread(locks[i], i, MYTHREAD + "-" + i);
+            holder[i] = new MyThread(locks[i], i, MYTHREAD + "-" + i).getThread();
         }
 
         synchronized (waitnotify) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -45,7 +45,14 @@ public class interrupt001a {
             name = n;
         }
 
+        // Each tested thread calls this once at startup. The debugger sets a
+        // breakpoint here: receiving the event is what makes a virtual thread
+        // visible to jdb with the default debug agent behavior, so the test
+        // does not need the -trackallthreads option.
+        static void threadStarted() {}
+
         public void run() {
+            threadStarted();
             synchronized (lock) {
                 synchronized (waitnotify) {
                     threadRunning = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,6 +113,9 @@ public class kill002a {
 }
 
 
+// Note: MyThread must extend Thread, not ThreadWrapper. jdb's kill command
+// (JVMTI StopThread) rejects a virtual thread that is unmounted in Object.wait()
+// with "Operation is not supported on the current frame". See JDK-8382272.
 class MyThread extends Thread {
     Object lock;
     String name;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002a.java
@@ -113,9 +113,8 @@ public class kill002a {
 }
 
 
-// Note: MyThread must extend Thread, not ThreadWrapper. jdb's kill command
-// (JVMTI StopThread) rejects a virtual thread that is unmounted in Object.wait()
-// with "Operation is not supported on the current frame". See JDK-8382272.
+// This test uses a platform thread because jdb's kill command cannot stop an
+// unmounted virtual thread waiting in Object.wait().
 class MyThread extends Thread {
     Object lock;
     String name;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.next.next001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -54,7 +55,7 @@ public class next001a {
         Thread holder [] = new Thread[numThreads];
 
         for (int i = 0; i < numThreads ; i++) {
-            holder[i] = new MyThread();
+            holder[i] = new MyThread(MYTHREAD + "-" + i).getThread();
             holder[i].start();
             try {
                 holder[i].join();
@@ -70,7 +71,11 @@ public class next001a {
 }
 
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
+    public MyThread(String name) {
+        super(name);
+    }
+
     public void run() {
         int runLocal = func1(100);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -97,7 +98,7 @@ public class pop001 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
-            String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+            String[] threads = jdb.getThreadIdsByName(MYTHREAD);
             if (threads.length != 1) {
                 log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);
                 log.complain("Found: " + threads.length);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
@@ -54,7 +54,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.pop.pop001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -66,7 +67,7 @@ public class pop001a {
     }
 }
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
 
     public MyThread (String name) {
         super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -59,6 +59,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -98,39 +98,7 @@ public class read001 extends JdbTest {
 
         // stop in lastBreak() method
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
-
-        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
-        // tested thread first hits threadStarted(); receiving that event is
-        // what makes a virtual thread visible to jdb with the default debug
-        // agent behavior, so count the hits to be sure every tested thread
-        // became visible before the lookup below.
-        int started = 0;
-        while (true) {
-            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
-            // Match the fully qualified method of the stop location as a single
-            // token: debuggee output can interleave with jdb's own output and
-            // split the "Breakpoint hit:" prefix away from the location, so do
-            // not require both in the same paragraph. The "(" suffix avoids
-            // matching jdb's "Set deferred breakpoint" messages.
-            Paragrep contGrep = new Paragrep(contReply);
-            if (contGrep.find(LAST_BREAK + "(") > 0) {
-                break;
-            }
-            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
-                started++;
-                continue;
-            }
-            failure("Stopped at unexpected location, expected " + LAST_BREAK
-                    + " or " + THREAD_STARTED_BREAK);
-            for (String line : contReply) {
-                log.complain("reply: " + line);
-            }
-            break;
-        }
-        if (started != 1) {
-            failure("Expected " + 1 + " threadStarted() hits, got: " + started);
-        }
+        waitForTestedThreadStarts(THREAD_STARTED_BREAK, 1);
 
         // return to testedInstanceMethod()
         reply = jdb.receiveReplyFor(JdbCommand.step);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -59,7 +59,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -88,6 +87,7 @@ public class read001 extends JdbTest {
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
     static final String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK     = DEBUGGEE_CLASS + ".lastBreak";
+    static final String THREAD_STARTED_BREAK = PACKAGE_NAME + ".read001aTestedThread.threadStarted";
 
     static final String SCENARIO_FILE = "jdb.scenario";
     static final int SCENARIO_COMMANDS_COUNT = 5;
@@ -98,7 +98,39 @@ public class read001 extends JdbTest {
 
         // stop in lastBreak() method
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
+
+        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
+        // tested thread first hits threadStarted(); receiving that event is
+        // what makes a virtual thread visible to jdb with the default debug
+        // agent behavior, so count the hits to be sure every tested thread
+        // became visible before the lookup below.
+        int started = 0;
+        while (true) {
+            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
+            // Match the fully qualified method of the stop location as a single
+            // token: debuggee output can interleave with jdb's own output and
+            // split the "Breakpoint hit:" prefix away from the location, so do
+            // not require both in the same paragraph. The "(" suffix avoids
+            // matching jdb's "Set deferred breakpoint" messages.
+            Paragrep contGrep = new Paragrep(contReply);
+            if (contGrep.find(LAST_BREAK + "(") > 0) {
+                break;
+            }
+            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
+                started++;
+                continue;
+            }
+            failure("Stopped at unexpected location, expected " + LAST_BREAK
+                    + " or " + THREAD_STARTED_BREAK);
+            for (String line : contReply) {
+                log.complain("reply: " + line);
+            }
+            break;
+        }
+        if (started != 1) {
+            failure("Expected " + 1 + " threadStarted() hits, got: " + started);
+        }
 
         // return to testedInstanceMethod()
         reply = jdb.receiveReplyFor(JdbCommand.step);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.read.read001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -87,7 +88,7 @@ class read001aTestedClass {
     char instanceFiledChar = 'x';
 }
 
-class read001aTestedThread extends Thread {
+class read001aTestedThread extends ThreadWrapper {
 
     Object startingMonitor = new Object();
     Object finishingMonitor = new Object();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001a.java
@@ -97,7 +97,14 @@ class read001aTestedThread extends ThreadWrapper {
         super(name);
     }
 
+    // Each tested thread calls this once at startup. The debugger sets a
+    // breakpoint here: receiving the event is what makes a virtual thread
+    // visible to jdb with the default debug agent behavior, so the test
+    // does not need the -trackallthreads option.
+    static void threadStarted() {}
+
     public void run() {
+        threadStarted();
         synchronized (startingMonitor) {
             startingMonitor.notifyAll();
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
@@ -53,7 +53,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -96,7 +97,7 @@ public class reenter001 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
-            String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+            String[] threads = jdb.getThreadIdsByName(MYTHREAD);
             if (threads.length != 1) {
                 log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);
                 log.complain("Found: " + threads.length);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.reenter.reenter001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -66,7 +67,7 @@ public class reenter001a {
     }
 }
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
 
     public MyThread (String name) {
         super(name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -57,7 +57,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -85,6 +84,7 @@ public class resume002 extends JdbTest {
     static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
     static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String THREAD_STARTED_BREAK = PACKAGE_NAME + ".MyThread.threadStarted";
 
     static final String THREAD_NAME      = "MyThread";
 
@@ -96,7 +96,39 @@ public class resume002 extends JdbTest {
         String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
+
+        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
+        // tested thread first hits threadStarted(); receiving that event is
+        // what makes a virtual thread visible to jdb with the default debug
+        // agent behavior, so count the hits to be sure every tested thread
+        // became visible before the lookup below.
+        int started = 0;
+        while (true) {
+            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
+            // Match the fully qualified method of the stop location as a single
+            // token: debuggee output can interleave with jdb's own output and
+            // split the "Breakpoint hit:" prefix away from the location, so do
+            // not require both in the same paragraph. The "(" suffix avoids
+            // matching jdb's "Set deferred breakpoint" messages.
+            Paragrep contGrep = new Paragrep(contReply);
+            if (contGrep.find(LAST_BREAK + "(") > 0) {
+                break;
+            }
+            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
+                started++;
+                continue;
+            }
+            failure("Stopped at unexpected location, expected " + LAST_BREAK
+                    + " or " + THREAD_STARTED_BREAK);
+            for (String line : contReply) {
+                log.complain("reply: " + line);
+            }
+            break;
+        }
+        if (started != resume002a.numThreads) {
+            failure("Expected " + resume002a.numThreads + " threadStarted() hits, got: " + started);
+        }
 
         String[] threadIds = jdb.getThreadIdsByName(THREAD_NAME);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -96,39 +96,7 @@ public class resume002 extends JdbTest {
         String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
-
-        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
-        // tested thread first hits threadStarted(); receiving that event is
-        // what makes a virtual thread visible to jdb with the default debug
-        // agent behavior, so count the hits to be sure every tested thread
-        // became visible before the lookup below.
-        int started = 0;
-        while (true) {
-            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
-            // Match the fully qualified method of the stop location as a single
-            // token: debuggee output can interleave with jdb's own output and
-            // split the "Breakpoint hit:" prefix away from the location, so do
-            // not require both in the same paragraph. The "(" suffix avoids
-            // matching jdb's "Set deferred breakpoint" messages.
-            Paragrep contGrep = new Paragrep(contReply);
-            if (contGrep.find(LAST_BREAK + "(") > 0) {
-                break;
-            }
-            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
-                started++;
-                continue;
-            }
-            failure("Stopped at unexpected location, expected " + LAST_BREAK
-                    + " or " + THREAD_STARTED_BREAK);
-            for (String line : contReply) {
-                log.complain("reply: " + line);
-            }
-            break;
-        }
-        if (started != resume002a.numThreads) {
-            failure("Expected " + resume002a.numThreads + " threadStarted() hits, got: " + started);
-        }
+        waitForTestedThreadStarts(THREAD_STARTED_BREAK, resume002a.numThreads);
 
         String[] threadIds = jdb.getThreadIdsByName(THREAD_NAME);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -97,7 +98,7 @@ public class resume002 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        String[] threadIds = jdb.getThreadIds(PACKAGE_NAME + "." + THREAD_NAME);
+        String[] threadIds = jdb.getThreadIdsByName(THREAD_NAME);
 
         reply = jdb.receiveReplyFor(JdbCommand.suspend);
         grep = new Paragrep(reply);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002a.java
@@ -111,7 +111,14 @@ class MyThread extends ThreadWrapper {
         this.name = name;
     }
 
+    // Each tested thread calls this once at startup. The debugger sets a
+    // breakpoint here: receiving the event is what makes a virtual thread
+    // visible to jdb with the default debug agent behavior, so the test
+    // does not need the -trackallthreads option.
+    static void threadStarted() {}
+
     public void run() {
+        threadStarted();
         synchronized (resume002a.waitnotify) {
             resume002a.waitnotify.notifyAll();
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.resume.resume002;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -51,7 +52,7 @@ public class resume002a {
         try {
             lock.setLock();
             for (int i = 0; i < numThreads ; i++) {
-                holder[i] = new MyThread(lock, "MyThread#" + i);
+                holder[i] = new MyThread(lock, "MyThread#" + i).getThread();
                 synchronized (waitnotify) {
                     holder[i].start();
                     waitnotify.wait();
@@ -99,12 +100,13 @@ class Lock {
     }
 }
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
 
     Lock lock;
     String name;
 
     MyThread (Lock l, String name) {
+        super(name);
         this.lock = l;
         this.name = name;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.step_up.step_up001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -54,7 +55,7 @@ public class step_up001a {
         Thread holder [] = new Thread[numThreads];
 
         for (int i = 0; i < numThreads ; i++) {
-            holder[i] = new MyThread();
+            holder[i] = new MyThread(MYTHREAD + "-" + i).getThread();
             holder[i].start();
             try {
                 holder[i].join();
@@ -70,7 +71,11 @@ public class step_up001a {
 }
 
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
+    public MyThread(String name) {
+        super(name);
+    }
+
     public void run() {
         int runLocal = func1(100);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,6 +103,9 @@ public class suspend001a {
     }
 }
 
+// Note: the tested thread classes must extend Thread, not ThreadWrapper.
+// Suspending a single virtual thread and continuing causes jdb to stop
+// responding (no prompt is received). See JDK-8382272.
 class Suspended extends Thread {
     String name;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
@@ -103,9 +103,8 @@ public class suspend001a {
     }
 }
 
-// Note: the tested thread classes must extend Thread, not ThreadWrapper.
-// Suspending a single virtual thread and continuing causes jdb to stop
-// responding (no prompt is received). See JDK-8382272.
+// This test uses a platform thread because suspending the tested virtual thread
+// and continuing causes jdb to stop responding.
 class Suspended extends Thread {
     String name;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-
 /*
  * @test
  *
@@ -82,32 +81,29 @@ public class thread002 extends JdbTest {
     static final String THREAD_NAME      = "MyThread";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        String[] threadIds = jdb.getThreadIdsByName(THREAD_NAME);
-
-        String[][] switchReplies = new String[thread002a.numThreads][];
+        // Resolve each tested thread id by its exact name instead of assuming that
+        // getThreadIdsByName(THREAD_NAME) returns the ids in creation order.
         for (int i = 0; i < thread002a.numThreads; i++) {
-            switchReplies[i] = jdb.receiveReplyFor(JdbCommand.thread + threadIds[i]);
+            String threadName = THREAD_NAME + "#" + i;
+            String[] ids = jdb.getThreadIdsByName(threadName);
+            if (ids.length != 1) {
+                failure("Expected exactly one thread named " + threadName
+                        + ", found: " + ids.length);
+                continue;
+            }
+            String[] switchReply = jdb.receiveReplyFor(JdbCommand.thread + ids[0]);
+            if (new Paragrep(switchReply).find(threadName) == 0) {
+                failure("jdb failed to switch to thread: " + threadName
+                        + " (id: " + ids[0] + ")");
+            }
             jdb.receiveReplyFor(JdbCommand.print + DEBUGGEE_CLASS + ".holder[" + i + "].name");
         }
 
         jdb.contToExit(1);
 
-        reply = jdb.getTotalReply();
-        grep = new Paragrep(reply);
-        for (int i = 0; i < threadIds.length; i++) {
-            count = new Paragrep(switchReplies[i]).find(THREAD_NAME + "#" + i);
-            if (count == 0) {
-                 failure("jdb failed to switch to thread: " + threadIds[i]);
-            }
-        }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -83,40 +83,7 @@ public class thread002 extends JdbTest {
     protected void runCases() {
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
-
-        // Continue until the main thread reaches lastBreak(). Each tested
-        // thread first hits threadStarted(); receiving that event is what
-        // makes a virtual thread visible to jdb with the default debug agent
-        // behavior, so count the hits to be sure every tested thread became
-        // visible before the lookup below.
-        int started = 0;
-        while (true) {
-            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
-            // Match the fully qualified method of the stop location as a single
-            // token: debuggee output can interleave with jdb's own output and
-            // split the "Breakpoint hit:" prefix away from the location, so do
-            // not require both in the same paragraph. The "(" suffix avoids
-            // matching jdb's "Set deferred breakpoint" messages.
-            Paragrep contGrep = new Paragrep(contReply);
-            if (contGrep.find(LAST_BREAK + "(") > 0) {
-                break;
-            }
-            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
-                started++;
-                continue;
-            }
-            failure("Stopped at unexpected location, expected " + LAST_BREAK
-                    + " or " + THREAD_STARTED_BREAK);
-            for (String line : contReply) {
-                log.complain("reply: " + line);
-            }
-            break;
-        }
-        if (started != thread002a.numThreads) {
-            failure("Expected " + thread002a.numThreads
-                    + " threadStarted() hits, got: " + started);
-        }
+        waitForTestedThreadStarts(THREAD_STARTED_BREAK, thread002a.numThreads);
 
         // Resolve each tested thread id by its exact name instead of assuming that
         // getThreadIdsByName(THREAD_NAME) returns the ids in creation order.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -90,10 +91,11 @@ public class thread002 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        String[] threadIds = jdb.getThreadIds(PACKAGE_NAME + "." + THREAD_NAME);
+        String[] threadIds = jdb.getThreadIdsByName(THREAD_NAME);
 
+        String[][] switchReplies = new String[thread002a.numThreads][];
         for (int i = 0; i < thread002a.numThreads; i++) {
-            jdb.receiveReplyFor(JdbCommand.thread + threadIds[i]);
+            switchReplies[i] = jdb.receiveReplyFor(JdbCommand.thread + threadIds[i]);
             jdb.receiveReplyFor(JdbCommand.print + DEBUGGEE_CLASS + ".holder[" + i + "].name");
         }
 
@@ -102,8 +104,8 @@ public class thread002 extends JdbTest {
         reply = jdb.getTotalReply();
         grep = new Paragrep(reply);
         for (int i = 0; i < threadIds.length; i++) {
-            count = grep.find(THREAD_NAME + "#" + i);
-            if (count != 1) {
+            count = new Paragrep(switchReplies[i]).find(THREAD_NAME + "#" + i);
+            if (count == 0) {
                  failure("jdb failed to switch to thread: " + threadIds[i]);
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -49,7 +49,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -77,13 +76,47 @@ public class thread002 extends JdbTest {
     static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
     static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String THREAD_STARTED_BREAK = PACKAGE_NAME + ".MyThread.threadStarted";
 
     static final String THREAD_NAME      = "MyThread";
 
     protected void runCases() {
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
+
+        // Continue until the main thread reaches lastBreak(). Each tested
+        // thread first hits threadStarted(); receiving that event is what
+        // makes a virtual thread visible to jdb with the default debug agent
+        // behavior, so count the hits to be sure every tested thread became
+        // visible before the lookup below.
+        int started = 0;
+        while (true) {
+            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
+            // Match the fully qualified method of the stop location as a single
+            // token: debuggee output can interleave with jdb's own output and
+            // split the "Breakpoint hit:" prefix away from the location, so do
+            // not require both in the same paragraph. The "(" suffix avoids
+            // matching jdb's "Set deferred breakpoint" messages.
+            Paragrep contGrep = new Paragrep(contReply);
+            if (contGrep.find(LAST_BREAK + "(") > 0) {
+                break;
+            }
+            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
+                started++;
+                continue;
+            }
+            failure("Stopped at unexpected location, expected " + LAST_BREAK
+                    + " or " + THREAD_STARTED_BREAK);
+            for (String line : contReply) {
+                log.complain("reply: " + line);
+            }
+            break;
+        }
+        if (started != thread002a.numThreads) {
+            failure("Expected " + thread002a.numThreads
+                    + " threadStarted() hits, got: " + started);
+        }
 
         // Resolve each tested thread id by its exact name instead of assuming that
         // getThreadIdsByName(THREAD_NAME) returns the ids in creation order.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.thread.thread002;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -51,7 +52,7 @@ public class thread002a {
         try {
             lock.setLock();
             for (int i = 0; i < numThreads ; i++) {
-                holder[i] = new MyThread(lock, "MyThread#" + i);
+                holder[i] = new MyThread(lock, "MyThread#" + i).getThread();
                 synchronized (waitnotify) {
                     holder[i].start();
                     waitnotify.wait();
@@ -99,12 +100,13 @@ class Lock {
     }
 }
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
 
     Lock lock;
     String name;
 
     MyThread (Lock l, String name) {
+        super(name);
         this.lock = l;
         this.name = name;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002a.java
@@ -111,7 +111,14 @@ class MyThread extends ThreadWrapper {
         this.name = name;
     }
 
+    // Each tested thread calls this once at startup. The debugger sets a
+    // breakpoint here: receiving the event is what makes a virtual thread
+    // visible to jdb with the default debug agent behavior, so the test
+    // does not need the -trackallthreads option.
+    static void threadStarted() {}
+
     public void run() {
+        threadStarted();
         synchronized (thread002a.waitnotify) {
             thread002a.waitnotify.notifyAll();
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
@@ -110,6 +110,8 @@ class Lock {
     }
 }
 
+// This test uses a platform thread because it verifies explicit ThreadGroup
+// placement, and virtual-thread builders cannot specify a ThreadGroup.
 class MyThread extends Thread {
 
     Lock lock;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002a.java
@@ -110,6 +110,8 @@ class Lock {
     }
 }
 
+// This test uses a platform thread because it verifies explicit ThreadGroup
+// placement, and virtual-thread builders cannot specify a ThreadGroup.
 class MyThread extends Thread {
 
     Lock lock;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -104,7 +105,7 @@ public class untrace001 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        threads = jdb.getThreadIdsByName(MYTHREAD);
 
         if (threads.length != 1) {
             log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
@@ -61,7 +61,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -89,6 +88,7 @@ public class untrace001 extends JdbTest {
     static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
     static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
+    static final String THREAD_STARTED_BREAK = PACKAGE_NAME + ".MyThread.threadStarted";
     static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
@@ -103,7 +103,39 @@ public class untrace001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
+
+        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
+        // tested thread first hits threadStarted(); receiving that event is
+        // what makes a virtual thread visible to jdb with the default debug
+        // agent behavior, so count the hits to be sure every tested thread
+        // became visible before the lookup below.
+        int started = 0;
+        while (true) {
+            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
+            // Match the fully qualified method of the stop location as a single
+            // token: debuggee output can interleave with jdb's own output and
+            // split the "Breakpoint hit:" prefix away from the location, so do
+            // not require both in the same paragraph. The "(" suffix avoids
+            // matching jdb's "Set deferred breakpoint" messages.
+            Paragrep contGrep = new Paragrep(contReply);
+            if (contGrep.find(LAST_BREAK + "(") > 0) {
+                break;
+            }
+            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
+                started++;
+                continue;
+            }
+            failure("Stopped at unexpected location, expected " + LAST_BREAK
+                    + " or " + THREAD_STARTED_BREAK);
+            for (String line : contReply) {
+                log.complain("reply: " + line);
+            }
+            break;
+        }
+        if (started != untrace001a.numThreads) {
+            failure("Expected " + untrace001a.numThreads + " threadStarted() hits, got: " + started);
+        }
 
         threads = jdb.getThreadIdsByName(MYTHREAD);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
@@ -103,39 +103,7 @@ public class untrace001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
-
-        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
-        // tested thread first hits threadStarted(); receiving that event is
-        // what makes a virtual thread visible to jdb with the default debug
-        // agent behavior, so count the hits to be sure every tested thread
-        // became visible before the lookup below.
-        int started = 0;
-        while (true) {
-            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
-            // Match the fully qualified method of the stop location as a single
-            // token: debuggee output can interleave with jdb's own output and
-            // split the "Breakpoint hit:" prefix away from the location, so do
-            // not require both in the same paragraph. The "(" suffix avoids
-            // matching jdb's "Set deferred breakpoint" messages.
-            Paragrep contGrep = new Paragrep(contReply);
-            if (contGrep.find(LAST_BREAK + "(") > 0) {
-                break;
-            }
-            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
-                started++;
-                continue;
-            }
-            failure("Stopped at unexpected location, expected " + LAST_BREAK
-                    + " or " + THREAD_STARTED_BREAK);
-            for (String line : contReply) {
-                log.complain("reply: " + line);
-            }
-            break;
-        }
-        if (started != untrace001a.numThreads) {
-            failure("Expected " + untrace001a.numThreads + " threadStarted() hits, got: " + started);
-        }
+        waitForTestedThreadStarts(THREAD_STARTED_BREAK, untrace001a.numThreads);
 
         threads = jdb.getThreadIdsByName(MYTHREAD);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.untrace.untrace001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -61,7 +62,7 @@ public class untrace001a {
 
         for (i = 0; i < numThreads ; i++) {
             locks[i]  = new Object();
-            holder[i] = new MyThread(locks[i], i, MYTHREAD + "-" + i);
+            holder[i] = new MyThread(locks[i], i, MYTHREAD + "-" + i).getThread();
         }
 
         synchronized (mainThreadLock0) {
@@ -126,12 +127,13 @@ public class untrace001a {
 }
 
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
     Object lock;
     int ind;
     String name;
 
     public MyThread (Object l, int i, String n) {
+        super(n);
         lock = l;
         ind = i;
         name = n;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001a.java
@@ -139,7 +139,14 @@ class MyThread extends ThreadWrapper {
         name = n;
     }
 
+    // Each tested thread calls this once at startup. The debugger sets a
+    // breakpoint here: receiving the event is what makes a virtual thread
+    // visible to jdb with the default debug agent behavior, so the test
+    // does not need the -trackallthreads option.
+    static void threadStarted() {}
+
     public void run() {
+        threadStarted();
         // Concatenate strings in advance to avoid lambda calculations later
         final String ThreadFinished = "Thread finished: " + this.name;
         final String ThreadInterrupted = "Thread was interrupted: " + this.name;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -95,7 +96,7 @@ public class where006 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        String[] threadIds = jdb.getThreadIds(PACKAGE_NAME + ".MyThread");
+        String[] threadIds = jdb.getThreadIdsByName("MyThread");
         reply = jdb.receiveReplyFor(JdbCommand.where + "all");
         for (int i = 0; i < where006a.numThreads; i++) {
             checkFrames(threadIds[i], reply, 5);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -49,7 +49,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -77,6 +76,7 @@ public class where006 extends JdbTest {
     static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
     static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String THREAD_STARTED_BREAK = PACKAGE_NAME + ".MyThread.threadStarted";
 
     static final String[][] FRAMES = new String[][] {
         {PACKAGE_NAME + ".MyThread.func5", "111"},
@@ -94,7 +94,39 @@ public class where006 extends JdbTest {
         String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
+
+        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
+        // tested thread first hits threadStarted(); receiving that event is
+        // what makes a virtual thread visible to jdb with the default debug
+        // agent behavior, so count the hits to be sure every tested thread
+        // became visible before the lookup below.
+        int started = 0;
+        while (true) {
+            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
+            // Match the fully qualified method of the stop location as a single
+            // token: debuggee output can interleave with jdb's own output and
+            // split the "Breakpoint hit:" prefix away from the location, so do
+            // not require both in the same paragraph. The "(" suffix avoids
+            // matching jdb's "Set deferred breakpoint" messages.
+            Paragrep contGrep = new Paragrep(contReply);
+            if (contGrep.find(LAST_BREAK + "(") > 0) {
+                break;
+            }
+            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
+                started++;
+                continue;
+            }
+            failure("Stopped at unexpected location, expected " + LAST_BREAK
+                    + " or " + THREAD_STARTED_BREAK);
+            for (String line : contReply) {
+                log.complain("reply: " + line);
+            }
+            break;
+        }
+        if (started != where006a.numThreads) {
+            failure("Expected " + where006a.numThreads + " threadStarted() hits, got: " + started);
+        }
 
         String[] threadIds = jdb.getThreadIdsByName("MyThread");
         reply = jdb.receiveReplyFor(JdbCommand.where + "all");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -94,39 +94,7 @@ public class where006 extends JdbTest {
         String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
-
-        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
-        // tested thread first hits threadStarted(); receiving that event is
-        // what makes a virtual thread visible to jdb with the default debug
-        // agent behavior, so count the hits to be sure every tested thread
-        // became visible before the lookup below.
-        int started = 0;
-        while (true) {
-            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
-            // Match the fully qualified method of the stop location as a single
-            // token: debuggee output can interleave with jdb's own output and
-            // split the "Breakpoint hit:" prefix away from the location, so do
-            // not require both in the same paragraph. The "(" suffix avoids
-            // matching jdb's "Set deferred breakpoint" messages.
-            Paragrep contGrep = new Paragrep(contReply);
-            if (contGrep.find(LAST_BREAK + "(") > 0) {
-                break;
-            }
-            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
-                started++;
-                continue;
-            }
-            failure("Stopped at unexpected location, expected " + LAST_BREAK
-                    + " or " + THREAD_STARTED_BREAK);
-            for (String line : contReply) {
-                log.complain("reply: " + line);
-            }
-            break;
-        }
-        if (started != where006a.numThreads) {
-            failure("Expected " + where006a.numThreads + " threadStarted() hits, got: " + started);
-        }
+        waitForTestedThreadStarts(THREAD_STARTED_BREAK, where006a.numThreads);
 
         String[] threadIds = jdb.getThreadIdsByName("MyThread");
         reply = jdb.receiveReplyFor(JdbCommand.where + "all");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006a.java
@@ -110,7 +110,14 @@ class MyThread extends ThreadWrapper {
    String name;
    MyThread(Lock l, String n) {super(n); this.lock = l; name = n;}
 
+   // Each tested thread calls this once at startup. The debugger sets a
+   // breakpoint here: receiving the event is what makes a virtual thread
+   // visible to jdb with the default debug agent behavior, so the test
+   // does not need the -trackallthreads option.
+   static void threadStarted() {}
+
    public void run() {
+       threadStarted();
       // Concatenate strings in advance to avoid lambda calculations later
       final String ThreadFinished = "Thread finished: " + this.name;
       int square = func1(10);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.where.where006;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -52,7 +53,7 @@ public class where006a {
 
         for (int i = 0; i < numThreads ; i++) {
            locks[i] = new Lock();
-           holder[i] = new MyThread(locks[i],"MyThread-" + i);
+           holder[i] = new MyThread(locks[i],"MyThread-" + i).getThread();
         }
 
         // lock monitor to prevent threads from finishing after they started
@@ -104,10 +105,10 @@ class Lock {
    }
 }
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
    Lock lock;
    String name;
-   MyThread(Lock l, String n) {this.lock = l; name = n;}
+   MyThread(Lock l, String n) {super(n); this.lock = l; name = n;}
 
    public void run() {
       // Concatenate strings in advance to avoid lambda calculations later

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
+ *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -84,7 +85,7 @@ public class wherei001 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        threads = jdb.getThreadIdsByName("MyThread");
 
         if (threads.length != 5) {
             log.complain("jdb should report 5 instance of " + DEBUGGEE_THREAD);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -83,39 +83,7 @@ public class wherei001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
-
-        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
-        // tested thread first hits threadStarted(); receiving that event is
-        // what makes a virtual thread visible to jdb with the default debug
-        // agent behavior, so count the hits to be sure every tested thread
-        // became visible before the lookup below.
-        int started = 0;
-        while (true) {
-            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
-            // Match the fully qualified method of the stop location as a single
-            // token: debuggee output can interleave with jdb's own output and
-            // split the "Breakpoint hit:" prefix away from the location, so do
-            // not require both in the same paragraph. The "(" suffix avoids
-            // matching jdb's "Set deferred breakpoint" messages.
-            Paragrep contGrep = new Paragrep(contReply);
-            if (contGrep.find(LAST_BREAK + "(") > 0) {
-                break;
-            }
-            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
-                started++;
-                continue;
-            }
-            failure("Stopped at unexpected location, expected " + LAST_BREAK
-                    + " or " + THREAD_STARTED_BREAK);
-            for (String line : contReply) {
-                log.complain("reply: " + line);
-            }
-            break;
-        }
-        if (started != wherei001a.numThreads) {
-            failure("Expected " + wherei001a.numThreads + " threadStarted() hits, got: " + started);
-        }
+        waitForTestedThreadStarts(THREAD_STARTED_BREAK, wherei001a.numThreads);
 
         threads = jdb.getThreadIdsByName("MyThread");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -44,7 +44,6 @@
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
- *      -jdb.option=-trackallthreads
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
@@ -72,6 +71,7 @@ public class wherei001 extends JdbTest {
     static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
     static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String THREAD_STARTED_BREAK = PACKAGE_NAME + ".MyThread.threadStarted";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
@@ -83,7 +83,39 @@ public class wherei001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.setBreakpointInMethod(THREAD_STARTED_BREAK);
+
+        // Continue until the debuggee reaches the LAST_BREAK breakpoint. Each
+        // tested thread first hits threadStarted(); receiving that event is
+        // what makes a virtual thread visible to jdb with the default debug
+        // agent behavior, so count the hits to be sure every tested thread
+        // became visible before the lookup below.
+        int started = 0;
+        while (true) {
+            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
+            // Match the fully qualified method of the stop location as a single
+            // token: debuggee output can interleave with jdb's own output and
+            // split the "Breakpoint hit:" prefix away from the location, so do
+            // not require both in the same paragraph. The "(" suffix avoids
+            // matching jdb's "Set deferred breakpoint" messages.
+            Paragrep contGrep = new Paragrep(contReply);
+            if (contGrep.find(LAST_BREAK + "(") > 0) {
+                break;
+            }
+            if (contGrep.find(THREAD_STARTED_BREAK + "(") > 0) {
+                started++;
+                continue;
+            }
+            failure("Stopped at unexpected location, expected " + LAST_BREAK
+                    + " or " + THREAD_STARTED_BREAK);
+            for (String line : contReply) {
+                log.complain("reply: " + line);
+            }
+            break;
+        }
+        if (started != wherei001a.numThreads) {
+            failure("Expected " + wherei001a.numThreads + " threadStarted() hits, got: " + started);
+        }
 
         threads = jdb.getThreadIdsByName("MyThread");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001a.java
@@ -94,7 +94,14 @@ class MyThread extends ThreadWrapper {
         name = n;
     }
 
+    // Each tested thread calls this once at startup. The debugger sets a
+    // breakpoint here: receiving the event is what makes a virtual thread
+    // visible to jdb with the default debug agent behavior, so the test
+    // does not need the -trackallthreads option.
+    static void threadStarted() {}
+
     public void run() {
+        threadStarted();
         int square = func1(100);
         wherei001a.log.display(name + " returns " + square);
         lock.releaseLock();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package nsk.jdb.wherei.wherei001;
 
+import jdk.test.lib.thread.ThreadWrapper;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -56,7 +57,7 @@ public class wherei001a {
 
         for (i = 0; i < numThreads ; i++) {
             locks[i] = new Lock();
-            holder[i] = new MyThread(locks[i],"MyThread-" + i);
+            holder[i] = new MyThread(locks[i],"MyThread-" + i).getThread();
         }
 
         // lock monitor to prevent threads from finishing after they started
@@ -81,13 +82,14 @@ public class wherei001a {
 }
 
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
     Lock lock;
     String name;
     // Concatenate strings in advance to avoid lambda calculations later
     final String ThreadFinished = "Thread finished: " + this.name;
 
     public MyThread (Lock l, String n) {
+        super(n);
         this.lock = l;
         name = n;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,51 @@ public abstract class JdbTest {
 
     protected void display(String message) {
         log.display(message);
+    }
+
+    /**
+     * Sets a breakpoint in the given method and then repeatedly continues the
+     * debuggee until the lastBreak breakpoint is reached, counting how many
+     * times threadStartedMethod is hit on the way. Each tested thread is
+     * expected to hit that method once at startup: receiving the event is
+     * what makes a virtual thread visible to jdb with the default debug
+     * agent behavior, so the tests do not need the -trackallthreads option.
+     * Fails if the number of hits differs from expectedThreads.
+     *
+     * The stop location is matched as one fully qualified token because
+     * debuggee output can interleave with jdb's "Breakpoint hit:" output and
+     * split the surrounding text across reply fragments. The "(" suffix
+     * avoids matching jdb's "Set deferred breakpoint" messages.
+     */
+    protected void waitForTestedThreadStarts(String threadStartedMethod, int expectedThreads) {
+        if (lastBreak.length() == 0) {
+            throw new Failure("waitForTestedThreadStarts requires lastBreak to be set");
+        }
+
+        jdb.setBreakpointInMethod(threadStartedMethod);
+
+        int started = 0;
+        while (true) {
+            String[] contReply = jdb.receiveReplyFor(JdbCommand.cont);
+            Paragrep contGrep = new Paragrep(contReply);
+            if (contGrep.find(lastBreak + "(") > 0) {
+                break;
+            }
+            if (contGrep.find(threadStartedMethod + "(") > 0) {
+                started++;
+                continue;
+            }
+            failure("Stopped at unexpected location, expected " + lastBreak
+                    + " or " + threadStartedMethod);
+            for (String line : contReply) {
+                log.complain("reply: " + line);
+            }
+            break;
+        }
+        if (started != expectedThreads) {
+            failure("Expected " + expectedThreads + " " + threadStartedMethod
+                    + " hits, got: " + started);
+        }
     }
 
     protected void launchJdbAndDebuggee(String debuggeeClass) throws Exception {


### PR DESCRIPTION
Converts the tested threads in nsk/jdb to jdk.test.lib.thread.ThreadWrapper so they can run under JTREG_TEST_THREAD_FACTORY=Virtual. Per JDK-8381657, the conversion targets "spawned threads that make actual work in the tests".

12 debuggees converted. Because jdb output identifies threads by name, threads that stored their name in a field without setting it now call super(name), and the debuggers look threads up with getThreadIdsByName(<name>) instead of getThreadIds(<class>) - after conversion the running class is java.lang.Thread / VirtualThread, not the test's own class. next001a and step_up001a additionally gain a naming constructor: unnamed virtual threads have an empty name (platform threads get "Thread-N"), which made jdb's breakpoint prompt unrecognizable to the harness.

10 of these tests pass -jdb.option=-trackallthreads in their @run block (per-test, following the nsk/jdi -includevirtualthreads precedent): jdb only tracks a virtual thread once it sees an event on it, so tested threads were otherwise missing from "threads" output. thread002's switch check now greps each thread command's own reply (the name appears three times in the accumulated output), and interrupt001's tid pattern matches on thread name rather than class.

Four tests stay on platform threads, each with a comment giving the reason:

threadgroup002 / threadgroups002 - their threads take super(group, name); Thread.Builder.OfVirtual has no
ThreadGroup option, and thread-group placement is what these tests exercise
kill/kill002 - jdb's kill (JVMTI StopThread) rejects a virtual thread unmounted in Object.wait() with "Operation is not supported on the current frame"
suspend/suspend001 - after "suspend <id>" of the virtual thread plus "cont", jdb stops responding (no prompt); happy to file a separate bug if this looks like a jdb/JDI issue worth tracking
trace001 and kill001 are unchanged - their threads already go through JDIThreadFactory, so they are virtual-capable

Testing: full nsk/jdb on linux-x64-OL-9 with the default factory and with JTREG_TEST_THREAD_FACTORY=Virtual - all pass in both; plus a five-platform run (linux-x64, linux-aarch64, macosx-x64, macosx-aarch64, windows-x64) in both modes


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382272](https://bugs.openjdk.org/browse/JDK-8382272): Update nsk/jdb tests to use ThreadWrapper (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [1355985b](https://git.openjdk.org/jdk/pull/32142/files/1355985bedb074b2d152a0c81291742eef197771)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32142/head:pull/32142` \
`$ git checkout pull/32142`

Update a local copy of the PR: \
`$ git checkout pull/32142` \
`$ git pull https://git.openjdk.org/jdk.git pull/32142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32142`

View PR using the GUI difftool: \
`$ git pr show -t 32142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32142.diff">https://git.openjdk.org/jdk/pull/32142.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32142#issuecomment-5145123511)
</details>
