### PR TITLE
8389588: [s390x] Zero build is broken after JDK-8388561

### DIFF
--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -478,9 +478,3 @@ int os::extra_bang_size_in_bytes() {
 
 void os::setup_fpu() {}
 
-uintptr_t os::vm_page_table_expansion_point() {
-  // On s390x, page table will dynamically expand based on user demand
-  // (eg mmap probing with high addresses). First expansion happens
-  // at 2^42 (4TB).
-  return nth_bit<uintptr_t>(42);
-}

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1999,6 +1999,13 @@ static void shuffle_fisher_yates(T* arr, unsigned num, FastRandom& frand) {
 uintptr_t os::vm_page_table_expansion_point() {
   return align_down(UINTPTR_MAX, os::vm_allocation_granularity());
 }
+#else
+uintptr_t os::vm_page_table_expansion_point() {
+  // On s390x, page table will dynamically expand based on user demand
+  // (eg mmap probing with high addresses). First expansion happens
+  // at 2^42 (4TB).
+  return nth_bit<uintptr_t>(42);
+}
 #endif
 
 // Helper for os::attempt_reserve_memory_between


### PR DESCRIPTION
`os::vm_page_table_expansion_point()` is missing in s390x zero configuration causing the build failure. 
Move S390x-specific definition to `os.cpp` as it already contains `#ifndef S390x`

Testing:

<details> 
<summary> Configure </summary>

```
bash configure --with-jvm-variants=zero --disable-warnings-as-errors
configure: Configuration created at Sun Aug  2 22:19:32 UTC 2026.
checking for basename... /usr/bin/basename
checking for dirname... /usr/bin/dirname
checking for file... /usr/bin/file
checking for ldd... /usr/bin/ldd
checking for echo... echo [builtin]
checking for tr... /usr/bin/tr
checking for uname... /usr/bin/uname
checking for wc... /usr/bin/wc
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for a sed that does not truncate output... /usr/bin/sed
checking for locale... /usr/bin/locale
checking for cygpath... [not found]
checking for wslpath... [not found]
checking for cmd.exe... [not found]
checking for lsb_release... /usr/bin/lsb_release
checking build system type... s390x-ibm-linux-gnu
checking host system type... s390x-ibm-linux-gnu
checking target system type... s390x-ibm-linux-gnu
checking openjdk-build os-cpu... linux-s390x
checking openjdk-build C library... gnu
checking openjdk-target os-cpu... linux-s390x
checking openjdk-target C library... gnu
checking compilation type... native
checking for top-level directory... /build/jdk
checking for bash... /usr/bin/bash
checking for cat... /usr/bin/cat
checking for chmod... /usr/bin/chmod
checking for cp... /usr/bin/cp
checking for cut... /usr/bin/cut
checking for date... /usr/bin/date
checking for gdiff... [not found]
checking for diff... /usr/bin/diff
checking for expr... /usr/bin/expr
checking for find... /usr/bin/find
checking for gunzip... /usr/bin/gunzip
checking for pigz... [not found]
checking for gzip... /usr/bin/gzip
checking for head... /usr/bin/head
checking for ln... /usr/bin/ln
checking for ls... /usr/bin/ls
checking for gmkdir... [not found]
checking for mkdir... /usr/bin/mkdir
checking for mktemp... /usr/bin/mktemp
checking for mv... /usr/bin/mv
checking for gawk... /usr/bin/gawk
checking for printf... printf [builtin]
checking for rm... /usr/bin/rm
checking for rmdir... /usr/bin/rmdir
checking for sh... /usr/bin/sh
checking for sort... /usr/bin/sort
checking for tail... /usr/bin/tail
checking for gtar... [not found]
checking for tar... /usr/bin/tar
checking for tee... /usr/bin/tee
checking for touch... /usr/bin/touch
checking for xargs... /usr/bin/xargs
checking for fgrep... /usr/bin/grep -F
checking for cmake... [not found]
checking for df... /usr/bin/df
checking for git... /usr/bin/git
checking for nice... /usr/bin/nice
checking for greadlink... [not found]
checking for readlink... /usr/bin/readlink
checking for whoami... /usr/bin/whoami
checking for cmp... /usr/bin/cmp
checking for uniq... /usr/bin/uniq
checking for build environment type... dev, default (calculated from 'auto')
checking for locale to use... C.UTF-8 (recommended)
checking if custom source is suppressed (openjdk-only)... disabled, default
checking for --enable-debug... disabled, default
checking which debug level to use... release
checking which variants of the JVM to build... zero
checking if absolute paths should be allowed in the build output... no, release build
checking for toolchain path... 
checking for sysroot... 
checking for extra path... 
checking where to store configuration... in default location
checking what configuration name to use... linux-s390x-zero-release
checking for zypper... [not found]
checking for apt-get... /usr/bin/apt-get
checking for pandoc... /usr/bin/pandoc
checking for pandoc version... 3.10
configure: WARNING: pandoc is version 3.10, not the recommended version 2.19.2
checking if the pandoc smart extension needs to be disabled for markdown... yes
checking if the pandoc tex_math_dollars extension needs to be disabled for markdown... yes
checking for gmake... /usr/bin/gmake
configure: Testing potential make at /usr/bin/gmake, found using gmake in PATH
configure: Using GNU make at /usr/bin/gmake (version: GNU Make 4.4.1)
checking if make --output-sync is supported... yes
checking for make --output-sync value... none, default
checking if find supports -delete... yes
checking what type of tar was found... gnu
checking that grep (/usr/bin/grep) -Fx handles empty lines in the pattern list correctly... yes
checking for unzip... /usr/bin/unzip
checking for zip... /usr/bin/zip
checking for greadelf... [not found]
checking for readelf... /usr/bin/readelf
checking for dot... /usr/bin/dot
checking for stat... /usr/bin/stat
checking for time... time [builtin]
checking for flock... /usr/bin/flock
checking for dtrace... [not found]
checking for gpatch... [not found]
checking for patch... /usr/bin/patch
checking if date is a GNU compatible version... yes
checking for ulimit... ulimit [builtin]
checking bash version... 5.3.9
checking if bash supports pipefail... yes
checking if bash supports errexit (-e)... yes
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for default LOG value... 
checking for JMOD compression type... zip-6, default
checking whether or not a JDK suitable for linking from the run-time image should be produced... disabled, default
checking if packaged modules are kept... enabled, default
checking for --with-extra-jlink-flags... <disabled>, default
checking for --with-build-user... ubuntu, default
checking for --with-jdk-rc-name... OpenJDK Platform, default
checking for --with-vendor-name... N/A, default
checking for --with-jdk-rc-company-name... N/A, default
checking for --with-vendor-url... https://openjdk.org/, default
checking for --with-vendor-bug-url... https://bugreport.java.com/bugreport/, default
checking for --with-vendor-vm-bug-url... https://bugreport.java.com/bugreport/crash.jsp, default
checking for --with-version-string... <none>, default
checking for --with-version-feature... 28, default
checking for --with-version-date... 2027-03-23, default
checking for --with-vendor-version-string... <disabled>, default
checking for --with-macosx-bundle-name-base... OpenJDK, default
checking for --with-macosx-bundle-id-base... net.java.openjdk-internal, default
checking for --with-macosx-bundle-build-version... 0, default
checking for version string... 28-internal-adhoc.ubuntu.jdk
checking for javac... /usr/bin/javac
checking for java... /usr/bin/java
configure: Found potential Boot JDK using java(c) in PATH
checking for Boot JDK... /usr/lib/jvm/java-27-openjdk-s390x
checking Boot JDK version... openjdk version "27-ea" 2026-09-15 OpenJDK Runtime Environment (build 27-ea+19-1-Ubuntu) OpenJDK 64-Bit Server VM (build 27-ea+19-1-Ubuntu, mixed mode, sharing)
checking for java [Boot JDK]... $BOOT_JDK/bin/java
checking for javac [Boot JDK]... $BOOT_JDK/bin/javac
checking for javadoc [Boot JDK]... $BOOT_JDK/bin/javadoc
checking for jar [Boot JDK]... $BOOT_JDK/bin/jar
checking if Boot JDK jar supports --date=TIMESTAMP... true
checking if Boot JDK is 32 or 64 bits... 64
checking for docs-reference JDK... no, using interim javadoc for the docs-reference targets
checking what source date to use... 1785709173, from 'current' (default)
checking if we should build with sound support... enabled, default
checking if we should build headless-only (no GUI)... disabled, default
checking if linker should clean out unused code (linktime-gc)... enabled, default
checking for graphviz dot... yes
checking for pandoc... yes
checking for --enable-full-docs... enabled, from default 'auto'
checking for cacerts file... default
checking for cacerts source... default
checking for --enable-unlimited-crypto... enabled, default
checking for jni library path... default
configure: Using default toolchain gcc (GNU Compiler Collection)
checking for gcc... /usr/bin/gcc
checking resolved symbolic links for CC... /usr/bin/s390x-linux-gnu-gcc-15
configure: Using gcc C compiler version 15.3.0 [gcc (Ubuntu 15.3.0-1ubuntu1) 15.3.0]
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether /usr/bin/gcc accepts -g... yes
checking for g++... /usr/bin/g++
checking resolved symbolic links for CXX... /usr/bin/s390x-linux-gnu-g++-15
configure: Using gcc C++ compiler version 15.3.0 [g++ (Ubuntu 15.3.0-1ubuntu1) 15.3.0]
checking whether /usr/bin/g++ accepts -g... yes
checking how to run the C preprocessor... /usr/bin/gcc -E
checking how to run the C++ preprocessor... /usr/bin/g++ -E
configure: Using gcc linker version 2.46.50.20260608 [GNU ld (GNU Binutils for Ubuntu) 2.46.50.20260608]
configure: comparing linker version to minimum version 2.18
checking for ar... /usr/bin/ar
checking for strip... /usr/bin/strip
checking for nm... /usr/bin/nm
checking for gobjcopy... [not found]
checking for objcopy... /usr/bin/objcopy
checking for gobjdump... [not found]
checking for objdump... /usr/bin/objdump
checking for c++filt... /usr/bin/c++filt
checking for jtreg... /usr/bin/jtreg
configure: WARNING: Ignoring jtreg from path since a valid jtreg home cannot be found
checking for jtreg test harness... no, not found
checking for jtreg jdk... no, using BOOT_JDK
checking for jmh (Java Microbenchmark Harness)... no, disabled
checking for jib... no
checking for tidy... [not found]
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for stdio.h... (cached) yes
checking size of int *... 8
checking for target address size... 64 bits
checking whether byte ordering is bigendian... yes
checking for --enable-branch-protection... disabled, default
checking for --with-native-debug-symbols-level... <none>, default (calculated from 'auto')
checking if CC supports "-fdebug-prefix-map=/build/jdk/="... yes
checking if CXX supports "-fdebug-prefix-map=/build/jdk/="... yes
checking if both CC and CXX support "-fdebug-prefix-map=/build/jdk/="... yes
checking for --enable-warnings-as-errors... disabled, from command line
checking if TARGET is x86... no
checking if CC supports "-fmacro-prefix-map=/build/jdk/="... yes
checking if CXX supports "-fmacro-prefix-map=/build/jdk/="... yes
checking if both CC and CXX support "-fmacro-prefix-map=/build/jdk/="... yes
checking how to prevent absolute paths in output... using compiler options
checking if CC supports "-ffp-contract=off"... yes
checking if CXX supports "-ffp-contract=off"... yes
checking if both CC and CXX support "-ffp-contract=off"... yes
checking if BUILD is x86... no
checking if BUILD_CC supports "-fmacro-prefix-map=/build/jdk/="... yes
checking if BUILD_CXX supports "-fmacro-prefix-map=/build/jdk/="... yes
checking if both BUILD_CC and BUILD_CXX support "-fmacro-prefix-map=/build/jdk/="... yes
checking how to prevent absolute paths in output... using compiler options
checking if BUILD_CC supports "-ffp-contract=off"... yes
checking if BUILD_CXX supports "-ffp-contract=off"... yes
checking if both BUILD_CC and BUILD_CXX support "-ffp-contract=off"... yes
checking how to run strip... --strip-debug
checking for --enable-aarch64-sve... disabled, from default 'auto'
checking what type of native debug symbols to use... external
checking if debuginfo compression with objcopy is done... disabled, default
checking if we should add external native debug symbols to the shipped bundles... no (default)
checking if native coverage is available... yes
checking for --enable-native-coverage... disabled, default
checking for --with-jcov-modules... <disabled>, default
checking if AddressSanitizer (asan) is available... yes
checking for --enable-asan... disabled, default
checking for --with-additional-ubsan-checks... <disabled>, default
checking if UndefinedBehaviorSanitizer (ubsan) is available... yes
checking for --enable-ubsan... disabled, default
checking if LeakSanitizer (lsan) is available... yes
checking for --enable-lsan... disabled, default
checking if static analyzer is available... yes
checking for --enable-static-analyzer... disabled, default
checking if fallback linker enabled... enabled, default
checking if static link of stdc++ is possible... yes
checking how to link with libstdc++... static
checking for ALSA... yes
checking for which libjpeg to use... bundled
checking for which giflib to use... bundled
checking for PNG... yes
checking for which libpng to use... bundled
checking for compress in -lz... yes
checking for which zlib to use... system
checking for system zlib functionality... ok
checking for which lcms to use... bundled
checking for which harfbuzz to use... bundled
checking for cups/cups.h... yes
checking for cups/ppd.h... yes
checking for fontconfig/fontconfig.h... yes
checking for FREETYPE... yes
checking for freetype... yes (using pkg-config)
Using freetype: system
checking for --enable-hsdis-bundling... disabled, default
checking what hsdis backend to use... 'none', hsdis will not be built
checking if hsdis should be bundled... no
checking for --with-print-assembly-options... <none>, default
checking for --enable-libffi-bundling... disabled, default
checking for LIBFFI... yes
checking if libffi works... yes
checking for FFI_GO_CLOSURES definition... yes
checking for cos in -lm... yes
checking for dlopen in -ldl... yes
checking for X... libraries , headers 
checking for gethostbyname... yes
checking for connect... yes
checking for remove... yes
checking for shmat... yes
checking for IceConnectionNumber in -lICE... yes
checking for X11/extensions/shape.h... yes
checking for X11/extensions/Xrender.h... yes
checking for X11/extensions/XTest.h... yes
checking for X11/Intrinsic.h... yes
checking for X11/extensions/Xrandr.h... yes
checking for JVM features enabled by the user... none
checking for JVM features disabled by the user... none
checking if platform is supported by CDS... yes
checking if JVM feature 'cds' is available... yes
checking for dtrace tool and platform support... no, s390
checking for sys/sdt.h... no
configure: Cannot enable dtrace with missing dependencies. See above.
checking if JVM feature 'dtrace' is available... no
checking if platform is supported by Shenandoah... no, s390x
checking if JVM feature 'shenandoahgc' is available... no
checking if platform is supported by ZGC... no, linux-s390x
checking if JVM feature 'zgc' is available... no
checking JVM features to use for variant 'zero'... 'cds epsilongc g1gc jni-check jvmti management parallelgc serialgc services vm-structs zero'
checking what hotspot build time to use... 2026-08-02T22:19:33Z (from --with-source-date)
checking if the jtreg failure handler is available... no (jtreg not present)
checking if the jtreg failure handler should be built... disabled, default
checking if the jtreg test thread factory is available... no (jtreg not present)
checking if the jtreg test thread factory should be built... disabled, from default 'auto'
checking if the CDS classlist generation should be enabled... enabled, from default 'auto'
checking if any translations should be excluded... no
checking if CDS archive is available... yes
checking if a default CDS archive should be generated... enabled, from default 'auto'
checking if CDS archive with no compact object headers is available... yes
checking if default CDS archives for no compact object headers should be generated... enabled, from default 'auto'
checking if CDS archive is available... yes
checking if compatible cds region alignment enabled... disabled, default
checking for --with-signing-hook... <disabled>, default
checking for signing hook... none
checking for --enable-java-warnings-as-errors... enabled, default
checking for number of cores... 64
checking for memory size... 515778 MB
checking for appropriate number of jobs to run in parallel... 64
checking whether to use javac server... enabled, default
checking flags for boot jdk java command ...  -Duser.language=en -Duser.country=US -Xlog:all=off:stdout -Xlog:all=warning:stderr 
checking flags for boot jdk java command for big workloads...  -Xms64M -Xmx2048M
checking flags for bootcycle boot jdk java command for big workloads... -Xms64M -Xmx2048M
checking flags for boot jdk java command for small workloads...  -Xms32M -Xmx512M -XX:TieredStopAtLevel=1
checking for --enable-icecc... disabled, default
checking if precompiled headers are available... yes
checking for --enable-precompiled-headers... enabled, from default 'auto'
checking for ccache... [not found]
checking if ccache is available... no, ccache binary missing or not executable
checking if ccache is enabled... disabled, default
checking if build directory is on local disk... yes
configure: creating /build/jdk/build/linux-s390x-zero-release/configure-support/config.status
config.status: creating /build/jdk/build/linux-s390x-zero-release/spec.gmk
config.status: creating /build/jdk/build/linux-s390x-zero-release/bootcycle-spec.gmk
config.status: creating /build/jdk/build/linux-s390x-zero-release/buildjdk-spec.gmk
config.status: creating /build/jdk/build/linux-s390x-zero-release/compare.sh
config.status: creating /build/jdk/build/linux-s390x-zero-release/Makefile

====================================================
The existing configuration has been successfully updated in
/build/jdk/build/linux-s390x-zero-release
using configure arguments '--with-jvm-variants=zero --disable-warnings-as-errors'.

Configuration summary:
* Name:           linux-s390x-zero-release
* Debug level:    release
* HS debug level: product
* JVM variants:   zero
* JVM features:   zero: 'cds epsilongc g1gc jni-check jvmti management parallelgc serialgc services vm-structs zero' 
* OpenJDK target: OS: linux, CPU architecture: s390, address length: 64
* Version string: 28-internal-adhoc.ubuntu.jdk (28-internal)
* Source date:    1785709173 (2026-08-02T22:19:33Z)

Tools summary:
* Boot JDK:       openjdk version "27-ea" 2026-09-15 OpenJDK Runtime Environment (build 27-ea+19-1-Ubuntu) OpenJDK 64-Bit Server VM (build 27-ea+19-1-Ubuntu, mixed mode, sharing) (at /usr/lib/jvm/java-27-openjdk-s390x)
* Toolchain:      gcc (GNU Compiler Collection)
* C Compiler:     Version 15.3.0 (at /usr/bin/gcc)
* C++ Compiler:   Version 15.3.0 (at /usr/bin/g++)

Build performance summary:
* Build jobs:     64
* Memory limit:   515778 MB

WARNING: The result of this configuration has overridden an older
configuration. You *should* run 'make clean' to make sure you get a
proper build. Failure to do so might result in strange build problems.

The following warnings were produced. Repeated here for convenience:
WARNING: pandoc is version 3.10, not the recommended version 2.19.2
WARNING: Ignoring jtreg from path since a valid jtreg home cannot be found

```

</details>

<details>
<summary>Build:</summary>

```
make images
Building target 'images' in configuration 'linux-s390x-zero-release'
Creating support/modules_libs/java.base/jrt-fs.jar
Updating support/modules_libs/java.base/zero/libjvm.so due to makefile changes
Updating support/modules_libs/java.base/libverify.so due to makefile changes
Updating support/modules_libs/java.base/libjava.so due to makefile changes
Updating support/modules_libs/java.base/libzip.so due to makefile changes
Updating support/modules_libs/java.base/libjimage.so due to makefile changes
Updating support/modules_libs/java.base/libjli.so due to makefile changes
Updating support/modules_libs/java.base/libnet.so due to makefile changes
Updating support/modules_libs/java.base/libnio.so due to makefile changes
Updating support/modules_libs/java.base/libjsig.so due to makefile changes
Updating support/modules_libs/java.base/libsyslookup.so due to makefile changes
Updating support/modules_libs/java.base/libfallbackLinker.so due to makefile changes
Updating support/modules_cmds/java.rmi/rmiregistry due to makefile changes
Updating support/modules_libs/java.prefs/libprefs.so due to makefile changes
Updating support/modules_cmds/jdk.compiler/javac due to makefile changes
Updating support/modules_libs/java.rmi/librmi.so due to makefile changes
Updating support/modules_libs/java.smartcardio/libj2pcsc.so due to makefile changes
Updating support/modules_cmds/jdk.jconsole/jconsole due to makefile changes
Updating support/modules_cmds/jdk.compiler/serialver due to makefile changes
Updating support/modules_libs/jdk.management.agent/libmanagement_agent.so due to makefile changes
Updating support/modules_libs/jdk.attach/libattach.so due to makefile changes
Updating support/modules_libs/java.security.jgss/libj2gss.so due to makefile changes
Updating support/modules_cmds/jdk.httpserver/jwebserver due to makefile changes
Updating support/modules_libs/jdk.crypto.cryptoki/libj2pkcs11.so due to makefile changes
Updating support/modules_cmds/jdk.jartool/jar due to makefile changes
Updating support/modules_cmds/jdk.jartool/jarsigner due to makefile changes
Updating support/modules_libs/java.management/libmanagement.so due to makefile changes
Updating support/modules_libs/java.instrument/libinstrument.so due to makefile changes
Updating support/modules_cmds/jdk.jlink/jimage due to makefile changes
Updating support/modules_cmds/jdk.jdeps/javap due to makefile changes
Updating support/modules_cmds/jdk.jlink/jlink due to makefile changes
Updating support/modules_cmds/jdk.jdeps/jdeps due to makefile changes
Updating support/modules_cmds/jdk.javadoc/javadoc due to makefile changes
Updating support/modules_libs/jdk.management/libmanagement_ext.so due to makefile changes
Updating support/modules_cmds/jdk.jdeps/jdeprscan due to makefile changes
Updating support/modules_cmds/jdk.jdeps/jnativescan due to makefile changes
Updating support/modules_cmds/jdk.jlink/jmod due to makefile changes
Updating support/modules_cmds/java.base/java due to makefile changes
Updating support/modules_cmds/jdk.jdi/jdb due to makefile changes
Updating support/modules_cmds/java.base/keytool due to makefile changes
Updating support/modules_libs/java.base/jexec due to makefile changes
Updating support/modules_libs/java.base/jspawnhelper due to makefile changes
Updating support/modules_cmds/jdk.jfr/jfr due to makefile changes
Updating support/modules_cmds/jdk.jpackage/jpackage due to makefile changes
Updating support/modules_cmds/jdk.jshell/jshell due to makefile changes
Updating support/modules_libs/jdk.net/libextnet.so due to makefile changes
Updating support/modules_cmds/jdk.jcmd/jinfo due to makefile changes
Updating support/modules_cmds/jdk.jcmd/jmap due to makefile changes
Updating support/modules_cmds/jdk.jcmd/jps due to makefile changes
Updating support/modules_cmds/jdk.jcmd/jstack due to makefile changes
Updating support/modules_cmds/jdk.jcmd/jstat due to makefile changes
Updating support/modules_cmds/jdk.jcmd/jcmd due to makefile changes
Updating support/modules_libs/jdk.sctp/libsctp.so due to makefile changes
Updating support/modules_cmds/jdk.jstatd/jstatd due to makefile changes
Updating jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/jpackageapplauncher due to makefile changes
Updating support/modules_libs/jdk.jdwp.agent/libdt_socket.so due to makefile changes
Updating jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/libjpackageapplauncheraux.so due to makefile changes
Updating support/modules_libs/jdk.jdwp.agent/libjdwp.so due to makefile changes
Updating support/modules_libs/java.desktop/libawt.so due to makefile changes
Updating support/modules_libs/java.desktop/libawt_headless.so due to makefile changes
Updating support/modules_libs/java.desktop/libawt_xawt.so due to makefile changes
Updating support/modules_libs/java.desktop/libjawt.so due to makefile changes
Updating support/modules_libs/java.desktop/libmlib_image.so due to makefile changes
Updating support/modules_libs/java.desktop/liblcms.so due to makefile changes
Updating support/modules_libs/java.desktop/libjavajpeg.so due to makefile changes
Updating support/modules_libs/java.desktop/libsplashscreen.so due to makefile changes
Creating support/modules_libs/java.desktop/libfontmanager.so from 0 file(s)
Updating support/modules_libs/java.desktop/libjsound.so due to makefile changes
Creating ct.sym classes
In file included from /build/jdk/src/java.desktop/share/native/libharfbuzz/hb.hh:566,
                 from /build/jdk/src/java.desktop/share/native/libharfbuzz/hb-ot-font.cc:27:
In function ‘int hb_memcmp(const void*, const void*, unsigned int)’,
    inlined from ‘int hb_array_t< <template-parameter-1-1> >::cmp(const hb_array_t< <template-parameter-1-1> >&) const [with Type = const char]’ at /build/jdk/src/java.desktop/share/native/libharfbuzz/hb-array.hh:171:22,
    inlined from ‘static int OT::post::accelerator_t::cmp_key(const void*, const void*, void*)’ at /build/jdk/src/java.desktop/share/native/libharfbuzz/hb-ot-post-table.hh:247:44,
    inlined from ‘bool hb_bsearch_impl(unsigned int*, const K&, V*, size_t, size_t, int (*)(const void*, const void*, Ts ...), Ts ...) [with V = short unsigned int; K = hb_array_t<const char>; Ts = {void*}]’ at /build/jdk/src/java.desktop/share/native/libharfbuzz/hb-algs.hh:1264:20,
    inlined from ‘V* hb_bsearch(const K&, V*, size_t, size_t, int (*)(const void*, const void*, Ts ...), Ts ...) [with V = short unsigned int; K = hb_array_t<const char>; Ts = {void*}]’ at /build/jdk/src/java.desktop/share/native/libharfbuzz/hb-algs.hh:1302:26,
    inlined from ‘bool OT::post::accelerator_t::get_glyph_from_name(const char*, int, hb_codepoint_t*) const’ at /build/jdk/src/java.desktop/share/native/libharfbuzz/hb-ot-post-table.hh:211:30,
    inlined from ‘hb_bool_t hb_ot_get_glyph_from_name(hb_font_t*, void*, const char*, int, hb_codepoint_t*, void*)’ at /build/jdk/src/java.desktop/share/native/libharfbuzz/hb-ot-font.cc:858:42:
/build/jdk/src/java.desktop/share/native/libharfbuzz/hb-algs.hh:1146:17: warning: ‘int memcmp(const void*, const void*, size_t)’ specified bound [2147483648, 4294967295] exceeds source size 1850 [-Wstringop-overread]
 1146 |   return memcmp (a, b, len);
      |          ~~~~~~~^~~~~~~~~~~
Compiling up to 4 files for BUILD_JIGSAW_TOOLS
Optimizing the exploded image
Creating java.security.sasl.jmod
Creating java.naming.jmod
Creating java.compiler.jmod
Creating java.datatransfer.jmod
Creating java.instrument.jmod
Creating java.sql.rowset.jmod
Creating java.smartcardio.jmod
Creating java.logging.jmod
Creating jdk.accessibility.jmod
Creating java.scripting.jmod
Creating java.transaction.xa.jmod
Creating java.se.jmod
Creating jdk.crypto.cryptoki.jmod
Creating java.sql.jmod
Creating jdk.incubator.vector.jmod
Creating java.management.rmi.jmod
Creating java.prefs.jmod
Creating jdk.charsets.jmod
Creating jdk.attach.jmod
Creating java.security.jgss.jmod
Creating java.management.jmod
Creating jdk.editpad.jmod
Creating jdk.dynalink.jmod
Creating java.rmi.jmod
Creating jdk.crypto.ec.jmod
Creating jdk.internal.jvmstat.jmod
Creating java.xml.crypto.jmod
Creating jdk.management.jmod
Creating java.net.http.jmod
Creating jdk.sctp.jmod
Creating jdk.internal.opt.jmod
Creating jdk.compiler.jmod
Creating jdk.naming.dns.jmod
Creating jdk.naming.rmi.jmod
Creating jdk.jshell.jmod
Creating jdk.internal.md.jmod
Creating jdk.jcmd.jmod
Creating jdk.net.jmod
Creating jdk.internal.ed.jmod
Creating jdk.jconsole.jmod
Creating jdk.security.jgss.jmod
Creating jdk.security.auth.jmod
Creating jdk.xml.dom.jmod
Creating jdk.internal.le.jmod
Creating jdk.httpserver.jmod
Creating jdk.jpackage.jmod
Creating jdk.javadoc.jmod
Creating jdk.management.agent.jmod
Creating jdk.unsupported.jmod
Creating interim java.logging.jmod
Creating jdk.jartool.jmod
Creating jdk.unsupported.desktop.jmod
Creating jdk.management.jfr.jmod
Creating jdk.jfr.jmod
Creating java.xml.jmod
Creating jdk.zipfs.jmod
Creating jdk.jdi.jmod
Creating jdk.jdeps.jmod
Creating jdk.nio.mapmode.jmod
Creating jdk.localedata.jmod
Creating jdk.jstatd.jmod
Creating jdk.jdwp.agent.jmod
Creating java.desktop.jmod
Creating interim java.base.jmod
Compiling up to 3 files for BUILD_DEMO_CodePointIM
Updating support/demos/image/jfc/CodePointIM/src.zip
Compiling up to 3 files for BUILD_DEMO_FileChooserDemo
Updating support/demos/image/jfc/FileChooserDemo/src.zip
Compiling up to 29 files for BUILD_DEMO_SwingSet2
Updating support/demos/image/jfc/SwingSet2/src.zip
Compiling up to 3 files for BUILD_DEMO_Font2DTest
Updating support/demos/image/jfc/Font2DTest/src.zip
Compiling up to 64 files for BUILD_DEMO_J2Ddemo
Updating support/demos/image/jfc/J2Ddemo/src.zip
Compiling up to 15 files for BUILD_DEMO_Metalworks
Updating support/demos/image/jfc/Metalworks/src.zip
Compiling up to 2 files for BUILD_DEMO_Notepad
Updating support/demos/image/jfc/Notepad/src.zip
Compiling up to 5 files for BUILD_DEMO_Stylepad
Updating support/demos/image/jfc/Stylepad/src.zip
Compiling up to 5 files for BUILD_DEMO_SampleTree
Updating support/demos/image/jfc/SampleTree/src.zip
Compiling up to 7 files for BUILD_DEMO_TableExample
Updating support/demos/image/jfc/TableExample/src.zip
Compiling up to 1 files for BUILD_DEMO_TransparentRuler
Updating support/demos/image/jfc/TransparentRuler/src.zip
Creating support/demos/image/jfc/CodePointIM/CodePointIM.jar
Creating support/demos/image/jfc/TransparentRuler/TransparentRuler.jar
Creating support/demos/image/jfc/FileChooserDemo/FileChooserDemo.jar
Creating support/demos/image/jfc/SampleTree/SampleTree.jar
Creating support/demos/image/jfc/Notepad/Notepad.jar
Creating support/demos/image/jfc/TableExample/TableExample.jar
Creating support/demos/image/jfc/Metalworks/Metalworks.jar
Creating support/demos/image/jfc/Stylepad/Stylepad.jar
Creating support/demos/image/jfc/Font2DTest/Font2DTest.jar
Creating support/demos/image/jfc/SwingSet2/SwingSet2.jar
Creating support/demos/image/jfc/J2Ddemo/J2Ddemo.jar
Creating interim jimage
Compiling up to 2 files for CLASSLIST_JAR
Creating support/classlist.jar
Creating jdk.jlink.jmod
Creating java.base.jmod
Creating jdk image
Creating CDS archive for jdk image for zero
Creating CDS-PREVIEW archive for jdk image for zero
Creating CDS-NOCOOPS archive for jdk image for zero
Creating CDS-NOCOOPS-PREVIEW archive for jdk image for zero
Creating CDS-NOCOH archive for jdk image for zero
Creating CDS-NOCOH-PREVIEW archive for jdk image for zero
Creating CDS-NOCOOPS-NOCOH archive for jdk image for zero
Creating CDS-NOCOOPS-NOCOH-PREVIEW archive for jdk image for zero
Finished building target 'images' in configuration 'linux-s390x-zero-release'
```

</details>

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389588](https://bugs.openjdk.org/browse/JDK-8389588): [s390x] Zero build is broken after JDK-8388561 (**Bug** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Harshit Dhiman](https://openjdk.org/census#hdhiman) (@Harshit470250 - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32165/head:pull/32165` \
`$ git checkout pull/32165`

Update a local copy of the PR: \
`$ git checkout pull/32165` \
`$ git pull https://git.openjdk.org/jdk.git pull/32165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32165`

View PR using the GUI difftool: \
`$ git pr show -t 32165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32165.diff">https://git.openjdk.org/jdk/pull/32165.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32165#issuecomment-5161288881)
</details>
