### PR TITLE
8388302: [lworld] allocate_inline_types_impl could dereference a null pointer

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -4083,6 +4083,7 @@ oop SharedRuntime::allocate_inline_types_impl(JavaThread* current, methodHandle 
     assert(reg_pos < (uint)arg_size, "");
     VMRegPair reg_pair = reg_pairs[reg_pos];
     oop* buffer = callerFrame.oopmapreg_to_oop_location(reg_pair.first(), &reg_map2);
+    guarantee(buffer != nullptr, "bad register save location");
     instanceHandle h_buffer(THREAD, (instanceOop)*buffer);
     InlineKlass* vk = InlineKlass::cast(holder);
     if (h_buffer.not_null()) {
@@ -4121,6 +4122,7 @@ oop SharedRuntime::allocate_inline_types_impl(JavaThread* current, methodHandle 
       assert(reg_pos < (uint)arg_size, "out of bound register?");
       VMRegPair reg_pair = reg_pairs[reg_pos];
       oop* buffer = callerFrame.oopmapreg_to_oop_location(reg_pair.first(), &reg_map2);
+      guarantee(buffer != nullptr, "bad register save location");
       instanceHandle h_buffer(THREAD, (instanceOop)*buffer);
       InlineKlass* vk = ss.as_inline_klass(holder);
       assert(vk != nullptr, "Unexpected klass");


### PR DESCRIPTION
Let's add a guarantee there. It's not so easy to prove that `callerFrame.oopmapreg_to_oop_location` does not return `nullptr`, but if it does, we are really in a bad situation, and there isn't much better to do than dying.

We are already doing a `guarantee` in another callsite of this method. In another, we "just" assert it's non null.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388302](https://bugs.openjdk.org/browse/JDK-8388302): [lworld] allocate_inline_types_impl could dereference a null pointer (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32170/head:pull/32170` \
`$ git checkout pull/32170`

Update a local copy of the PR: \
`$ git checkout pull/32170` \
`$ git pull https://git.openjdk.org/jdk.git pull/32170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32170`

View PR using the GUI difftool: \
`$ git pr show -t 32170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32170.diff">https://git.openjdk.org/jdk/pull/32170.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32170#issuecomment-5163609770)
</details>
