### PR TITLE
8389533: ProblemList gc/g1/TestCodeCacheUnloadDuringConcurrentMark.java in Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -44,6 +44,7 @@ vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 829
 vmTestbase/nsk/stress/thread/thread006.java 8321476 linux-all
 
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
+gc/g1/TestCodeCacheUnloadDuringConcurrentMark.java 8388169 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList gc/g1/TestCodeCacheUnloadDuringConcurrentMark.java in Xcomp mode.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389533](https://bugs.openjdk.org/browse/JDK-8389533): ProblemList gc/g1/TestCodeCacheUnloadDuringConcurrentMark.java in Xcomp mode (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32154/head:pull/32154` \
`$ git checkout pull/32154`

Update a local copy of the PR: \
`$ git checkout pull/32154` \
`$ git pull https://git.openjdk.org/jdk.git pull/32154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32154`

View PR using the GUI difftool: \
`$ git pr show -t 32154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32154.diff">https://git.openjdk.org/jdk/pull/32154.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32154#issuecomment-5145650910)
</details>
