### PR TITLE
8389538: StringUtils::string_match may underflow-read a buffer

### DIFF
--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -189,7 +189,7 @@ class StringMatcher {
           if (ch == string_match_eos ||
               ch == string_match_comma) {
             // Anchor word is at end of pattern, so treat it as a fixed pattern.
-            size_t remaining_len = string_end - matchp;
+            int remaining_len = (int)(string_end - matchp);
             if (anchor_len > remaining_len) {
               // The anchor word does not fit into the remainder of the string, so we can give up on this list item.
               matchp = nullptr;

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -189,6 +189,12 @@ class StringMatcher {
           if (ch == string_match_eos ||
               ch == string_match_comma) {
             // Anchor word is at end of pattern, so treat it as a fixed pattern.
+            size_t remaining_len = string_end - matchp;
+            if (anchor_len > remaining_len) {
+              // The anchor word does not fit into the remainder of the string, so we can give up on this list item.
+              matchp = nullptr;
+              continue;
+            }
             const char* limitp = string_end - anchor_len;
             matchp = limitp;
             patp = begp;

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -33,6 +33,8 @@
 #include <string.h>
 
 int StringUtils::replace_no_expand(char* string, const char* from, const char* to) {
+  assert(strcmp(from, "") != 0, "mustn't be empty");
+
   int replace_count = 0;
   size_t from_len = strlen(from);
   size_t to_len = strlen(to);
@@ -109,6 +111,11 @@ class StringMatcher {
     // note that begp is now advanced over ch1
     assert(ch1 > 0, "regular char only");
     const char* matchp = match;
+    int remaining_len = (int)(match_end - matchp);
+    if (anchor_length > remaining_len) {
+      return nullptr;
+    }
+
     const char* limitp = match_end - anchor_length;
     while (matchp <= limitp) {
       int mch = _string_getc(matchp, match_end);

--- a/test/hotspot/gtest/utilities/test_stringUtils.cpp
+++ b/test/hotspot/gtest/utilities/test_stringUtils.cpp
@@ -76,7 +76,7 @@ TEST(StringUtils, ClassListMatch) {
   // Wild card matching doesn't look backwards
   const char* str = "xabc";
   const char* pat = "*abc";
-  bool match = StringUtils::class_list_match(pat, str);
+  bool match =  StringUtils::class_list_match(pat, &str[3]);
   EXPECT_FALSE(match);
 
   // Package name supports both / and .

--- a/test/hotspot/gtest/utilities/test_stringUtils.cpp
+++ b/test/hotspot/gtest/utilities/test_stringUtils.cpp
@@ -71,3 +71,18 @@ TEST_VM(StringUtils, replace_no_expand) {
   deleted = StringUtils::replace_no_expand(s2, "\n", "");
   ASSERT_EQ(deleted, 0);
 }
+
+TEST(StringUtils, ClassListMatch) {
+  // Wild card matching doesn't look backwards
+  const char* str = "xabc";
+  const char* pat = "*abc";
+  bool r = StringUtils::class_list_match(pat, &str[3]);
+  bool match =  StringUtils::class_list_match(pat, str);
+  EXPECT_FALSE(match);
+
+  // Package name supports both / and .
+  str = "java/lang/String";
+  pat = "java.lang.String";
+  match =  StringUtils::class_list_match(pat, str);
+  EXPECT_TRUE(match);
+}

--- a/test/hotspot/gtest/utilities/test_stringUtils.cpp
+++ b/test/hotspot/gtest/utilities/test_stringUtils.cpp
@@ -76,8 +76,7 @@ TEST(StringUtils, ClassListMatch) {
   // Wild card matching doesn't look backwards
   const char* str = "xabc";
   const char* pat = "*abc";
-  bool r = StringUtils::class_list_match(pat, &str[3]);
-  bool match =  StringUtils::class_list_match(pat, str);
+  bool match = StringUtils::class_list_match(pat, str);
   EXPECT_FALSE(match);
 
   // Package name supports both / and .


### PR DESCRIPTION
Hi,

We need to check whether the subtraction `string_end - anchor_len` produces a valid index into the string. The current code may dereference an out of bounds pointer. This mistake was in two places. I also added an assert because the `from` string shouldn't be `""` (it'll loop forever).

Testing: Just the gtests for StringUtils and GHA tier1.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389538](https://bugs.openjdk.org/browse/JDK-8389538): StringUtils::string_match may underflow-read a buffer (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32156/head:pull/32156` \
`$ git checkout pull/32156`

Update a local copy of the PR: \
`$ git checkout pull/32156` \
`$ git pull https://git.openjdk.org/jdk.git pull/32156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32156`

View PR using the GUI difftool: \
`$ git pr show -t 32156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32156.diff">https://git.openjdk.org/jdk/pull/32156.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32156#issuecomment-5166589918)
</details>
