### PR TITLE
8389589: [TEST_BUG] java/awt/FullScreen/SetFSWindow/FSFrame.java hides failure by swallowing exception

### DIFF
--- a/test/jdk/java/awt/FullScreen/SetFSWindow/FSFrame.java
+++ b/test/jdk/java/awt/FullScreen/SetFSWindow/FSFrame.java
@@ -119,7 +119,7 @@ public class FSFrame extends Frame {
                 System.out.println("Dumped screen shot to " + name);
             } catch (IOException ignored) {}
 
-            throw new Error("Some pixel colors not correct; FS window may not" +
+            throw new RuntimeException("Some pixel colors not correct; FS window may not" +
                             " have been displayed correctly");
         }
     }

--- a/test/jdk/java/awt/FullScreen/SetFSWindow/FSFrame.java
+++ b/test/jdk/java/awt/FullScreen/SetFSWindow/FSFrame.java
@@ -22,12 +22,21 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @key headful
  * @bug 6240507 6662642
- * @summary verify that isFullScreenSupported and getFullScreenWindow work
+ * @summary verify that isFullScreenSupported work
  * correctly. Note that the test may fail on older Gnome versions (see bug 6500686).
  * @run main FSFrame
+ */
+
+/*
+ * @test id=windows_d3d_false
+ * @key headful
+ * @bug 6240507 6662642
+ * @summary verify that isFullScreenSupported work
+ * correctly. Note that the test may fail on older Gnome versions (see bug 6500686).
+ * @requires (os.family == "windows")
  * @run main/othervm -Dsun.java2d.d3d=false FSFrame
  */
 
@@ -47,24 +56,12 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import javax.imageio.ImageIO;
 
