### PR TITLE
8388631: Copy StackMapTable for the current frame

### DIFF
--- a/src/hotspot/share/classfile/stackMapFrame.hpp
+++ b/src/hotspot/share/classfile/stackMapFrame.hpp
@@ -102,7 +102,7 @@ class StackMapFrame : public ResourceObj {
         _stack[i] = VerificationType::bogus_type();
       }
     }
-    _assert_unset_fields = cp._assert_unset_fields;
+    set_assert_unset_fields(cp.assert_unset_fields());
     _verifier = nullptr;
   }
 
@@ -139,6 +139,8 @@ class StackMapFrame : public ResourceObj {
     return new StackMapFrame(*smf);
   }
 
+  StackMapFrame& operator=(StackMapFrame const&) = delete;
+
   inline void set_offset(int32_t offset)      { _offset = offset; }
   inline void set_verifier(ClassVerifier* v)  { _verifier = v; }
   inline void set_flags(u1 flags)             { _flags = flags; }
@@ -160,8 +162,17 @@ class StackMapFrame : public ResourceObj {
     return _assert_unset_fields;
   }
 
+  static AssertUnsetFieldTable* copy_unset_fields(AssertUnsetFieldTable* unset_fields) {
+    AssertUnsetFieldTable* new_table = new AssertUnsetFieldTable();
+    auto copy_unset_field = [&] (const NameAndSig& key, const bool& value) {
+      new_table->put(key, value);
+    };
+    unset_fields->iterate_all(copy_unset_field);
+    return new_table;
+  }
+
   void set_assert_unset_fields(AssertUnsetFieldTable* table) {
-    _assert_unset_fields = table;
+    _assert_unset_fields = copy_unset_fields(table);
   }
 
   // Called when verifying putfields to mark strict instance fields as satisfied

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -748,6 +748,12 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
     }
   }
 
+  // The stackmap table will receive a read-only deep copy of the initial strict fields since
+  // the "current frame" will modify this table when a putfield is encountered during verification.
+  // What parsing the StackMapTable attribute, the reader will allocate new tables for frames if
+  // they are EARLY_LARVAL, otherwise this read-only initial set will be shared.
+  StackMapFrame::AssertUnsetFieldTable* read_only_strict_fields = StackMapFrame::copy_unset_fields(strict_fields);
+
   // Initial stack map frame: offset is 0, stack is initially empty.
   StackMapFrame current_frame(max_locals, max_stack, strict_fields, this);
   // Set initial locals
@@ -776,7 +782,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
 
   Array<u1>* stackmap_data = m->stackmap_data();
   StackMapStream stream(stackmap_data);
-  StackMapReader reader(this, &stream, code_data, code_length, &current_frame, max_locals, max_stack, strict_fields, THREAD);
+  StackMapReader reader(this, &stream, code_data, code_length, &current_frame, max_locals, max_stack, read_only_strict_fields, THREAD);
   StackMapTable stackmap_table(&reader, CHECK_VERIFY(this));
 
   LogTarget(Debug, verification) lt;

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -750,7 +750,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
 
   // The stackmap table will receive a read-only deep copy of the initial strict fields since
   // the "current frame" will modify this table when a putfield is encountered during verification.
-  // What parsing the StackMapTable attribute, the reader will allocate new tables for frames if
+  // When parsing the StackMapTable attribute, the reader will allocate new tables for frames if
   // they are EARLY_LARVAL, otherwise this read-only initial set will be shared.
   StackMapFrame::AssertUnsetFieldTable* read_only_strict_fields = StackMapFrame::copy_unset_fields(strict_fields);
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/ControlFlowAlias.jasm
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/ControlFlowAlias.jasm
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+class ControlFlowAlias extends Parent {
+    @Strict int x;
+
+    ControlFlowAlias(boolean a) {
+        if (a) {
+            x = 0;
+        }
+        super(); // FAIL: Strict field x never set on this path AND stackmap is wrong
+    }
+}
+*/
+
+identity class ControlFlowAlias extends Parent version 72:65535
+{
+  strict Field x:I;
+
+  Method       "<init>":"(Z)V"
+    stack 2 locals 2
+  {
+         iload_1;
+         ifeq              L12;
+         aload_0;
+         iconst_1;
+         putfield          Field x:"I";
+         goto              L15;
+  L12:   stack_frame_type  same;
+         goto              L15;
+  L15:   stack_frame_type  same;
+         aload_0;
+         invokespecial     Method Parent."<init>":"()V";
+         return;
+  }
+} // End of ControlFlowAlias

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java
@@ -31,6 +31,7 @@
  *          BadChild1.jasm
  *          StrictFieldNotSubset.jasm
  *          ControlFlowChildBad.jasm
+ *          ControlFlowAlias.jasm
  *          TryCatchChildBad.jasm
  *          NestedEarlyLarval.jcod
  *          EndsInEarlyLarval.jcod
@@ -44,6 +45,7 @@
  * @run main/othervm -Xlog:verification StrictInstanceFieldsTest
  */
 
+import java.util.Arrays;
 import java.lang.reflect.Field;
 import jdk.test.lib.helpers.StrictInit;
 
@@ -51,7 +53,15 @@ public class StrictInstanceFieldsTest {
 
     public static <T> void negativeTest(Class<T> clazz, String msg, boolean... args) throws Exception {
         try {
-            T child = clazz.getDeclaredConstructor().newInstance(args);
+            Class<?>[] parameters = new Class<?>[args.length];
+            Object[] ctorArgs = new Object[args.length];
+            Arrays.fill(parameters, boolean.class);
+
+            for (int i = 0; i < args.length; i++) {
+                ctorArgs[i] = new Boolean(args[i]);
+            }
+
+            T child = clazz.getDeclaredConstructor(parameters).newInstance(ctorArgs);
             System.out.println(child);
             throw new RuntimeException("Should fail verification");
         } catch (java.lang.VerifyError e) {
@@ -111,6 +121,9 @@ public class StrictInstanceFieldsTest {
 
         // Constructor with control flow but field is not initialized
         negativeTest(ControlFlowChildBad.class, "Inconsistent stackmap frames at branch target", true, false);
+
+        // Constructor with control flow but field is not initialized and stackmap is malformed
+        negativeTest(ControlFlowAlias.class, "All strict final fields must be initialized before super()", false);
 
         // Constructor with try-catch but field is not initialized
         negativeTest(TryCatchChildBad.class, "Inconsistent stackmap frames at branch target");


### PR DESCRIPTION
The table which holds the set of strict fields was previously being aliased between frames, meaning it was possible for the state to be unintentionally shared between stack map frames. This aliasing issue couples two different "lineages" which start at the initial set of unset fields calculated during method verification, so the patch separates these lineages by creating deep-copies when necessary. Verified with tier 1-5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388631](https://bugs.openjdk.org/browse/JDK-8388631): Copy StackMapTable for the current frame (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32200/head:pull/32200` \
`$ git checkout pull/32200`

Update a local copy of the PR: \
`$ git checkout pull/32200` \
`$ git pull https://git.openjdk.org/jdk.git pull/32200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32200`

View PR using the GUI difftool: \
`$ git pr show -t 32200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32200.diff">https://git.openjdk.org/jdk/pull/32200.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32200#issuecomment-5181084946)
</details>
