### PR TITLE
8389611: vframeStreamCommon::skip_prefixed_method_and_wrappers: unsigned underflow in prefix length leads to out-of-bounds read

### DIFF
--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -575,8 +575,11 @@ void vframeStreamCommon::skip_prefixed_method_and_wrappers() {
     }
     const char* name = method()->name()->as_C_string();
     size_t name_len = strlen(name);
+    if (name_len >= prefixed_name_len) {
+      break; // the name can't be the unprefixed version of prefixed_name
+    }
     size_t prefix_len = prefixed_name_len - name_len;
-    if (prefix_len <= 0 || strcmp(name, prefixed_name + prefix_len) != 0) {
+    if (strcmp(name, prefixed_name + prefix_len) != 0) {
       break; // prefixed name isn't prefixed version of method name, can't be a wrapper
     }
     for (; prefix_index >= 0; --prefix_index) {

--- a/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/PrefixedNativeStackWalk.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/PrefixedNativeStackWalk.java
@@ -35,9 +35,9 @@
  * vframeStreamCommon::skip_prefixed_method_and_wrappers() (vframe.cpp).
  *
  * The agent registers "wrapped_" as a native method prefix, so resolving the
- * native wrapped_walk() strips the prefix, finds the non-native walk() and
- * binds wrapped_walk() to walk()'s native entry point. That marks wrapped_walk()
- * as a prefixed native method, which is what makes a security stack walk enter
+ * native wrapped_go() strips the prefix, finds the non-native go() and binds
+ * wrapped_go() to go()'s native entry point. That marks wrapped_go() as a
+ * prefixed native method, which is what makes a security stack walk enter
  * skip_prefixed_method_and_wrappers().
  *
  * While the native method runs, the stack is

--- a/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/PrefixedNativeStackWalk.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/PrefixedNativeStackWalk.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389611
+ * @summary Walking the stack over a JVMTI-prefixed native method must not
+ *          underflow the prefix length when the calling method has a longer name.
+ * @requires vm.jvmti
+ * @run main/othervm/native -agentlib:PrefixedNativeStackWalk PrefixedNativeStackWalk
+ */
+
+/*
+ * Regression test for the unsigned underflow in
+ * vframeStreamCommon::skip_prefixed_method_and_wrappers() (vframe.cpp).
+ *
+ * The agent registers "wrapped_" as a native method prefix, so resolving the
+ * native wrapped_walk() strips the prefix, finds the non-native walk() and
+ * binds wrapped_walk() to walk()'s native entry point. That marks wrapped_walk()
+ * as a prefixed native method, which is what makes a security stack walk enter
+ * skip_prefixed_method_and_wrappers().
+ *
+ * While the native method runs, the stack is
+ *
+ *     wrapped_go()                        <- prefixed native
+ *     go()                                <- wrapper
+ *     callerFrameWithALongerMethodName()  <- same class, longer name
+ *     main()
+ *
+ * and the native code asks the VM for the calling class at depth 1 (see the
+ * library) to make it walk that chain. After the wrapper frame is matched the
+ * name being stripped is "go", and the next frame in the same class has a
+ * longer name, so
+ *
+ *     size_t prefix_len = prefixed_name_len - name_len;
+ *
+ * underflows. The old guard, prefix_len <= 0, is never true for an unsigned
+ * type, so strcmp() went on to read at prefixed_name + prefix_len, i.e. before
+ * the string. The fixed code stops as soon as the name is not shorter.
+ *
+ * Note that the over-read is a single byte inside the resource area, so an
+ * unfixed VM does not reliably fail here; it is undefined behaviour that shows
+ * up under a sanitizer build. What this test always covers is the path itself:
+ * the walk must terminate at the expected frame and the VM must stay healthy.
+ */
+
+public class PrefixedNativeStackWalk {
+
+    // Resolved through the "wrapped_" prefix registered by the agent, so this
+    // ends up bound to Java_PrefixedNativeStackWalk_go() and is flagged as a
+    // prefixed native method.
+    private static native boolean wrapped_go();
+
+    // The wrapper method the prefix mechanism looks for: same class, same
+    // signature, not native.
+    private static boolean go() {
+        return wrapped_go();
+    }
+
+    // Calls the wrapper from the same class under a longer name. The length
+    // difference to go() is what used to make the prefix length underflow, so
+    // this method must keep a name longer than the wrapper's.
+    private static boolean callerFrameWithALongerMethodName() {
+        return go();
+    }
+
+    public static void main(String[] args) {
+        if (!callerFrameWithALongerMethodName()) {
+            throw new RuntimeException("Stack walk over the prefixed native method failed");
+        }
+        System.out.println("Test PASSED");
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/libPrefixedNativeStackWalk.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/libPrefixedNativeStackWalk.cpp
@@ -43,10 +43,9 @@ Java_PrefixedNativeStackWalk_go(JNIEnv* jni, jclass cls) {
     LOG("FindClass(java/lang/String) failed\n");
     return JNI_FALSE;
   }
-  JNINativeMethod methods[1];
-  memset(methods, 0, sizeof(methods));
-
-  jint res = jni->RegisterNatives(boot_cls, methods, 0);
+  // No methods to register: the walk happens before the (empty) method list is
+  // looked at, so the list itself is never read.
+  jint res = jni->RegisterNatives(boot_cls, nullptr, 0);
   if (res != 0) {
     LOG("RegisterNatives returned %d, expected 0\n", (int)res);
     return JNI_FALSE;

--- a/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/libPrefixedNativeStackWalk.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/libPrefixedNativeStackWalk.cpp
@@ -27,7 +27,7 @@
 
 extern "C" {
 
-static const char* const NativeMethodPrefix = "wrapped_";
+static const char* const NATIVE_METHOD_PREFIX = "wrapped_";
 
 // Implements PrefixedNativeStackWalk.wrapped_go(): the "wrapped_" prefix is
 // stripped when the VM resolves wrapped_go(), so the entry point it looks for
@@ -73,9 +73,9 @@ Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
     return JNI_ERR;
   }
 
-  err = jvmti->SetNativeMethodPrefix(NativeMethodPrefix);
+  err = jvmti->SetNativeMethodPrefix(NATIVE_METHOD_PREFIX);
   if (err != JVMTI_ERROR_NONE) {
-    LOG("SetNativeMethodPrefix(\"%s\") failed with %d\n", NativeMethodPrefix, err);
+    LOG("SetNativeMethodPrefix(\"%s\") failed with %d\n", NATIVE_METHOD_PREFIX, err);
     return JNI_ERR;
   }
   return JNI_OK;

--- a/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/libPrefixedNativeStackWalk.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/SetNativeMethodPrefix/libPrefixedNativeStackWalk.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <string.h>
+#include "jvmti.h"
+#include "jvmti_common.hpp"
+
+extern "C" {
+
+static const char* const NativeMethodPrefix = "wrapped_";
+
+// Implements PrefixedNativeStackWalk.wrapped_go(): the "wrapped_" prefix is
+// stripped when the VM resolves wrapped_go(), so the entry point it looks for
+// is the one of the wrapper method, go().
+JNIEXPORT jboolean JNICALL
+Java_PrefixedNativeStackWalk_go(JNIEnv* jni, jclass cls) {
+  // RegisterNatives on a class of a named module loaded by the boot loader makes
+  // the VM determine the calling class at depth 1. That walk steps over this
+  // prefixed native frame and its wrapper, which is the code under test. Passing
+  // no methods keeps the call itself a no-op: nothing is (re-)bound.
+  jclass boot_cls = jni->FindClass("java/lang/String");
+  if (boot_cls == nullptr) {
+    LOG("FindClass(java/lang/String) failed\n");
+    return JNI_FALSE;
+  }
+  JNINativeMethod methods[1];
+  memset(methods, 0, sizeof(methods));
+
+  jint res = jni->RegisterNatives(boot_cls, methods, 0);
+  if (res != 0) {
+    LOG("RegisterNatives returned %d, expected 0\n", (int)res);
+    return JNI_FALSE;
+  }
+  LOG("Stack walk over the prefixed native method completed\n");
+  return JNI_TRUE;
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
+  jvmtiEnv* jvmti = nullptr;
+  if (jvm->GetEnv((void**)&jvmti, JVMTI_VERSION) != JNI_OK || jvmti == nullptr) {
+    LOG("Could not initialize JVMTI env\n");
+    return JNI_ERR;
+  }
+
+  jvmtiCapabilities caps;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_set_native_method_prefix = 1;
+
+  jvmtiError err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("AddCapabilities failed with %d\n", err);
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetNativeMethodPrefix(NativeMethodPrefix);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG("SetNativeMethodPrefix(\"%s\") failed with %d\n", NativeMethodPrefix, err);
+    return JNI_ERR;
+  }
+  return JNI_OK;
+}
+
+} // extern "C"


### PR DESCRIPTION
In `vframeStreamCommon::skip_prefixed_method_and_wrappers()`, `prefix_len` is a `size_t` computed as `prefixed_name_len - name_len`, so the `prefix_len <= 0` guard only ever catches `prefix_len == 0`. When the next method on the stack has a longer name than the prefixed native method, the subtraction underflows, the guard passes, and `strcmp` reads at `prefixed_name + prefix_len`, which has wrapped to a pointer before the string. The walk is only reached when a JVMTI agent has registered a native method prefix with `SetNativeMethodPrefix`, which several profilers do.

The fix checks the lengths before subtracting. `name_len >= prefixed_name_len` covers the `prefix_len == 0` case the old guard was meant to catch, so nothing changes for inputs that were already handled correctly, and `prefix_len` is now in `[1, prefixed_name_len)` for the comparisons that follow.

The test registers `wrapped_` as a prefix and declares a native `wrapped_go()` next to a non-native `go()` with the same signature, so resolving `wrapped_go()` strips the prefix and binds it to `go()`'s entry point as a prefixed native. The native code then calls `RegisterNatives` with no methods on a boot loader class, since that asks the VM for the calling class at depth 1 and walks over the native frame, its wrapper and the longer-named caller below.

Note that the test does not fail on an unfixed VM: `strcmp` stops at the first mismatching byte, so the over-read is a single byte inside the resource-area chunk the string came from, which no sanitizer will flag. It covers a path nothing else covers and locks in the guard. I confirmed the underflow is reached by temporarily printing the lengths from the VM.

Testing:

- [x] `test/hotspot/jtreg:tier1`, linux-x86_64 fastdebug: 3583 passed, 7 failed. The failures are `gc/TestTransparentHugePagesHeap.java` and `runtime/os/TestTracePageSizes.java`, which fail on this machine because of its transparent huge page settings and are unrelated to the change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389611](https://bugs.openjdk.org/browse/JDK-8389611): vframeStreamCommon::skip_prefixed_method_and_wrappers: unsigned underflow in prefix length leads to out-of-bounds read (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32180/head:pull/32180` \
`$ git checkout pull/32180`

Update a local copy of the PR: \
`$ git checkout pull/32180` \
`$ git pull https://git.openjdk.org/jdk.git pull/32180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32180`

View PR using the GUI difftool: \
`$ git pr show -t 32180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32180.diff">https://git.openjdk.org/jdk/pull/32180.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32180#issuecomment-5168542062)
</details>
