### PR TITLE
8388400: Incorrect null check in jdk.internal.jrtfs.ExplodedImage$PathNode constructor

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/ExplodedImage.java
@@ -122,7 +122,7 @@ class ExplodedImage extends SystemImage {
         private PathNode(String name, PathNode link) {
             super(name, link.getFileAttributes());
             this.file = null;
-            this.link = Objects.requireNonNull(link);
+            this.link = link;
             this.directories = null;
             this.childNames = null;
         }

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
@@ -78,7 +78,7 @@ class JrtFileSystem extends FileSystem {
     private final JrtFileSystemProvider provider;
     private final JrtPath rootPath = new JrtPath(this, "/");
     private volatile boolean isOpen;
-    private volatile boolean isClosable;
+    private final boolean isClosable;
     private SystemImage image;
 
     /**


### PR DESCRIPTION
Can I please get a review of this trivial change which addresses a review comment that was brought up during JEP-401 review https://bugs.openjdk.org/browse/JDK-8388400?

This is the same fix that was proposed in the valhalla repo a while back https://github.com/openjdk/valhalla/pull/2649 but wasn't integrated because the code freeze was in place.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388400](https://bugs.openjdk.org/browse/JDK-8388400): Incorrect null check in jdk.internal.jrtfs.ExplodedImage$PathNode constructor (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32145/head:pull/32145` \
`$ git checkout pull/32145`

Update a local copy of the PR: \
`$ git checkout pull/32145` \
`$ git pull https://git.openjdk.org/jdk.git pull/32145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32145`

View PR using the GUI difftool: \
`$ git pr show -t 32145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32145.diff">https://git.openjdk.org/jdk/pull/32145.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32145#issuecomment-5142324090)
</details>
