### PR TITLE
Remove deprecation from URLDecoder.decode + URLEncoder.encode method (default charset)

### DIFF
--- a/src/java.base/share/classes/java/net/URLDecoder.java
+++ b/src/java.base/share/classes/java/net/URLDecoder.java
@@ -95,14 +95,10 @@ public final class URLDecoder {
      * are represented by any consecutive sequences of the form
      * "<i>{@code %xy}</i>".
      * @param s the {@code String} to decode
-     * @deprecated The resulting string may vary depending on the
-     *          default charset. Instead, use the decode(String,String) method
-     *          to specify the encoding.
      * @return the newly decoded {@code String}
      * @throws IllegalArgumentException if the implementation encounters malformed
      * escape sequences
      */
-    @Deprecated
     public static String decode(String s) {
         return decode(s, Charset.defaultCharset());
     }

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -150,12 +150,8 @@ public final class URLEncoder {
      * as the encoding scheme to obtain the bytes for unsafe characters.
      *
      * @param   s   {@code String} to be translated.
-     * @deprecated The resulting string may vary depending on the
-     *             default charset. Instead, use the encode(String,String)
-     *             method to specify the encoding.
      * @return  the translated {@code String}.
      */
-    @Deprecated
     public static String encode(String s) {
         return encode(s, Charset.defaultCharset());
     }


### PR DESCRIPTION
JEP 400: UTF-8 by Default.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewers without OpenJDK IDs
 * @SAM-LATITUDE5500 (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32161/head:pull/32161` \
`$ git checkout pull/32161`

Update a local copy of the PR: \
`$ git checkout pull/32161` \
`$ git pull https://git.openjdk.org/jdk.git pull/32161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32161`

View PR using the GUI difftool: \
`$ git pr show -t 32161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32161.diff">https://git.openjdk.org/jdk/pull/32161.diff</a>

</details>
