### PR TITLE
8389152: Move null assignment outside debug block when clearing CRLs that exceed the maximum length

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
@@ -676,7 +676,7 @@ class URICertStore extends CertStoreSpi {
      */
     private static Collection<X509CRL> getMatchingCRLs
         (X509CRL crl, CRLSelector selector) {
-        if (selector == null || (crl != null && selector.match(crl))) {
+        if (crl != null && (selector == null || selector.match(crl))) {
             return Collections.singletonList(crl);
         } else {
             return Collections.emptyList();

--- a/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
@@ -651,8 +651,9 @@ class URICertStore extends CertStoreSpi {
                     // configured maximum length.
                     if (debug != null) {
                         debug.println("Discarding CRL: " + iae.getMessage());
-                        crl = null;
                     }
+                    lastModified = 0;
+                    crl = null;
                 }
             }
             return getMatchingCRLs(crl, selector);

--- a/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
@@ -654,6 +654,7 @@ class URICertStore extends CertStoreSpi {
                     }
                     lastModified = 0;
                     crl = null;
+                    return Collections.emptyList();
                 }
             }
             return getMatchingCRLs(crl, selector);


### PR DESCRIPTION
Please review this change. Thanks!

**Description:**

When an oversized CRL is fetched, the cached `crl` is cleared only when debugging is enabled, and `lastModified` is not reset.

**Solution:**

Always clear the cached `crl` and reset `lastModified` when an oversized CRL is discarded.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389152](https://bugs.openjdk.org/browse/JDK-8389152): Move null assignment outside debug block when clearing CRLs that exceed the maximum length (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32164/head:pull/32164` \
`$ git checkout pull/32164`

Update a local copy of the PR: \
`$ git checkout pull/32164` \
`$ git pull https://git.openjdk.org/jdk.git pull/32164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32164`

View PR using the GUI difftool: \
`$ git pr show -t 32164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32164.diff">https://git.openjdk.org/jdk/pull/32164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32164#issuecomment-5157893562)
</details>
