### PR TITLE
8389512: [lworld] Stale acmp profile data causes repeated deoptimization

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2108,13 +2108,13 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   // Leverage profiling at acmp
   if (UseACmpProfile) {
     method()->acmp_profiled_type(bci(), left_type, right_type, left_ptr, right_ptr, left_inline_type, right_inline_type);
-    if (too_many_traps_or_recompiles(Deoptimization::Reason_class_check)) {
+    if (too_many_traps_or_recompiles(Deoptimization::Reason_class_check) || too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
       left_type = nullptr;
       right_type = nullptr;
       left_inline_type = true;
       right_inline_type = true;
     }
-    if (too_many_traps_or_recompiles(Deoptimization::Reason_null_check)) {
+    if (too_many_traps_or_recompiles(Deoptimization::Reason_null_check) || too_many_traps_or_recompiles(Deoptimization::Reason_null_assert)) {
       left_ptr = ProfileUnknownNull;
       right_ptr = ProfileUnknownNull;
     }


### PR DESCRIPTION
Acmp speculates a lot. But we deopt with reasons that we are not checking before generating the speculative paths. Let's make all of that agree. In practice, it's not quite easy to show a case with endless deopt: we often hit something else that makes it not happen, but the fix is rather obvious.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389512](https://bugs.openjdk.org/browse/JDK-8389512): [lworld] Stale acmp profile data causes repeated deoptimization (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32194/head:pull/32194` \
`$ git checkout pull/32194`

Update a local copy of the PR: \
`$ git checkout pull/32194` \
`$ git pull https://git.openjdk.org/jdk.git pull/32194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32194`

View PR using the GUI difftool: \
`$ git pr show -t 32194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32194.diff">https://git.openjdk.org/jdk/pull/32194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32194#issuecomment-5179859963)
</details>
