### PR TITLE
8389509: SetPrinterDevice check GlobalAlloc return value

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -4259,6 +4259,12 @@ static BOOL SetPrinterDevice(LPTSTR pszDeviceName, HGLOBAL* p_hDevMode,
 
   // Allocate a global handle big enough to hold DEVNAMES.
   HGLOBAL   hDevNames = ::GlobalAlloc(GHND, devNameSize);
+  if (hDevNames == NULL) {
+    ::GlobalFree(hDevMode);
+    ::GlobalFree(p2);
+    return FALSE;
+  }
+
   DEVNAMES* pDevNames = (DEVNAMES*)::GlobalLock(hDevNames);
 
   // Copy the DEVNAMES information from PRINTER_INFO_2 structure.

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -4266,6 +4266,12 @@ static BOOL SetPrinterDevice(LPTSTR pszDeviceName, HGLOBAL* p_hDevMode,
   }
 
   DEVNAMES* pDevNames = (DEVNAMES*)::GlobalLock(hDevNames);
+  if (pDevNames == NULL) {
+    ::GlobalFree(hDevNames);
+    ::GlobalFree(hDevMode);
+    ::GlobalFree(p2);
+    return FALSE;
+  }
 
   // Copy the DEVNAMES information from PRINTER_INFO_2 structure.
   pDevNames->wDriverOffset = sizeof(DEVNAMES)/sizeof(TCHAR);


### PR DESCRIPTION
We miss to check the rv of GlobalAlloc at one code location, this should better be adjusted.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389509](https://bugs.openjdk.org/browse/JDK-8389509): SetPrinterDevice check GlobalAlloc return value (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32151/head:pull/32151` \
`$ git checkout pull/32151`

Update a local copy of the PR: \
`$ git checkout pull/32151` \
`$ git pull https://git.openjdk.org/jdk.git pull/32151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32151`

View PR using the GUI difftool: \
`$ git pr show -t 32151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32151.diff">https://git.openjdk.org/jdk/pull/32151.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32151#issuecomment-5143420199)
</details>
