### PR TITLE
8388917: G1: "guarantee(variance() > -1.0) failed: variance should be >= 0" when running java -XX:G1NumCardsCostSampleThreshold=0  -XX:MetaspaceSize=1024K -version

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -381,11 +381,13 @@
           "Threshold for the number of cards when reporting remembered set "\
           "card cost related prediction samples. A sample must involve "    \
           "the same or more than that number of cards to be used.")         \
+          range(1, UINT_MAX)                                                \
                                                                             \
   product(uint, G1NumCodeRootsCostSampleThreshold, 100, DIAGNOSTIC,         \
           "Threshold for the number of code roots when reporting code root "\
           "scan cost related prediction samples. A sample must involve "    \
           "the same or more than this number of code roots to be used.")    \
+          range(1, UINT_MAX)                                                \
                                                                             \
   develop(bool, G1ForceOptionalEvacuation, false,                           \
           "Force optional evacuation for all GCs where there are old gen "  \


### PR DESCRIPTION
G1 predicts pause times from samples  of phase time and amount of work, e.g. ms per card. Samples with very few cards are dominated by fixed overheads (timer granularity, phase setup) and their cost per card is mostly noise, so `G1NumCardsCostSampleThreshold` and `G1NumCodeRootsCostSampleThreshold` accept only samples with at least that many cards/code roots.

Zero is not a sensible value for these thresholds: it disables this noise filtering entirely. That is what crashes the VM in this issue (`guarantee(variance() > -1.0) failed` in `TruncatedSeq::add()` when the first collections merge no cards).

This change restricts both flags to `range(1, UINT_MAX)` (the code roots flag has the same division-by-zero hazard), so zero is rejected at startup.

Test: tier1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388917](https://bugs.openjdk.org/browse/JDK-8388917): G1: "guarantee(variance() &gt; -1.0) failed: variance should be &gt;= 0" when running java -XX:G1NumCardsCostSampleThreshold=0  -XX:MetaspaceSize=1024K -version (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32166/head:pull/32166` \
`$ git checkout pull/32166`

Update a local copy of the PR: \
`$ git checkout pull/32166` \
`$ git pull https://git.openjdk.org/jdk.git pull/32166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32166`

View PR using the GUI difftool: \
`$ git pr show -t 32166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32166.diff">https://git.openjdk.org/jdk/pull/32166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32166#issuecomment-5160989042)
</details>
