### PR TITLE
8389539: Clarify equivalence class sizing with value objects

### DIFF
--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -174,8 +174,12 @@ public class Object {
      * indistinguishable value objects ({@code x == y} has the value
      * {@code true}).
      * <p>
-     * In other words, under the object equality equivalence
-     * relation, each equivalence class only has a single element.
+     * Therefore, under the object equality equivalence relation, each
+     * equivalence class only has a single element for identity
+     * classes. For value classes, there is not necessarily a similar
+     * constraint as multiple indistinguishable value objects could be
+     * constructed, depending on the semantics of the particular value
+     * class.
      *
      * @apiNote
      * It is generally necessary to override the {@link #hashCode() hashCode}


### PR DESCRIPTION
Another update to Object.equals to better support value classes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389539](https://bugs.openjdk.org/browse/JDK-8389539): Clarify equivalence class sizing with value objects (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32158/head:pull/32158` \
`$ git checkout pull/32158`

Update a local copy of the PR: \
`$ git checkout pull/32158` \
`$ git pull https://git.openjdk.org/jdk.git pull/32158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32158`

View PR using the GUI difftool: \
`$ git pr show -t 32158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32158.diff">https://git.openjdk.org/jdk/pull/32158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32158#issuecomment-5147507197)
</details>
