### PR TITLE
8347266: C2: Verify that Node::Identity() doesn't return new nodes

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -733,7 +733,8 @@
           "the IGVN worklist drains")                                       \
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \
-          "Verify Iterative Global Value Numbering =FEDCBA, with:"          \
+          "Verify Iterative Global Value Numbering =GFEDCBA, with:"         \
+          "  G: verify Node::Identity return an existing node"              \
           "  F: verify Node::Ideal does not return nullptr if the node"     \
                 "hash has changed"                                          \
           "  E: verify node specific invariants"                            \

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2379,7 +2379,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
 
     // One unique input.
-    DEBUG_ONLY(Node* ident = Identity(phase));
+    DEBUG_ONLY(Node* ident = phase->apply_identity(this));
     // The unique input must eventually be detected by the Identity call.
 #ifdef ASSERT
     if (ident != uin && !ident->is_top() && !must_wait_for_region_in_irreducible_loop(phase)) {

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4039,7 +4039,7 @@ void IdealLoopTree::split_fall_in( PhaseIdealLoop *phase, int fall_in_cnt ) {
       // disappear it.  In JavaGrande I have a case where this useless
       // Phi is the loop limit and prevents recognizing a CountedLoop
       // which in turn prevents removing an empty loop.
-      Node *id_old_phi = old_phi->Identity(&igvn);
+      Node *id_old_phi = igvn.apply_identity(old_phi);
       if( id_old_phi != old_phi ) { // Found a simple identity?
         // Note that I cannot call 'replace_node' here, because
         // that will yank the edge from old_phi to the Region and

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4039,7 +4039,7 @@ void IdealLoopTree::split_fall_in( PhaseIdealLoop *phase, int fall_in_cnt ) {
       // disappear it.  In JavaGrande I have a case where this useless
       // Phi is the loop limit and prevents recognizing a CountedLoop
       // which in turn prevents removing an empty loop.
-      Node *id_old_phi = igvn.apply_identity(old_phi);
+      Node* id_old_phi = igvn.apply_identity(old_phi);
       if( id_old_phi != old_phi ) { // Found a simple identity?
         // Note that I cannot call 'replace_node' here, because
         // that will yank the edge from old_phi to the Region and

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -140,7 +140,7 @@ Node* PhaseIdealLoop::split_thru_phi(Node* n, Node* region, int policy) {
       // otherwise it will be not updated during igvn->transform since
       // igvn->type(x) is set to x->Value() already.
       x->raise_bottom_type(t);
-      Node* y = x->Identity(&_igvn);
+      Node* y = _igvn.apply_identity(x);
       if (y != x) {
         wins.add_win(i);
         x = y;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -6208,7 +6208,7 @@ Node* MergeMemNode::Identity(PhaseGVN* phase) {
 //------------------------------Ideal------------------------------------------
 // This method is invoked recursively on chains of MergeMem nodes
 Node *MergeMemNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  if (Identity(phase) != this) {
+  if (phase->apply_identity(this) != this) {
     // Let Identity handle this case
     return nullptr;
   }

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1994,7 +1994,7 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
 
   // Do nothing here if Identity will find a value
   // (to avoid infinite chain of value phis generation).
-  if (this != Identity(phase)) {
+  if (this != phase->apply_identity(this)) {
     return nullptr;
   }
 
@@ -2109,7 +2109,7 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
       // otherwise it will be not updated during igvn->transform since
       // igvn->type(x) is set to x->Value() already.
       x->raise_bottom_type(t);
-      Node* y = x->Identity(igvn);
+      Node* y = igvn->apply_identity(x);
       if (y != x) {
         x = y;
       } else {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -685,6 +685,14 @@ Node* PhaseGVN::apply_ideal(Node* k, bool can_reshape) {
   return i;
 }
 
+Node* PhaseGVN::apply_identity(Node* n) {
+  DEBUG_ONLY(uint old_unique = C->unique();)
+  Node* const i = n->Identity(this);
+  assert(i->_idx < old_unique,
+         "Identity() must return an existing node");
+  return i;
+}
+
 //------------------------------transform--------------------------------------
 // Return a node which computes the same function as this node, but
 // in a faster or cheaper fashion.
@@ -736,7 +744,7 @@ Node* PhaseGVN::transform(Node* n) {
   }
 
   // Now check for Identities
-  i = k->Identity(this);        // Look for a nearby replacement
+  i = apply_identity(k);        // Look for a nearby replacement
   if (i != k) {                 // Found? Return replacement!
     set_progress();
     return i;
@@ -2142,7 +2150,7 @@ void PhaseIterGVN::verify_Identity_for(Node* n) {
     return;
   }
 
-  Node* i = n->Identity(this);
+  Node* i = apply_identity(n);
   // If we cannot find any other Identity, we are happy.
   if (i == n) {
     verify_empty_worklist(n);
@@ -2306,7 +2314,7 @@ Node *PhaseIterGVN::transform_old(Node* n) {
   }
 
   // Now check for Identities
-  i = k->Identity(this);      // Look for a nearby replacement
+  i = apply_identity(k);      // Look for a nearby replacement
   if (i != k) {                // Found? Return replacement!
     set_progress();
     add_users_to_worklist(k);

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -686,13 +686,10 @@ Node* PhaseGVN::apply_ideal(Node* k, bool can_reshape) {
 }
 
 Node* PhaseGVN::apply_identity(Node* n) {
-#ifdef ASSERT
-  bool verify_identity = is_verify_Identity();
-  uint old_unique = verify_identity ? C->unique() : 0;
-#endif
+  NOT_PRODUCT(uint old_unique = is_verify_Identity_return() ? C->unique() : 0;)
   Node* const i = n->Identity(this);
-  assert(!verify_identity || i->_idx < old_unique,
-         "Identity() must return an existing node");
+  NOT_PRODUCT(assert(!is_verify_Identity_return() || i->_idx < old_unique,
+                      "Identity() must return an existing node");)
   return i;
 }
 

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -686,9 +686,12 @@ Node* PhaseGVN::apply_ideal(Node* k, bool can_reshape) {
 }
 
 Node* PhaseGVN::apply_identity(Node* n) {
-  DEBUG_ONLY(uint old_unique = C->unique();)
+#ifdef ASSERT
+  bool verify_identity = is_verify_Identity();
+  uint old_unique = verify_identity ? C->unique() : 0;
+#endif
   Node* const i = n->Identity(this);
-  assert(i->_idx < old_unique,
+  assert(!verify_identity || i->_idx < old_unique,
          "Identity() must return an existing node");
   return i;
 }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -686,10 +686,10 @@ Node* PhaseGVN::apply_ideal(Node* k, bool can_reshape) {
 }
 
 Node* PhaseGVN::apply_identity(Node* n) {
-  NOT_PRODUCT(uint old_unique = is_verify_Identity_return() ? C->unique() : 0;)
+  DEBUG_ONLY(uint old_unique = is_verify_Identity_return() ? C->unique() : 0;)
   Node* const i = n->Identity(this);
-  NOT_PRODUCT(assert(!is_verify_Identity_return() || i->_idx < old_unique,
-                      "Identity() must return an existing node");)
+  assert(!is_verify_Identity_return() || i->_idx < old_unique,
+         "Identity() must return an existing node");
   return i;
 }
 

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -451,6 +451,9 @@ public:
   // Helper to call Node::Ideal() and BarrierSetC2::ideal_node().
   Node* apply_ideal(Node* i, bool can_reshape);
 
+  // Helper to call Node::Identity() and verify that it returns an existing node.
+  Node* apply_identity(Node* n);
+
 #ifdef ASSERT
   void dump_infinite_loop_info(Node* n, const char* where);
   // Check for a simple dead loop when a data node references itself.

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -459,6 +459,13 @@ public:
   // Check for a simple dead loop when a data node references itself.
   void dead_loop_check(Node *n);
 #endif
+
+#ifndef PRODUCT
+  static bool is_verify_Identity() {
+    // '-XX:VerifyIterativeGVN=1000'
+    return ((VerifyIterativeGVN % 10000) / 1000) == 1;
+  }
+#endif
 };
 
 //------------------------------PhaseIterGVN-----------------------------------
@@ -672,10 +679,6 @@ public:
   static bool is_verify_Ideal() {
     // '-XX:VerifyIterativeGVN=100'
     return ((VerifyIterativeGVN % 1000) / 100) == 1;
-  }
-  static bool is_verify_Identity() {
-    // '-XX:VerifyIterativeGVN=1000'
-    return ((VerifyIterativeGVN % 10000) / 1000) == 1;
   }
   static bool is_verify_invariants() {
     // '-XX:VerifyIterativeGVN=10000'

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -463,7 +463,7 @@ public:
 #ifndef PRODUCT
   static bool is_verify_Identity_return() {
     // '-XX:VerifyIterativeGVN=1000000'
-    return ((VerifyIterativeGVN % 10000000) / 1000000) == 1;
+    return ((VerifyIterativeGVN % 10'000'000) / 1'000'000) == 1;
   }
 #endif
 };

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -461,9 +461,9 @@ public:
 #endif
 
 #ifndef PRODUCT
-  static bool is_verify_Identity() {
-    // '-XX:VerifyIterativeGVN=1000'
-    return ((VerifyIterativeGVN % 10000) / 1000) == 1;
+  static bool is_verify_Identity_return() {
+    // '-XX:VerifyIterativeGVN=1000000'
+    return ((VerifyIterativeGVN % 10000000) / 1000000) == 1;
   }
 #endif
 };
@@ -679,6 +679,10 @@ public:
   static bool is_verify_Ideal() {
     // '-XX:VerifyIterativeGVN=100'
     return ((VerifyIterativeGVN % 1000) / 100) == 1;
+  }
+  static bool is_verify_Identity() {
+    // '-XX:VerifyIterativeGVN=1000'
+    return ((VerifyIterativeGVN % 10000) / 1000) == 1;
   }
   static bool is_verify_invariants() {
     // '-XX:VerifyIterativeGVN=10000'

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -329,7 +329,7 @@ JVMFlag::Error TypeProfileLevelConstraintFunc(uint value, bool verbose) {
 }
 
 JVMFlag::Error VerifyIterativeGVNConstraintFunc(uint value, bool verbose) {
-  const int max_modes = 6;
+  const int max_modes = 7;
   uint original_value = value;
   for (int i = 0; i < max_modes; i++) {
     if (value % 10 > 1) {

--- a/test/hotspot/jtreg/compiler/c2/TestVerifyIterativeGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestVerifyIterativeGVN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
  * @test
  * @bug 8238756 8351889
  * @requires vm.debug == true & vm.flavor == "server"
- * @summary Run with -Xcomp to test -XX:VerifyIterativeGVN=111111 in debug builds.
+ * @summary Run with -Xcomp to test -XX:VerifyIterativeGVN=1111111 in debug builds.
  *
- * @run main/othervm/timeout=300 -Xcomp -XX:VerifyIterativeGVN=111111 compiler.c2.TestVerifyIterativeGVN
+ * @run main/othervm/timeout=300 -Xcomp -XX:VerifyIterativeGVN=1111111 compiler.c2.TestVerifyIterativeGVN
  */
 package compiler.c2;
 


### PR DESCRIPTION
Please review this PR. Thanks!

**Description:**

`Node::Identity()` is expected to return a node that already exists in the graph. However, this contract is not currently verified.

**Solution:**

Add `PhaseGVN::apply_identity()` to invoke `Node::Identity()` and verify in debug builds that the returned node existed before the call.

**Test:**

GHA, 
make test TEST="hotspot:hotspot_compiler"  JTREG="JAVA_OPTIONS=-XX:VerifyIterativeGVN=1000"

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8347266](https://bugs.openjdk.org/browse/JDK-8347266): C2: Verify that Node::Identity() doesn't return new nodes (**Enhancement** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32188/head:pull/32188` \
`$ git checkout pull/32188`

Update a local copy of the PR: \
`$ git checkout pull/32188` \
`$ git pull https://git.openjdk.org/jdk.git pull/32188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32188`

View PR using the GUI difftool: \
`$ git pr show -t 32188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32188.diff">https://git.openjdk.org/jdk/pull/32188.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32188#issuecomment-5173649800)
</details>
