### PR TITLE
8389498: Enable HttpClient debug logging in java/net/httpclient/http2/H2GoAwayPromptConnectionClose.java test

### DIFF
--- a/test/jdk/java/net/httpclient/http2/H2GoAwayPromptConnectionClose.java
+++ b/test/jdk/java/net/httpclient/http2/H2GoAwayPromptConnectionClose.java
@@ -74,7 +74,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @build jdk.test.lib.net.SimpleSSLContext jdk.test.lib.RandomFactory jdk.test.lib.net.URIBuilder
  * @comment An arbitrary high value for idle connection timeout to prevent idle
  *          connection management from closing the HTTP/2 connection
- * @run junit/othervm -Djdk.httpclient.keepalive.timeout.h2=36000 ${test.main.class}
+ * @run junit/othervm -Djdk.httpclient.keepalive.timeout.h2=36000
+ *                    -Djdk.internal.httpclient.debug=true
+ *                    ${test.main.class}
  */
 class H2GoAwayPromptConnectionClose {
 


### PR DESCRIPTION
Can I please get a review of this test-only change which enables debug logging of the `HttpClient` in the `java/net/httpclient/http2/H2GoAwayPromptConnectionClose.java` test?

As noted in https://bugs.openjdk.org/browse/JDK-8389498, this test timed out unexpectedly once in our CI. If/when this test times out again, this debug logging should hopefully provide some hints on what's going on. I've verified that the generated logs in this test don't overflow the jtreg limit, so we should be able to get hold of the entire logs from any timing out run.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389498](https://bugs.openjdk.org/browse/JDK-8389498): Enable HttpClient debug logging in java/net/httpclient/http2/H2GoAwayPromptConnectionClose.java test (**Sub-task** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32143/head:pull/32143` \
`$ git checkout pull/32143`

Update a local copy of the PR: \
`$ git checkout pull/32143` \
`$ git pull https://git.openjdk.org/jdk.git pull/32143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32143`

View PR using the GUI difftool: \
`$ git pr show -t 32143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32143.diff">https://git.openjdk.org/jdk/pull/32143.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32143#issuecomment-5141714086)
</details>
