### PR TITLE
8384109: Update NegativeArraySizeExceptionTest  to check arrays of value classes

### DIFF
--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NegativeArraySizeException/NegativeArraySizeExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NegativeArraySizeException/NegativeArraySizeExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,8 +33,30 @@
 import java.lang.reflect.Array;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.valueclass.AsValueClass;
 
 public class NegativeArraySizeExceptionTest {
+
+    @AsValueClass
+    static class VClass {
+        Integer x;
+        Integer y;
+        VClass(Integer x, Integer y) { this.x = x; this.y = y; }
+    }
+
+    @FunctionalInterface
+    interface AllocAction {
+        void run() throws Exception;
+    }
+
+    private static void assertNASE(int size, AllocAction action) throws Exception {
+        try {
+            action.run();
+            throw new RuntimeException("Array allocation with negative size expected to fail!");
+        } catch (NegativeArraySizeException e) {
+            Asserts.assertEQ(Integer.toString(size), e.getMessage());
+        }
+    }
 
     private static void fail () throws Exception {
         throw new RuntimeException("Array allocation with negative size expected to fail!");
@@ -299,6 +321,19 @@ public class NegativeArraySizeExceptionTest {
             fail();
         } catch (NegativeArraySizeException e) {
             Asserts.assertEQ("-2147483648", e.getMessage());
+        }
+
+
+        // Tests for value class arrays (migrated Integer and custom VClass).
+        int[] negativeSizes = { minusOne, Integer.MIN_VALUE };
+        Class<?>[] valueTypes = { Integer.class, VClass.class };
+        for (int size : negativeSizes) {
+            for (Class<?> type : valueTypes) {
+                assertNASE(size, () -> Array.newInstance(type, size));
+                assertNASE(size, () -> Array.newInstance(type, new int[] {3, size}));
+                assertNASE(size, () -> Array.newInstance(type, new int[] {size, 3}));
+                assertNASE(size, () -> Array.newInstance(type, new int[] {0, size}));
+            }
         }
 
         Asserts.assertEQ(r, null, "Expected all tries to allocate negative array to fail.");


### PR DESCRIPTION
Adds value class array cases to the existing NegativeArraySizeExceptionTest: the migrated Integer, and a custom VClass with Integer fields marked @jdk.test.lib.valueclass.AsValueClass, so the same source runs as an identity class
by default and as a value class under the ValueClassPlugin. Covers direct allocation, Array.newInstance and multi-dimensional arrays, via a small assertNASE helper looping over the negative sizes and types




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384109](https://bugs.openjdk.org/browse/JDK-8384109): Update NegativeArraySizeExceptionTest  to check arrays of value classes (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32189/head:pull/32189` \
`$ git checkout pull/32189`

Update a local copy of the PR: \
`$ git checkout pull/32189` \
`$ git pull https://git.openjdk.org/jdk.git pull/32189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32189`

View PR using the GUI difftool: \
`$ git pr show -t 32189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32189.diff">https://git.openjdk.org/jdk/pull/32189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32189#issuecomment-5181662113)
</details>
