### PR TITLE
8389140: VarHandle CAS should not initialize value class

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -346,7 +346,6 @@ UNSAFE_ENTRY(jint, Unsafe_FieldLayout(JNIEnv *env, jobject unsafe, jobject field
 UNSAFE_ENTRY(jarray, Unsafe_NewSpecialArray(JNIEnv *env, jobject unsafe, jclass elmClass, jint len, jint layoutKind)) {
   oop mirror = JNIHandles::resolve_non_null(elmClass);
   Klass* klass = java_lang_Class::as_Klass(mirror);
-  klass->initialize(CHECK_NULL);
   if (len < 0) {
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Array length is negative");
   }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -313,6 +313,15 @@ public final class Unsafe {
 
     private native int fieldLayout0(Object o);
 
+    /**
+     * Returns an array compatible with the requested layout layout kind.
+     * The returned array does not necessarily contain initialized data.
+     * It is the responsibility of the caller to ensure that each read index is initialized.
+     * @param componentType class of the elements of the array
+     * @param length length of the array
+     * @param layoutKind opaque value describing the requested layout of the array's content
+     * @return an array whose contents is potentially uninitialized
+     */
     public native Object[] newSpecialArray(Class<?> componentType,
                                                   int length, int layoutKind);
 

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -313,15 +313,6 @@ public final class Unsafe {
 
     private native int fieldLayout0(Object o);
 
-    /**
-     * Returns an array compatible with the requested layout layout kind.
-     * The returned array does not necessarily contain initialized data.
-     * It is the responsibility of the caller to ensure that each read index is initialized.
-     * @param componentType class of the elements of the array, must not be null
-     * @param length length of the array
-     * @param layoutKind opaque value describing the requested layout of the array's content
-     * @return an array whose contents is potentially uninitialized
-     */
     public native Object[] newSpecialArray(Class<?> componentType,
                                                   int length, int layoutKind);
 

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -314,7 +314,7 @@ public final class Unsafe {
     private native int fieldLayout0(Object o);
 
     /**
-     * Returns an array compatible with the requested layout layout kind.
+     * Returns an array compatible with the requested layout kind.
      * The returned array does not necessarily contain initialized data.
      * It is the responsibility of the caller to ensure that each read index is initialized.
      * @param componentType class of the elements of the array, must not be null

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -317,7 +317,7 @@ public final class Unsafe {
      * Returns an array compatible with the requested layout layout kind.
      * The returned array does not necessarily contain initialized data.
      * It is the responsibility of the caller to ensure that each read index is initialized.
-     * @param componentType class of the elements of the array
+     * @param componentType class of the elements of the array, must not be null
      * @param length length of the array
      * @param layoutKind opaque value describing the requested layout of the array's content
      * @return an array whose contents is potentially uninitialized

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatArrayDoesNotInitialize.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatArrayDoesNotInitialize.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @summary Test that creating an array of T does not initialize class T
+ * @library /test/lib
+ * @enablePreview
+ * @compile FlatArrayDoesNotInitialize.java
+ * @run main/othervm runtime.valhalla.inlinetypes.FlatArrayDoesNotInitialize
+ */
+package runtime.valhalla.inlinetypes;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+
+public class FlatArrayDoesNotInitialize {
+    static boolean initialized;
+
+    static value class MyValue {
+        static {
+            initialized = true;
+        }
+    }
+
+    public static void main(String[] args) {
+        MyValue[] array = new MyValue[1];
+        VarHandle handle = MethodHandles.arrayElementVarHandle(MyValue[].class);
+        if (initialized) {
+            throw new AssertionError("Should not be initialized");
+        }
+        if (!(boolean) handle.compareAndSet(array, 0, null, null)) {
+            throw new AssertionError("CAS failed");
+        }
+        if (initialized) {
+            throw new AssertionError("Should not be initialized");
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatArrayDoesNotInitialize.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlatArrayDoesNotInitialize.java
@@ -25,7 +25,6 @@
 /*
  * @test
  * @summary Test that creating an array of T does not initialize class T
- * @library /test/lib
  * @enablePreview
  * @compile FlatArrayDoesNotInitialize.java
  * @run main/othervm runtime.valhalla.inlinetypes.FlatArrayDoesNotInitialize


### PR DESCRIPTION
When creating a new array of type T, the type T should not be initialized. This is the case for all types (classes and value classes). The reason that this code was added is probably because in a previous Valhalla model, the VM filled in a default value for each flattened array element, which necessitated the initialization of the class.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389140](https://bugs.openjdk.org/browse/JDK-8389140): VarHandle CAS should not initialize value class (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32193/head:pull/32193` \
`$ git checkout pull/32193`

Update a local copy of the PR: \
`$ git checkout pull/32193` \
`$ git pull https://git.openjdk.org/jdk.git pull/32193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32193`

View PR using the GUI difftool: \
`$ git pr show -t 32193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32193.diff">https://git.openjdk.org/jdk/pull/32193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32193#issuecomment-5290048514)
</details>
