### PR TITLE
8389581: RISC-V: building fails with clang toolchain

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7520,7 +7520,7 @@ instruct maxF_reg_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr) %{
   ins_encode %{
     __ minmax_fp(as_FloatRegister($dst$$reg),
                  as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg),
-                 __ FLOAT_TYPE::single_precision, false /* is_min */);
+                 C2_MacroAssembler::FLOAT_TYPE::single_precision, false /* is_min */);
   %}
 
   ins_pipe(pipe_class_default);
@@ -7551,7 +7551,7 @@ instruct minF_reg_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr) %{
   ins_encode %{
     __ minmax_fp(as_FloatRegister($dst$$reg),
                  as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg),
-                 __ FLOAT_TYPE::single_precision, true /* is_min */);
+                 C2_MacroAssembler::FLOAT_TYPE::single_precision, true /* is_min */);
   %}
 
   ins_pipe(pipe_class_default);
@@ -7582,7 +7582,7 @@ instruct maxD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
   ins_encode %{
     __ minmax_fp(as_FloatRegister($dst$$reg),
                  as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg),
-                 __ FLOAT_TYPE::double_precision, false /* is_min */);
+                 C2_MacroAssembler::FLOAT_TYPE::double_precision, false /* is_min */);
   %}
 
   ins_pipe(pipe_class_default);
@@ -7613,7 +7613,7 @@ instruct minD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
   ins_encode %{
     __ minmax_fp(as_FloatRegister($dst$$reg),
                  as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg),
-                 __ FLOAT_TYPE::double_precision, true /* is_min */);
+                 C2_MacroAssembler::FLOAT_TYPE::double_precision, true /* is_min */);
   %}
 
   ins_pipe(pipe_class_default);
@@ -8695,7 +8695,7 @@ instruct min_HF_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr)
 
   ins_encode %{
     __ minmax_fp($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister,
-                 __ FLOAT_TYPE::half_precision, true /* is_min */);
+                 C2_MacroAssembler::FLOAT_TYPE::half_precision, true /* is_min */);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -8725,7 +8725,7 @@ instruct max_HF_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr)
 
   ins_encode %{
     __ minmax_fp($dst$$FloatRegister, $src1$$FloatRegister, $src2$$FloatRegister,
-                 __ FLOAT_TYPE::half_precision, false /* is_min */);
+                 C2_MacroAssembler::FLOAT_TYPE::half_precision, false /* is_min */);
   %}
   ins_pipe(pipe_class_default);
 %}


### PR DESCRIPTION
Hi all,

When using the clang toolchain to build the riscv image on vision five2 board, the building fails.
This patch uses the explicit `C2_MacroAssembler` to fix the building error.

Best Regards,
-- Guoxiong

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389581](https://bugs.openjdk.org/browse/JDK-8389581): RISC-V: building fails with clang toolchain (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32162/head:pull/32162` \
`$ git checkout pull/32162`

Update a local copy of the PR: \
`$ git checkout pull/32162` \
`$ git pull https://git.openjdk.org/jdk.git pull/32162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32162`

View PR using the GUI difftool: \
`$ git pr show -t 32162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32162.diff">https://git.openjdk.org/jdk/pull/32162.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32162#issuecomment-5157437308)
</details>
