### PR TITLE
8385163: JMX: Use recommended MessageDigest comparison method

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/remote/security/HashedPasswordManager.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/security/HashedPasswordManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,7 +204,7 @@ public final class HashedPasswordManager {
                 byte[] passwordBytes = new byte[byteBuffer.limit()];
                 byteBuffer.get(passwordBytes);
                 byte[] hash = digest.digest(passwordBytes);
-                return Arrays.equals(hash, targetHash);
+                return MessageDigest.isEqual(hash, targetHash);
             } catch (NoSuchAlgorithmException ex) {
                 if (logger.debugOn()) {
                     logger.debug("authenticate", "Unrecognized hash algorithm : "


### PR DESCRIPTION
JMX has been using Arrays.equals() where it should be using MessageDigest.isEqual().

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385163](https://bugs.openjdk.org/browse/JDK-8385163): JMX: Use recommended MessageDigest comparison method (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32181/head:pull/32181` \
`$ git checkout pull/32181`

Update a local copy of the PR: \
`$ git checkout pull/32181` \
`$ git pull https://git.openjdk.org/jdk.git pull/32181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32181`

View PR using the GUI difftool: \
`$ git pr show -t 32181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32181.diff">https://git.openjdk.org/jdk/pull/32181.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32181#issuecomment-5168866041)
</details>
