### PR TITLE
8384644: Document that HttpResponse::body can return null

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -159,11 +159,10 @@ public interface HttpResponse<T> {
      * {@code String}, or {@code Path}) or it may represent an object with
      * which the body is read, such as an {@link java.io.InputStream}.
      *
-     * <p> Depending on the response's {@linkplain #statusCode() status code} a
-     * body may not always be available, and an implementation may return {@code
-     * null} in such cases. Exactly when {@code null} can be returned is
-     * implementation dependent. It is therefore recommended that the caller
-     * always check for {@code null} while dereferencing the result.
+     * <p> Depending on the response's {@linkplain #statusCode() status code} or
+     * the {@link BodyHandler} used for the request, a body may not always be
+     * available. It is therefore recommended that the caller always check for
+     * {@code null} while dereferencing the result.
      *
      * <p> If this {@code HttpResponse} was returned from an invocation of
      * {@link #previousResponse()} then this method always returns {@code null}

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -159,18 +159,16 @@ public interface HttpResponse<T> {
      * {@code String}, or {@code Path}) or it may represent an object with
      * which the body is read, such as an {@link java.io.InputStream}.
      *
-     * <p> If this {@code HttpResponse} was returned from an invocation of
-     * {@link #previousResponse()} then this method returns {@code null}
-     *
-     * @apiNote
-     *
-     * Depending on the response's {@linkplain #statusCode() status code} a body
-     * may not always be available, and an implementation may return {@code
+     * <p> Depending on the response's {@linkplain #statusCode() status code} a
+     * body may not always be available, and an implementation may return {@code
      * null} in such cases. Exactly when {@code null} can be returned is
      * implementation dependent. It is therefore recommended that the caller
      * always check for {@code null} while dereferencing the result.
      *
-     * @return the body
+     * <p> If this {@code HttpResponse} was returned from an invocation of
+     * {@link #previousResponse()} then this method always returns {@code null}
+     *
+     * @return the body, or {@code null} if the body is not available
      */
     public T body();
 

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -162,6 +162,12 @@ public interface HttpResponse<T> {
      * <p> If this {@code HttpResponse} was returned from an invocation of
      * {@link #previousResponse()} then this method returns {@code null}
      *
+     * @apiNote
+     *
+     * Exactly when {@code null} can be returned is implementation dependent. It
+     * is therefore recommended that the caller always check for {@code null}
+     * while dereferencing the result.
+     *
      * @return the body
      */
     public T body();

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -164,9 +164,11 @@ public interface HttpResponse<T> {
      *
      * @apiNote
      *
-     * Exactly when {@code null} can be returned is implementation dependent. It
-     * is therefore recommended that the caller always check for {@code null}
-     * while dereferencing the result.
+     * Depending on the response's {@linkplain #statusCode() status code} a body
+     * may not always be available, and an implementation may return {@code
+     * null} in such cases. Exactly when {@code null} can be returned is
+     * implementation dependent. It is therefore recommended that the caller
+     * always check for {@code null} while dereferencing the result.
      *
      * @return the body
      */


### PR DESCRIPTION
Document that `java.net.http.HttpResponse#body()` can return null.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Change requires CSR request [JDK-8389872](https://bugs.openjdk.org/browse/JDK-8389872) to be approved
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8384644](https://bugs.openjdk.org/browse/JDK-8384644): Document that HttpResponse::body can return null (**Enhancement** - P4)
 * [JDK-8389872](https://bugs.openjdk.org/browse/JDK-8389872): Document that HttpResponse::body can return null (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32196/head:pull/32196` \
`$ git checkout pull/32196`

Update a local copy of the PR: \
`$ git checkout pull/32196` \
`$ git pull https://git.openjdk.org/jdk.git pull/32196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32196`

View PR using the GUI difftool: \
`$ git pr show -t 32196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32196.diff">https://git.openjdk.org/jdk/pull/32196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32196#issuecomment-5180354384)
</details>
