### PR TITLE
Fix/ip multicast all

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -296,7 +296,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
 #if defined(__linux__)
     if (domain == AF_INET && type == SOCK_DGRAM) {
         int arg = 0;
-        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (char *)&arg, sizeof(arg)) < 0) &&
+        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0) &&
             (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
                                          JNU_JAVANETPKG "SocketException",
@@ -320,7 +320,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
 
         /* Disable IPV6_MULTICAST_ALL if option supported */
         arg = 0;
-        if ((setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, (char *)&arg, sizeof(arg)) < 0) &&
+        if ((setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0) &&
             (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
                                      JNU_JAVANETPKG "SocketException",

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -294,10 +294,9 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
     }
 
 #if defined(__linux__)
-    if (type == SOCK_DGRAM) {
+    if (domain == AF_INET && type == SOCK_DGRAM) {
         int arg = 0;
-        int level = (domain == AF_INET6) ? IPPROTO_IPV6 : IPPROTO_IP;
-        if ((setsockopt(fd, level, IP_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0) &&
+        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, &arg, sizeof(arg)) < 0) &&
             (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
                                          JNU_JAVANETPKG "SocketException",
@@ -321,7 +320,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
 
         /* Disable IPV6_MULTICAST_ALL if option supported */
         arg = 0;
-        if ((setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0) &&
+        if ((setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, &arg, sizeof(arg)) < 0) &&
             (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
                                      JNU_JAVANETPKG "SocketException",

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -296,7 +296,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
 #if defined(__linux__)
     if (domain == AF_INET && type == SOCK_DGRAM) {
         int arg = 0;
-        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, &arg, sizeof(arg)) < 0) &&
+        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (char *)&arg, sizeof(arg)) < 0) &&
             (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
                                          JNU_JAVANETPKG "SocketException",
@@ -320,7 +320,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
 
         /* Disable IPV6_MULTICAST_ALL if option supported */
         arg = 0;
-        if ((setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, &arg, sizeof(arg)) < 0) &&
+        if ((setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, (char *)&arg, sizeof(arg)) < 0) &&
             (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
                                      JNU_JAVANETPKG "SocketException",


### PR DESCRIPTION
In looking at Net.c, it appears we are trying to set IP_MULTICAST_ALL for both ipv4 and ipv6 sockets. For ipv6, this doesn't make sense and we are instead disabling IPV6_RECVPKTINFO since IP_MULTICAST_ALL (having value of 49) corresponds with IPV6_RECVPKTINFO, for IPPROTO_IPV6.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32183/head:pull/32183` \
`$ git checkout pull/32183`

Update a local copy of the PR: \
`$ git checkout pull/32183` \
`$ git pull https://git.openjdk.org/jdk.git pull/32183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32183`

View PR using the GUI difftool: \
`$ git pr show -t 32183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32183.diff">https://git.openjdk.org/jdk/pull/32183.diff</a>

</details>
