### PR TITLE
8389552: [s390]: Build fails due to missing CodeCache declaration in continuationEntry_s390.inline.hpp

### DIFF
--- a/src/hotspot/cpu/s390/continuationEntry_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuationEntry_s390.inline.hpp
@@ -26,6 +26,7 @@
 #ifndef CPU_S390_CONTINUATIONENTRY_S390_INLINE_HPP
 #define CPU_S390_CONTINUATIONENTRY_S390_INLINE_HPP
 
+#include "code/codeCache.hpp"
 #include "oops/method.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/registerMap.hpp"


### PR DESCRIPTION
Please review this change. Thanks!

Add codeCache.hpp include to fix s390 build failure.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389552](https://bugs.openjdk.org/browse/JDK-8389552): [s390]: Build fails due to missing CodeCache declaration in continuationEntry_s390.inline.hpp (**Bug** - P3)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32159/head:pull/32159` \
`$ git checkout pull/32159`

Update a local copy of the PR: \
`$ git checkout pull/32159` \
`$ git pull https://git.openjdk.org/jdk.git pull/32159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32159`

View PR using the GUI difftool: \
`$ git pr show -t 32159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32159.diff">https://git.openjdk.org/jdk/pull/32159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32159#issuecomment-5148989945)
</details>
