### PR TITLE
8384611: Add value class test coverage to java.util HashMap and HashSet

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -172,9 +172,14 @@ jdk_util = \
     :jdk_stream
 
 valhalla_adopted = \
-    java/util/Collections/AddAll.java \
     java/util/Arrays \
-    java/util/Collections
+    java/util/Collections \
+    java/util/HashMap \
+    java/util/HashSet \
+    java/util/Hashtable \
+    java/util/LinkedHashMap \
+    java/util/LinkedHashSet \
+    java/util/LinkedList
 
 # All util components not part of some other util category
 jdk_util_other = \

--- a/test/jdk/java/util/Collections/AddAll.java
+++ b/test/jdk/java/util/Collections/AddAll.java
@@ -59,7 +59,7 @@ public class AddAll {
 
     private static Random rnd = new Random();
 
-    static <T> void test(Collection<T> c, BiFunction<Integer, Integer,T[]> rangeFactory) {
+    static <T> void test(Collection<T> c, BiFunction<Integer, Integer, T[]> rangeFactory) {
         int x = 0;
         for (int i = 0; i < N; i++) {
             int rangeLen = rnd.nextInt(10);

--- a/test/jdk/java/util/Collections/AddAll.java
+++ b/test/jdk/java/util/Collections/AddAll.java
@@ -41,37 +41,38 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.function.BiFunction;
 
 public class AddAll {
     static final int N = 100;
     public static void main(String[] args) {
-        test(new ArrayList<Integer>());
-        test(new LinkedList<Integer>());
-        test(new HashSet<Integer>());
-        test(new LinkedHashSet<Integer>());
+        test(new ArrayList<Integer>(), AddAll::range);
+        test(new LinkedList<Integer>(), AddAll::range);
+        test(new HashSet<Integer>(), AddAll::range);
+        test(new LinkedHashSet<Integer>(), AddAll::range);
 
-        testTuple(new ArrayList<VClass>());
-        testTuple(new LinkedList<VClass>());
-        testTuple(new HashSet<VClass>());
-        testTuple(new LinkedHashSet<VClass>());
+        test(new ArrayList<VClass>(), AddAll::rangeTuple);
+        test(new LinkedList<VClass>(), AddAll::rangeTuple);
+        test(new HashSet<VClass>(), AddAll::rangeTuple);
+        test(new LinkedHashSet<VClass>(), AddAll::rangeTuple);
     }
 
     private static Random rnd = new Random();
 
-    static void test(Collection<Integer> c) {
+    static <T> void test(Collection<T> c, BiFunction<Integer, Integer,T[]> rangeFactory) {
         int x = 0;
         for (int i = 0; i < N; i++) {
             int rangeLen = rnd.nextInt(10);
-            if (Collections.addAll(c, range(x, x + rangeLen)) !=
+            if (Collections.addAll(c, rangeFactory.apply(x, x + rangeLen)) !=
                     (rangeLen != 0))
                 throw new RuntimeException("" + rangeLen);
             x += rangeLen;
         }
         if (c instanceof List) {
-            if (!c.equals(Arrays.asList(range(0, x))))
+            if (!c.equals(Arrays.asList(rangeFactory.apply(0, x))))
                 throw new RuntimeException(x +": "+c);
         } else {
-            if (!c.equals(new HashSet<Integer>(Arrays.asList(range(0, x)))))
+            if (!c.equals(new HashSet<T>(Arrays.asList(rangeFactory.apply(0, x)))))
                 throw new RuntimeException(x +": "+c);
         }
     }
@@ -81,24 +82,6 @@ public class AddAll {
         for (int i = from, j=0; i < to; i++, j++)
             result[j] = new Integer(i);
         return result;
-    }
-
-    static void testTuple(Collection<VClass> c) {
-        int x = 0;
-        for (int i = 0; i < N; i++) {
-            int rangeLen = rnd.nextInt(10);
-            if (Collections.addAll(c, rangeTuple(x, x + rangeLen)) !=
-                    (rangeLen != 0))
-                throw new RuntimeException("" + rangeLen);
-            x += rangeLen;
-        }
-        if (c instanceof List) {
-            if (!c.equals(Arrays.asList(rangeTuple(0, x))))
-                throw new RuntimeException(x + ": " + c);
-        } else {
-            if (!c.equals(new HashSet<VClass>(Arrays.asList(rangeTuple(0, x)))))
-                throw new RuntimeException(x + ": " + c);
-        }
     }
 
     private static VClass[] rangeTuple(int from, int to) {

--- a/test/jdk/java/util/Collections/BigBinarySearch.java
+++ b/test/jdk/java/util/Collections/BigBinarySearch.java
@@ -40,35 +40,28 @@ import java.util.RandomAccess;
 
 public class BigBinarySearch {
 
-    static class SparseTupleList extends AbstractList<VClass> implements RandomAccess {
-        final Map<Integer, VClass> m = new HashMap<>();
-        public VClass get(int i) { return m.getOrDefault(i, new VClass(0, new int[] { 0 })); }
-        public int size() { return Collections.max(m.keySet()) + 1; }
-        public VClass set(int i, VClass v) { return m.put(i, v); }
-    }
-
     // Allows creation of very "big" collections without using too
     // many real resources
-    static class SparseIntegerList
-        extends AbstractList<Integer>
-        implements RandomAccess
-    {
-        private Map<Integer,Integer> m = new HashMap<>();
+    static class SparseList<T> extends AbstractList<T> implements RandomAccess {
+        private final Map<Integer, T> m = new HashMap<>();
+        private final T zero;
 
-        public Integer get(int i) {
-            if (i < 0) throw new IndexOutOfBoundsException(""+i);
-            Integer v = m.get(i);
-            return (v == null) ? Integer.valueOf(0) : v;
+        SparseList(T zero) { this.zero = zero; }
+
+        public T get(int i) {
+            if (i < 0) throw new IndexOutOfBoundsException("" + i);
+            T v = m.get(i);
+            return (v == null) ? zero : v;
         }
 
         public int size() {
             return Collections.max(m.keySet()) + 1;
         }
 
-        public Integer set(int i, Integer v) {
-            if (i < 0) throw new IndexOutOfBoundsException(""+i);
-            Integer ret = get(i);
-            if (v == 0)
+        public T set(int i, T v) {
+            if (i < 0) throw new IndexOutOfBoundsException("" + i);
+            T ret = get(i);
+            if (v.equals(zero))
                 m.remove(i);
             else
                 m.put(i, v);
@@ -77,14 +70,14 @@ public class BigBinarySearch {
     }
 
     /** Checks that binarySearch finds an element where we got it. */
-    private static void checkBinarySearch(List<Integer> l, int i) {
+    private static <T extends Comparable<T>> void checkBinarySearch(List<T> l, int i) {
         try { equal(i, Collections.binarySearch(l, l.get(i))); }
         catch (Throwable t) { unexpected(t); }
     }
 
     /** Checks that binarySearch finds an element where we got it. */
-    private static void checkBinarySearch(List<Integer> l, int i,
-                                          Comparator<Integer> comparator) {
+    private static <T> void checkBinarySearch(List<T> l, int i,
+                                              Comparator<T> comparator) {
         try { equal(i, Collections.binarySearch(l, l.get(i), comparator)); }
         catch (Throwable t) { unexpected(t); }
     }
@@ -93,7 +86,7 @@ public class BigBinarySearch {
         final int n = (1<<30) + 47;
 
         System.out.println("binarySearch(List<Integer>, Integer)");
-        List<Integer> big = new SparseIntegerList();
+        List<Integer> big = new SparseList<>(0);
         big.set(  0, -44);
         big.set(  1, -43);
         big.set(n-2,  43);
@@ -112,13 +105,13 @@ public class BigBinarySearch {
         for (int i : ints)
             checkBinarySearch(big, i, reverse);
 
-        System.out.println("binarySearch(SparseTupleList, Tuple)");
-        SparseTupleList vl = new SparseTupleList();
+        System.out.println("binarySearch(SparseList<VClass>, VClass)");
+        List<VClass> vl = new SparseList<>(new VClass(0, new int[] { 0 }));
         vl.set(0, new VClass(0, new int[] { 0 }));
         vl.set(1, new VClass(1, new int[] { 1 }));
         vl.set(n - 2, new VClass(n - 2, new int[] { n - 2 }));
         vl.set(n - 1, new VClass(n - 1, new int[] { n - 1 }));
-        equal(n - 1, Collections.binarySearch(vl, new VClass(n - 1, new int[] { n - 1 })));
+        checkBinarySearch(vl, n - 1);
     }
 
     //--------------------- Infrastructure ---------------------------

--- a/test/jdk/java/util/Collections/BinarySearchNullComparator.java
+++ b/test/jdk/java/util/Collections/BinarySearchNullComparator.java
@@ -36,15 +36,14 @@ import java.util.List;
 public class BinarySearchNullComparator {
 
     public static void main(String[] args) throws Exception {
-        List list = Arrays.asList(new String[] {"I", "Love", "You"});
+        test(Arrays.asList("I", "Love", "You"), "You", 2);
+        test(Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), new VClass(3, new int[] { 3 })),
+             new VClass(3, new int[] { 3 }), 2);
+    }
 
-        int result = Collections.binarySearch(list, "You", null);
-        if (result != 2)
+    private static <T> void test(List<T> list, T key, int expected) throws Exception {
+        int result = Collections.binarySearch(list, key, null);
+        if (result != expected)
             throw new Exception("Result: " + result);
-
-        List<VClass> values = Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), new VClass(3, new int[] { 3 }));
-        int vresult = Collections.binarySearch(values, new VClass(3, new int[] { 3 }), null);
-        if (vresult != 2)
-            throw new Exception("Value result: " + vresult);
     }
 }

--- a/test/jdk/java/util/Collections/CheckedListReplaceAll.java
+++ b/test/jdk/java/util/Collections/CheckedListReplaceAll.java
@@ -37,23 +37,14 @@ public class CheckedListReplaceAll {
 
     public static void main(String[] args) {
         List unwrapped = Arrays.asList(new Object[]{1, 2, 3});
-        List<Object> wrapped = Collections.checkedList(unwrapped, Integer.class);
-
-        UnaryOperator evil = e -> (((int) e) % 2 != 0) ? e : "evil";
-
-        try {
-            wrapped.replaceAll(evil);
-            System.out.printf("Bwahaha! I have defeated you! %s\n", wrapped);
-            throw new RuntimeException("String added to checked List<Integer>");
-        } catch (ClassCastException thwarted) {
-            thwarted.printStackTrace(System.out);
-            System.out.println("Curses! Foiled again!");
-        }
+        testReplaceAllWrongType(Collections.checkedList(unwrapped, Integer.class),
+                                 e -> (((int) e) % 2 != 0) ? e : "evil",
+                                 "String added to checked List<Integer>");
 
         unwrapped = Arrays.asList(new Object[]{});  // Empty list
-        wrapped = Collections.checkedList(unwrapped, Integer.class);
+        List<Object> wrapped = Collections.checkedList(unwrapped, Integer.class);
         try {
-            wrapped.replaceAll((UnaryOperator)null);
+            wrapped.replaceAll((UnaryOperator) null);
             System.out.printf("Bwahaha! I have defeated you! %s\n", wrapped);
             throw new RuntimeException("NPE not thrown when passed a null operator");
         } catch (NullPointerException thwarted) {
@@ -67,9 +58,17 @@ public class CheckedListReplaceAll {
             throw new RuntimeException("value checkedList replaceAll failed");
 
         List raw = Collections.checkedList(new ArrayList<VClass>(Arrays.asList(new VClass(1, new int[] { 1 }))), VClass.class);
+        testReplaceAllWrongType(raw, e -> "not a Tuple", "value checkedList replaceAll accepted wrong type");
+    }
+
+    private static void testReplaceAllWrongType(List wrapped, UnaryOperator badOperator, String failMessage) {
         try {
-            raw.replaceAll(e -> "not a Tuple");
-            throw new RuntimeException("value checkedList replaceAll accepted wrong type");
-        } catch (ClassCastException expected) { }
+            wrapped.replaceAll(badOperator);
+            System.out.printf("Bwahaha! I have defeated you! %s\n", wrapped);
+            throw new RuntimeException(failMessage);
+        } catch (ClassCastException thwarted) {
+            thwarted.printStackTrace(System.out);
+            System.out.println("Curses! Foiled again!");
+        }
     }
 }

--- a/test/jdk/java/util/Collections/CheckedMapReplaceAll.java
+++ b/test/jdk/java/util/Collections/CheckedMapReplaceAll.java
@@ -43,16 +43,9 @@ public class CheckedMapReplaceAll {
 
         Map<Integer,Double> wrapped = Collections.checkedMap(unwrapped, Integer.class, Double.class);
 
-        BiFunction evil = (k, v) -> (((int)k) % 2 != 0) ? v : "evil";
-
-        try {
-            wrapped.replaceAll(evil);
-            System.out.printf("Bwahaha! I have defeated you! %s\n", wrapped);
-            throw new RuntimeException("String added to checked Map<Integer,Double>");
-        } catch (ClassCastException thwarted) {
-            thwarted.printStackTrace(System.out);
-            System.out.println("Curses! Foiled again!");
-        }
+        testReplaceAllWrongType(wrapped,
+                                 (k, v) -> (((int)k) % 2 != 0) ? v : "evil",
+                                 "String added to checked Map<Integer, Double>");
 
         Map<VClass,VClass> vMap = Collections.checkedMap(new HashMap<>(), VClass.class, VClass.class);
         vMap.put(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }));
@@ -60,11 +53,19 @@ public class CheckedMapReplaceAll {
         if (!vMap.get(new VClass(1, new int[] { 1 })).equals(new VClass(3, new int[] { 3 })))
             throw new RuntimeException("value checkedMap replaceAll failed");
 
-        Map raw = Collections.checkedMap(new HashMap<VClass,VClass>(), VClass.class, VClass.class);
+        Map raw = Collections.checkedMap(new HashMap<VClass, VClass>(), VClass.class, VClass.class);
         raw.put(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }));
+        testReplaceAllWrongType(raw, (k, v) -> "not a Tuple", "value checkedMap replaceAll accepted wrong type");
+    }
+
+    private static void testReplaceAllWrongType(Map wrapped, BiFunction badOperator, String failMessage) {
         try {
-            raw.replaceAll((k, v) -> "not a Tuple");
-            throw new RuntimeException("value checkedMap replaceAll accepted wrong type");
-        } catch (ClassCastException expected) { }
+            wrapped.replaceAll(badOperator);
+            System.out.printf("Bwahaha! I have defeated you! %s\n", wrapped);
+            throw new RuntimeException(failMessage);
+        } catch (ClassCastException thwarted) {
+            thwarted.printStackTrace(System.out);
+            System.out.println("Curses! Foiled again!");
+        }
     }
 }

--- a/test/jdk/java/util/Collections/CheckedQueue.java
+++ b/test/jdk/java/util/Collections/CheckedQueue.java
@@ -77,8 +77,7 @@ public class CheckedQueue {
             abq.add(Integer.toString(i));
         }
 
-        Queue q = Collections.checkedQueue(abq, String.class);
-        q.add(0);
+        testAddWrongType(abq, String.class, 0);
     }
 
     /**
@@ -88,10 +87,12 @@ public class CheckedQueue {
      */
     @Test(expectedExceptions = ClassCastException.class)
     public void testAddFail2() {
-        ArrayBlockingQueue<String> abq = new ArrayBlockingQueue(1);
-        Queue q = Collections.checkedQueue(abq, String.class);
+        testAddWrongType(new ArrayBlockingQueue<String>(1), String.class, 0);
+    }
 
-        q.add(0);
+    private static void testAddWrongType(Queue rawQueue, Class<?> type, Object wrongTypeElement) {
+        Queue q = Collections.checkedQueue(rawQueue, type);
+        q.add(wrongTypeElement);
     }
 
     /**
@@ -154,14 +155,15 @@ public class CheckedQueue {
     }
 
     @Test
-    public void testValueCheckedQueue() {
+    public void testValueCheckedQueuePeek() {
         Queue<VClass> q = Collections.checkedQueue(new ArrayDeque<>(), VClass.class);
         q.add(new VClass(1, new int[] { 1 }));
         if (!q.peek().equals(new VClass(1, new int[] { 1 })))
             fail("value checkedQueue peek failed");
-        try {
-            ((Queue) q).add("not a Tuple");
-            fail("value checkedQueue accepted wrong type");
-        } catch (ClassCastException expected) { }
+    }
+
+    @Test(expectedExceptions = ClassCastException.class)
+    public void testValueCheckedQueueAddFail() {
+        testAddWrongType(new ArrayDeque<VClass>(), VClass.class, "not a Tuple");
     }
 }

--- a/test/jdk/java/util/Collections/Enum.java
+++ b/test/jdk/java/util/Collections/Enum.java
@@ -32,6 +32,7 @@ import jdk.test.lib.valueclass.VClass;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
+import java.util.function.IntFunction;
 
 public class Enum {
 
@@ -39,20 +40,18 @@ public class Enum {
 
     public static void main(String[] args) throws Exception {
         int[] sizes = {0, 10, 100};
-        for (int i=0; i<sizes.length; i++) {
-            Vector v = new Vector();
-            int size = sizes[i];
-            for (int j=0; j<size; j++)
-                v.add(new Integer(j));
-            List l = Collections.list(v.elements());
-            if (!l.equals(v))
-                throw new Exception("Copy failed: "+size);
-        }
+        for (int size : sizes)
+            test(size, Integer::valueOf);
 
-        Vector<VClass> vv = new Vector<>();
-        for (int j = 0; j < SIZE; j++) vv.add(new VClass(j, new int[] { j }));
-        List<VClass> vl = Collections.list(vv.elements());
-        if (!vl.equals(vv))
-            throw new RuntimeException("value Enumeration -> List failed");
+        test(SIZE, j -> new VClass(j, new int[] { j }));
+    }
+
+    private static void test(int size, IntFunction<Object> factory) throws Exception {
+        Vector v = new Vector();
+        for (int j = 0; j < size; j++)
+            v.add(factory.apply(j));
+        List l = Collections.list(v.elements());
+        if (!l.equals(v))
+            throw new Exception("Copy failed: " + size);
     }
 }

--- a/test/jdk/java/util/Collections/Frequency.java
+++ b/test/jdk/java/util/Collections/Frequency.java
@@ -34,35 +34,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.IntFunction;
 
 public class Frequency {
     static final int N = 100;
 
     public static void main(String[] args) {
-        test(new ArrayList<Integer>());
-        test(new LinkedList<Integer>());
-        testValue();
+        test(new ArrayList<Integer>(), Integer::valueOf);
+        test(new LinkedList<Integer>(), Integer::valueOf);
+        test(new ArrayList<VClass>(), i -> new VClass(i, new int[] { i }));
+        test(new LinkedList<VClass>(), i -> new VClass(i, new int[] { i }));
     }
 
-    static void test(List<Integer> list) {
+    static <T> void test(List<T> list, IntFunction<T> factory) {
         for (int i = 0; i < N; i++)
             for (int j = 0; j < i; j++)
-                list.add(i);
+                list.add(factory.apply(i));
         Collections.shuffle(list);
 
         for (int i = 0; i < N; i++)
-            if (Collections.frequency(list, i) != i)
+            if (Collections.frequency(list, factory.apply(i)) != i)
                 throw new RuntimeException(list.getClass() + ": " + i);
-    }
-
-    static void testValue() {
-        List<VClass> values = new ArrayList<>();
-        for (int i = 0; i < N; i++)
-            for (int j = 0; j < i; j++)
-                values.add(new VClass(i, new int[] { i }));
-        Collections.shuffle(values);
-        for (int i = 0; i < N; i++)
-            if (Collections.frequency(values, new VClass(i, new int[] { i })) != i)
-                throw new RuntimeException("value frequency: " + i);
     }
 }

--- a/test/jdk/java/util/Collections/NullComparator.java
+++ b/test/jdk/java/util/Collections/NullComparator.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.IntFunction;
 
 public class NullComparator {
 
@@ -54,28 +55,25 @@ public class NullComparator {
         if (Arrays.binarySearch(a, new Integer(69)) != 69)
             throw new Exception("Arrays.binarySearch");
 
-        List tmp = new ArrayList(list);
-        Collections.sort(tmp, null);
-        if (!tmp.equals(sorted))
-            throw new Exception("Collections.sort");
-        if (Collections.binarySearch(tmp, new Integer(69)) != 69)
-            throw new Exception("Collections.binarySearch");
-        if (!Collections.min(list, null).equals(new Integer(0)))
-            throw new Exception("Collections.min");
-        if (!Collections.max(list, null).equals(new Integer(99)))
-            throw new Exception("Collections.max");
+        testCollectionsNullComparator(list, Integer::valueOf, "");
 
         List<VClass> vlist = new ArrayList<>();
         for (int i = 0; i < 100; i++) vlist.add(new VClass(i, new int[] { i }));
         Collections.shuffle(vlist);
-        Collections.sort(vlist, null);
-        for (int i = 0; i < 100; i++)
-            if (!vlist.get(i).equals(new VClass(i, new int[] { i }))) throw new Exception("value Collections.sort");
-        if (Collections.binarySearch(vlist, new VClass(69, new int[] { 69 }), null) != 69)
-            throw new Exception("value binarySearch");
-        if (!Collections.min(vlist, null).equals(new VClass(0, new int[] { 0 })))
-            throw new Exception("value min");
-        if (!Collections.max(vlist, null).equals(new VClass(99, new int[] { 99 })))
-            throw new Exception("value max");
+        testCollectionsNullComparator(vlist, i -> new VClass(i, new int[] { i }), "value ");
+    }
+
+    private static <T> void testCollectionsNullComparator(List<T> list, IntFunction<T> factory, String label) throws Exception {
+        List<T> tmp = new ArrayList<>(list);
+        Collections.sort(tmp, null);
+        for (int i = 0; i < tmp.size(); i++)
+            if (!tmp.get(i).equals(factory.apply(i)))
+                throw new Exception(label + "Collections.sort");
+        if (Collections.binarySearch(tmp, factory.apply(69), null) != 69)
+            throw new Exception(label + "Collections.binarySearch");
+        if (!Collections.min(list, null).equals(factory.apply(0)))
+            throw new Exception(label + "Collections.min");
+        if (!Collections.max(list, null).equals(factory.apply(99)))
+            throw new Exception(label + "Collections.max");
     }
 }

--- a/test/jdk/java/util/Collections/ReverseOrder.java
+++ b/test/jdk/java/util/Collections/ReverseOrder.java
@@ -68,25 +68,22 @@ public class ReverseOrder {
 
     public static void main(String[] args) throws Exception {
         Foo[] a = { new Foo(2), new Foo(3), new Foo(1) };
-        List list = Arrays.asList(a);
-        Comparator cmp = Collections.reverseOrder();
-        Collections.sort(list, cmp);
-
         Foo[] golden = { new Foo(3), new Foo(2), new Foo(1) };
         List goldenList = Arrays.asList(golden);
-        if (!list.equals(goldenList))
-            throw new Exception(list.toString());
 
-        Comparator clone = serialClone(cmp);
-        List list2 = Arrays.asList(a);
-        Collections.sort(list2, clone);
-        if (!list2.equals(goldenList))
-            throw new Exception(list.toString());
+        Comparator cmp = Collections.reverseOrder();
+        checkReverseSort(Arrays.asList(a), cmp, goldenList);
+        checkReverseSort(Arrays.asList(a), serialClone(cmp), goldenList);
 
-        List<VClass> vl = Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(3, new int[] { 3 }), new VClass(2, new int[] { 2 }));
-        Collections.sort(vl, Collections.reverseOrder());
-        if (!vl.equals(Arrays.asList(new VClass(3, new int[] { 3 }), new VClass(2, new int[] { 2 }), new VClass(1, new int[] { 1 }))))
-            throw new RuntimeException("value reverseOrder failed");
+        List<VClass> vGolden = Arrays.asList(new VClass(3, new int[] { 3 }), new VClass(2, new int[] { 2 }), new VClass(1, new int[] { 1 }));
+        checkReverseSort(Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(3, new int[] { 3 }), new VClass(2, new int[] { 2 })),
+                          Collections.reverseOrder(), vGolden);
+    }
+
+    static void checkReverseSort(List list, Comparator cmp, List golden) throws Exception {
+        Collections.sort(list, cmp);
+        if (!list.equals(golden))
+            throw new Exception(list.toString());
     }
 }
 

--- a/test/jdk/java/util/Collections/ReverseOrder2.java
+++ b/test/jdk/java/util/Collections/ReverseOrder2.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.IntFunction;
 
 public class ReverseOrder2 {
     static final int N = 100;
@@ -67,14 +68,9 @@ public class ReverseOrder2 {
 
         test(new ArrayList<String>());
         test(new LinkedList<String>());
-        test2(new ArrayList<Integer>());
-        test2(new LinkedList<Integer>());
-
-        List<VClass> values = new ArrayList<>(Arrays.asList(new VClass(0, new int[] { 0 }), new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 })));
-        Collections.shuffle(values);
-        Collections.sort(values, Collections.reverseOrder());
-        if (!values.equals(Arrays.asList(new VClass(2, new int[] { 2 }), new VClass(1, new int[] { 1 }), new VClass(0, new int[] { 0 }))))
-            throw new RuntimeException("value reverseOrder2 failed");
+        test2(new ArrayList<Integer>(), Integer::valueOf, N);
+        test2(new LinkedList<Integer>(), Integer::valueOf, N);
+        test2(new ArrayList<VClass>(), i -> new VClass(i, new int[] { i }), 3);
     }
 
     static void test(List<String> list) {
@@ -99,18 +95,15 @@ public class ReverseOrder2 {
             golden.add(String.valueOf(i));
     }
 
-    static void test2(List<Integer> list) {
-        for (int i = 0; i < N; i++)
-            list.add(i);
+    static <T> void test2(List<T> list, IntFunction<T> factory, int n) {
+        for (int i = 0; i < n; i++)
+            list.add(factory.apply(i));
         Collections.shuffle(list);
         Collections.sort(list, Collections.reverseOrder(null));
-        equal(list, golden2);
-    }
-
-    private static final List<Integer> golden2 = new ArrayList<>(N);
-    static {
-        for (int i = N-1; i >= 0; i--)
-            golden2.add(i);
+        List<T> golden = new ArrayList<>(n);
+        for (int i = n - 1; i >= 0; i--)
+            golden.add(factory.apply(i));
+        equal(list, golden);
     }
 
     //--------------------- Infrastructure ---------------------------

--- a/test/jdk/java/util/Collections/Ser.java
+++ b/test/jdk/java/util/Collections/Ser.java
@@ -36,8 +36,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 public class Ser {
 
@@ -56,91 +54,27 @@ public class Ser {
     }
 
     public static void main(String[] args) throws Exception {
+        checkSerialization(Collections.EMPTY_SET, "empty set");
+        checkSerialization(Collections.EMPTY_LIST, "empty list");
+        checkSerialization(Collections.singleton("gumby"), "singleton");
+        checkSerialization(Collections.nCopies(50, "gumby"), "nCopies");
+        checkSerialization(Collections.singleton(new SerV(1)), "value singleton");
+        checkSerialization(Collections.nCopies(5, new SerV(2)), "value nCopies");
+    }
 
+    private static void checkSerialization(Object obj, String label) throws Exception {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             ObjectOutputStream out = new ObjectOutputStream(bos);
-            out.writeObject(Collections.EMPTY_SET);
+            out.writeObject(obj);
             out.flush();
             ObjectInputStream in = new ObjectInputStream(
                     new ByteArrayInputStream(bos.toByteArray()));
 
-            if (!Collections.EMPTY_SET.equals(in.readObject()))
-                throw new RuntimeException("empty set Ser/Deser failure.");
+            if (!obj.equals(in.readObject()))
+                throw new RuntimeException(label + " Ser/Deser failure.");
         } catch (Exception e) {
-            throw new RuntimeException("Failed to serialize empty set:" + e);
-        }
-
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ObjectOutputStream out = new ObjectOutputStream(bos);
-            out.writeObject(Collections.EMPTY_LIST);
-            out.flush();
-            ObjectInputStream in = new ObjectInputStream(
-                    new ByteArrayInputStream(bos.toByteArray()));
-
-            if (!Collections.EMPTY_LIST.equals(in.readObject()))
-                throw new RuntimeException("empty list Ser/Deser failure.");
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to serialize empty list:" + e);
-        }
-
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ObjectOutputStream out = new ObjectOutputStream(bos);
-            Set gumby = Collections.singleton("gumby");
-            out.writeObject(gumby);
-            out.flush();
-            ObjectInputStream in = new ObjectInputStream(
-                    new ByteArrayInputStream(bos.toByteArray()));
-
-            if (!gumby.equals(in.readObject()))
-                throw new RuntimeException("Singleton Ser/Deser failure.");
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to serialize singleton:" + e);
-        }
-
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ObjectOutputStream out = new ObjectOutputStream(bos);
-            List gumbies = Collections.nCopies(50, "gumby");
-            out.writeObject(gumbies);
-            out.flush();
-            ObjectInputStream in = new ObjectInputStream(
-                    new ByteArrayInputStream(bos.toByteArray()));
-
-            if (!gumbies.equals(in.readObject()))
-                throw new RuntimeException("nCopies Ser/Deser failure.");
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to serialize nCopies:" + e);
-        }
-
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ObjectOutputStream out = new ObjectOutputStream(bos);
-            Set<SerV> one = Collections.singleton(new SerV(1));
-            out.writeObject(one);
-            out.flush();
-            ObjectInputStream in = new ObjectInputStream(
-                    new ByteArrayInputStream(bos.toByteArray()));
-            if (!one.equals(in.readObject()))
-                throw new RuntimeException("value singleton Ser/Deser failure");
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to serialize value singleton: " + e);
-        }
-
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ObjectOutputStream out = new ObjectOutputStream(bos);
-            List<SerV> many = Collections.nCopies(5, new SerV(2));
-            out.writeObject(many);
-            out.flush();
-            ObjectInputStream in = new ObjectInputStream(
-                    new ByteArrayInputStream(bos.toByteArray()));
-            if (!many.equals(in.readObject()))
-                throw new RuntimeException("value nCopies Ser/Deser failure");
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to serialize value nCopies: " + e);
+            throw new RuntimeException("Failed to serialize " + label + ":" + e);
         }
     }
 }

--- a/test/jdk/java/util/Collections/SingletonIterator.java
+++ b/test/jdk/java/util/Collections/SingletonIterator.java
@@ -41,6 +41,9 @@ import static org.testng.Assert.fail;
 
 @Test(groups = "unit")
 public class SingletonIterator {
+
+    static class SingletonException extends RuntimeException { }
+
     static void assertIteratorExhausted(Iterator<?> it) {
         assertFalse(it.hasNext());
         try {
@@ -50,31 +53,23 @@ public class SingletonIterator {
         it.forEachRemaining(e -> { throw new AssertionError("action called incorrectly"); });
     }
 
-    public void testForEachRemaining() {
-        Iterator<String> it = Collections.singleton("TheOne").iterator();
+    private static <T> void checkSingletonIterator(T value) {
+        Iterator<T> it = Collections.singleton(value).iterator();
         AtomicInteger cnt = new AtomicInteger(0);
-
-        it.forEachRemaining(s -> {
-            assertEquals("TheOne", s);
+        it.forEachRemaining(v -> {
+            assertEquals(v, value);
             cnt.incrementAndGet();
         });
-
         assertEquals(cnt.get(), 1);
         assertIteratorExhausted(it);
     }
 
-    static class SingletonException extends RuntimeException { }
+    public void testForEachRemaining() {
+        checkSingletonIterator("TheOne");
+    }
 
-    @Test
     public void testValueSingletonIterator() {
-        Iterator<VClass> it = Collections.singleton(new VClass(42, new int[] { 42 })).iterator();
-        AtomicInteger cnt = new AtomicInteger(0);
-        it.forEachRemaining(v -> {
-            if (!v.equals(new VClass(42, new int[] { 42 }))) throw new RuntimeException("wrong value");
-            cnt.incrementAndGet();
-        });
-        assertEquals(cnt.get(), 1);
-        assertIteratorExhausted(it);
+        checkSingletonIterator(new VClass(42, new int[] { 42 }));
     }
 
     public void testThrowFromForEachRemaining() {

--- a/test/jdk/java/util/Collections/Swap.java
+++ b/test/jdk/java/util/Collections/Swap.java
@@ -38,20 +38,19 @@ public class Swap {
     static final int SIZE = 100;
 
     public static void main(String[] args) throws Exception {
-        List l = new ArrayList(Collections.nCopies(100, Boolean.FALSE));
-        l.set(0, Boolean.TRUE);
-        for (int i=0; i < SIZE-1; i++)
-            Collections.swap(l, i, i+1);
+        test(Boolean.TRUE, Boolean.FALSE);
+        test(new VClass(1, new int[] { 1 }), new VClass(0, new int[] { 0 }));
+    }
 
-        List l2 = new ArrayList(Collections.nCopies(100, Boolean.FALSE));
-        l2.set(SIZE-1, Boolean.TRUE);
-        if (!l.equals(l2))
+    static <T> void test(T marked, T unmarked) throws Exception {
+        List<T> l = new ArrayList<>(Collections.nCopies(SIZE, unmarked));
+        l.set(0, marked);
+        for (int i = 0; i < SIZE - 1; i++)
+            Collections.swap(l, i, i + 1);
+
+        List<T> golden = new ArrayList<>(Collections.nCopies(SIZE, unmarked));
+        golden.set(SIZE - 1, marked);
+        if (!l.equals(golden))
             throw new RuntimeException("Wrong result");
-
-        List<VClass> vl = new ArrayList<>(Collections.nCopies(SIZE, new VClass(0, new int[] { 0 })));
-        vl.set(0, new VClass(1, new int[] { 1 }));
-        for (int i = 0; i < SIZE - 1; i++) Collections.swap(vl, i, i + 1);
-        if (!vl.get(SIZE - 1).equals(new VClass(1, new int[] { 1 })))
-            throw new RuntimeException("value swap failed");
     }
 }

--- a/test/jdk/java/util/Collections/T6433170.java
+++ b/test/jdk/java/util/Collections/T6433170.java
@@ -60,16 +60,16 @@ public class T6433170 {
                  checkedCollection(new Vector(), String.class),
                  Object.class));
 
-        Collection<VClass> vc = checkedCollection(new ArrayList<>(), VClass.class);
-        List mixed = Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), "not a Tuple");
-        THROWS(ClassCastException.class,
-               new F(){void f(){ vc.addAll(mixed); }});
-        checkEmpty(vc);
+        test(checkedCollection(new ArrayList<>(), VClass.class),
+             Arrays.asList(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }), "not a Tuple"));
     }
 
     void test(final Collection checked) {
+        test(checked, Arrays.asList("1", 2, "3"));
+    }
+
+    void test(final Collection checked, final List mixedList) {
         checkEmpty(checked);
-        final List mixedList = Arrays.asList("1", 2, "3");
         THROWS(ClassCastException.class,
                new F(){void f(){ checked.addAll(mixedList); }});
         checkEmpty(checked);

--- a/test/jdk/java/util/HashMap/KeySetRemove.java
+++ b/test/jdk/java/util/HashMap/KeySetRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,19 +26,28 @@
  * @bug 4286765
  * @summary HashMap and TreeMap entrySet().remove(k) spuriously returned
  *          false if the Map previously mapped k to null.
+ * @library /test/lib
  */
 
+import jdk.test.lib.valueclass.VClass;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
 public class KeySetRemove {
     public static void main(String[] args) throws Exception {
-        Map[] m = {new HashMap(), new TreeMap()};
-        for (int i=0; i<m.length; i++) {
+        Map[] m = { new HashMap(), new TreeMap() };
+        for (int i = 0; i < m.length; i++) {
             m[i].put("bananas", null);
             if (!m[i].keySet().remove("bananas"))
-                throw new Exception("Yes, we have no bananas: "+i);
+                throw new Exception("Yes, we have no bananas: " + i);
+        }
+
+        Map[] valueMaps = { new HashMap<>(), new TreeMap<>() };
+        for (int i = 0; i < valueMaps.length; i++) {
+            valueMaps[i].put(new VClass(1, new int[] { 1 }), null);
+            if (!valueMaps[i].keySet().remove(new VClass(1, new int[] { 1 })))
+                throw new Exception("Value banana was not removed: " + i);
         }
     }
 }

--- a/test/jdk/java/util/HashMap/KeySetRemove.java
+++ b/test/jdk/java/util/HashMap/KeySetRemove.java
@@ -47,7 +47,7 @@ public class KeySetRemove {
         for (int i = 0; i < valueMaps.length; i++) {
             valueMaps[i].put(new VClass(1, new int[] { 1 }), null);
             if (!valueMaps[i].keySet().remove(new VClass(1, new int[] { 1 })))
-                throw new Exception("Value banana was not removed: " + i);
+                throw new Exception("VClass{1, [1]} was not removed: " + i);
         }
     }
 }

--- a/test/jdk/java/util/HashMap/KeySetRemove.java
+++ b/test/jdk/java/util/HashMap/KeySetRemove.java
@@ -36,18 +36,16 @@ import java.util.TreeMap;
 
 public class KeySetRemove {
     public static void main(String[] args) throws Exception {
-        Map[] m = { new HashMap(), new TreeMap() };
-        for (int i = 0; i < m.length; i++) {
-            m[i].put("bananas", null);
-            if (!m[i].keySet().remove("bananas"))
-                throw new Exception("Yes, we have no bananas: " + i);
-        }
+        test("bananas");
+        test(new VClass(1, new int[] { 1 }));
+    }
 
-        Map[] valueMaps = { new HashMap<>(), new TreeMap<>() };
-        for (int i = 0; i < valueMaps.length; i++) {
-            valueMaps[i].put(new VClass(1, new int[] { 1 }), null);
-            if (!valueMaps[i].keySet().remove(new VClass(1, new int[] { 1 })))
-                throw new Exception("VClass{1, [1]} was not removed: " + i);
+    private static void test(Object key) throws Exception {
+        Map[] maps = { new HashMap(), new TreeMap() };
+        for (int i = 0; i < maps.length; i++) {
+            maps[i].put(key, null);
+            if (!maps[i].keySet().remove(key))
+                throw new Exception(key + " was not removed: " + i);
         }
     }
 }

--- a/test/jdk/java/util/HashMap/NullKeyAtResize.java
+++ b/test/jdk/java/util/HashMap/NullKeyAtResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,19 +27,27 @@
  * @summary If the key to be inserted into a HashMap is null and the table
  * needs to be resized as part of the insertion then addEntry will try to
  * recalculate the hash of a null key. This will fail with an NPE.
+ * @library /test/lib
  */
 
+import jdk.test.lib.valueclass.VClass;
 import java.util.*;
+import java.util.function.IntFunction;
 
 public class NullKeyAtResize {
     public static void main(String[] args) throws Exception {
+        test(Integer::valueOf);
+        test(i -> new VClass(i, new int[] { i }));
+    }
+
+    private static void test(IntFunction<Object> keyFactory) throws Exception {
         List<Object> old_order = new ArrayList<>();
         Map<Object,Object> m = new HashMap<>(16);
         int number = 0;
         while(number < 100000) {
             m.put(null,null); // try to put in null. This may cause resize.
             m.remove(null); // remove it.
-            Integer adding = (number += 100);
+            Object adding = keyFactory.apply(number += 100);
             m.put(adding, null); // try to put in a number. This wont cause resize.
             List<Object> new_order = new ArrayList<>();
             new_order.addAll(m.keySet());

--- a/test/jdk/java/util/HashMap/PutNullKey.java
+++ b/test/jdk/java/util/HashMap/PutNullKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,10 @@
  * @bug 8046085
  * @summary Ensure that when trees are being used for collisions that null key
  * insertion still works.
+ * @library /test/lib
  */
 
+import jdk.test.lib.valueclass.AsValueClass;
 import java.util.*;
 import java.util.stream.IntStream;
 
@@ -78,10 +80,59 @@ public class PutNullKey {
         }
     }
 
+    @AsValueClass
+    public static class CollidingHashValue implements Comparable<CollidingHashValue> {
+
+        private final int value;
+
+        public CollidingHashValue(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int hashCode() {
+            // intentionally bad hashcode. Force into first bin.
+            return 0;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (null == o) {
+                return false;
+            }
+
+            if (o.getClass() != CollidingHashValue.class) {
+                return false;
+            }
+
+            return value == ((CollidingHashValue) o).value;
+        }
+
+        @Override
+        public int compareTo(CollidingHashValue o) {
+            return value - o.value;
+        }
+    }
+
     public static void main(String[] args) throws Exception {
+        testCollidingHash();
+        testCollidingHashValue();
+    }
+
+    private static void testCollidingHash() {
         Map<Object,Object> m = new HashMap<>(INITIAL_CAPACITY, LOAD_FACTOR);
         IntStream.range(0, SIZE)
                 .mapToObj(CollidingHash::new)
+                .forEach(e -> { m.put(e, e); });
+
+        // kaboom?
+        m.put(null, null);
+    }
+
+    private static void testCollidingHashValue() {
+        Map<Object,Object> m = new HashMap<>(INITIAL_CAPACITY, LOAD_FACTOR);
+        IntStream.range(0, SIZE)
+                .mapToObj(CollidingHashValue::new)
                 .forEach(e -> { m.put(e, e); });
 
         // kaboom?

--- a/test/jdk/java/util/HashMap/PutNullKey.java
+++ b/test/jdk/java/util/HashMap/PutNullKey.java
@@ -64,20 +64,12 @@ public class PutNullKey {
 
         @Override
         public boolean equals(Object o) {
-            if (null == o) {
-                return false;
-            }
-
-            if (o.getClass() != CollidingHash.class) {
-                return false;
-            }
-
-            return value == ((CollidingHash) o).value;
+            return o instanceof CollidingHash t && value == t.value;
         }
 
         @Override
         public int compareTo(CollidingHash o) {
-            return value - o.value;
+            return Integer.compare(value, o.value);
         }
     }
 
@@ -98,20 +90,12 @@ public class PutNullKey {
 
         @Override
         public boolean equals(Object o) {
-            if (null == o) {
-                return false;
-            }
-
-            if (o.getClass() != CollidingHashValue.class) {
-                return false;
-            }
-
-            return value == ((CollidingHashValue) o).value;
+            return o instanceof CollidingHashValue t && value == t.value;
         }
 
         @Override
         public int compareTo(CollidingHashValue o) {
-            return value - o.value;
+            return Integer.compare(value, o.value);
         }
     }
 

--- a/test/jdk/java/util/HashMap/PutNullKey.java
+++ b/test/jdk/java/util/HashMap/PutNullKey.java
@@ -31,6 +31,7 @@
 
 import jdk.test.lib.valueclass.AsValueClass;
 import java.util.*;
+import java.util.function.IntFunction;
 import java.util.stream.IntStream;
 
 public class PutNullKey {
@@ -115,24 +116,14 @@ public class PutNullKey {
     }
 
     public static void main(String[] args) throws Exception {
-        testCollidingHash();
-        testCollidingHashValue();
+        testCollidingHash(CollidingHash::new);
+        testCollidingHash(CollidingHashValue::new);
     }
 
-    private static void testCollidingHash() {
+    private static void testCollidingHash(IntFunction<?> function) {
         Map<Object,Object> m = new HashMap<>(INITIAL_CAPACITY, LOAD_FACTOR);
         IntStream.range(0, SIZE)
-                .mapToObj(CollidingHash::new)
-                .forEach(e -> { m.put(e, e); });
-
-        // kaboom?
-        m.put(null, null);
-    }
-
-    private static void testCollidingHashValue() {
-        Map<Object,Object> m = new HashMap<>(INITIAL_CAPACITY, LOAD_FACTOR);
-        IntStream.range(0, SIZE)
-                .mapToObj(CollidingHashValue::new)
+                .mapToObj(function)
                 .forEach(e -> { m.put(e, e); });
 
         // kaboom?

--- a/test/jdk/java/util/HashMap/ReplaceExisting.java
+++ b/test/jdk/java/util/HashMap/ReplaceExisting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,11 @@
  * @summary Verify that replacing the value for an existing key does not
  * corrupt active iterators, in particular due to a resize() occurring and
  * not updating modCount.
+ * @library /test/lib
  * @run main ReplaceExisting
  */
 
+import jdk.test.lib.valueclass.VClass;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,6 +45,8 @@ public class ReplaceExisting {
         for (int i = 0; i <= ENTRIES; i++) {
             HashMap<Integer,Integer> hm = prepHashMap();
             testItr(hm, i);
+            HashMap<VClass,Integer> tupleHm = prepTupleHashMap();
+            testTupleItr(tupleHm, i);
         }
     }
 
@@ -52,6 +56,15 @@ public class ReplaceExisting {
         // Add items to one more than the resize threshold
         for (int i = 0; i < ENTRIES; i++) {
             hm.put(i*10, i*10);
+        }
+        return hm;
+    }
+
+    private static HashMap<VClass,Integer> prepTupleHashMap() {
+        HashMap<VClass,Integer> hm = new HashMap<>(16, 0.75f);
+        // Add items to one more than the resize threshold
+        for (int i = 0; i < ENTRIES; i++) {
+            hm.put(new VClass(i * 10, new int[] { i * 10 }), i * 10);
         }
         return hm;
     }
@@ -88,6 +101,44 @@ public class ReplaceExisting {
         // Finish itr + collecting returned elems
         while(itr.hasNext()) {
             Integer retVal = itr.next();
+            if (!collected.add(retVal)) {
+                throw new RuntimeException("Corrupt iterator: key " + retVal + " already encountered");
+            }
+        }
+
+        // Compare returned elems to original copy of keys
+        if (!keys.equals(collected)) {
+            throw new RuntimeException("Collected keys do not match original set of keys");
+        }
+    }
+
+    private static void testTupleItr(HashMap<VClass,Integer> hm, int elemBeforePut) {
+        if (elemBeforePut > hm.size()) {
+            throw new IllegalArgumentException("Error in test: elemBeforePut must be <= HashMap size");
+        }
+        // Create a copy of the keys
+        HashSet<VClass> keys = new HashSet<>(hm.size());
+        keys.addAll(hm.keySet());
+
+        HashSet<VClass> collected = new HashSet<>(hm.size());
+
+        // Run itr for elemBeforePut items, collecting returned elems
+        Iterator<VClass> itr = hm.keySet().iterator();
+        for (int i = 0; i < elemBeforePut; i++) {
+            VClass retVal = itr.next();
+            if (!collected.add(retVal)) {
+                throw new RuntimeException("Corrupt iterator: key " + retVal + " already encountered");
+            }
+        }
+
+        // Do put() to replace entry (and resize table when bug present)
+        if (null == hm.put(new VClass(0, new int[] { 0 }), 100)) {
+            throw new RuntimeException("Error in test: expected key (0, 0) to be in the HashMap");
+        }
+
+        // Finish itr + collecting returned elems
+        while(itr.hasNext()) {
+            VClass retVal = itr.next();
             if (!collected.add(retVal)) {
                 throw new RuntimeException("Corrupt iterator: key " + retVal + " already encountered");
             }

--- a/test/jdk/java/util/HashMap/ReplaceExisting.java
+++ b/test/jdk/java/util/HashMap/ReplaceExisting.java
@@ -27,11 +27,9 @@
  * @summary Verify that replacing the value for an existing key does not
  * corrupt active iterators, in particular due to a resize() occurring and
  * not updating modCount.
- * @library /test/lib
  * @run main ReplaceExisting
  */
 
-import jdk.test.lib.valueclass.VClass;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,8 +43,6 @@ public class ReplaceExisting {
         for (int i = 0; i <= ENTRIES; i++) {
             HashMap<Integer,Integer> hm = prepHashMap();
             testItr(hm, i);
-            HashMap<VClass,Integer> tupleHm = prepTupleHashMap();
-            testTupleItr(tupleHm, i);
         }
     }
 
@@ -56,15 +52,6 @@ public class ReplaceExisting {
         // Add items to one more than the resize threshold
         for (int i = 0; i < ENTRIES; i++) {
             hm.put(i*10, i*10);
-        }
-        return hm;
-    }
-
-    private static HashMap<VClass,Integer> prepTupleHashMap() {
-        HashMap<VClass,Integer> hm = new HashMap<>(16, 0.75f);
-        // Add items to one more than the resize threshold
-        for (int i = 0; i < ENTRIES; i++) {
-            hm.put(new VClass(i * 10, new int[] { i * 10 }), i * 10);
         }
         return hm;
     }
@@ -112,41 +99,4 @@ public class ReplaceExisting {
         }
     }
 
-    private static void testTupleItr(HashMap<VClass,Integer> hm, int elemBeforePut) {
-        if (elemBeforePut > hm.size()) {
-            throw new IllegalArgumentException("Error in test: elemBeforePut must be <= HashMap size");
-        }
-        // Create a copy of the keys
-        HashSet<VClass> keys = new HashSet<>(hm.size());
-        keys.addAll(hm.keySet());
-
-        HashSet<VClass> collected = new HashSet<>(hm.size());
-
-        // Run itr for elemBeforePut items, collecting returned elems
-        Iterator<VClass> itr = hm.keySet().iterator();
-        for (int i = 0; i < elemBeforePut; i++) {
-            VClass retVal = itr.next();
-            if (!collected.add(retVal)) {
-                throw new RuntimeException("Corrupt iterator: key " + retVal + " already encountered");
-            }
-        }
-
-        // Do put() to replace entry (and resize table when bug present)
-        if (null == hm.put(new VClass(0, new int[] { 0 }), 100)) {
-            throw new RuntimeException("Error in test: expected key (0, 0) to be in the HashMap");
-        }
-
-        // Finish itr + collecting returned elems
-        while(itr.hasNext()) {
-            VClass retVal = itr.next();
-            if (!collected.add(retVal)) {
-                throw new RuntimeException("Corrupt iterator: key " + retVal + " already encountered");
-            }
-        }
-
-        // Compare returned elems to original copy of keys
-        if (!keys.equals(collected)) {
-            throw new RuntimeException("Collected keys do not match original set of keys");
-        }
-    }
 }

--- a/test/jdk/java/util/HashMap/ReplaceExisting.java
+++ b/test/jdk/java/util/HashMap/ReplaceExisting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/HashMap/SetValue.java
+++ b/test/jdk/java/util/HashMap/SetValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,10 @@
  * @bug 4627516
  * @summary HashMap.Entry.setValue() returns new value (as opposed to old)
  * @author jbloch
+ * @library /test/lib
  */
 
+import jdk.test.lib.valueclass.VClass;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,9 +39,25 @@ public class SetValue {
     static final String newValue = "new";
 
     public static void main(String[] args) throws Exception {
+        testStringValue();
+        testVClass();
+    }
+
+    private static void testStringValue() {
         Map m = new HashMap();
         m.put(key, oldValue);
         Map.Entry e = (Map.Entry) m.entrySet().iterator().next();
+        Object returnVal = e.setValue(newValue);
+        if (!returnVal.equals(oldValue))
+            throw new RuntimeException("Return value: " + returnVal);
+    }
+
+    private static void testVClass() {
+        Map<String, VClass> m = new HashMap<>();
+        VClass oldValue = new VClass(1, new int[] { 1 });
+        VClass newValue = new VClass(2, new int[] { 2 });
+        m.put(key, oldValue);
+        Map.Entry<String, VClass> e = m.entrySet().iterator().next();
         Object returnVal = e.setValue(newValue);
         if (!returnVal.equals(oldValue))
             throw new RuntimeException("Return value: " + returnVal);

--- a/test/jdk/java/util/HashMap/SetValue.java
+++ b/test/jdk/java/util/HashMap/SetValue.java
@@ -34,30 +34,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SetValue {
-    static final String key      = "key";
-    static final String oldValue = "old";
-    static final String newValue = "new";
 
     public static void main(String[] args) throws Exception {
-        testStringValue();
-        testVClass();
+        test("key", "old", "new");
+        test("key", new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }));
     }
 
-    private static void testStringValue() {
+    private static void test(Object key, Object oldValue, Object newValue) {
         Map m = new HashMap();
         m.put(key, oldValue);
         Map.Entry e = (Map.Entry) m.entrySet().iterator().next();
-        Object returnVal = e.setValue(newValue);
-        if (!returnVal.equals(oldValue))
-            throw new RuntimeException("Return value: " + returnVal);
-    }
-
-    private static void testVClass() {
-        Map<String, VClass> m = new HashMap<>();
-        VClass oldValue = new VClass(1, new int[] { 1 });
-        VClass newValue = new VClass(2, new int[] { 2 });
-        m.put(key, oldValue);
-        Map.Entry<String, VClass> e = m.entrySet().iterator().next();
         Object returnVal = e.setValue(newValue);
         if (!returnVal.equals(oldValue))
             throw new RuntimeException("Return value: " + returnVal);

--- a/test/jdk/java/util/HashMap/ToArray.java
+++ b/test/jdk/java/util/HashMap/ToArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,27 +31,26 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.LongStream;
+import jdk.test.lib.valueclass.VClass;
 
 /*
  * @test
  * @bug 8336669
  * @summary HashMap.toArray() behavior tests
  * @author tvaleev
+ * @library /test/lib
  */
 public class ToArray {
-    // An interned identity class holding an int (like non-Preview Integer)
-    record Int(int intValue) implements Comparable<Int> {
-        @Override
-        public int compareTo(Int o) {
-            return Integer.compare(intValue, o.intValue);
-        }
-    }
 
     public static void main(String[] args) {
         checkMap(false);
         checkMap(true);
         checkSet(false);
         checkSet(true);
+        checkVClassMap(false);
+        checkVClassMap(true);
+        checkVClassSet(false);
+        checkVClassSet(true);
     }
 
     private static <T extends Comparable<T>> void checkToArray(String message, T[] expected, Collection<T> collection,
@@ -160,5 +159,47 @@ public class ToArray {
         }
         checkToArray("Collisions", LongStream.range(0, 100).mapToObj(x -> x | (x << 32))
                 .toArray(Long[]::new), longSet, !ordered);
+    }
+
+    private static void checkVClassMap(boolean ordered) {
+        Map<VClass, VClass> map = ordered ? new LinkedHashMap<>() : new HashMap<>();
+        checkToArray("Empty-tuple-keys", new VClass[0], map.keySet(), !ordered);
+        checkToArray("Empty-tuple-values", new VClass[0], map.values(), !ordered);
+
+        List<VClass> keys = new ArrayList<>();
+        List<VClass> values = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            keys.add(new VClass(i, new int[] { i }));
+            values.add(new VClass(i * 2, new int[] { i * 2 }));
+            map.put(new VClass(i, new int[] { i }), new VClass(i * 2, new int[] { i * 2 }));
+            checkToArray(i + "-tuple-keys", keys.toArray(new VClass[0]), map.keySet(), !ordered);
+            checkToArray(i + "-tuple-values", values.toArray(new VClass[0]), map.values(), !ordered);
+        }
+        map.clear();
+        checkToArray("Empty-tuple-keys", new VClass[0], map.keySet(), !ordered);
+        checkToArray("Empty-tuple-values", new VClass[0], map.values(), !ordered);
+    }
+
+    private static void checkVClassSet(boolean ordered) {
+        Collection<VClass> set = ordered ? new LinkedHashSet<>() : new HashSet<>();
+        checkToArray("Empty-tuple", new VClass[0], set, !ordered);
+        set.add(new VClass(1, new int[] { 1 }));
+        checkToArray("One-tuple", new VClass[]{new VClass(1, new int[] { 1 })}, set, !ordered);
+        set.add(new VClass(2, new int[] { 2 }));
+        checkToArray("Two-tuple", new VClass[]{new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 })}, set, !ordered);
+
+        Collection<VClass> tupleSet = ordered ? new LinkedHashSet<>() : new HashSet<>();
+        for (int x = 0; x < 100; x++) {
+            tupleSet.add(new VClass(x, new int[] { x }));
+        }
+        checkToArray("100-tuple", LongStream.range(0, 100).mapToObj(x -> new VClass((int) x, new int[] { (int) x }))
+                .toArray(VClass[]::new), tupleSet, !ordered);
+        tupleSet.clear();
+        checkToArray("After-clear-tuple", new VClass[0], tupleSet, !ordered);
+        for (int x = 0; x < 100; x++) {
+            tupleSet.add(new VClass(x, new int[] { -31 * x }));
+        }
+        checkToArray("Collisions-tuple", LongStream.range(0, 100).mapToObj(x -> new VClass((int) x, new int[] { -31 * (int) x }))
+                .toArray(VClass[]::new), tupleSet, !ordered);
     }
 }

--- a/test/jdk/java/util/HashMap/ToArray.java
+++ b/test/jdk/java/util/HashMap/ToArray.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.IntFunction;
 import java.util.stream.LongStream;
 import jdk.test.lib.valueclass.VClass;
 
@@ -119,22 +120,32 @@ public class ToArray {
     }
 
     private static void checkMap(boolean ordered) {
-        Map<String, String> map = ordered ? new LinkedHashMap<>() : new HashMap<>();
-        checkToArray("Empty-keys", new String[0], map.keySet(), !ordered);
-        checkToArray("Empty-values", new String[0], map.values(), !ordered);
+        checkMapImpl(ordered, String::valueOf, new String[0]);
+    }
 
-        List<String> keys = new ArrayList<>();
-        List<String> values = new ArrayList<>();
+    private static void checkVClassMap(boolean ordered) {
+        checkMapImpl(ordered, i -> new VClass(i, new int[] { i }), new VClass[0]);
+    }
+
+    private static <T extends Comparable<T>> void checkMapImpl(boolean ordered, IntFunction<T> factory, T[] emptyArray) {
+        Map<T, T> map = ordered ? new LinkedHashMap<>() : new HashMap<>();
+        checkToArray("Empty-keys", emptyArray, map.keySet(), !ordered);
+        checkToArray("Empty-values", emptyArray, map.values(), !ordered);
+
+        List<T> keys = new ArrayList<>();
+        List<T> values = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
-            keys.add(String.valueOf(i));
-            values.add(String.valueOf(i * 2));
-            map.put(String.valueOf(i), String.valueOf(i * 2));
-            checkToArray(i + "-keys", keys.toArray(new String[0]), map.keySet(), !ordered);
-            checkToArray(i + "-values", values.toArray(new String[0]), map.values(), !ordered);
+            T key = factory.apply(i);
+            T value = factory.apply(i * 2);
+            keys.add(key);
+            values.add(value);
+            map.put(key, value);
+            checkToArray(i + "-keys", keys.toArray(emptyArray), map.keySet(), !ordered);
+            checkToArray(i + "-values", values.toArray(emptyArray), map.values(), !ordered);
         }
         map.clear();
-        checkToArray("Empty-keys", new String[0], map.keySet(), !ordered);
-        checkToArray("Empty-values", new String[0], map.values(), !ordered);
+        checkToArray("Empty-keys", emptyArray, map.keySet(), !ordered);
+        checkToArray("Empty-values", emptyArray, map.values(), !ordered);
     }
 
     private static void checkSet(boolean ordered) {
@@ -157,24 +168,5 @@ public class ToArray {
         }
         checkToArray("Collisions", LongStream.range(0, 100).mapToObj(x -> x | (x << 32))
                 .toArray(Long[]::new), longSet, !ordered);
-    }
-
-    private static void checkVClassMap(boolean ordered) {
-        Map<VClass, VClass> map = ordered ? new LinkedHashMap<>() : new HashMap<>();
-        checkToArray("Empty-tuple-keys", new VClass[0], map.keySet(), !ordered);
-        checkToArray("Empty-tuple-values", new VClass[0], map.values(), !ordered);
-
-        List<VClass> keys = new ArrayList<>();
-        List<VClass> values = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-            keys.add(new VClass(i, new int[] { i }));
-            values.add(new VClass(i * 2, new int[] { i * 2 }));
-            map.put(new VClass(i, new int[] { i }), new VClass(i * 2, new int[] { i * 2 }));
-            checkToArray(i + "-tuple-keys", keys.toArray(new VClass[0]), map.keySet(), !ordered);
-            checkToArray(i + "-tuple-values", values.toArray(new VClass[0]), map.values(), !ordered);
-        }
-        map.clear();
-        checkToArray("Empty-tuple-keys", new VClass[0], map.keySet(), !ordered);
-        checkToArray("Empty-tuple-values", new VClass[0], map.values(), !ordered);
     }
 }

--- a/test/jdk/java/util/HashMap/ToArray.java
+++ b/test/jdk/java/util/HashMap/ToArray.java
@@ -49,8 +49,6 @@ public class ToArray {
         checkSet(true);
         checkVClassMap(false);
         checkVClassMap(true);
-        checkVClassSet(false);
-        checkVClassSet(true);
     }
 
     private static <T extends Comparable<T>> void checkToArray(String message, T[] expected, Collection<T> collection,
@@ -178,28 +176,5 @@ public class ToArray {
         map.clear();
         checkToArray("Empty-tuple-keys", new VClass[0], map.keySet(), !ordered);
         checkToArray("Empty-tuple-values", new VClass[0], map.values(), !ordered);
-    }
-
-    private static void checkVClassSet(boolean ordered) {
-        Collection<VClass> set = ordered ? new LinkedHashSet<>() : new HashSet<>();
-        checkToArray("Empty-tuple", new VClass[0], set, !ordered);
-        set.add(new VClass(1, new int[] { 1 }));
-        checkToArray("One-tuple", new VClass[]{new VClass(1, new int[] { 1 })}, set, !ordered);
-        set.add(new VClass(2, new int[] { 2 }));
-        checkToArray("Two-tuple", new VClass[]{new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 })}, set, !ordered);
-
-        Collection<VClass> tupleSet = ordered ? new LinkedHashSet<>() : new HashSet<>();
-        for (int x = 0; x < 100; x++) {
-            tupleSet.add(new VClass(x, new int[] { x }));
-        }
-        checkToArray("100-tuple", LongStream.range(0, 100).mapToObj(x -> new VClass((int) x, new int[] { (int) x }))
-                .toArray(VClass[]::new), tupleSet, !ordered);
-        tupleSet.clear();
-        checkToArray("After-clear-tuple", new VClass[0], tupleSet, !ordered);
-        for (int x = 0; x < 100; x++) {
-            tupleSet.add(new VClass(x, new int[] { -31 * x }));
-        }
-        checkToArray("Collisions-tuple", LongStream.range(0, 100).mapToObj(x -> new VClass((int) x, new int[] { -31 * (int) x }))
-                .toArray(VClass[]::new), tupleSet, !ordered);
     }
 }

--- a/test/jdk/java/util/HashMap/TreeBinAssert.java
+++ b/test/jdk/java/util/HashMap/TreeBinAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,11 @@
  * @test
  * @bug 8205399
  * @summary Check for AssertionError from HashMap TreeBin after Iterator.remove
+ * @library /test/lib
  * @run testng/othervm -esa TreeBinAssert
  */
 
+import jdk.test.lib.valueclass.AsValueClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.annotations.BeforeTest;
@@ -170,6 +172,64 @@ public class TreeBinAssert {
 
         @Override public int compareTo(Key k) {
             return Integer.compare(this.hash, k.hash);
+        }
+    }
+
+    @AsValueClass
+    static class KeyVClass implements Comparable<KeyVClass> {
+        final int hash;
+
+        public KeyVClass(int desiredHash) {
+            // Account for processing done by HashMap
+            this.hash = desiredHash ^ (desiredHash >>> 16);
+        }
+
+        @Override public int hashCode() { return this.hash; }
+
+        @Override public boolean equals(Object o) {
+            return o.hashCode() == this.hashCode();
+        }
+
+        @Override public int compareTo(KeyVClass k) {
+            return Integer.compare(this.hash, k.hash);
+        }
+    }
+
+    @Test(dataProvider = "SizeAndHashes")
+    public void testMapVClass(int size, int[] hashes) {
+        Map<KeyVClass,Integer> map = new HashMap<>(size);
+
+        doTestVClass(map, hashes,
+                     (c,k) -> { ((Map<KeyVClass,Integer>)c).put(k,0); },
+                     (c)   -> { return ((Map<KeyVClass,Integer>)c).keySet().iterator(); }
+        );
+    }
+
+    @Test(dataProvider = "SizeAndHashes")
+    public void testSetVClass(int size, int[] hashes) {
+        Set<KeyVClass> set = new LinkedHashSet<>(size);
+
+        doTestVClass(set, hashes,
+                     (c,k) -> { ((Set<KeyVClass>)c).add(k); },
+                     (c)   -> { return ((Set<KeyVClass>)c).iterator(); }
+        );
+    }
+
+    private void doTestVClass(Object collection, int[] hashes,
+                              BiConsumer<Object,KeyVClass> addKey,
+                              Function<Object,Iterator<KeyVClass>> mkItr) {
+        Iterator<KeyVClass> itr = null;
+        for (int h : hashes) {
+            if (h == ITR_RM) {
+                if (itr == null) {
+                    itr = mkItr.apply(collection);
+                }
+                itr.next();
+                itr.remove();
+            } else {
+                itr = null;
+                addKey.accept(collection, new KeyVClass(h));
+            }
         }
     }
 }

--- a/test/jdk/java/util/HashMap/TreeBinAssert.java
+++ b/test/jdk/java/util/HashMap/TreeBinAssert.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 
 public class TreeBinAssert {
     private static final int ITR_RM = -1; // Remove an item via Iterator
@@ -117,28 +118,49 @@ public class TreeBinAssert {
 
     @Test(dataProvider = "SizeAndHashes")
     public void testMap(int size, int[] hashes) {
-        Map<Key,Integer> map = new HashMap<>(size);
+        testMapImpl(size, hashes, Key::new);
+    }
+
+    @Test(dataProvider = "SizeAndHashes")
+    public void testMapVClass(int size, int[] hashes) {
+        testMapImpl(size, hashes, KeyVClass::new);
+    }
+
+    private <T> void testMapImpl(int size, int[] hashes, IntFunction<T> keyFactory) {
+        Map<T, Integer> map = new HashMap<>(size);
 
         doTest(map, hashes,
-               (c,k) -> { ((Map<Key,Integer>)c).put(k,0); },
-               (c)   -> { return ((Map<Key,Integer>)c).keySet().iterator(); }
+               (c,k) -> { ((Map<T, Integer>) c).put(k,0); },
+               (c)   -> { return ((Map<T, Integer>) c).keySet().iterator(); },
+               keyFactory
         );
     }
 
     @Test(dataProvider = "SizeAndHashes")
     public void testSet(int size, int[] hashes) {
-        Set<Key> set = new LinkedHashSet<>(size);
+        testSetImpl(size, hashes, Key::new);
+    }
+
+    @Test(dataProvider = "SizeAndHashes")
+    public void testSetVClass(int size, int[] hashes) {
+        testSetImpl(size, hashes, KeyVClass::new);
+    }
+
+    private <T> void testSetImpl(int size, int[] hashes, IntFunction<T> keyFactory) {
+        Set<T> set = new LinkedHashSet<>(size);
 
         doTest(set, hashes,
-               (c,k) -> { ((Set<Key>)c).add(k); },
-               (c)   -> { return ((Set<Key>)c).iterator(); }
+               (c,k) -> { ((Set<T>) c).add(k); },
+               (c)   -> { return ((Set<T>) c).iterator(); },
+               keyFactory
         );
     }
 
-    private void doTest(Object collection, int[] hashes,
-                        BiConsumer<Object,Key> addKey,
-                        Function<Object,Iterator<Key>> mkItr) {
-        Iterator<Key> itr = null; // saved iterator, used for removals
+    private <T> void doTest(Object collection, int[] hashes,
+                            BiConsumer<Object,T> addKey,
+                            Function<Object,Iterator<T>> mkItr,
+                            IntFunction<T> keyFactory) {
+        Iterator<T> itr = null; // saved iterator, used for removals
         for (int h : hashes) {
             if (h == ITR_RM) {
                 if (itr == null) {
@@ -148,7 +170,7 @@ public class TreeBinAssert {
                 itr.remove();
             } else {
                 itr = null;
-                addKey.accept(collection, new Key(h));
+                addKey.accept(collection, keyFactory.apply(h));
             }
         }
     }
@@ -192,44 +214,6 @@ public class TreeBinAssert {
 
         @Override public int compareTo(KeyVClass k) {
             return Integer.compare(this.hash, k.hash);
-        }
-    }
-
-    @Test(dataProvider = "SizeAndHashes")
-    public void testMapVClass(int size, int[] hashes) {
-        Map<KeyVClass,Integer> map = new HashMap<>(size);
-
-        doTestVClass(map, hashes,
-                     (c,k) -> { ((Map<KeyVClass,Integer>)c).put(k,0); },
-                     (c)   -> { return ((Map<KeyVClass,Integer>)c).keySet().iterator(); }
-        );
-    }
-
-    @Test(dataProvider = "SizeAndHashes")
-    public void testSetVClass(int size, int[] hashes) {
-        Set<KeyVClass> set = new LinkedHashSet<>(size);
-
-        doTestVClass(set, hashes,
-                     (c,k) -> { ((Set<KeyVClass>)c).add(k); },
-                     (c)   -> { return ((Set<KeyVClass>)c).iterator(); }
-        );
-    }
-
-    private void doTestVClass(Object collection, int[] hashes,
-                              BiConsumer<Object,KeyVClass> addKey,
-                              Function<Object,Iterator<KeyVClass>> mkItr) {
-        Iterator<KeyVClass> itr = null;
-        for (int h : hashes) {
-            if (h == ITR_RM) {
-                if (itr == null) {
-                    itr = mkItr.apply(collection);
-                }
-                itr.next();
-                itr.remove();
-            } else {
-                itr = null;
-                addKey.accept(collection, new KeyVClass(h));
-            }
         }
     }
 }

--- a/test/jdk/java/util/HashMap/TreeBinAssert.java
+++ b/test/jdk/java/util/HashMap/TreeBinAssert.java
@@ -157,8 +157,8 @@ public class TreeBinAssert {
     }
 
     private <T> void doTest(Object collection, int[] hashes,
-                            BiConsumer<Object,T> addKey,
-                            Function<Object,Iterator<T>> mkItr,
+                            BiConsumer<Object, T> addKey,
+                            Function<Object, Iterator<T>> mkItr,
                             IntFunction<T> keyFactory) {
         Iterator<T> itr = null; // saved iterator, used for removals
         for (int h : hashes) {

--- a/test/jdk/java/util/HashMap/TreeBinAssert.java
+++ b/test/jdk/java/util/HashMap/TreeBinAssert.java
@@ -130,8 +130,8 @@ public class TreeBinAssert {
         Map<T, Integer> map = new HashMap<>(size);
 
         doTest(map, hashes,
-               (c,k) -> { ((Map<T, Integer>) c).put(k,0); },
-               (c)   -> { return ((Map<T, Integer>) c).keySet().iterator(); },
+               (c, k) -> { ((Map<T, Integer>) c).put(k,0); },
+               (c)    -> { return ((Map<T, Integer>) c).keySet().iterator(); },
                keyFactory
         );
     }
@@ -150,8 +150,8 @@ public class TreeBinAssert {
         Set<T> set = new LinkedHashSet<>(size);
 
         doTest(set, hashes,
-               (c,k) -> { ((Set<T>) c).add(k); },
-               (c)   -> { return ((Set<T>) c).iterator(); },
+               (c, k) -> { ((Set<T>) c).add(k); },
+               (c)    -> { return ((Set<T>) c).iterator(); },
                keyFactory
         );
     }

--- a/test/jdk/java/util/Hashtable/EqualsCast.java
+++ b/test/jdk/java/util/Hashtable/EqualsCast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,10 @@
  * @summary Hashtable was less robust to extension that it could have been
  *          because the equals and Hashcode methods used internals
  *          unnecessarily.  (java.security.Provider tickled this sensitivity.)
+ * @library /test/lib
  */
+
+import jdk.test.lib.valueclass.VClass;
 
 import java.security.Provider;
 import java.util.Map;
@@ -36,7 +39,9 @@ public class EqualsCast {
     public static void main(String[] args) throws Exception {
         Map m1 = new MyProvider("foo", 69, "baz");
         Map m2 = new MyProvider("foo", 69, "baz");
-        m1.equals(m2);
+        if (!m1.equals(m2)) {
+            throw new RuntimeException("Provider maps are not equal");
+        }
     }
 }
 
@@ -48,6 +53,7 @@ class MyProvider extends Provider {
         super(name, version, info);
         this.name = name;
         put("Signature.sigalg", "sigimpl");
+        put(new VClass(1, new int[] { 1 }), new VClass(2, new int[] { 2 }));
     }
 
     public String getName() {

--- a/test/jdk/java/util/Hashtable/SimpleSerialization.java
+++ b/test/jdk/java/util/Hashtable/SimpleSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,11 +43,15 @@ import java.util.Map;
 
 public class SimpleSerialization {
     public static void main(final String[] args) throws Exception {
-        Hashtable<String, String> h1 = new Hashtable<>();
-
         System.err.println("*** BEGIN TEST ***");
 
-        h1.put("key", "value");
+        test(new Hashtable<String, String>(), "key", "value");
+        test(new Hashtable<Integer, Integer>(), 1, 2);
+    }
+
+    private static <K, V> void test(Hashtable<K, V> h1, K key, V value)
+            throws Exception {
+        h1.put(key, value);
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
@@ -66,11 +70,14 @@ public class SimpleSerialization {
         }
 
         if (false == h1.equals(deserializedObject)) {
-             Hashtable<String, String> d1 = (Hashtable<String, String>) h1;
-            for(Map.Entry entry: h1.entrySet()) {
-                System.err.println("h1.key::" + entry.getKey() + " d1.containsKey()::" + d1.containsKey((String) entry.getKey()));
-                System.err.println("h1.value::" + entry.getValue() + " d1.contains()::" + d1.contains(entry.getValue()));
-                System.err.println("h1.value == d1.value " + entry.getValue().equals(d1.get((String) entry.getKey())));
+            Hashtable<?, ?> copy = (Hashtable<?, ?>) deserializedObject;
+            for (Map.Entry<K, V> entry : h1.entrySet()) {
+                System.err.println("h1.key::" + entry.getKey()
+                        + " copy.containsKey()::" + copy.containsKey(entry.getKey()));
+                System.err.println("h1.value::" + entry.getValue()
+                        + " copy.contains()::" + copy.contains(entry.getValue()));
+                System.err.println("h1.value equals copy.value "
+                        + entry.getValue().equals(copy.get(entry.getKey())));
             }
 
             throw new RuntimeException(getFailureText(h1, deserializedObject));

--- a/test/jdk/java/util/LinkedHashMap/ComputeIfAbsentAccessOrder.java
+++ b/test/jdk/java/util/LinkedHashMap/ComputeIfAbsentAccessOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@ import java.util.*;
 
 public class ComputeIfAbsentAccessOrder {
     public static void main(String args[]) throws Throwable {
+        testStringKeys();
+        testIntegerKeys();
+    }
+
+    private static void testStringKeys() {
         LinkedHashMap<String,Object> map = new LinkedHashMap<>(2, 0.75f, true);
         map.put("first", null);
         map.put("second", null);
@@ -42,6 +47,23 @@ public class ComputeIfAbsentAccessOrder {
                 .orElseThrow(() -> new RuntimeException("no value"));
         if(!"first".equals(key)) {
             throw new RuntimeException("not expected value " + "first" + "!=" + key);
+        }
+    }
+
+    private static void testIntegerKeys() {
+        LinkedHashMap<Integer,Object> map = new LinkedHashMap<>(2, 0.75f, true);
+        Integer first = Integer.valueOf(1996);
+        Integer second = Integer.valueOf(2026);
+        map.put(first, null);
+        map.put(second, null);
+
+        map.computeIfAbsent(first, l -> null); // should do nothing
+
+        Integer key = map.keySet().stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("no value"));
+        if (!first.equals(key)) {
+            throw new RuntimeException("not expected value " + first + "!=" + key);
         }
     }
 }

--- a/test/jdk/java/util/LinkedHashMap/ComputeIfAbsentAccessOrder.java
+++ b/test/jdk/java/util/LinkedHashMap/ComputeIfAbsentAccessOrder.java
@@ -36,7 +36,7 @@ public class ComputeIfAbsentAccessOrder {
     }
 
     private static void test(Object first, Object second) {
-        LinkedHashMap<Object,Object> map = new LinkedHashMap<>(2, 0.75f, true);
+        LinkedHashMap<Object, Object> map = new LinkedHashMap<>(2, 0.75f, true);
         map.put(first, null);
         map.put(second, null);
 

--- a/test/jdk/java/util/LinkedHashMap/ComputeIfAbsentAccessOrder.java
+++ b/test/jdk/java/util/LinkedHashMap/ComputeIfAbsentAccessOrder.java
@@ -31,35 +31,18 @@ import java.util.*;
 
 public class ComputeIfAbsentAccessOrder {
     public static void main(String args[]) throws Throwable {
-        testStringKeys();
-        testIntegerKeys();
+        test("first", "second");
+        test(Integer.valueOf(1996), Integer.valueOf(2026));
     }
 
-    private static void testStringKeys() {
-        LinkedHashMap<String,Object> map = new LinkedHashMap<>(2, 0.75f, true);
-        map.put("first", null);
-        map.put("second", null);
-
-        map.computeIfAbsent("first", l -> null); // should do nothing
-
-        String key = map.keySet().stream()
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException("no value"));
-        if(!"first".equals(key)) {
-            throw new RuntimeException("not expected value " + "first" + "!=" + key);
-        }
-    }
-
-    private static void testIntegerKeys() {
-        LinkedHashMap<Integer,Object> map = new LinkedHashMap<>(2, 0.75f, true);
-        Integer first = Integer.valueOf(1996);
-        Integer second = Integer.valueOf(2026);
+    private static void test(Object first, Object second) {
+        LinkedHashMap<Object,Object> map = new LinkedHashMap<>(2, 0.75f, true);
         map.put(first, null);
         map.put(second, null);
 
         map.computeIfAbsent(first, l -> null); // should do nothing
 
-        Integer key = map.keySet().stream()
+        Object key = map.keySet().stream()
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("no value"));
         if (!first.equals(key)) {

--- a/test/jdk/java/util/LinkedHashMap/EmptyMapIterator.java
+++ b/test/jdk/java/util/LinkedHashMap/EmptyMapIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,13 +30,29 @@
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 public class EmptyMapIterator {
     public static void main(String[] args) throws Exception {
+        testStringKeys();
+        testIntegerKeys();
+    }
+
+    private static void testStringKeys() throws Exception {
         HashMap map = new HashMap();
         Iterator iter = map.entrySet().iterator();
         map.put("key", "value");
+        expectConcurrentModification(iter);
+    }
 
+    private static void testIntegerKeys() throws Exception {
+        HashMap<Integer,Integer> map = new HashMap<>();
+        Iterator<Map.Entry<Integer,Integer>> iter = map.entrySet().iterator();
+        map.put(Integer.valueOf(1), Integer.valueOf(2));
+        expectConcurrentModification(iter);
+    }
+
+    private static void expectConcurrentModification(Iterator<?> iter) throws Exception {
         try {
             iter.next();
             throw new Exception("No exception thrown");

--- a/test/jdk/java/util/LinkedHashMap/EmptyMapIterator.java
+++ b/test/jdk/java/util/LinkedHashMap/EmptyMapIterator.java
@@ -34,21 +34,14 @@ import java.util.Map;
 
 public class EmptyMapIterator {
     public static void main(String[] args) throws Exception {
-        testStringKeys();
-        testIntegerKeys();
+        test("key", "value");
+        test(Integer.valueOf(1), Integer.valueOf(2));
     }
 
-    private static void testStringKeys() throws Exception {
-        HashMap map = new HashMap();
-        Iterator iter = map.entrySet().iterator();
-        map.put("key", "value");
-        expectConcurrentModification(iter);
-    }
-
-    private static void testIntegerKeys() throws Exception {
-        HashMap<Integer,Integer> map = new HashMap<>();
-        Iterator<Map.Entry<Integer,Integer>> iter = map.entrySet().iterator();
-        map.put(Integer.valueOf(1), Integer.valueOf(2));
+    private static void test(Object key, Object value) throws Exception {
+        HashMap<Object, Object> map = new HashMap<>();
+        Iterator<Map.Entry<Object, Object>> iter = map.entrySet().iterator();
+        map.put(key, value);
         expectConcurrentModification(iter);
     }
 

--- a/test/jdk/java/util/LinkedList/AddAll.java
+++ b/test/jdk/java/util/LinkedList/AddAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,10 @@
  * @test
  * @bug 4163207
  * @summary AddAll was prepending instead of appending!
+ * @library /test/lib
  */
+
+import jdk.test.lib.valueclass.VClass;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,8 +37,13 @@ import java.util.List;
 
 public class AddAll {
     public static void main(String[] args) throws Exception {
-        List head = Collections.nCopies(7, "deadly sin");
-        List tail = Collections.nCopies(4, "basic food group");
+        testAddAll(Collections.nCopies(7, "deadly sin"),
+                   Collections.nCopies(4, "basic food group"));
+        testAddAll(Collections.nCopies(7, new VClass(7, new int[] { 1 })),
+                   Collections.nCopies(4, new VClass(4, new int[] { 2 })));
+    }
+
+    private static void testAddAll(List head, List tail) {
         List l1 = new ArrayList(head);
         List l2 = new LinkedList(head);
         l1.addAll(tail);

--- a/test/jdk/java/util/LinkedList/Clone.java
+++ b/test/jdk/java/util/LinkedList/Clone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,10 @@
  * @summary Cloning a subclass of LinkedList results in an object that isn't
  *          an instance of the subclass.  The same applies to TreeSet and
  *          TreeMap.
+ * @library /test/lib
  */
+
+import jdk.test.lib.valueclass.VClass;
 
 import java.util.LinkedList;
 import java.util.TreeMap;
@@ -35,45 +38,73 @@ import java.util.TreeSet;
 
 public class Clone {
     public static void main(String[] args) {
+        testStrings();
+        testVClass();
+    }
+
+    private static void testStrings() {
         LinkedList2 l = new LinkedList2();
-        LinkedList2 lClone = (LinkedList2) l.clone();
-        if (!(l.equals(lClone) && lClone.equals(l)))
-            throw new RuntimeException("LinkedList.clone() is broken 1.");
+        checkLinkedListClone(l, "LinkedList.clone() is broken 1.");
         l.add("a");
-        lClone = (LinkedList2) l.clone();
-        if (!(l.equals(lClone) && lClone.equals(l)))
-            throw new RuntimeException("LinkedList.clone() is broken 2.");
+        checkLinkedListClone(l, "LinkedList.clone() is broken 2.");
         l.add("b");
-        lClone = (LinkedList2) l.clone();
-        if (!(l.equals(lClone) && lClone.equals(l)))
-            throw new RuntimeException("LinkedList.clone() is broken 2.");
+        checkLinkedListClone(l, "LinkedList.clone() is broken 3.");
 
 
         TreeSet2 s = new TreeSet2();
-        TreeSet2 sClone = (TreeSet2) s.clone();
-        if (!(s.equals(sClone) && sClone.equals(s)))
-            throw new RuntimeException("TreeSet.clone() is broken.");
+        checkTreeSetClone(s, "TreeSet.clone() is broken.");
         s.add("a");
-        sClone = (TreeSet2) s.clone();
-        if (!(s.equals(sClone) && sClone.equals(s)))
-            throw new RuntimeException("TreeSet.clone() is broken.");
+        checkTreeSetClone(s, "TreeSet.clone() is broken.");
         s.add("b");
-        sClone = (TreeSet2) s.clone();
-        if (!(s.equals(sClone) && sClone.equals(s)))
-            throw new RuntimeException("TreeSet.clone() is broken.");
+        checkTreeSetClone(s, "TreeSet.clone() is broken.");
 
         TreeMap2 m = new TreeMap2();
+        checkTreeMapClone(m, "TreeMap.clone() is broken.");
+        m.put("a", "b");
+        checkTreeMapClone(m, "TreeMap.clone() is broken.");
+        m.put("c", "d");
+        checkTreeMapClone(m, "TreeMap.clone() is broken.");
+    }
+
+    private static void testVClass() {
+        LinkedList2 l = new LinkedList2();
+        checkLinkedListClone(l, "LinkedList.clone() is broken for VClass 1.");
+        l.add(new VClass(1, new int[] { 0 }));
+        checkLinkedListClone(l, "LinkedList.clone() is broken for VClass 2.");
+        l.add(new VClass(2, new int[] { 0 }));
+        checkLinkedListClone(l, "LinkedList.clone() is broken for VClass 3.");
+
+        TreeSet2 s = new TreeSet2();
+        checkTreeSetClone(s, "TreeSet.clone() is broken for VClass 1.");
+        s.add(new VClass(1, new int[] { 0 }));
+        checkTreeSetClone(s, "TreeSet.clone() is broken for VClass 2.");
+        s.add(new VClass(2, new int[] { 0 }));
+        checkTreeSetClone(s, "TreeSet.clone() is broken for VClass 3.");
+
+        TreeMap2 m = new TreeMap2();
+        checkTreeMapClone(m, "TreeMap.clone() is broken for VClass 1.");
+        m.put(new VClass(1, new int[] { 0 }), new VClass(1, new int[] { 1 }));
+        checkTreeMapClone(m, "TreeMap.clone() is broken for VClass 2.");
+        m.put(new VClass(2, new int[] { 0 }), new VClass(2, new int[] { 1 }));
+        checkTreeMapClone(m, "TreeMap.clone() is broken for VClass 3.");
+    }
+
+    private static void checkLinkedListClone(LinkedList2 l, String message) {
+        LinkedList2 lClone = (LinkedList2) l.clone();
+        if (!(l.equals(lClone) && lClone.equals(l)))
+            throw new RuntimeException(message);
+    }
+
+    private static void checkTreeSetClone(TreeSet2 s, String message) {
+        TreeSet2 sClone = (TreeSet2) s.clone();
+        if (!(s.equals(sClone) && sClone.equals(s)))
+            throw new RuntimeException(message);
+    }
+
+    private static void checkTreeMapClone(TreeMap2 m, String message) {
         TreeMap2 mClone = (TreeMap2) m.clone();
         if (!(m.equals(mClone) && mClone.equals(m)))
-            throw new RuntimeException("TreeMap.clone() is broken.");
-        m.put("a", "b");
-        mClone = (TreeMap2) m.clone();
-        if (!(m.equals(mClone) && mClone.equals(m)))
-            throw new RuntimeException("TreeMap.clone() is broken.");
-        m.put("c", "d");
-        mClone = (TreeMap2) m.clone();
-        if (!(m.equals(mClone) && mClone.equals(m)))
-            throw new RuntimeException("TreeMap.clone() is broken.");
+            throw new RuntimeException(message);
     }
 
     private static class LinkedList2 extends LinkedList {}

--- a/test/jdk/java/util/LinkedList/Clone.java
+++ b/test/jdk/java/util/LinkedList/Clone.java
@@ -35,58 +35,35 @@ import jdk.test.lib.valueclass.VClass;
 import java.util.LinkedList;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.IntFunction;
 
 public class Clone {
     public static void main(String[] args) {
-        testStrings();
-        testVClass();
+        test(i -> "elem" + i);
+        test(i -> new VClass(i, new int[] { 0 }));
     }
 
-    private static void testStrings() {
+    private static void test(IntFunction<Object> elementFactory) {
         LinkedList2 l = new LinkedList2();
         checkLinkedListClone(l, "LinkedList.clone() is broken 1.");
-        l.add("a");
+        l.add(elementFactory.apply(1));
         checkLinkedListClone(l, "LinkedList.clone() is broken 2.");
-        l.add("b");
+        l.add(elementFactory.apply(2));
         checkLinkedListClone(l, "LinkedList.clone() is broken 3.");
 
-
         TreeSet2 s = new TreeSet2();
         checkTreeSetClone(s, "TreeSet.clone() is broken.");
-        s.add("a");
+        s.add(elementFactory.apply(1));
         checkTreeSetClone(s, "TreeSet.clone() is broken.");
-        s.add("b");
+        s.add(elementFactory.apply(2));
         checkTreeSetClone(s, "TreeSet.clone() is broken.");
 
         TreeMap2 m = new TreeMap2();
         checkTreeMapClone(m, "TreeMap.clone() is broken.");
-        m.put("a", "b");
+        m.put(elementFactory.apply(1), elementFactory.apply(-1));
         checkTreeMapClone(m, "TreeMap.clone() is broken.");
-        m.put("c", "d");
+        m.put(elementFactory.apply(2), elementFactory.apply(-2));
         checkTreeMapClone(m, "TreeMap.clone() is broken.");
-    }
-
-    private static void testVClass() {
-        LinkedList2 l = new LinkedList2();
-        checkLinkedListClone(l, "LinkedList.clone() is broken for VClass 1.");
-        l.add(new VClass(1, new int[] { 0 }));
-        checkLinkedListClone(l, "LinkedList.clone() is broken for VClass 2.");
-        l.add(new VClass(2, new int[] { 0 }));
-        checkLinkedListClone(l, "LinkedList.clone() is broken for VClass 3.");
-
-        TreeSet2 s = new TreeSet2();
-        checkTreeSetClone(s, "TreeSet.clone() is broken for VClass 1.");
-        s.add(new VClass(1, new int[] { 0 }));
-        checkTreeSetClone(s, "TreeSet.clone() is broken for VClass 2.");
-        s.add(new VClass(2, new int[] { 0 }));
-        checkTreeSetClone(s, "TreeSet.clone() is broken for VClass 3.");
-
-        TreeMap2 m = new TreeMap2();
-        checkTreeMapClone(m, "TreeMap.clone() is broken for VClass 1.");
-        m.put(new VClass(1, new int[] { 0 }), new VClass(1, new int[] { 1 }));
-        checkTreeMapClone(m, "TreeMap.clone() is broken for VClass 2.");
-        m.put(new VClass(2, new int[] { 0 }), new VClass(2, new int[] { 1 }));
-        checkTreeMapClone(m, "TreeMap.clone() is broken for VClass 3.");
     }
 
     private static void checkLinkedListClone(LinkedList2 l, String message) {

--- a/test/jdk/java/util/LinkedList/Clone.java
+++ b/test/jdk/java/util/LinkedList/Clone.java
@@ -39,7 +39,7 @@ import java.util.function.IntFunction;
 
 public class Clone {
     public static void main(String[] args) {
-        test(i -> "elem" + i);
+        test(i -> String.valueOf(i));
         test(i -> new VClass(i, new int[] { 0 }));
     }
 
@@ -60,9 +60,9 @@ public class Clone {
 
         TreeMap2 m = new TreeMap2();
         checkTreeMapClone(m, "TreeMap.clone() is broken.");
-        m.put(elementFactory.apply(1), elementFactory.apply(-1));
+        m.put(elementFactory.apply(1), elementFactory.apply(2));
         checkTreeMapClone(m, "TreeMap.clone() is broken.");
-        m.put(elementFactory.apply(2), elementFactory.apply(-2));
+        m.put(elementFactory.apply(3), elementFactory.apply(4));
         checkTreeMapClone(m, "TreeMap.clone() is broken.");
     }
 


### PR DESCRIPTION
Changed Tests:

HashMap/KeySetRemove.java: equal ValueClass keys mapped to null can be removed from HashMap and TreeMap.

HashMap/NullKeyAtResize.java: null-key resize behavior remains correct when surrounding keys are ValueClass instances.

HashMap/PutNullKey.java: colliding comparable tree-bin keys are value-capable via @AsValueClass.

HashMap/ReplaceExisting.java: replacing an existing ValueClass key during active iteration does not corrupt the iterator.

HashMap/SetValue.java: Map.Entry.setValue() returns the old ValueClass value.

HashMap/ToArray.java: toArray() coverage is added for ValueClass keys, values, and set elements across hash and linked variants.

HashMap/TreeBinAssert.java: tree-bin iterator-removal coverage now uses a value-capable key.

Hashtable/EqualsCast.java: Provider/Hashtable equality now includes matching ValueClass key/value entries.

Hashtable/SimpleSerialization.java: serialization round-trip now also covers Hashtable<Integer,Integer>.

LinkedHashMap/ComputeIfAbsentAccessOrder.java: access-order behavior is repeated with Integer keys.

LinkedHashMap/EmptyMapIterator.java: fail-fast iterator behavior is repeated with Integer key/value entries.

LinkedList/AddAll.java: append-order behavior is repeated with ValueClass elements.

LinkedList/Clone.java: clone/equality checks for LinkedList, TreeSet, and TreeMap subclasses now include ValueClass contents.

Unchanged Tests:

HashMap/HashMapCloneLeak.java: unchanged because the test depends on WeakReference reachability. Value objects are not valid weak-reference targets, so adding VClass would not match the regression being tested.

HashMap/OverrideIsEmpty.java: unchanged because the test is about HashMap subclass method dispatch. Value classes cannot extend HashMap, and changing only the key/value payload would not add meaningful value-class coverage.

HashMap/WhiteBoxResizeTest.java: unchanged because it is a white-box/internal capacity and table-sizing test using reflection/VarHandles over HashMap, LinkedHashMap, HashSet, and WeakHashMap internals. Its purpose is sizing/lazy allocation/resize arithmetic, not key/value equality or value-object behavior.

HashMap/ToString.java: unchanged because it specifically verifies that HashMap.Entry.toString() does not throw when the map contains null keys or values. Adding value-class keys or values would not extend the original null-handling regression in a meaningful way.

HashSet/Serialization.java: unchanged because the existing HashSet serialization round trip already provides platform value-class coverage when run under the Valhalla preview configuration.

Hashtable/DeserializedLength.java: unchanged because it already uses Integer keys and values. Under preview, that gives platform value-class coverage while preserving the test’s original focus on deserialized table capacity.

Hashtable/HashCode.java: unchanged because it intentionally tests the hash code of an empty Hashtable. Adding value-class entries would create a different non-empty-map test.

Hashtable/IllegalLoadFactor.java: unchanged because it validates constructor load-factor arguments and does not insert keys or values. Value-class semantics are irrelevant to this regression.

Hashtable/ReadObject.java: unchanged because it tests that deserialization does not call an overridable put method in a Hashtable subclass. Value classes cannot be Hashtable subclasses.

Hashtable/SelfRef.java: unchanged because it tests self-referential mutable identity maps in toString and hashCode. Value objects are not the self-referential identity object under test.

Hashtable/SerializationDeadlock.java: unchanged because it tests synchronization/deadlock behavior during serialization of mutually referential Hashtable identity objects. Adding value-class entries would be incidental.

LinkedHashMap/Basic.java: unchanged because it already uses Integer keys and values throughout, giving broad value-class coverage under preview.

LinkedHashMap/Cache.java: unchanged because it already uses Integer keys, so the cache/eldest-entry behavior is covered with platform value-class keys under preview.

LinkedHashSet/Basic.java: unchanged because the existing Integer element coverage already exercises value-class set behavior under preview, including equality, hashing, cloning, serialization, iteration, and clear behavior.

LinkedList/ComodifiedRemove.java: unchanged because it already uses Integer elements. The fail-fast iterator behavior is therefore covered with platform value-class elements under preview.

LinkedList/Remove.java: unchanged because it already uses an Integer element. The list-iterator remove/add behavior is covered with platform value-class elements under preview.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384611](https://bugs.openjdk.org/browse/JDK-8384611): Add value class test coverage to java.util HashMap and HashSet (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32201/head:pull/32201` \
`$ git checkout pull/32201`

Update a local copy of the PR: \
`$ git checkout pull/32201` \
`$ git pull https://git.openjdk.org/jdk.git pull/32201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32201`

View PR using the GUI difftool: \
`$ git pr show -t 32201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32201.diff">https://git.openjdk.org/jdk/pull/32201.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32201#issuecomment-5181970538)
</details>
