### PR TITLE
8388295: [lworld] C2: inline_unsafe_flat_access could dereference a null pointer

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2675,7 +2675,7 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
     return false;
   }
   ciType* mirror_type = value_klass_node->const_oop()->as_instance()->java_mirror_type();
-  if (!mirror_type->is_inlinetype()) {
+  if (mirror_type == nullptr || !mirror_type->is_inlinetype()) {
     // Dead code
     return false;
   }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2676,7 +2676,8 @@ bool LibraryCallKit::inline_unsafe_flat_access(bool is_store, AccessKind kind) {
   }
   ciType* mirror_type = value_klass_node->const_oop()->as_instance()->java_mirror_type();
   if (mirror_type == nullptr || !mirror_type->is_inlinetype()) {
-    // Dead code
+    // While mirror_type should not be null, there is no simple argument of that, so let's be safe, and bailout if it happens.
+    // Otherwise, if mirror_type is not null, but not an inline type, that is dead code. Bailout as well.
     return false;
   }
   ciInlineKlass* value_klass = mirror_type->as_inline_klass();


### PR DESCRIPTION
In
https://github.com/openjdk/jdk/blob/ef218b0341643d31ae533c978bc6574fdfb8382d/src/hotspot/share/opto/library_call.cpp#L2678-L2679

it is not easy to prove `mirror_type` cannot be `nullptr`. It should be fine because of Java types around the intrinsics, but it's a kinda long chain to come there. Rather than risking a null pointer dereference, let's just bailout of the intrinsics if we get a null pointer here. Safe and simple.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388295](https://bugs.openjdk.org/browse/JDK-8388295): [lworld] C2: inline_unsafe_flat_access could dereference a null pointer (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32171/head:pull/32171` \
`$ git checkout pull/32171`

Update a local copy of the PR: \
`$ git checkout pull/32171` \
`$ git pull https://git.openjdk.org/jdk.git pull/32171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32171`

View PR using the GUI difftool: \
`$ git pr show -t 32171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32171.diff">https://git.openjdk.org/jdk/pull/32171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32171#issuecomment-5163676203)
</details>
