### PR TITLE
8388366: Launcher test stability regardless of the default locale

### DIFF
--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -22,9 +22,6 @@
  */
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /*
  * @test

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -335,8 +335,8 @@ public class Settings extends TestHelper {
         containsDefaultOptions(tr);
     }
 
-    private static TestResult doExecWithUSLocale(
-            String command, String... args) {
+    private static TestResult doExecWithUSLocale(String command,
+                                                 String... args) {
         String[] commandLine = new String[args.length + 3];
         commandLine[0] = command;
         commandLine[1] = "-Duser.language=en";

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -22,6 +22,9 @@
  */
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /*
  * @test
@@ -153,7 +156,7 @@ public class Settings extends TestHelper {
             stackSize = 448;
         }
         TestResult tr;
-        tr = doExec(javaCmd, "-Xms64m", "-Xmx512m",
+        tr = doExecWithEnglishLocale(javaCmd, "-Xms64m", "-Xmx512m",
                 "-Xss" + stackSize + "k", "-XshowSettings", "-jar", testJar.getAbsolutePath());
         // Check the stack size logs printed by -XshowSettings to verify -Xss meaningfully.
         checkContains(tr, STACKSIZE_SETTINGS);
@@ -162,7 +165,7 @@ public class Settings extends TestHelper {
             System.out.println(tr);
             throw new RuntimeException("test fails");
         }
-        tr = doExec(javaCmd, "-Xms65536k", "-Xmx712m",
+        tr = doExecWithEnglishLocale(javaCmd, "-Xms65536k", "-Xmx712m",
                 "-Xss" + (stackSize * 1024), "-XshowSettings", "-jar", testJar.getAbsolutePath());
         checkContains(tr, STACKSIZE_SETTINGS);
         containsDefaultOptions(tr);
@@ -174,14 +177,14 @@ public class Settings extends TestHelper {
 
     static void runTestOptionAll() throws IOException {
         init();
-        TestResult tr = doExec(javaCmd, "-XshowSettings:all");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:all");
         tr.checkPositive();
         containsAllOptions(tr);
         checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionVM() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:vm");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:vm");
         tr.checkPositive();
         checkContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -190,7 +193,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionProperty() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:properties");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:properties");
         tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkContains(tr, PROP_SETTINGS);
@@ -199,7 +202,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionLocale() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:locale");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:locale");
         tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -212,7 +215,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionSecurity() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security");
         tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -223,7 +226,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionSecurityProps() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security:properties");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security:properties");
         tr.checkPositive();
         checkContains(tr, SEC_PROPS_SETTINGS);
         checkNotContains(tr, SEC_PROVIDER_SETTINGS);
@@ -234,7 +237,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionSecurityProv() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security:providers");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security:providers");
         tr.checkPositive();
         checkNotContains(tr, SEC_PROPS_SETTINGS);
         checkContains(tr, SEC_PROVIDER_SETTINGS);
@@ -248,7 +251,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionSecurityTLS() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security:tls");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security:tls");
         tr.checkPositive();
         checkNotContains(tr, SEC_PROPS_SETTINGS);
         checkNotContains(tr, SEC_PROVIDER_SETTINGS);
@@ -262,7 +265,7 @@ public class Settings extends TestHelper {
 
     // ensure error message is printed when unrecognized option used
     static void runTestOptionBadSecurityOption() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:security:bad");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security:bad");
         tr.checkNegative();
         checkContains(tr, BAD_SEC_OPTION_MSG);
         // we print all security settings in such scenario
@@ -271,7 +274,7 @@ public class Settings extends TestHelper {
         checkNotContains(tr, SEC_TLS_SETTINGS);
     }
     static void runTestOptionSystem() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings:system");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:system");
         tr.checkPositive();
         if (System.getProperty("os.name").contains("Linux")) {
             checkNotContains(tr, VM_SETTINGS);
@@ -288,7 +291,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestBadOptions() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettingsBadOption");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettingsBadOption");
         tr.checkNegative();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -296,7 +299,7 @@ public class Settings extends TestHelper {
         checkContains(tr, "Unrecognized option: -XshowSettingsBadOption");
 
         // no such component option
-        tr = doExec(javaCmd, "-XshowSettings:BadOption");
+        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:BadOption");
         tr.checkNegative();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -304,22 +307,22 @@ public class Settings extends TestHelper {
         checkContains(tr, ERR_MSG);
 
         // don't allow invalid sub options
-        tr = doExec(javaCmd, "-XshowSettings:locale:bad");
+        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:locale:bad");
         tr.checkNegative();
         checkContains(tr, ERR_MSG);
 
         // don't allow ":" as an option
-        tr = doExec(javaCmd, "-XshowSettings:");
+        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:");
         tr.checkNegative();
         checkContains(tr, ERR_MSG);
 
         // case-sensitive test
-        tr = doExec(javaCmd, "-XshowSettings:VM");
+        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:VM");
         tr.checkNegative();
         checkContains(tr, ERR_MSG);
 
         // exclude this enum value
-        tr = doExec(javaCmd, "-XshowSettings:empty");
+        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:empty");
         tr.checkNegative();
         checkContains(tr, ERR_MSG);
 
@@ -327,12 +330,23 @@ public class Settings extends TestHelper {
     }
 
     static void runTest7123582() throws IOException {
-        TestResult tr = doExec(javaCmd, "-XshowSettings", "-version");
+        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings", "-version");
         if (!tr.isOK()) {
             System.out.println(tr);
             throw new RuntimeException("test fails");
         }
         containsDefaultOptions(tr);
+    }
+
+    private static TestResult doExecWithEnglishLocale(
+        String command, String... args) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(command);
+        cmd.add("-Duser.language=en");
+        cmd.add("-Duser.country=US");
+        cmd.addAll(Arrays.asList(args));
+
+        return doExec(cmd.toArray(new String[cmd.size()]));
     }
 
     public static void main(String... args) throws IOException {

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -156,7 +156,7 @@ public class Settings extends TestHelper {
             stackSize = 448;
         }
         TestResult tr;
-        tr = doExecWithEnglishLocale(javaCmd, "-Xms64m", "-Xmx512m",
+        tr = doExecWithUSLocale(javaCmd, "-Xms64m", "-Xmx512m",
                 "-Xss" + stackSize + "k", "-XshowSettings", "-jar", testJar.getAbsolutePath());
         // Check the stack size logs printed by -XshowSettings to verify -Xss meaningfully.
         checkContains(tr, STACKSIZE_SETTINGS);
@@ -165,7 +165,7 @@ public class Settings extends TestHelper {
             System.out.println(tr);
             throw new RuntimeException("test fails");
         }
-        tr = doExecWithEnglishLocale(javaCmd, "-Xms65536k", "-Xmx712m",
+        tr = doExecWithUSLocale(javaCmd, "-Xms65536k", "-Xmx712m",
                 "-Xss" + (stackSize * 1024), "-XshowSettings", "-jar", testJar.getAbsolutePath());
         checkContains(tr, STACKSIZE_SETTINGS);
         containsDefaultOptions(tr);
@@ -177,14 +177,14 @@ public class Settings extends TestHelper {
 
     static void runTestOptionAll() throws IOException {
         init();
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:all");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:all");
         tr.checkPositive();
         containsAllOptions(tr);
         checkNotContains(tr, USAGE_HEADER);
     }
 
     static void runTestOptionVM() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:vm");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:vm");
         tr.checkPositive();
         checkContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -193,7 +193,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionProperty() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:properties");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:properties");
         tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkContains(tr, PROP_SETTINGS);
@@ -202,7 +202,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionLocale() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:locale");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:locale");
         tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -215,7 +215,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionSecurity() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:security");
         tr.checkPositive();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -226,7 +226,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionSecurityProps() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security:properties");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:security:properties");
         tr.checkPositive();
         checkContains(tr, SEC_PROPS_SETTINGS);
         checkNotContains(tr, SEC_PROVIDER_SETTINGS);
@@ -237,7 +237,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionSecurityProv() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security:providers");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:security:providers");
         tr.checkPositive();
         checkNotContains(tr, SEC_PROPS_SETTINGS);
         checkContains(tr, SEC_PROVIDER_SETTINGS);
@@ -251,7 +251,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestOptionSecurityTLS() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security:tls");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:security:tls");
         tr.checkPositive();
         checkNotContains(tr, SEC_PROPS_SETTINGS);
         checkNotContains(tr, SEC_PROVIDER_SETTINGS);
@@ -265,7 +265,7 @@ public class Settings extends TestHelper {
 
     // ensure error message is printed when unrecognized option used
     static void runTestOptionBadSecurityOption() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:security:bad");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:security:bad");
         tr.checkNegative();
         checkContains(tr, BAD_SEC_OPTION_MSG);
         // we print all security settings in such scenario
@@ -274,7 +274,7 @@ public class Settings extends TestHelper {
         checkNotContains(tr, SEC_TLS_SETTINGS);
     }
     static void runTestOptionSystem() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:system");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings:system");
         tr.checkPositive();
         if (System.getProperty("os.name").contains("Linux")) {
             checkNotContains(tr, VM_SETTINGS);
@@ -291,7 +291,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTestBadOptions() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettingsBadOption");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettingsBadOption");
         tr.checkNegative();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -299,7 +299,7 @@ public class Settings extends TestHelper {
         checkContains(tr, "Unrecognized option: -XshowSettingsBadOption");
 
         // no such component option
-        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:BadOption");
+        tr = doExecWithUSLocale(javaCmd, "-XshowSettings:BadOption");
         tr.checkNegative();
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
@@ -307,22 +307,22 @@ public class Settings extends TestHelper {
         checkContains(tr, ERR_MSG);
 
         // don't allow invalid sub options
-        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:locale:bad");
+        tr = doExecWithUSLocale(javaCmd, "-XshowSettings:locale:bad");
         tr.checkNegative();
         checkContains(tr, ERR_MSG);
 
         // don't allow ":" as an option
-        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:");
+        tr = doExecWithUSLocale(javaCmd, "-XshowSettings:");
         tr.checkNegative();
         checkContains(tr, ERR_MSG);
 
         // case-sensitive test
-        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:VM");
+        tr = doExecWithUSLocale(javaCmd, "-XshowSettings:VM");
         tr.checkNegative();
         checkContains(tr, ERR_MSG);
 
         // exclude this enum value
-        tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings:empty");
+        tr = doExecWithUSLocale(javaCmd, "-XshowSettings:empty");
         tr.checkNegative();
         checkContains(tr, ERR_MSG);
 
@@ -330,7 +330,7 @@ public class Settings extends TestHelper {
     }
 
     static void runTest7123582() throws IOException {
-        TestResult tr = doExecWithEnglishLocale(javaCmd, "-XshowSettings", "-version");
+        TestResult tr = doExecWithUSLocale(javaCmd, "-XshowSettings", "-version");
         if (!tr.isOK()) {
             System.out.println(tr);
             throw new RuntimeException("test fails");
@@ -338,15 +338,14 @@ public class Settings extends TestHelper {
         containsDefaultOptions(tr);
     }
 
-    private static TestResult doExecWithEnglishLocale(
-        String command, String... args) {
-        List<String> cmd = new ArrayList<>();
-        cmd.add(command);
-        cmd.add("-Duser.language=en");
-        cmd.add("-Duser.country=US");
-        cmd.addAll(Arrays.asList(args));
-
-        return doExec(cmd.toArray(new String[cmd.size()]));
+    private static TestResult doExecWithUSLocale(
+            String command, String... args) {
+        String[] commandLine = new String[args.length + 3];
+        commandLine[0] = command;
+        commandLine[1] = "-Duser.language=en";
+        commandLine[2] = "-Duser.country=US";
+        System.arraycopy(args, 0, commandLine, 3, args.length);
+        return doExec(commandLine);
     }
 
     public static void main(String... args) throws IOException {


### PR DESCRIPTION
Please review this change. Thanks!

The launcher test Settings.java compares command output against expected text. The test was sensitive to the default locale because the expected output was assumed to be in English.

This change makes the test run with the en-US locale explicitly to ensure stable test results regardless of the default locale.

Testing:
- jtreg test/jdk/tools/launcher/Settings.java with LANG=zh_CN.utf8 and LC_ALL=zh_CN.utf8: passed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388366](https://bugs.openjdk.org/browse/JDK-8388366): Launcher test stability regardless of the default locale (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32167/head:pull/32167` \
`$ git checkout pull/32167`

Update a local copy of the PR: \
`$ git checkout pull/32167` \
`$ git pull https://git.openjdk.org/jdk.git pull/32167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32167`

View PR using the GUI difftool: \
`$ git pr show -t 32167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32167.diff">https://git.openjdk.org/jdk/pull/32167.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32167#issuecomment-5161797149)
</details>
