### PR TITLE
8389537: (fs) Failure in querying attributes of a OneDrive folder over SMB (win)

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -96,6 +96,7 @@ class WindowsConstants {
     public static final int ERROR_NOT_SAME_DEVICE       = 17;
     public static final int ERROR_NOT_READY             = 21;
     public static final int ERROR_SHARING_VIOLATION     = 32;
+    public static final int ERROR_NOT_SUPPORTED         = 50;
     public static final int ERROR_NETWORK_ACCESS_DENIED = 65;
     public static final int ERROR_FILE_EXISTS           = 80;
     public static final int ERROR_INVALID_PARAMETER     = 87;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -390,16 +390,22 @@ class WindowsFileAttributes
         if (supportsGetFileInformationByName()) {
             try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(SIZEOF_STAT_BASIC_INFO)) {
                 long addr = buffer.address();
-                GetFileInformationByName(path.getPathForWin32Calls(),
-                                            FileStatBasicByNameInfo, addr,
-                                            SIZEOF_STAT_BASIC_INFO);
+                try {
+                    GetFileInformationByName(path.getPathForWin32Calls(),
+                                                FileStatBasicByNameInfo, addr,
+                                                SIZEOF_STAT_BASIC_INFO);
 
-                // GetFileInformationByName() doesn't follow reparse points so if
-                // we discover that this is a reparse point and if we're being asked
-                // to follow links, then drop to the slow path.
-                int fileAttrs = unsafe.getInt(addr + OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES);
-                if (!isReparsePoint(fileAttrs) || !followLinks) {
-                    return fromStatBasicInfo(addr);
+                    // GetFileInformationByName() doesn't follow reparse points so if
+                    // we discover that this is a reparse point and if we're being asked
+                    // to follow links, then drop to the slow path.
+                    int fileAttrs = unsafe.getInt(addr + OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES);
+                    if (!isReparsePoint(fileAttrs) || !followLinks) {
+                        return fromStatBasicInfo(addr);
+                    }
+                } catch (WindowsException exc) {
+                    if (exc.lastError() != ERROR_NOT_SUPPORTED) {
+                        throw exc;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Even if the `GetFileInformationByName()` API is supported by the OS, the
API may return with the error `ERROR_NOT_SUPPORTED` for certain
endpoints like OneDrive folders mounted on SMB.  Prior to this patch,
this caused the call to read filesystem attributes to terminate with the
`java.nio.file.FileSystemException` ("The request is not supported").

This patch fixes the problem so that when `GetFileInformationByName()`
fails with `ERROR_NOT_SUPPORTED`, then we drop to the slow path (opening
the file handle, calling `GetFileInformationByHandle()`, followed by
closing the file handle).

Reproducing this problem requires both OneDrive folders and SMB shares,
so (as far as I am aware) it's not possible to recreate the environment
in a test.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389537](https://bugs.openjdk.org/browse/JDK-8389537): (fs) Failure in querying attributes of a OneDrive folder over SMB (win) (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32155/head:pull/32155` \
`$ git checkout pull/32155`

Update a local copy of the PR: \
`$ git checkout pull/32155` \
`$ git pull https://git.openjdk.org/jdk.git pull/32155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32155`

View PR using the GUI difftool: \
`$ git pr show -t 32155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32155.diff">https://git.openjdk.org/jdk/pull/32155.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32155#issuecomment-5146856882)
</details>
