### PR TITLE
8389705: RawBytecodeHelper doesn't check bounds passed to unsafe code

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/RawBytecodeHelper.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/RawBytecodeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,6 +247,11 @@ public final class RawBytecodeHelper {
             JSR_W = 201;
 
     public record CodeRange(byte[] array, int length) {
+        public CodeRange {
+            // Don't use IAE formatter - this length comes from implementation, any
+            // out-of-bounds is an implementation defect instead of a user error
+            Preconditions.checkIndex(length, array.length + 1, Preconditions.AIOOBE_FORMATTER);
+        }
         public RawBytecodeHelper start() {
             return new RawBytecodeHelper(this);
         }

--- a/test/jdk/jdk/classfile/UtilTest.java
+++ b/test/jdk/jdk/classfile/UtilTest.java
@@ -142,5 +142,6 @@ class UtilTest {
     void testRawBytecodeHelperCodeRangeCheck() {
         assertThrows(IndexOutOfBoundsException.class, () -> RawBytecodeHelper.of(new byte[0], 1));
         assertThrows(IndexOutOfBoundsException.class, () -> RawBytecodeHelper.of(new byte[1], Integer.MAX_VALUE));
+        assertThrows(IndexOutOfBoundsException.class, () -> RawBytecodeHelper.of(new byte[16], -42));
     }
 }

--- a/test/jdk/jdk/classfile/UtilTest.java
+++ b/test/jdk/jdk/classfile/UtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8338546
+ * @bug 8338546 8389705
  * @summary Testing ClassFile Util.
  * @library java.base
  * @modules java.base/jdk.internal.constant
@@ -136,5 +136,11 @@ class UtilTest {
         }
 
         assertArrayEquals(lengths, RawBytecodeHelper.LENGTHS);
+    }
+
+    @Test
+    void testRawBytecodeHelperCodeRangeCheck() {
+        assertThrows(IndexOutOfBoundsException.class, () -> RawBytecodeHelper.of(new byte[0], 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> RawBytecodeHelper.of(new byte[1], Integer.MAX_VALUE));
     }
 }


### PR DESCRIPTION
This internal endpoint used only by trusted code is missing bound checks. Since this endpoint leads to direct unsafe usage, we should better gatekeep here.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389705](https://bugs.openjdk.org/browse/JDK-8389705): RawBytecodeHelper doesn't check bounds passed to unsafe code (**Bug** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32195/head:pull/32195` \
`$ git checkout pull/32195`

Update a local copy of the PR: \
`$ git checkout pull/32195` \
`$ git pull https://git.openjdk.org/jdk.git pull/32195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32195`

View PR using the GUI difftool: \
`$ git pr show -t 32195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32195.diff">https://git.openjdk.org/jdk/pull/32195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32195#issuecomment-5180146826)
</details>