-public class FSFrame extends Frame implements Runnable {
+public class FSFrame extends Frame {
 
-    // Don't start the test until the window is visible
-    boolean visible = false;
-    Robot robot = null;
-    static volatile boolean done = false;
+    static FSFrame frame;
+    static Robot robot = null;
 
     public void paint(Graphics g) {
-        if (!visible && getWidth() != 0 && getHeight() != 0) {
-            visible = true;
-            try {
-                GraphicsDevice gd = getGraphicsConfiguration().getDevice();
-                robot = new Robot(gd);
-            } catch (Exception e) {
-                System.out.println("Problem creating robot: cannot verify FS " +
-                                   "window display");
-            }
-        }
         g.setColor(Color.green);
         g.fillRect(0, 0, getWidth(), getHeight());
     }
@@ -91,7 +88,6 @@ public class FSFrame extends Frame implements Runnable {
 
     void checkFSDisplay(boolean fsSupported) {
         GraphicsConfiguration gc = getGraphicsConfiguration();
-        GraphicsDevice gd = gc.getDevice();
         Rectangle r = gc.getBounds();
         Insets in = null;
         if (!fsSupported) {
@@ -103,9 +99,7 @@ public class FSFrame extends Frame implements Runnable {
         BufferedImage bImg = robot.createScreenCapture(r);
         // Check that all four corners and middle pixel match the window's
         // fill color
-        if (robot == null) {
-            return;
-        }
+
         boolean colorCorrect = true;
         colorCorrect &= checkColor(0, 0, bImg);
         colorCorrect &= checkColor(0, bImg.getHeight() - 1, bImg);
@@ -122,8 +116,9 @@ public class FSFrame extends Frame implements Runnable {
                     (fsSupported?"supported":"not_supported")+".png";
             try {
                 ImageIO.write(bImg, "png", new File(name));
-                System.out.println("Dumped screen shot to "+name);
-            } catch (IOException ex) {}
+                System.out.println("Dumped screen shot to " + name);
+            } catch (IOException ignored) {}
+
             throw new Error("Some pixel colors not correct; FS window may not" +
                             " have been displayed correctly");
         }
@@ -134,69 +129,47 @@ public class FSFrame extends Frame implements Runnable {
         try {
             // None of these should throw an exception
             final boolean fs = gd.isFullScreenSupported();
+
             System.out.println("FullscreenSupported: " + (fs ? "yes" : "no"));
             gd.setFullScreenWindow(this);
+            // Give the system time to set the FS window and display it
+            // properly
+            robot.delay(2000);
+
+            // See if FS window got displayed correctly
             try {
-                // Give the system time to set the FS window and display it
-                // properly
-                Thread.sleep(2000);
-            } catch (Exception e) {}
-                // See if FS window got displayed correctly
-            try {
-                EventQueue.invokeAndWait(new Runnable() {
-                    public void run() {
-                        repaint();
-                        checkFSDisplay(fs);
-                    }
-                });
+                EventQueue.invokeAndWait(this::repaint);
             } catch (InvocationTargetException | InterruptedException ex) {
                 ex.printStackTrace();
             }
+
+            robot.waitForIdle(500);
+
+            checkFSDisplay(fs);
+        } finally {
             // reset window
             gd.setFullScreenWindow(null);
-            try {
-                // Give the system time to set the FS window and display it
-                // properly
-                Thread.sleep(2000);
-            } catch (Exception e) {}
-        } catch (SecurityException e) {
-            e.printStackTrace();
-            throw new Error("Failure: should not get an exception when " +
-                            "calling isFSSupported or setFSWindow");
+            // Give the system time to set the FS window and display it
+            // properly
+            robot.delay(2000);
         }
     }
 
-    public void run() {
-        boolean firstTime = true;
-        while (!done) {
-            if (visible) {
-                checkFSFunctionality();
-                done = true;
-            } else {
-                // sleep while we wait
-                try {
-                    // Give the system time to set the FS window and display it
-                    // properly
-                    Thread.sleep(100);
-                } catch (Exception e) {}
-            }
-        }
-        System.out.println("PASS");
-    }
+    public static void main(String[] args) throws Exception {
+        try {
+            frame = new FSFrame();
+            frame.setUndecorated(true);
+            frame.setSize(500, 500);
+            frame.setVisible(true);
 
-    public static void main(String args[]) {
-        FSFrame frame = new FSFrame();
-        frame.setUndecorated(true);
-        Thread t = new Thread(frame);
-        frame.setSize(500, 500);
-        frame.setVisible(true);
-        t.start();
-        while (!done) {
-            try {
-                // Do not exit the main thread until the test is finished
-                Thread.sleep(1000);
-            } catch (Exception e) {}
+            robot = new Robot(frame.getGraphicsConfiguration().getDevice());
+            robot.waitForIdle(1000);
+
+            frame.checkFSFunctionality();
+
+            System.out.println("PASS");
+        } finally {
+            frame.dispose();
         }
-        frame.dispose();
     }
 }


### PR DESCRIPTION
While working on [JDK-8379673](https://bugs.openjdk.org/browse/JDK-8379673), I noticed that an `Error` thrown by the test is being swallowed in a `catch` block:

```java
try {
    EventQueue.invokeAndWait(new Runnable() {
        public void run() {
            repaint();
            checkFSDisplay(fs); // throws Error on failure
        }
    });
} catch (InvocationTargetException | InterruptedException ex) {
    ex.printStackTrace();
}
```

There are a few other issues with the test:

* Robot creation failure is ignored.
* The screenshot is taken immediately after `repaint()`. As a result, the test may capture the frame before rendering has actually completed.
* A separate thread is not really necessary.
* `-Dsun.java2d.d3d=false` test run is only applicable for Windows.


---
The changeset fixes the issues described above, simplifies the test, and limits the `-Dsun.java2d.d3d=false` test run to Windows only.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389589](https://bugs.openjdk.org/browse/JDK-8389589): [TEST_BUG] java/awt/FullScreen/SetFSWindow/FSFrame.java hides failure by swallowing exception (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32168/head:pull/32168` \
`$ git checkout pull/32168`

Update a local copy of the PR: \
`$ git checkout pull/32168` \
`$ git pull https://git.openjdk.org/jdk.git pull/32168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32168`

View PR using the GUI difftool: \
`$ git pr show -t 32168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32168.diff">https://git.openjdk.org/jdk/pull/32168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32168#issuecomment-5162531621)
</details>
