### PR TITLE
8346476: Thread/TestAlwaysPreTouchStacks fails when run with specific JVM options

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022 SAP SE. All rights reserved.
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
@@ -86,10 +86,8 @@ public class TestAlwaysPreTouchStacks {
               "-XX:+UnlockDiagnosticVMOptions",
               "-Xmx100M",
               "-XX:NativeMemoryTracking=summary", "-XX:+PrintNMTStatistics");
-      // Set the tested flag explicitly for both children. External VM options are
-      // prepended by createTestJavaProcessBuilder, so an externally supplied
-      // -XX:+AlwaysPreTouchStacks would otherwise also apply to the control run and
-      // both runs would commit the same amount of stack (JDK-8346476).
+      // Set the tested flag explicitly for both children, so it can't be affected
+      // by externally supplied VM options.
       vmArgs.add(preTouch ? "-XX:+AlwaysPreTouchStacks" : "-XX:-AlwaysPreTouchStacks");
       if (System.getProperty("os.name").contains("Linux")) {
           vmArgs.add("-XX:-UseMadvPopulateWrite");

--- a/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestAlwaysPreTouchStacks.java
@@ -86,9 +86,11 @@ public class TestAlwaysPreTouchStacks {
               "-XX:+UnlockDiagnosticVMOptions",
               "-Xmx100M",
               "-XX:NativeMemoryTracking=summary", "-XX:+PrintNMTStatistics");
-      if (preTouch){
-          vmArgs.add("-XX:+AlwaysPreTouchStacks");
-      }
+      // Set the tested flag explicitly for both children. External VM options are
+      // prepended by createTestJavaProcessBuilder, so an externally supplied
+      // -XX:+AlwaysPreTouchStacks would otherwise also apply to the control run and
+      // both runs would commit the same amount of stack (JDK-8346476).
+      vmArgs.add(preTouch ? "-XX:+AlwaysPreTouchStacks" : "-XX:-AlwaysPreTouchStacks");
       if (System.getProperty("os.name").contains("Linux")) {
           vmArgs.add("-XX:-UseMadvPopulateWrite");
       }


### PR DESCRIPTION
The test compares committed thread-stack memory in two child JVMs, with and without -XX:+AlwaysPreTouchStacks. Since JDK-8342074, external jtreg VM options are propagated to both children. When -XX:+AlwaysPreTouchStacks is supplied externally, the control child inherits it, so both children use pre-touch and the comparison is invalid. This change appends an explicit positive option to the pre-touch child and an explicit negative option to the control child, while preserving all other inherited VM options.

On Linux x64, the reported configuration reproduced the problem: both children reported 141922304 committed stack bytes. With the fix, the pre-touch child reported 141922304 bytes and the control child reported 2441216 bytes, and the test passed. It also passed with no external AlwaysPreTouchStacks option and with an externally supplied -XX:-AlwaysPreTouchStacks. The original report had different NMT values, but the same command-line contamination was reproduced.

The later macOS/AArch64 sighting is separate: the child option polarity was already correct, but NMT reported 163840 committed bytes for the pre-touch child and 933888 for the control. This change does not address that failure; the test is currently problem-listed on macosx-aarch64 under JDK-8383372



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8346476](https://bugs.openjdk.org/browse/JDK-8346476): Thread/TestAlwaysPreTouchStacks fails when run with specific JVM options (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32172/head:pull/32172` \
`$ git checkout pull/32172`

Update a local copy of the PR: \
`$ git checkout pull/32172` \
`$ git pull https://git.openjdk.org/jdk.git pull/32172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32172`

View PR using the GUI difftool: \
`$ git pr show -t 32172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32172.diff">https://git.openjdk.org/jdk/pull/32172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32172#issuecomment-5169614909)
</details>
