### PR TITLE
8388480: System.arraycopy fails to partially copy nullable flat arrays

### DIFF
--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -244,85 +244,91 @@ void FlatArrayKlass::copy_array(arrayOop s, int src_pos,
   ObjArrayKlass* dk = ObjArrayKlass::cast(d->klass());
   Klass* d_elem_klass = dk->element_klass();
   Klass* s_elem_klass = sk->element_klass();
-  /**** CMH: compare and contrast impl, re-factor once we find edge cases... ****/
 
   if (sk->is_flatArray_klass()) {
     assert(sk == this, "Unexpected call to copy_array");
     FlatArrayKlass* fsk = FlatArrayKlass::cast(sk);
-    // Check subtype, all src homogeneous, so just once
-    if (!s_elem_klass->is_subtype_of(d_elem_klass)) {
-      THROW(vmSymbols::java_lang_ArrayStoreException());
-    }
-
     flatArrayOop sa = flatArrayOop(s);
 
     // flatArray-to-flatArray
     if (dk->is_flatArray_klass()) {
-      // element types MUST be exact, subtype check would be dangerous
-      if (d_elem_klass != this->element_klass()) {
-        THROW(vmSymbols::java_lang_ArrayStoreException());
-      }
-
-      FlatArrayKlass* fdk = FlatArrayKlass::cast(dk);
-      InlineKlass* vk = InlineKlass::cast(s_elem_klass);
       flatArrayOop da = flatArrayOop(d);
+      if (d_elem_klass == this->element_klass()) {
+        FlatArrayKlass* fdk = FlatArrayKlass::cast(dk);
 
-      // We have already checked that src_pos and dst_pos are valid indices.
-      FlatArrayPayload src_payload(sa, src_pos, fsk);
-      FlatArrayPayload dst_payload(da, dst_pos, fdk);
+        // We have already checked that src_pos and dst_pos are valid indices.
+        FlatArrayPayload src_payload(sa, src_pos, fsk);
+        FlatArrayPayload dst_payload(da, dst_pos, fdk);
 
-      if (fsk->layout_kind() == fdk->layout_kind()) {
-        // Because source and destination have the same layout, we do not have
-        // to worry about null checks and atomicity problems and can call the
-        // Access API directly.
-        int index_delta;
-        if (needs_backwards_copy(sa, src_pos, da, dst_pos, length)) {
-          index_delta = -1;
-          src_payload.advance_index(length - 1);
-          dst_payload.advance_index(length - 1);
-        } else {
-          index_delta = 1;
-        }
-
-        for (int i = 0; i < length; i++) {
-          HeapAccess<>::value_copy(src_payload, dst_payload);
-          src_payload.advance_index(index_delta);
-          dst_payload.advance_index(index_delta);
-        }
-      } else {
-        // We need to allocate a buffer object to facilitate the copy between
-        // the different layouts. Keep the payload in a handle so we can reload
-        // the oops.
-        FlatArrayPayload::Handle src_payload_handle = src_payload.make_handle(THREAD);
-        FlatArrayPayload::Handle dst_payload_handle = dst_payload.make_handle(THREAD);
-
-        inlineOop buffer = vk->allocate_instance(CHECK);
-        BufferedValuePayload buf_payload(buffer);
-
-        // Reload the oops from the payload handles.
-        src_payload = src_payload_handle();
-        dst_payload = dst_payload_handle();
-
-        const bool dst_is_null_restricted = !LayoutKindHelper::is_nullable_flat(dst_payload.layout_kind());
-
-        // fsk->layout_kind() != fdk->layout_kind() implies that s != d, which
-        // means that the copy is disjoint and we do not need to worry about
-        // needs_backwards_copy.
-        for (int i = 0; i < length; i++) {
-          // Copy via buffer
-          if (src_payload.is_payload_null() || !src_payload.copy_to(buf_payload)) {
-            // The source payload is null. Nothing to copy.
-            if (dst_is_null_restricted) {
-              // The destination does not support null.
-              THROW(vmSymbols::java_lang_NullPointerException());
-            }
+        if (fsk->layout_kind() == fdk->layout_kind()) {
+          // Because source and destination have the same layout, we do not have
+          // to worry about null checks and atomicity problems and can call the
+          // Access API directly.
+          int index_delta;
+          if (needs_backwards_copy(sa, src_pos, da, dst_pos, length)) {
+            index_delta = -1;
+            src_payload.advance_index(length - 1);
+            dst_payload.advance_index(length - 1);
           } else {
-            dst_payload.copy_from(buf_payload);
+            index_delta = 1;
           }
 
-          // Advance to next element
-          src_payload.next_element();
-          dst_payload.next_element();
+          for (int i = 0; i < length; i++) {
+            HeapAccess<>::value_copy(src_payload, dst_payload);
+            src_payload.advance_index(index_delta);
+            dst_payload.advance_index(index_delta);
+          }
+        } else {
+          // We need to allocate a buffer object to facilitate the copy between
+          // the different layouts. Keep the payload in a handle so we can reload
+          // the oops.
+          FlatArrayPayload::Handle src_payload_handle = src_payload.make_handle(THREAD);
+          FlatArrayPayload::Handle dst_payload_handle = dst_payload.make_handle(THREAD);
+
+          InlineKlass* vk = InlineKlass::cast(s_elem_klass);
+          inlineOop buffer = vk->allocate_instance(CHECK);
+          BufferedValuePayload buf_payload(buffer);
+
+          // Reload the oops from the payload handles.
+          src_payload = src_payload_handle();
+          dst_payload = dst_payload_handle();
+
+          const bool dst_is_null_restricted = !LayoutKindHelper::is_nullable_flat(dst_payload.layout_kind());
+
+          // fsk->layout_kind() != fdk->layout_kind() implies that s != d, which
+          // means that the copy is disjoint and we do not need to worry about
+          // needs_backwards_copy.
+          for (int i = 0; i < length; i++) {
+            // Copy via buffer
+            if (src_payload.is_payload_null() || !src_payload.copy_to(buf_payload)) {
+              // The source payload is null. Nothing to copy.
+              if (dst_is_null_restricted) {
+                // The destination does not support null.
+                THROW(vmSymbols::java_lang_NullPointerException());
+              }
+            } else {
+              dst_payload.copy_from(buf_payload);
+            }
+
+            // Advance to next element
+            src_payload.next_element();
+            dst_payload.next_element();
+          }
+        }
+      } else {
+        // flat arrays with different element types, can only copy nulls (if destination array accepts them)
+        flatArrayHandle sh(THREAD, sa);
+        flatArrayHandle dh(THREAD, da);
+        bool dst_null_free = da->is_null_free_array();
+        for (int i = 0; i < length; i++) {
+          if (sh->obj_at_is_null(src_pos + i)) {
+            if (dst_null_free) {
+              THROW(vmSymbols::java_lang_NullPointerException());
+            }
+            dh->obj_at_put(dst_pos + i, nullptr);
+          } else {
+            THROW(vmSymbols::java_lang_ArrayStoreException());
+          }
         }
       }
     } else {

--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -227,15 +227,8 @@ void FlatArrayKlass::copy_array(arrayOop s, int src_pos,
     THROW(vmSymbols::java_lang_ArrayStoreException());
   }
 
-  // Check if all offsets and lengths are non negative
-  if (src_pos < 0 || dst_pos < 0 || length < 0) {
-    THROW(vmSymbols::java_lang_ArrayIndexOutOfBoundsException());
-  }
-  // Check if the ranges are valid
-  if  ( (((unsigned int) length + (unsigned int) src_pos) > (unsigned int) s->length())
-      || (((unsigned int) length + (unsigned int) dst_pos) > (unsigned int) d->length()) ) {
-    THROW(vmSymbols::java_lang_ArrayIndexOutOfBoundsException());
-  }
+  array_copy_offsets_and_range_check(s, src_pos, d, dst_pos, length, CHECK);
+
   // Check zero copy
   if (length == 0)
     return;
@@ -248,11 +241,12 @@ void FlatArrayKlass::copy_array(arrayOop s, int src_pos,
   if (sk->is_flatArray_klass()) {
     assert(sk == this, "Unexpected call to copy_array");
     FlatArrayKlass* fsk = FlatArrayKlass::cast(sk);
-    flatArrayOop sa = flatArrayOop(s);
+    flatArrayOop sa = oop_cast<flatArrayOop>(s);
 
     // flatArray-to-flatArray
     if (dk->is_flatArray_klass()) {
-      flatArrayOop da = flatArrayOop(d);
+      flatArrayOop da = oop_cast<flatArrayOop>(d);
+
       if (d_elem_klass == this->element_klass()) {
         FlatArrayKlass* fdk = FlatArrayKlass::cast(dk);
 
@@ -347,8 +341,8 @@ void FlatArrayKlass::copy_array(arrayOop s, int src_pos,
     // refArray-to-flatArray
     assert(s->is_refArray(), "Expected refArray");
     assert(d->is_flatArray(), "Expected flatArray");
-    refArrayOop sa = refArrayOop(s);
-    flatArrayOop da = flatArrayOop(d);
+    refArrayOop sa = oop_cast<refArrayOop>(s);
+    flatArrayOop da = oop_cast<flatArrayOop>(d);
 
     for (int i = 0; i < length; i++) {
       da->obj_at_put( dst_pos + i, sa->obj_at(src_pos + i), CHECK);

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -279,6 +279,50 @@ void ObjArrayKlass::copy_array(arrayOop s, int src_pos, arrayOop d,
   ShouldNotReachHere();
 }
 
+void ObjArrayKlass::array_copy_offsets_and_range_check(arrayOop s, int src_pos,
+                                                       arrayOop d, int dst_pos, int length, TRAPS) {
+  // Check if all offsets and lengths are non negative
+  if (src_pos < 0 || dst_pos < 0 || length < 0) {
+    // Pass specific exception reason.
+    ResourceMark rm(THREAD);
+    stringStream ss;
+    if (src_pos < 0) {
+      ss.print("arraycopy: source index %d out of bounds for object array[%d]",
+               src_pos, s->length());
+    } else if (dst_pos < 0) {
+      ss.print(
+          "arraycopy: destination index %d out of bounds for object array[%d]",
+          dst_pos, d->length());
+    } else {
+      ss.print("arraycopy: length %d is negative", length);
+    }
+    THROW_MSG(vmSymbols::java_lang_ArrayIndexOutOfBoundsException(),
+              ss.as_string());
+  }
+
+  // Check if the ranges are valid
+  if ((((unsigned int)length + (unsigned int)src_pos) >
+       (unsigned int)s->length()) ||
+      (((unsigned int)length + (unsigned int)dst_pos) >
+       (unsigned int)d->length())) {
+    // Pass specific exception reason.
+    ResourceMark rm(THREAD);
+    stringStream ss;
+    if (((unsigned int)length + (unsigned int)src_pos) >
+        (unsigned int)s->length()) {
+      ss.print(
+          "arraycopy: last source index %u out of bounds for object array[%d]",
+          (unsigned int)length + (unsigned int)src_pos, s->length());
+    } else {
+      ss.print("arraycopy: last destination index %u out of bounds for object "
+                      "array[%d]",
+                      (unsigned int)length + (unsigned int)dst_pos, d->length());
+    }
+    THROW_MSG(vmSymbols::java_lang_ArrayIndexOutOfBoundsException(),
+              ss.as_string());
+  }
+}
+
 bool ObjArrayKlass::can_be_primary_super_slow() const {
   if (!bottom_klass()->can_be_primary_super())
     // array of interfaces

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -104,6 +104,8 @@ class ObjArrayKlass : public ArrayKlass {
 
   // Copying
   void copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos, int length, TRAPS) override;
+  void array_copy_offsets_and_range_check(arrayOop s, int src_pos,
+                                          arrayOop d, int dst_pos, int length, TRAPS);
 
   // Compute protection domain
   oop protection_domain() const override { return bottom_klass()->protection_domain(); }

--- a/src/hotspot/share/oops/refArrayKlass.cpp
+++ b/src/hotspot/share/oops/refArrayKlass.cpp
@@ -224,46 +224,7 @@ void RefArrayKlass::copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos,
     THROW_MSG(vmSymbols::java_lang_ArrayStoreException(), ss.as_string());
   }
 
-  // Check if all offsets and lengths are non negative
-  if (src_pos < 0 || dst_pos < 0 || length < 0) {
-    // Pass specific exception reason.
-    ResourceMark rm(THREAD);
-    stringStream ss;
-    if (src_pos < 0) {
-      ss.print("arraycopy: source index %d out of bounds for object array[%d]",
-               src_pos, s->length());
-    } else if (dst_pos < 0) {
-      ss.print(
-          "arraycopy: destination index %d out of bounds for object array[%d]",
-          dst_pos, d->length());
-    } else {
-      ss.print("arraycopy: length %d is negative", length);
-    }
-    THROW_MSG(vmSymbols::java_lang_ArrayIndexOutOfBoundsException(),
-              ss.as_string());
-  }
-
-  // Check if the ranges are valid
-  if ((((unsigned int)length + (unsigned int)src_pos) >
-       (unsigned int)s->length()) ||
-      (((unsigned int)length + (unsigned int)dst_pos) >
-       (unsigned int)d->length())) {
-    // Pass specific exception reason.
-    ResourceMark rm(THREAD);
-    stringStream ss;
-    if (((unsigned int)length + (unsigned int)src_pos) >
-        (unsigned int)s->length()) {
-      ss.print(
-          "arraycopy: last source index %u out of bounds for object array[%d]",
-          (unsigned int)length + (unsigned int)src_pos, s->length());
-    } else {
-      ss.print("arraycopy: last destination index %u out of bounds for object "
-               "array[%d]",
-               (unsigned int)length + (unsigned int)dst_pos, d->length());
-    }
-    THROW_MSG(vmSymbols::java_lang_ArrayIndexOutOfBoundsException(),
-              ss.as_string());
-  }
+  array_copy_offsets_and_range_check(s, src_pos, d, dst_pos, length, CHECK);
 
   // Special case. Boundary cases must be checked first
   // This allows the following call: copy_array(s, s.length(), d.length(), 0).

--- a/src/hotspot/share/oops/refArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/refArrayOop.inline.hpp
@@ -65,6 +65,9 @@ inline void refArrayOopDesc::obj_at_put(int index, oop value, TRAPS) {
   if (is_null_free_array() && value == nullptr) {
     THROW_MSG(vmSymbols::java_lang_NullPointerException(), "Cannot store null in a null-restricted array");
   }
+  if (value != nullptr && !value->klass()->is_subtype_of(this->element_klass())) {
+    THROW(vmSymbols::java_lang_ArrayStoreException());
+  }
   obj_at_put(index, value);
 }
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestArrayCopy.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestArrayCopy.java
@@ -23,6 +23,7 @@
 
 /**
  * @test TestArrayCopy
+ * @bug 8388480
  * @library /test/lib
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestArrayCopy.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestArrayCopy.java
@@ -1,0 +1,597 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test TestArrayCopy
+ * @library /test/lib
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @run main/othervm runtime.valhalla.inlinetypes.TestArrayCopy
+ */
+
+package runtime.valhalla.inlinetypes;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+import jdk.test.lib.Asserts;
+
+public class TestArrayCopy {
+
+    static value record SmallPoint(byte x, byte y) { }
+    static interface MyInterface {}
+
+    @LooselyConsistentValue
+    static value class MyValue implements MyInterface {
+        int i;
+        short s;
+
+        public MyValue(int i, short s) {
+            this.i = i;
+            this.s = s;
+        }
+    }
+
+    static value record Complex(double r, double i) { }
+
+    static void test_0() {
+        var a = new MyValue[10];
+        Object npe = null;
+        try {
+            System.arraycopy(null, 0, a, 1, 2);
+        } catch (NullPointerException e) {
+            npe = e;
+        }
+        Asserts.assertNotNull(npe, "Missing NullPointerException");
+    }
+
+    static void test_1() {
+        var a = new MyValue[10];
+        Object npe = null;
+        try {
+            System.arraycopy(a, 0, null, 1, 2);
+        } catch (NullPointerException e) {
+            npe = e;
+        }
+      Asserts.assertNotNull(npe, "Missing NullPointerException");
+    }
+
+    static void test_2() {
+        var a = new MyValue[10];
+        Object ase = null;
+        try {
+            System.arraycopy(a, 0, new Object(), 1, 2);
+        } catch (ArrayStoreException e) {
+            ase = e;
+        }
+        Asserts.assertNotNull(ase, "Missing ArrayStoreException");
+    }
+
+    static void test_3() {
+        var a = new MyValue[10];
+        Object ase = null;
+        try {
+            System.arraycopy(new Object(), 0, a, 1, 2);
+        } catch (ArrayStoreException e) {
+            ase = e;
+        }
+        Asserts.assertNotNull(ase, "Missing ArrayStoreException");
+    }
+
+    static void test_4() {
+        var a = new MyValue[10];
+        Object ase = null;
+        try {
+            System.arraycopy(a, 0, new int[10], 1, 2);
+        } catch (ArrayStoreException e) {
+            ase = e;
+        }
+        Asserts.assertNotNull(ase, "Missing ArrayStoreException");
+    }
+
+    static void test_5() {
+        var a = new MyValue[10];
+        Object ase = null;
+        try {
+            System.arraycopy(new int[10], 0, a, 1, 2);
+        } catch (ArrayStoreException e) {
+            ase = e;
+        }
+        Asserts.assertNotNull(ase, "Missing ArrayStoreException");
+    }
+
+    static void test_6() {
+        var a = new MyValue[10];
+        var b = new MyValue[8];
+        Object ioobe = null;
+        try {
+            System.arraycopy(a, -1, b, 1, 2);
+        } catch (IndexOutOfBoundsException e) {
+            ioobe = e;
+        }
+        Asserts.assertNotNull(ioobe, "Missing IndexOutOfBoundsException");
+    }
+
+    static void test_7() {
+        var a = new MyValue[10];
+        var b = new MyValue[8];
+        Object ioobe = null;
+        try {
+            System.arraycopy(a, 0, b, -1, 2);
+        } catch (IndexOutOfBoundsException e) {
+            ioobe = e;
+        }
+        Asserts.assertNotNull(ioobe, "Missing IndexOutOfBoundsException");
+    }
+
+    static void test_8() {
+        var a = new MyValue[10];
+        var b = new MyValue[8];
+        Object ioobe = null;
+        try {
+            System.arraycopy(a, 0, b, 1, -2);
+        } catch (IndexOutOfBoundsException e) {
+            ioobe = e;
+        }
+        Asserts.assertNotNull(ioobe, "Missing IndexOutOfBoundsException");
+    }
+
+    static void test_9() {
+        var a = new MyValue[5];
+        var b = new MyValue[10];
+        Object ioobe = null;
+        try {
+            System.arraycopy(a, 0, b, 1, 6);
+        } catch (IndexOutOfBoundsException e) {
+            ioobe = e;
+        }
+        Asserts.assertNotNull(ioobe, "Missing IndexOutOfBoundsException");
+    }
+
+    static void test_10() {
+        var a = new MyValue[10];
+        var b = new MyValue[5];
+        Object ioobe = null;
+        try {
+            System.arraycopy(a, 0, b, 1, 5);
+        } catch (IndexOutOfBoundsException e) {
+            ioobe = e;
+        }
+        Asserts.assertNotNull(ioobe, "Missing IndexOutOfBoundsException");
+    }
+
+    static void test_11() {
+        var a = new SmallPoint[10];
+        var b = new MyValue[10];
+        var sp = new SmallPoint((byte)1, (byte)2);
+        var mv = new MyValue(2, (short)3);
+        for (int i = 0; i < 10; i++) {
+            a[i] = sp;
+            b[i] = mv;
+        }
+        // Must not throw ArrayStoreException (nothing is copied)
+        System.arraycopy(a, 0, b, 0, 0);
+    }
+
+    static void test_12() {
+        var a = new SmallPoint[10];
+        var b = new MyValue[10];
+        // Must not throw ArrayStoreException (copying nulls)
+        System.arraycopy(a, 0, b, 1, 5);
+    }
+
+    static void test_13() {
+        var a = new SmallPoint[10];
+        var b = new SmallPoint[10];
+        var c = new SmallPoint[10];
+        for (int i = 0; i < 10; i++) {
+            a[i] = new SmallPoint((byte)i, (byte)(i+1));
+            b[i] = new SmallPoint((byte)(i*10), (byte)((i+1)*10));;
+            c[i] = b[i];
+        }
+        System.arraycopy(a, 2, c, 4, 3);
+        for (int i = 0; i < 4; i++) {
+            Asserts.assertEquals(c[i], b[i]);
+        }
+        for (int i = 0; i < 3; i++) {
+            Asserts.assertEquals(c[4 + i], a[2 + i]);
+        }
+        for (int i = 7; i < 10; i++) {
+            Asserts.assertEquals(c[i], b[i]);
+        }
+    }
+
+    static void test_14() {
+        var a = new SmallPoint[10];
+        var b = new MyValue[10];
+        var sp = new SmallPoint((byte)1, (byte)2);
+        for (int i = 0; i < 10; i++) {
+            a[i] = sp;
+        }
+        // Must not throw ArrayStoreException (copying nulls)
+        System.arraycopy(b, 3, a, 4, 5);
+        for (int i = 0 ; i < 4; i++) {
+            Asserts.assertNotNull(a[i]);
+        }
+        for (int i = 4; i < 9; i++) {
+            Asserts.assertNull(a[i]);
+        }
+        Asserts.assertNotNull(a[9]);
+    }
+
+    static void test_15() {
+        var a = new SmallPoint[10];
+        var b = new MyValue[10];
+        var sp = new SmallPoint((byte)1, (byte)2);
+        for (int i = 0; i < 10; i++) {
+            a[i] = sp;
+        }
+        b[7] = new MyValue(1, (short)2);
+        Object ase = null;
+        try {
+          System.arraycopy(b, 3, a, 4, 5);
+        } catch (ArrayStoreException e) {
+          ase  = e;
+        }
+        Asserts.assertNotNull(ase);
+        for (int i = 0 ; i < 4; i++) {
+            Asserts.assertNotNull(a[i]);
+        }
+        for (int i = 4; i < 8; i++) {
+            Asserts.assertNull(a[i]);
+        }
+        Asserts.assertNotNull(a[8]);
+        Asserts.assertNotNull(a[9]);
+    }
+
+    static void test_16() {
+        var a = new MyValue[10];
+        var mv = new MyValue(1, (short)2);
+        for (int i = 0; i < 10; i++) {
+            a[i] = mv;
+        }
+        var b = new MyInterface[10];
+        System.arraycopy(a, 1, b, 2, 3);
+        for (int i = 0 ; i < 2; i++) {
+            Asserts.assertNull(b[i]);
+        }
+        for (int i = 0; i < 3; i++) {
+            Asserts.assertEquals(b[2+i], a[1+i]);
+        }
+        for (int i = 5; i < 10; i++) {
+            Asserts.assertNull(b[i]);
+        }
+    }
+
+      static void test_17() {
+        var a =  new MyInterface[10];
+        var mv = new MyValue(1, (short)2);
+        for (int i = 0; i < 10; i++) {
+            a[i] = mv;
+        }
+        var b = new MyValue[10];
+        System.arraycopy(a, 1, b, 2, 3);
+        for (int i = 0 ; i < 2; i++) {
+            Asserts.assertNull(b[i]);
+        }
+        for (int i = 0; i < 3; i++) {
+            Asserts.assertEquals(b[2+i], a[1+i]);
+        }
+        for (int i = 5; i < 10; i++) {
+            Asserts.assertNull(b[i]);
+        }
+    }
+
+    static void test_18() {
+        var a = new MyValue[10];
+        var mv = new MyValue(1, (short)2);
+        for (int i = 5; i < 10; i++) {
+            a[i] = mv;
+        }
+        var b = new Comparable[10];
+        var mi = Integer.valueOf(3);
+        for (int i = 0; i < 10; i++) {
+            b[i] = mi;
+        }
+        Object ase = null;
+        try {
+            System.arraycopy(a, 1, b, 2, 6);
+        } catch (ArrayStoreException e) {
+            ase = e;
+        }
+        Asserts.assertNotNull(ase);
+        Asserts.assertEQ(b[0], mi);
+        Asserts.assertEQ(b[1], mi);
+        for (int i = 2; i < 6; i++) {
+            Asserts.assertNull(b[i]);
+        }
+        for (int i = 6; i < 10; i++) {
+            Asserts.assertEQ(b[i], mi);
+        }
+    }
+
+    static void test_19() {
+        var a = new MyValue[10];
+        var mv = new MyValue(1, (short)2);
+        for (int i = 5; i < 10; i++) {
+            a[i] = mv;
+        }
+        var b = new Complex[10];
+        var mc = new Complex(4.0d, 2.0d);
+        for (int i = 0; i < 10; i++) {
+            b[i] = mc;
+        }
+        Object ase = null;
+        try {
+            System.arraycopy(a, 1, b, 2, 6);
+        } catch (ArrayStoreException e) {
+            ase = e;
+        }
+        Asserts.assertNotNull(ase);
+        Asserts.assertEQ(b[0], mc);
+        Asserts.assertEQ(b[1], mc);
+        for (int i = 2; i < 6; i++) {
+            Asserts.assertNull(b[i]);
+        }
+        for (int i = 6; i < 10; i++) {
+            Asserts.assertEQ(b[i], mc);
+        }
+    }
+
+    static void test_20() {
+        var a = new SmallPoint[10];
+        var sp = new SmallPoint((byte)1, (byte)2);
+        var b = (SmallPoint[])ValueClass.newNullRestrictedAtomicArray(SmallPoint.class, 10, sp);
+        var c = (SmallPoint[])ValueClass.newNullRestrictedAtomicArray(SmallPoint.class, 10, sp);
+        for (int i = 0; i < 10; i++) {
+            a[i] = new SmallPoint((byte)i, (byte)(i+1));
+            b[i] = new SmallPoint((byte)(i*10), (byte)((i+1)*10));;
+            c[i] = b[i];
+        }
+        System.arraycopy(a, 2, c, 4, 3);
+        for (int i = 0; i < 4; i++) {
+            Asserts.assertEquals(c[i], b[i]);
+        }
+        for (int i = 0; i < 3; i++) {
+            Asserts.assertEquals(c[4 + i], a[2 + i]);
+        }
+        for (int i = 7; i < 10; i++) {
+            Asserts.assertEquals(c[i], b[i]);
+        }
+    }
+
+    static void test_21() {
+        var a = new SmallPoint[10];
+        var sp = new SmallPoint((byte)1, (byte)2);
+        var b = (SmallPoint[])ValueClass.newNullRestrictedAtomicArray(SmallPoint.class, 10, sp);
+        var c = (SmallPoint[])ValueClass.newNullRestrictedAtomicArray(SmallPoint.class, 10, sp);
+        for (int i = 0; i < 10; i++) {
+            a[i] = new SmallPoint((byte)i, (byte)(i+1));
+            b[i] = new SmallPoint((byte)(i*10), (byte)((i+1)*10));
+            c[i] = b[i];
+        }
+        a[4] = null;
+        Object npe = null;
+        try {
+            System.arraycopy(a, 2, c, 4, 3);
+        } catch (NullPointerException e) {
+            npe = e;
+        }
+        Asserts.assertNotNull(npe);
+        for (int i = 0; i < 4; i++) {
+            Asserts.assertEquals(c[i], b[i]);
+        }
+        for (int i = 0; i < 2; i++) {
+            Asserts.assertEquals(c[4 + i], a[2 + i]);
+        }
+        for (int i = 6; i < 10; i++) {
+            Asserts.assertEquals(c[i], b[i]);
+        }
+    }
+
+    static void test_22() {
+        var a = new SmallPoint[10];
+        var c = new Complex(2.0d, 4.0d);
+        var b = (Complex[])ValueClass.newNullRestrictedAtomicArray(Complex.class, 10, c);
+        Object npe = null;
+        try {
+            System.arraycopy(a, 2, b, 4, 3);
+        } catch (NullPointerException e) {
+            npe = e;
+        }
+        Asserts.assertNotNull(npe);
+        for (int i = 0; i < 10; i++) {
+            Asserts.assertEquals(b[i], c);
+        }
+    }
+
+    static void test_23() {
+        var a = (SmallPoint[])ValueClass.newReferenceArray(SmallPoint.class, 10);
+        var b = new SmallPoint[10];
+        SmallPoint sp0 = new SmallPoint((byte)1, (byte)2);
+        SmallPoint sp1 = new SmallPoint((byte)3, (byte)4);
+        for (int i = 0; i < 10; i++) {
+            a[i] = sp0;
+            b[i] = sp1;
+        }
+        System.arraycopy(a, 2, b, 4, 3);
+        for (int i = 0; i < 4; i++) {
+            Asserts.assertEquals(b[i], sp1);
+        }
+        for (int i = 4; i < 7; i++) {
+            Asserts.assertEquals(b[i], sp0);
+        }
+        for (int i = 7; i < 10; i++) {
+            Asserts.assertEquals(b[i], sp1);
+        }
+    }
+
+    static void test_24() {
+        SmallPoint sp0 = new SmallPoint((byte)1, (byte)2);
+        SmallPoint sp1 = new SmallPoint((byte)3, (byte)4);
+        var a = (SmallPoint[])ValueClass.newReferenceArray(SmallPoint.class, 10);
+        var b = (SmallPoint[])ValueClass.newNullRestrictedAtomicArray(SmallPoint.class, 10, sp1);
+        for (int i = 0; i < 10; i++) {
+            a[i] = sp0;
+        }
+        a[4] = null;
+        Object npe = null;
+        try {
+            System.arraycopy(a, 2, b, 4, 3);
+        } catch(NullPointerException e) {
+            npe = e;
+        }
+        Asserts.assertNotNull(npe);
+        for (int i = 0; i < 4; i++) {
+            Asserts.assertEquals(b[i], sp1);
+        }
+        for (int i = 4; i < 6; i++) {
+            Asserts.assertEquals(b[i], sp0);
+        }
+        for (int i = 6; i < 10; i++) {
+            Asserts.assertEquals(b[i], sp1);
+        }
+    }
+
+    static void test_25() {
+        var a = new SmallPoint[10];
+        var b = new SmallPoint[10];
+        for (int i = 0; i < 10; i++) {
+            a[i] = new SmallPoint((byte)i, (byte)(i+1));
+            b[i] = a[i];
+        }
+        System.arraycopy(b, 2, b, 4, 5);
+        for (int i = 0; i < 4; i++) {
+            Asserts.assertEquals(b[i], a[i]);
+        }
+        for (int i = 0; i < 5; i++) {
+            Asserts.assertEquals(b[4 + i], a[2 + i]);
+        }
+        for (int i = 9; i < 10; i++) {
+            Asserts.assertEquals(b[i], a[i]);
+        }
+    }
+
+    static void test_26() {
+        var a = new SmallPoint[10];
+        var mv = new MyValue(1, (short)2);
+        var b = (MyValue[])ValueClass.newNullRestrictedAtomicArray(MyValue.class, 10, mv);
+        Object npe = null;
+        try {
+            System.arraycopy(a, 1, b, 3, 2);
+        } catch (NullPointerException e) {
+            npe = e;
+        }
+        Asserts.assertNotNull(npe);
+        for (int i = 0; i < 10; i++) {
+            Asserts.assertEquals(b[i], mv);
+        }
+    }
+
+    static void test_27() {
+        var a = new String[10];
+        for (int i = 0; i < 10; i++) {
+            a[i] = "hello";
+        }
+        var b = new SmallPoint[10];
+        Object ase = null;
+        try {
+            System.arraycopy(a, 2, b, 3, 2);
+        } catch(ArrayStoreException e) {
+            ase = e;
+        }
+        Asserts.assertNotNull(ase);
+        for (int i = 0; i < 10; i++) {
+            Asserts.assertNull(b[i]);
+        }
+    }
+
+    static void test_28() {
+        var a = new String[10];
+        var b = new SmallPoint[10];
+        System.arraycopy(a, 2, b, 3, 2);
+        for (int i = 0; i < 10; i++) {
+            Asserts.assertNull(b[i]);
+        }
+    }
+
+    static void test_29() {
+        var a = (SmallPoint[])ValueClass.newReferenceArray(SmallPoint.class, 10);
+        var b = (SmallPoint[])ValueClass.newNullableAtomicArray(SmallPoint.class, 10);
+        var sp = new SmallPoint((byte)1, (byte)3);
+        for (int i = 2; i < 5; i++) {
+            a[i] = sp;
+        }
+        System.arraycopy(a, 2, b, 3, 5);
+        for (int i = 0; i < 3; i++) {
+            Asserts.assertNull(b[i]);
+        }
+        for (int i = 3; i < 6; i++) {
+            Asserts.assertEquals(b[i], sp);
+        }
+        for (int i = 6; i < 10; i++) {
+            Asserts.assertNull(b[i]);
+        }
+    }
+
+    static void test_30() {
+        var mv = new MyValue(3, (short)5);
+        var a = (MyValue[])ValueClass.newNullRestrictedAtomicArray(MyValue.class, 10, mv);
+        var b = new MyValue[10];
+        System.arraycopy(a, 3, b, 1, 4);
+        Asserts.assertNull(b[0]);
+        for (int i = 1; i < 5; i++) {
+            Asserts.assertEquals(b[i], mv);
+        }
+        for (int i = 5; i < 10; i++) {
+            Asserts.assertNull(b[i]);
+        }
+    }
+
+    public static void main(String[] args) {
+        var test = new TestArrayCopy();
+        Class c = test.getClass();
+        ArrayList<String> failures = new ArrayList<>();
+        for (Method m : c.getDeclaredMethods()) {
+            if (m.getName().startsWith("test_")) {
+                try {
+                    System.out.println("Running " + m.getName());
+                    m.invoke(null);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    failures.add(m.getName());
+                }
+            }
+        }
+        if (!failures.isEmpty()) {
+            System.out.print("Failed tests: ");
+            for (String s: failures) {
+                System.out.print(s + " ");
+            }
+            System.out.println("");
+            throw new RuntimeException("Some tests failed");
+        }
+    }
+}


### PR DESCRIPTION
This fixes the implementation of System.arraycopy() when flat arrays are involved (preview feature of JEP 401).
New tests have been added to ensure correct behavior in all configurations.

Testing in progress with Mach5, tiers 1 to 4 (6 tasks remaining).

Fred

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388480](https://bugs.openjdk.org/browse/JDK-8388480): System.arraycopy fails to partially copy nullable flat arrays (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32184/head:pull/32184` \
`$ git checkout pull/32184`

Update a local copy of the PR: \
`$ git checkout pull/32184` \
`$ git pull https://git.openjdk.org/jdk.git pull/32184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32184`

View PR using the GUI difftool: \
`$ git pr show -t 32184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32184.diff">https://git.openjdk.org/jdk/pull/32184.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32184#issuecomment-5171327391)
</details>
