### PR TITLE
8389624: C2: Skip redundant AND mask in LibraryCallKit::inline_native_hashcode intrinsic when compact headers are disabled

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5575,7 +5575,10 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   // Java spec says that HashCode is an int so there's no point in capturing
   // an 'X'-sized hashcode (32 in 32-bit build or 64 in 64-bit build).
   hshifted_header      = ConvX2I(hshifted_header);
-  Node *hash_val       = _gvn.transform(new AndINode(hshifted_header, hash_mask));
+  // On LP64 without compact headers, bits [42:63] of the mark word are zero,
+  // so bit 31 of the shifted result is already clear — the mask is redundant.
+  Node *hash_val = LP64_ONLY(!UseCompactObjectHeaders ? hshifted_header :)
+                   _gvn.transform(new AndINode(hshifted_header, hash_mask));
 
   Node *no_hash_val    = _gvn.intcon(markWord::no_hash);
   Node *chk_assigned   = _gvn.transform(new CmpINode( hash_val, no_hash_val));


### PR DESCRIPTION
Hi, please consider.
In LibraryCallKit::inline_native_hashcode(), the identity hash is extracted from the mark word as:
```
hash_val = ConvX2I(URShiftX(header, hash_shift)) & hash_mask
```
```
   Without compact object headers, the 64-bit mark word layout is:
    unused:22 | hash:31 | unused_gap:4 | age:4 | self-fwd:1 | lock:2
```
The hash occupies bits [11:41] and the upper 22 bits [42:63] are always zero. Since URShiftX(header, 11) is a logical (unsigned) right shift, bit 31 of the truncated 32-bit result corresponds to bit 42 of the mark word, which is guaranteed to be zero. Therefore the subsequent AndI with hash_mask (0x7FFFFFFF) is redundant: all bits above bit 30 are already clear.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389624](https://bugs.openjdk.org/browse/JDK-8389624): C2: Skip redundant AND mask in LibraryCallKit::inline_native_hashcode intrinsic when compact headers are disabled (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32179/head:pull/32179` \
`$ git checkout pull/32179`

Update a local copy of the PR: \
`$ git checkout pull/32179` \
`$ git pull https://git.openjdk.org/jdk.git pull/32179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32179`

View PR using the GUI difftool: \
`$ git pr show -t 32179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32179.diff">https://git.openjdk.org/jdk/pull/32179.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32179#issuecomment-5168488325)
</details>
