### PR TITLE
8337680: failure_handler does not handle repeated commands well

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/HtmlSection.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/HtmlSection.java
@@ -26,6 +26,8 @@ package jdk.test.failurehandler;
 import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.Set;
 
 public class HtmlSection {
     protected final HtmlSection rootSection;
@@ -39,6 +41,7 @@ public class HtmlSection {
     protected final PrintWriter pw;
     protected final PrintWriter textWriter;
     protected boolean closed;
+    private final Set<String> sectionIds;
 
     private HtmlSection child;
 
@@ -56,6 +59,7 @@ public class HtmlSection {
         // main
         if (rootSection == null) {
             this.rootSection = this;
+            this.sectionIds = new HashSet<>();
             this.pw.println("<html>");
 
             this.pw.println("<head>");
@@ -68,6 +72,7 @@ public class HtmlSection {
             this.pw.println("<body>");
         } else {
             this.rootSection = rootSection;
+            this.sectionIds = null;
             this.pw.print("<ul>");
         }
     }
@@ -151,15 +156,31 @@ public class HtmlSection {
         return current;
     }
 
+    /**
+     * Returns {@code base} if no section has used it as an id yet, otherwise
+     * {@code base} with the first free numeric suffix ("-2", "-3", ...), and
+     * records the returned id as used. Keeps every section id unique so that
+     * anchors, {@code data-toggle} and {@code data-show} references resolve to
+     * the right occurrence when a command name is repeated (JDK-8337680).
+     */
+    private static String uniqueId(HtmlSection root, String base) {
+        String id = base;
+        for (int i = 2; !root.sectionIds.add(id); i++) {
+            id = base + "-" + i;
+        }
+        return id;
+    }
+
     private static class SubSection extends HtmlSection {
         private final HtmlSection parent;
 
         public SubSection(HtmlSection parent, String name,
                           HtmlSection rootSection) {
             super(parent.pw,
-                    parent.id.isEmpty()
-                            ? name
-                            : String.format("%s.%s", parent.id, name),
+                    uniqueId(rootSection,
+                            parent.id.isEmpty()
+                                    ? name
+                                    : String.format("%s.%s", parent.id, name)),
                     name, rootSection);
             this.parent = parent;
             pw.printf("<li><a name='%1$s'/><a href='#%1$s' data-toggle=\"%1$s\" >%2$s</a><div id='%1$s'><code><pre>",

--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/HtmlSection.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/HtmlSection.java
@@ -72,7 +72,7 @@ public class HtmlSection {
             this.pw.println("<body>");
         } else {
             this.rootSection = rootSection;
-            this.sectionIds = null;
+            this.sectionIds = new HashSet<>();
             this.pw.print("<ul>");
         }
     }
@@ -161,7 +161,7 @@ public class HtmlSection {
      * {@code base} with the first free numeric suffix ("-2", "-3", ...), and
      * records the returned id as used. Keeps every section id unique so that
      * anchors, {@code data-toggle} and {@code data-show} references resolve to
-     * the right occurrence when a command name is repeated (JDK-8337680).
+     * the right occurrence when a command name is repeated.
      */
     private static String uniqueId(HtmlSection root, String base) {
         String id = base;

--- a/test/failure_handler/test/unit/jdk/test/failurehandler/HtmlSectionTest.java
+++ b/test/failure_handler/test/unit/jdk/test/failurehandler/HtmlSectionTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.failurehandler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/*
+ * Verifies that repeated and non-contiguous command names produce unique
+ * section ids in the generated HTML, so every occurrence's output is
+ * reachable (JDK-8337680).
+ */
+public class HtmlSectionTest {
+
+    private static String generate(String... commands) throws Exception {
+        Path dir = Files.createTempDirectory("HtmlSectionTest");
+        HtmlPage page = new HtmlPage(dir, "processes.html", false);
+        HtmlSection root = page.getRootSection();
+        int run = 0;
+        for (String command : commands) {
+            HtmlSection s = root.createChildren(command.split("\\."));
+            s.getWriter().println("MARKER-" + (++run));
+        }
+        root.close();
+        page.close();
+        return Files.readString(dir.resolve("processes.html"));
+    }
+
+    private static List<String> divIds(String html) {
+        List<String> ids = new ArrayList<>();
+        Matcher m = Pattern.compile("div id='([^']*)'").matcher(html);
+        while (m.find()) {
+            ids.add(m.group(1));
+        }
+        return ids;
+    }
+
+    private static void assertUniqueIds(String html) {
+        List<String> ids = divIds(html);
+        Assert.assertEquals("duplicate section ids in: " + ids,
+                ids.size(), new HashSet<>(ids).size());
+    }
+
+    // The id of the section whose opening tag most closely precedes the given
+    // text; output is written right after its section is created, so this is
+    // the section containing it.
+    private static String sectionIdOf(String html, String text) {
+        int at = html.indexOf(text);
+        Assert.assertTrue("missing " + text, at >= 0);
+        Matcher m = Pattern.compile("div id='([^']*)'").matcher(html.substring(0, at));
+        String id = null;
+        while (m.find()) {
+            id = m.group(1);
+        }
+        Assert.assertNotNull("no section before " + text, id);
+        return id;
+    }
+
+    @Test
+    public void repeatedCommand() throws Exception {
+        // JDK-8337680, first case: the same command run twice, separated by
+        // another command.
+        String html = generate("jhsdb.jstack.live.mixed",
+                               "jinfo",
+                               "jhsdb.jstack.live.mixed");
+        assertUniqueIds(html);
+        for (int i = 1; i <= 3; i++) {
+            Assert.assertTrue("missing output of run " + i,
+                    html.contains("MARKER-" + i));
+        }
+        // each occurrence's output is in its own section
+        Assert.assertEquals("jhsdb.jstack.live.mixed", sectionIdOf(html, "MARKER-1"));
+        Assert.assertNotEquals(sectionIdOf(html, "MARKER-1"), sectionIdOf(html, "MARKER-3"));
+    }
+
+    @Test
+    public void tripleRepetition() throws Exception {
+        String html = generate("jinfo", "jcmd", "jinfo", "jstack", "jinfo");
+        assertUniqueIds(html);
+        Assert.assertNotEquals(sectionIdOf(html, "MARKER-1"), sectionIdOf(html, "MARKER-3"));
+        Assert.assertNotEquals(sectionIdOf(html, "MARKER-3"), sectionIdOf(html, "MARKER-5"));
+        Assert.assertNotEquals(sectionIdOf(html, "MARKER-1"), sectionIdOf(html, "MARKER-5"));
+    }
+
+    @Test
+    public void suffixCollisionWithRealName() throws Exception {
+        // a command literally named "jcmd-2" must not collide with the
+        // generated suffix for a repeated "jcmd"
+        String html = generate("jcmd-2", "jcmd", "jinfo", "jcmd");
+        assertUniqueIds(html);
+        Assert.assertNotEquals(sectionIdOf(html, "MARKER-2"), sectionIdOf(html, "MARKER-4"));
+    }
+
+    @Test
+    public void adjacentIdenticalCommandsShareSection() throws Exception {
+        // adjacent identical commands reuse the open section (existing
+        // behavior): one section, both outputs in it
+        String html = generate("jinfo", "jinfo");
+        assertUniqueIds(html);
+        Assert.assertEquals(sectionIdOf(html, "MARKER-1"), sectionIdOf(html, "MARKER-2"));
+    }
+
+    @Test
+    public void nonContiguousPrefix() throws Exception {
+        // JDK-8337680, second case: the same top-level tool name used again
+        // after an intervening command.
+        String html = generate("jcmd.compiler.codecache",
+                               "jinfo",
+                               "jcmd.compiler.codelist");
+        assertUniqueIds(html);
+        for (int i = 1; i <= 3; i++) {
+            Assert.assertTrue("missing output of run " + i,
+                    html.contains("MARKER-" + i));
+        }
+    }
+
+    @Test
+    public void adjacentPrefixSharingPreserved() throws Exception {
+        // Adjacent commands with a common prefix share the open sections;
+        // their ids must remain the plain name path, without suffixes.
+        String html = generate("jcmd.compiler.codecache",
+                               "jcmd.compiler.codelist");
+        List<String> ids = divIds(html);
+        Assert.assertTrue(ids.contains("jcmd"));
+        Assert.assertTrue(ids.contains("jcmd.compiler"));
+        Assert.assertTrue(ids.contains("jcmd.compiler.codecache"));
+        Assert.assertTrue(ids.contains("jcmd.compiler.codelist"));
+        assertUniqueIds(html);
+    }
+}


### PR DESCRIPTION
The failure handler keys each HTML section id by the command's name path, so when a command name occurs again after an intervening command - the same command repeated, or the same top-level tool reused, as in "jcmd.compiler.codecache jinfo jcmd.compiler.codelist" - a second section with the same id is written. Anchors and the data-toggle / data-show javascript resolve ids via document.getElementById, which returns the first match, so the later occurrence's output is unreachable. These are the two cases reported in the bug.

Fix: the root section keeps a registry of issued ids; a repeated id gets the first free numeric suffix ("jcmd-2", ...). Displayed names are unchanged, adjacent commands with a shared prefix still share their sections, children of a suffixed section are unique automatically, and the registry also prevents collisions with a command literally named like a suffix. The only external id reconstruction, ToolKit.link(), is keyed by PID and unaffected.

Ids can still repeat across appended fragments (each invocation appends a complete HTML document); that is pre-existing and tracked as JDK-8389541.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8337680](https://bugs.openjdk.org/browse/JDK-8337680): failure_handler does not handle repeated commands well (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32157/head:pull/32157` \
`$ git checkout pull/32157`

Update a local copy of the PR: \
`$ git checkout pull/32157` \
`$ git pull https://git.openjdk.org/jdk.git pull/32157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32157`

View PR using the GUI difftool: \
`$ git pr show -t 32157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32157.diff">https://git.openjdk.org/jdk/pull/32157.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32157#issuecomment-5163812374)
</details>
