### PR TITLE
8389514: HttpClientImpl$SelectorManager.deregistrations collection is always empty resulting in dead code

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1228,7 +1228,6 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         private final Selector selector;
         private volatile boolean closed;
         private final List<AsyncEvent> registrations;
-        private final List<AsyncTriggerEvent> deregistrations;
         private final Logger debug;
         private final Logger debugtimeout;
         private final HttpClientImpl owner;
@@ -1242,7 +1241,6 @@ final class HttpClientImpl extends HttpClient implements Trackable {
             debugtimeout = ref.debugtimeout;
             pool = ref.connectionPool();
             registrations = new ArrayList<>();
-            deregistrations = new ArrayList<>();
             selector = Selector.open();
         }
 
@@ -1328,9 +1326,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                     // OK - nothing to do...
                 }
                 toAbort.addAll(this.registrations);
-                toAbort.addAll(this.deregistrations);
                 this.registrations.clear();
-                this.deregistrations.clear();
             } finally {
                 lock.unlock();
             }
@@ -1402,10 +1398,6 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                         assert errorList.isEmpty();
                         assert readyList.isEmpty();
                         assert resetList.isEmpty();
-                        for (AsyncTriggerEvent event : deregistrations) {
-                            event.handle();
-                        }
-                        deregistrations.clear();
                         for (AsyncEvent event : registrations) {
                             if (event instanceof AsyncTriggerEvent) {
                                 readyList.add(event);


### PR DESCRIPTION
Can I please get a review of this change which removes the `deregistrations` field from an internal class of the `HttpClient`?

As noted in https://bugs.openjdk.org/browse/JDK-8389514, this collection never gets populated and as a result the call sites which `clear()` or iterate over this collection are all dead code. It has been this way ever since this field was introduced in Java 11 through https://bugs.openjdk.org/browse/JDK-8197564.

I'm running existing tests to verify that nothing breaks unexpectedly.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389514](https://bugs.openjdk.org/browse/JDK-8389514): HttpClientImpl$SelectorManager.deregistrations collection is always empty resulting in dead code (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32152/head:pull/32152` \
`$ git checkout pull/32152`

Update a local copy of the PR: \
`$ git checkout pull/32152` \
`$ git pull https://git.openjdk.org/jdk.git pull/32152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32152`

View PR using the GUI difftool: \
`$ git pr show -t 32152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32152.diff">https://git.openjdk.org/jdk/pull/32152.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32152#issuecomment-5143530101)
</details>
