### PR TITLE
8384600: Improve java_lang_Throwable::fill_in_stack_trace

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -61,7 +61,6 @@
 #include "oops/symbol.hpp"
 #include "oops/typeArrayOop.inline.hpp"
 #include "prims/jvmtiExport.hpp"
-#include "prims/methodHandles.hpp"
 #include "prims/resolvedMethodTable.hpp"
 #include "runtime/continuationJavaClasses.inline.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"

--- a/src/hotspot/share/classfile/javaStackTraceClasses.cpp
+++ b/src/hotspot/share/classfile/javaStackTraceClasses.cpp
@@ -375,7 +375,7 @@ static inline const char* method_id_to_name(InstanceKlass* holder, int method_id
 
 static inline Symbol* method_id_to_name_symbol(InstanceKlass* holder, int method_id) {
   Method* method = holder->method_with_orig_idnum(method_id);
-  return (method == nullptr) ? SymbolTable::new_symbol("<redefined deleted>") : method->name();
+  return (method == nullptr) ? SymbolTable::new_symbol("unknown_deleted_by_redefinition") : method->name();
 }
 
 // Print stack trace element to the specified output stream.

--- a/src/hotspot/share/classfile/javaStackTraceClasses.cpp
+++ b/src/hotspot/share/classfile/javaStackTraceClasses.cpp
@@ -211,6 +211,32 @@ class BacktraceBuilder: public StackObj {
     return hidden != nullptr;
   }
 
+  void expand(TRAPS) {
+    refArrayHandle old_head(THREAD, _head);
+    PauseNoSafepointVerifier pnsv(&_nsv);
+
+    refArrayOop head = oopFactory::new_objectArray(trace_size, CHECK);
+    refArrayHandle new_head(THREAD, head);
+
+    typeArrayOop methods = oopFactory::new_longArray(trace_chunk_size, CHECK);
+    typeArrayHandle new_methods(THREAD, methods);
+
+    refArrayOop mirrors = oopFactory::new_objectArray(trace_chunk_size, CHECK);
+    refArrayHandle new_mirrors(THREAD, mirrors);
+
+    if (!old_head.is_null()) {
+      old_head->obj_at_put(trace_next_offset, new_head());
+    }
+    new_head->obj_at_put(trace_methods_offset, new_methods());
+    new_head->obj_at_put(trace_mirrors_offset, new_mirrors());
+    new_head->obj_at_put(trace_hidden_offset, nullptr);
+
+    _head    = new_head();
+    _methods_and_bcis = new_methods();
+    _mirrors = new_mirrors();
+    _index = 0;
+  }
+
  public:
 
   // Offsets into oop for backtrace() and constants.
@@ -240,34 +266,6 @@ class BacktraceBuilder: public StackObj {
     // head is the preallocated backtrace
     _head = backtrace();
     _backtrace = refArrayHandle(thread, _head);
-    _index = 0;
-  }
-
- private:
-  // Move this up.
-  void expand(TRAPS) {
-    refArrayHandle old_head(THREAD, _head);
-    PauseNoSafepointVerifier pnsv(&_nsv);
-
-    refArrayOop head = oopFactory::new_objectArray(trace_size, CHECK);
-    refArrayHandle new_head(THREAD, head);
-
-    typeArrayOop methods = oopFactory::new_longArray(trace_chunk_size, CHECK);
-    typeArrayHandle new_methods(THREAD, methods);
-
-    refArrayOop mirrors = oopFactory::new_objectArray(trace_chunk_size, CHECK);
-    refArrayHandle new_mirrors(THREAD, mirrors);
-
-    if (!old_head.is_null()) {
-      old_head->obj_at_put(trace_next_offset, new_head());
-    }
-    new_head->obj_at_put(trace_methods_offset, new_methods());
-    new_head->obj_at_put(trace_mirrors_offset, new_mirrors());
-    new_head->obj_at_put(trace_hidden_offset, nullptr);
-
-    _head    = new_head();
-    _methods_and_bcis = new_methods();
-    _mirrors = new_mirrors();
     _index = 0;
   }
 
@@ -1153,6 +1151,7 @@ void java_lang_LiveStackFrameInfo::set_operands(oop obj, oop value) {
 void java_lang_LiveStackFrameInfo::set_mode(oop obj, int value) {
   obj->int_field_put(_mode_offset, value);
 }
+
 
 // java_lang_StackTraceElement
 

--- a/src/hotspot/share/classfile/javaStackTraceClasses.cpp
+++ b/src/hotspot/share/classfile/javaStackTraceClasses.cpp
@@ -206,7 +206,7 @@ class BacktraceBuilder: public StackObj {
     assert(mirrors != nullptr, "mirror array should be initialized in backtrace");
     return mirrors;
   }
-  static bool has_hidden_top_frame(objArrayHandle chunk) {
+  static bool has_hidden_top_frame(refArrayHandle chunk) {
     oop hidden = chunk->obj_at(trace_hidden_offset);
     return hidden != nullptr;
   }
@@ -226,7 +226,7 @@ class BacktraceBuilder: public StackObj {
   // constructor for new backtrace
   BacktraceBuilder(TRAPS): _head(nullptr), _methods_and_bcis(nullptr), _mirrors(nullptr), _has_hidden_top_frame(false) {
     expand(CHECK);
-    _backtrace = Handle(THREAD, _head);
+    _backtrace = refArrayHandle(THREAD, _head);
     _index = 0;
   }
 
@@ -243,6 +243,8 @@ class BacktraceBuilder: public StackObj {
     _index = 0;
   }
 
+ private:
+  // Move this up.
   void expand(TRAPS) {
     refArrayHandle old_head(THREAD, _head);
     PauseNoSafepointVerifier pnsv(&_nsv);
@@ -269,6 +271,7 @@ class BacktraceBuilder: public StackObj {
     _index = 0;
   }
 
+ public:
   refArrayOop backtrace() {
     return _backtrace();
   }
@@ -336,7 +339,7 @@ class BacktraceIterator : public StackObj {
     }
   }
  public:
-  BacktraceIterator(objArrayHandle result, Thread* thread) {
+  BacktraceIterator(refArrayHandle result, Thread* thread) {
     init(result, thread);
     assert(_methods.is_null() || _methods->length() == BacktraceBuilder::trace_chunk_size, "lengths don't match");
   }
@@ -841,7 +844,7 @@ bool java_lang_Throwable::get_top_method_and_bci(oop throwable, Method** method,
 
   // If the exception happened in a frame that has been hidden, i.e.,
   // omitted from the back trace, we can not compute the message.
-  oop hidden = backtrace(throwable)->obj_at(trace_hidden_offset);
+  oop hidden = backtrace(throwable)->obj_at(BacktraceBuilder::trace_hidden_offset);
   if (hidden != nullptr) {
     return false;
   }

--- a/src/hotspot/share/classfile/javaStackTraceClasses.cpp
+++ b/src/hotspot/share/classfile/javaStackTraceClasses.cpp
@@ -231,7 +231,7 @@ class BacktraceBuilder: public StackObj {
     new_head->obj_at_put(trace_mirrors_offset, new_mirrors());
     new_head->obj_at_put(trace_hidden_offset, nullptr);
 
-    _head    = new_head();
+    _head = new_head();
     _methods_and_bcis = new_methods();
     _mirrors = new_mirrors();
     _index = 0;

--- a/src/hotspot/share/classfile/javaStackTraceClasses.cpp
+++ b/src/hotspot/share/classfile/javaStackTraceClasses.cpp
@@ -26,6 +26,7 @@
 #include "classfile/javaStackTraceClasses.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/stringTable.hpp"
+#include "classfile/symbolTable.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "code/debugInfo.hpp"
 #include "code/pcDesc.hpp"
@@ -40,8 +41,6 @@
 #include "oops/refArrayOop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "oops/typeArrayOop.inline.hpp"
-#include "runtime/continuationEntry.inline.hpp"
-#include "runtime/continuationJavaClasses.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaCalls.hpp"
@@ -49,55 +48,27 @@
 #include "runtime/safepointVerifiers.hpp"
 #include "runtime/vframe.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/ostream.hpp"
 #include "utilities/preserveException.hpp"
 
-// Internal methods to compose bits of the backtrace in java_lang_Throwable
-class Backtrace: AllStatic {
- public:
-  // Helper backtrace functions to store bci|version together.
-  static int merge_bci_and_version(int bci, int version);
-  static int merge_mid_and_cpref(int mid, int cpref);
-  static int bci_at(unsigned int merged);
-  static int version_at(unsigned int merged);
-  static int mid_at(unsigned int merged);
-  static int cpref_at(unsigned int merged);
-  static int get_line_number(Method* method, int bci);
-  static Symbol* get_source_file_name(InstanceKlass* holder, int version);
-};
+// Inline helper functions
 
-
-inline int Backtrace::merge_bci_and_version(int bci, int version) {
-  // only store u2 for version, checking for overflow.
-  if (version > USHRT_MAX || version < 0) version = USHRT_MAX;
-  assert((u2)bci == bci, "bci should be short");
-  return build_int_from_shorts((u2)version, (u2)bci);
+static inline int64_t merge_method_id_bci_and_version(u2 method_id, u2 bci, int version) {
+  return (int64_t)(((uint64_t)version << 32) | (uint32_t)build_int_from_shorts(method_id, bci));
 }
 
-inline int Backtrace::merge_mid_and_cpref(int mid, int cpref) {
-  // only store u2 for mid and cpref, checking for overflow.
-  assert((u2)mid == mid, "mid should be short");
-  assert((u2)cpref == cpref, "cpref should be short");
-  return build_int_from_shorts((u2)cpref, (u2)mid);
+static inline int version_at(int64_t merged) {
+  return (int)((uint64_t)merged >> 32);
 }
 
-inline int Backtrace::bci_at(unsigned int merged) {
-  return extract_high_short_from_int(merged);
+static inline int method_id_at(int64_t merged) {
+  return extract_low_short_from_int((uint32_t)merged);
 }
 
-inline int Backtrace::version_at(unsigned int merged) {
-  return extract_low_short_from_int(merged);
+static inline int bci_at(int64_t merged) {
+  return extract_high_short_from_int((uint32_t)merged);
 }
 
-inline int Backtrace::mid_at(unsigned int merged) {
-  return extract_high_short_from_int(merged);
-}
-
-inline int Backtrace::cpref_at(unsigned int merged) {
-  return extract_low_short_from_int(merged);
-}
-
-inline int Backtrace::get_line_number(Method* method, int bci) {
+static inline int get_line_number(Method* method, int bci) {
   int line_number = 0;
   if (method->is_native()) {
     // Negative value different from -1 below, enabling Java code in
@@ -109,19 +80,6 @@ inline int Backtrace::get_line_number(Method* method, int bci) {
     line_number = method->line_number_from_bci(bci);
   }
   return line_number;
-}
-
-inline Symbol* Backtrace::get_source_file_name(InstanceKlass* holder, int version) {
-  // RedefineClasses() currently permits redefine operations to
-  // happen in parallel using a "last one wins" philosophy. That
-  // spec laxness allows the constant pool entry associated with
-  // the source_file_name_index for any older constant pool version
-  // to be unstable so we shouldn't try to use it.
-  if (holder->constants()->version() != version) {
-    return nullptr;
-  } else {
-    return holder->source_file_name();
-  }
 }
 
 // java_lang_Throwable
@@ -216,9 +174,7 @@ void java_lang_Throwable::print(oop throwable, outputStream* st) {
   }
 }
 
-// After this many redefines, the stack trace is unreliable.
 static inline bool version_matches(Method* method, int version) {
-  assert(version < USHRT_MAX, "version is too big");
   return method != nullptr && (method->constants()->version() == version);
 }
 
@@ -232,71 +188,53 @@ class BacktraceBuilder: public StackObj {
  private:
   refArrayHandle  _backtrace;
   refArrayOop     _head;
-  typeArrayOop    _methods;
-  typeArrayOop    _bcis;
+  typeArrayOop    _methods_and_bcis;
   refArrayOop     _mirrors;
-  typeArrayOop    _names; // Needed to insulate method name against redefinition.
   // True if the top frame of the backtrace is omitted because it shall be hidden.
   bool            _has_hidden_top_frame;
   int             _index;
   NoSafepointVerifier _nsv;
 
-  enum {
-    trace_methods_offset = java_lang_Throwable::trace_methods_offset,
-    trace_bcis_offset    = java_lang_Throwable::trace_bcis_offset,
-    trace_mirrors_offset = java_lang_Throwable::trace_mirrors_offset,
-    trace_names_offset   = java_lang_Throwable::trace_names_offset,
-    trace_conts_offset   = java_lang_Throwable::trace_conts_offset,
-    trace_next_offset    = java_lang_Throwable::trace_next_offset,
-    trace_hidden_offset  = java_lang_Throwable::trace_hidden_offset,
-    trace_size           = java_lang_Throwable::trace_size,
-    trace_chunk_size     = java_lang_Throwable::trace_chunk_size
-  };
-
   // get info out of chunks
-  static typeArrayOop get_methods(refArrayHandle chunk) {
+  static typeArrayOop get_methods_and_bcis(refArrayHandle chunk) {
     typeArrayOop methods = typeArrayOop(chunk->obj_at(trace_methods_offset));
     assert(methods != nullptr, "method array should be initialized in backtrace");
     return methods;
-  }
-  static typeArrayOop get_bcis(refArrayHandle chunk) {
-    typeArrayOop bcis = typeArrayOop(chunk->obj_at(trace_bcis_offset));
-    assert(bcis != nullptr, "bci array should be initialized in backtrace");
-    return bcis;
   }
   static refArrayOop get_mirrors(refArrayHandle chunk) {
     refArrayOop mirrors = refArrayOop(chunk->obj_at(trace_mirrors_offset));
     assert(mirrors != nullptr, "mirror array should be initialized in backtrace");
     return mirrors;
   }
-  static typeArrayOop get_names(refArrayHandle chunk) {
-    typeArrayOop names = typeArrayOop(chunk->obj_at(trace_names_offset));
-    assert(names != nullptr, "names array should be initialized in backtrace");
-    return names;
-  }
-  static bool has_hidden_top_frame(refArrayHandle chunk) {
+  static bool has_hidden_top_frame(objArrayHandle chunk) {
     oop hidden = chunk->obj_at(trace_hidden_offset);
     return hidden != nullptr;
   }
 
  public:
 
+  // Offsets into oop for backtrace() and constants.
+  enum {
+    trace_methods_offset = 0,
+    trace_mirrors_offset = 1,
+    trace_next_offset    = 2,
+    trace_hidden_offset  = 3,
+    trace_size           = 4,
+    trace_chunk_size     = 32
+  };
+
   // constructor for new backtrace
-  BacktraceBuilder(TRAPS): _head(nullptr), _methods(nullptr), _bcis(nullptr), _mirrors(nullptr), _names(nullptr), _has_hidden_top_frame(false) {
+  BacktraceBuilder(TRAPS): _head(nullptr), _methods_and_bcis(nullptr), _mirrors(nullptr), _has_hidden_top_frame(false) {
     expand(CHECK);
-    _backtrace = refArrayHandle(THREAD, _head);
+    _backtrace = Handle(THREAD, _head);
     _index = 0;
   }
 
   BacktraceBuilder(Thread* thread, refArrayHandle backtrace) {
-    _methods = get_methods(backtrace);
-    _bcis = get_bcis(backtrace);
+    _methods_and_bcis = get_methods_and_bcis(backtrace);
     _mirrors = get_mirrors(backtrace);
-    _names = get_names(backtrace);
     _has_hidden_top_frame = has_hidden_top_frame(backtrace);
-    assert(_methods->length() == _bcis->length() &&
-           _methods->length() == _mirrors->length() &&
-           _mirrors->length() == _names->length(),
+    assert(_methods_and_bcis->length() == _mirrors->length(),
            "method and source information arrays should match");
 
     // head is the preallocated backtrace
@@ -312,32 +250,22 @@ class BacktraceBuilder: public StackObj {
     refArrayOop head = oopFactory::new_objectArray(trace_size, CHECK);
     refArrayHandle new_head(THREAD, head);
 
-    typeArrayOop methods = oopFactory::new_shortArray(trace_chunk_size, CHECK);
+    typeArrayOop methods = oopFactory::new_longArray(trace_chunk_size, CHECK);
     typeArrayHandle new_methods(THREAD, methods);
-
-    typeArrayOop bcis = oopFactory::new_intArray(trace_chunk_size, CHECK);
-    typeArrayHandle new_bcis(THREAD, bcis);
 
     refArrayOop mirrors = oopFactory::new_objectArray(trace_chunk_size, CHECK);
     refArrayHandle new_mirrors(THREAD, mirrors);
-
-    typeArrayOop names = oopFactory::new_symbolArray(trace_chunk_size, CHECK);
-    typeArrayHandle new_names(THREAD, names);
 
     if (!old_head.is_null()) {
       old_head->obj_at_put(trace_next_offset, new_head());
     }
     new_head->obj_at_put(trace_methods_offset, new_methods());
-    new_head->obj_at_put(trace_bcis_offset, new_bcis());
     new_head->obj_at_put(trace_mirrors_offset, new_mirrors());
-    new_head->obj_at_put(trace_names_offset, new_names());
     new_head->obj_at_put(trace_hidden_offset, nullptr);
 
     _head    = new_head();
-    _methods = new_methods();
-    _bcis = new_bcis();
+    _methods_and_bcis = new_methods();
     _mirrors = new_mirrors();
-    _names  = new_names();
     _index = 0;
   }
 
@@ -357,13 +285,9 @@ class BacktraceBuilder: public StackObj {
       method = mhandle();
     }
 
-    _methods->ushort_at_put(_index, method->orig_method_idnum());
-    _bcis->int_at_put(_index, Backtrace::merge_bci_and_version(bci, method->constants()->version()));
-
-    // Note:this doesn't leak symbols because the mirror in the backtrace keeps the
-    // klass owning the symbols alive so their refcounts aren't decremented.
-    Symbol* name = method->name();
-    _names->symbol_at_put(_index, name);
+    _methods_and_bcis->long_at_put(_index,
+                                   merge_method_id_bci_and_version(
+                                       method->orig_method_idnum(), bci, method->constants()->version()));
 
     // We need to save the mirrors in the backtrace to keep the class
     // from being unloaded while we still have this stack trace.
@@ -379,10 +303,10 @@ class BacktraceBuilder: public StackObj {
       // to indicate that this backtrace has a hidden top frame.
       // But this code is used before TRUE is allocated.
       // Therefore let's just use an arbitrary legal oop
-      // available right here. _methods is a short[].
-      assert(_methods != nullptr, "we need a legal oop");
+      // available right here. _methods_and_bcis is a long[].
+      assert(_methods_and_bcis != nullptr, "we need a legal oop");
       _has_hidden_top_frame = true;
-      _head->obj_at_put(trace_hidden_offset, _methods);
+      _head->obj_at_put(trace_hidden_offset, _methods_and_bcis);
     }
   }
 };
@@ -391,10 +315,9 @@ struct BacktraceElement : public StackObj {
   int _method_id;
   int _bci;
   int _version;
-  Symbol* _name;
   Handle _mirror;
-  BacktraceElement(Handle mirror, int mid, int version, int bci, Symbol* name) :
-                   _method_id(mid), _bci(bci), _version(version), _name(name), _mirror(mirror) {}
+  BacktraceElement(Handle mirror, int mid, int version, int bci) :
+                   _method_id(mid), _bci(bci), _version(version), _mirror(mirror) {}
 };
 
 class BacktraceIterator : public StackObj {
@@ -402,36 +325,32 @@ class BacktraceIterator : public StackObj {
   refArrayHandle  _result;
   refArrayHandle  _mirrors;
   typeArrayHandle _methods;
-  typeArrayHandle _bcis;
-  typeArrayHandle _names;
 
   void init(refArrayHandle result, Thread* thread) {
     // Get method id, bci, version and mirror from chunk
     _result = result;
     if (_result.not_null()) {
-      _methods = typeArrayHandle(thread, BacktraceBuilder::get_methods(_result));
-      _bcis = typeArrayHandle(thread, BacktraceBuilder::get_bcis(_result));
+      _methods = typeArrayHandle(thread, BacktraceBuilder::get_methods_and_bcis(_result));
       _mirrors = refArrayHandle(thread, BacktraceBuilder::get_mirrors(_result));
-      _names = typeArrayHandle(thread, BacktraceBuilder::get_names(_result));
       _index = 0;
     }
   }
  public:
-  BacktraceIterator(refArrayHandle result, Thread* thread) {
+  BacktraceIterator(objArrayHandle result, Thread* thread) {
     init(result, thread);
-    assert(_methods.is_null() || _methods->length() == java_lang_Throwable::trace_chunk_size, "lengths don't match");
+    assert(_methods.is_null() || _methods->length() == BacktraceBuilder::trace_chunk_size, "lengths don't match");
   }
 
   BacktraceElement next(Thread* thread) {
+    int64_t merged_method_data = _methods->long_at(_index);
     BacktraceElement e (Handle(thread, _mirrors->obj_at(_index)),
-                        _methods->ushort_at(_index),
-                        Backtrace::version_at(_bcis->int_at(_index)),
-                        Backtrace::bci_at(_bcis->int_at(_index)),
-                        _names->symbol_at(_index));
+                        method_id_at(merged_method_data),
+                        version_at(merged_method_data),
+                        bci_at(merged_method_data));
     _index++;
 
-    if (_index >= java_lang_Throwable::trace_chunk_size) {
-      int next_offset = java_lang_Throwable::trace_next_offset;
+    if (_index >= BacktraceBuilder::trace_chunk_size) {
+      int next_offset = BacktraceBuilder::trace_next_offset;
       // Get next chunk
       refArrayHandle result (thread, refArrayOop(_result->obj_at(next_offset)));
       init(result, thread);
@@ -444,17 +363,28 @@ class BacktraceIterator : public StackObj {
   }
 };
 
+static inline const char* method_id_to_name(InstanceKlass* holder, int method_id) {
+  // If no method was found with this original idnum, it was deleted.  This is rare
+  // and has been deprecated.
+  Method* method = holder->method_with_orig_idnum(method_id);
+  return method == nullptr ? "<redefined deleted>" : method->name()->as_C_string();
+}
+
+static inline Symbol* method_id_to_name_symbol(InstanceKlass* holder, int method_id) {
+  Method* method = holder->method_with_orig_idnum(method_id);
+  return (method == nullptr) ? SymbolTable::new_symbol("<redefined deleted>") : method->name();
+}
 
 // Print stack trace element to the specified output stream.
 // The output is formatted into a stringStream and written to the outputStream in one step.
 static void print_stack_element_to_stream(outputStream* st, Handle mirror, int method_id,
-                                          int version, int bci, Symbol* name) {
+                                          int version, int bci) {
   ResourceMark rm;
   stringStream ss;
 
   InstanceKlass* holder = java_lang_Class::as_InstanceKlass(mirror());
   const char* klass_name  = holder->external_name();
-  char* method_name = name->as_C_string();
+  const char* method_name = method_id_to_name(holder, method_id);
   ss.print("\tat %s.%s(", klass_name, method_name);
 
   // Print module information
@@ -470,17 +400,17 @@ static void print_stack_element_to_stream(outputStream* st, Handle mirror, int m
   }
 
   char* source_file_name = nullptr;
-  Symbol* source = Backtrace::get_source_file_name(holder, version);
+  Symbol* source = holder->source_file_name(version);
   if (source != nullptr) {
     source_file_name = source->as_C_string();
   }
 
-  // The method can be null if the requested class version is gone
+  // Now get the exact method from the current or previous version of the InstanceKlass, if it exists.
   Method* method = holder->method_with_orig_idnum(method_id, version);
   if (!version_matches(method, version)) {
-    ss.print("Redefined)");
+    ss.print("(Redefined)");
   } else {
-    int line_number = Backtrace::get_line_number(method, bci);
+    int line_number = get_line_number(method, bci);
     if (line_number == -2) {
       ss.print("Native Method)");
     } else {
@@ -509,7 +439,7 @@ void java_lang_Throwable::print_stack_element(outputStream *st, Method* method, 
   Handle mirror (Thread::current(),  method->method_holder()->java_mirror());
   int method_id = method->orig_method_idnum();
   int version = method->constants()->version();
-  print_stack_element_to_stream(st, mirror, method_id, version, bci, method->name());
+  print_stack_element_to_stream(st, mirror, method_id, version, bci);
 }
 
 /**
@@ -533,7 +463,7 @@ void java_lang_Throwable::print_stack_trace(Handle throwable, outputStream* st) 
 
     while (iter.repeat()) {
       BacktraceElement bte = iter.next(THREAD);
-      print_stack_element_to_stream(st, bte._mirror, bte._method_id, bte._version, bte._bci, bte._name);
+      print_stack_element_to_stream(st, bte._mirror, bte._method_id, bte._version, bte._bci);
     }
     if (THREAD->can_call_java()) {
       // Call getCause() which doesn't necessarily return the _cause field.
@@ -766,7 +696,6 @@ void java_lang_Throwable::allocate_backtrace(Handle throwable, TRAPS) {
   set_backtrace(throwable(), bt.backtrace());
 }
 
-
 void java_lang_Throwable::fill_in_stack_trace_of_preallocated_backtrace(Handle throwable) {
   // Fill in stack trace into preallocated backtrace (no GC)
 
@@ -795,7 +724,7 @@ void java_lang_Throwable::fill_in_stack_trace_of_preallocated_backtrace(Handle t
     chunk_count++;
 
     // Bail-out for deep stacks
-    if (chunk_count >= trace_chunk_size) break;
+    if (chunk_count >= BacktraceBuilder::trace_chunk_size) break;
   }
   set_depth(throwable(), chunk_count);
   log_info(stacktrace)("%s, %d", throwable->klass()->external_name(), chunk_count);
@@ -832,13 +761,16 @@ void java_lang_Throwable::get_stack_trace_elements(int depth, Handle backtrace,
     }
 
     InstanceKlass* holder = java_lang_Class::as_InstanceKlass(bte._mirror());
+    // Get the exact method if it has been redefined and still exists.
     methodHandle method (THREAD, holder->method_with_orig_idnum(bte._method_id, bte._version));
+    // Get the method name from the method_id.
+    Symbol* method_name = method_id_to_name_symbol(holder, bte._method_id);
 
     java_lang_StackTraceElement::fill_in(stack_trace_element, holder,
                                          method,
                                          bte._version,
                                          bte._bci,
-                                         bte._name,
+                                         method_name,
                                          CHECK);
   }
 }
@@ -1009,7 +941,7 @@ void java_lang_StackTraceElement::decode_file_and_line(Handle java_class,
                                                        oop& source_file,
                                                        int& line_number, TRAPS) {
   // Fill in source file name and line number.
-  source = Backtrace::get_source_file_name(holder, version);
+  source = holder->source_file_name(version);
   source_file = java_lang_Class::source_file(java_class());
   if (source != nullptr) {
     // Class was not redefined. We can trust its cache if set,
@@ -1025,7 +957,7 @@ void java_lang_StackTraceElement::decode_file_and_line(Handle java_class,
       java_lang_Class::set_source_file(java_class(), source_file);
     }
   }
-  line_number = Backtrace::get_line_number(method(), bci);
+  line_number = get_line_number(method(), bci);
 }
 
 // java_lang_ClassFrameInfo
@@ -1218,7 +1150,6 @@ void java_lang_LiveStackFrameInfo::set_operands(oop obj, oop value) {
 void java_lang_LiveStackFrameInfo::set_mode(oop obj, int value) {
   obj->int_field_put(_mode_offset, value);
 }
-
 
 // java_lang_StackTraceElement
 

--- a/src/hotspot/share/classfile/javaStackTraceClasses.hpp
+++ b/src/hotspot/share/classfile/javaStackTraceClasses.hpp
@@ -44,19 +44,6 @@ class java_lang_Throwable: AllStatic {
   friend class BacktraceIterator;
 
  private:
-  // Trace constants
-  enum {
-    trace_methods_offset = 0,
-    trace_bcis_offset    = 1,
-    trace_mirrors_offset = 2,
-    trace_names_offset   = 3,
-    trace_conts_offset   = 4,
-    trace_next_offset    = 5,
-    trace_hidden_offset  = 6,
-    trace_size           = 7,
-    trace_chunk_size     = 32
-  };
-
   static int _backtrace_offset;
   static int _detailMessage_offset;
   static int _stackTrace_offset;
@@ -109,9 +96,6 @@ class java_lang_Throwable: AllStatic {
   static void java_printStackTrace(Handle throwable, TRAPS);
   // Gets the method and bci of the top frame (TOS). Returns false if this failed.
   static bool get_top_method_and_bci(oop throwable, Method** method, int* bci);
-
-  // Debugging
-  friend class JavaClasses;
 };
 
 // Interface to java.lang.StackTraceElement objects

--- a/src/hotspot/share/fixit
+++ b/src/hotspot/share/fixit
@@ -1,0 +1,5 @@
+#!/bin/csh -f
+foreach f (`cat file.list`)
+   sed -e "s/javaLangThrowable/javaStackTraceClasses/" $f > $f.new
+   mv $f.new $f
+end

--- a/src/hotspot/share/fixit
+++ b/src/hotspot/share/fixit
@@ -1,5 +1,0 @@
-#!/bin/csh -f
-foreach f (`cat file.list`)
-   sed -e "s/javaLangThrowable/javaStackTraceClasses/" $f > $f.new
-   mv $f.new $f
-end

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3406,6 +3406,17 @@ Symbol* InstanceKlass::source_file_name() const               { return _constant
 u2 InstanceKlass::source_file_name_index() const              { return _constants->source_file_name_index(); }
 void InstanceKlass::set_source_file_name_index(u2 sourcefile_index) { _constants->set_source_file_name_index(sourcefile_index); }
 
+Symbol* InstanceKlass::source_file_name(int version) const {
+  // Return the source file name for this version of the classfile, if redefined with RedefineClasses
+  const InstanceKlass* holder = get_klass_version(version);
+  if (holder == nullptr) {
+    // Redefined previous class has been cleaned up.
+    return nullptr;
+  } else {
+    return holder->source_file_name();
+  }
+}
+
 // minor and major version numbers of class file
 u2 InstanceKlass::minor_version() const                 { return _constants->minor_version(); }
 void InstanceKlass::set_minor_version(u2 minor_version) { _constants->set_minor_version(minor_version); }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -771,6 +771,7 @@ public:
   Symbol* source_file_name() const;
   u2 source_file_name_index() const;
   void set_source_file_name_index(u2 sourcefile_index);
+  Symbol* source_file_name(int version) const;
 
   // minor and major version numbers of class file
   u2 minor_version() const;

--- a/src/hotspot/share/oops/typeArrayOop.hpp
+++ b/src/hotspot/share/oops/typeArrayOop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,9 +107,6 @@ private:
 
   jbyte byte_at_acquire(int which) const;
   void release_byte_at_put(int which, jbyte contents);
-
-  Symbol* symbol_at(int which) const;
-  void symbol_at_put(int which, Symbol* contents);
 
   // Sizing
 

--- a/src/hotspot/share/oops/typeArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/typeArrayOop.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,26 +161,5 @@ inline jbyte typeArrayOopDesc::byte_at_acquire(int which) const {
 inline void typeArrayOopDesc::release_byte_at_put(int which, jbyte contents) {
   AtomicAccess::release_store(byte_at_addr(which), contents);
 }
-
-// Java thinks Symbol arrays are just arrays of either long or int, since
-// there doesn't seem to be T_ADDRESS, so this is a bit of unfortunate
-// casting
-#ifdef _LP64
-inline Symbol* typeArrayOopDesc::symbol_at(int which) const {
-  return *reinterpret_cast<Symbol**>(long_at_addr(which));
-}
-
-inline void typeArrayOopDesc::symbol_at_put(int which, Symbol* contents) {
-  *reinterpret_cast<Symbol**>(long_at_addr(which)) = contents;
-}
-#else
-inline Symbol* typeArrayOopDesc::symbol_at(int which) const {
-  return *reinterpret_cast<Symbol**>(int_at_addr(which));
-}
-inline void typeArrayOopDesc::symbol_at_put(int which, Symbol* contents) {
-  *reinterpret_cast<Symbol**>(int_at_addr(which)) = contents;
-}
-#endif // _LP64
-
 
 #endif // SHARE_OOPS_TYPEARRAYOOP_INLINE_HPP

--- a/test/hotspot/jtreg/runtime/Throwable/ThrowableIntrospectionSegfault.java
+++ b/test/hotspot/jtreg/runtime/Throwable/ThrowableIntrospectionSegfault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class ThrowableIntrospectionSegfault {
         try {
 
             // Retrieve the class of throwable.backtrace[0][0].
-            Class class2 = ((Object[]) ((Object[]) backtrace)[2])[0].getClass();
+            Class class2 = ((Object[]) ((Object[]) backtrace)[1])[0].getClass();
 
             // Segfault occurs while executing this line, to retrieve the name of
             // this class.

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,10 +118,24 @@ public class RedefineRunningMethodsWithBacktrace {
                     }
                     public static void infinite() {}
                     public static void throwable() {
-                        throw new RuntimeException("throwable called");
+                        throw new RuntimeException("throwable called"); /* line 13 */
                     }
                 }
                 """;
+
+    private static boolean matchSource(String source) {
+        // The first version is in this file, the second version was cleaned up.
+        return source == null ||
+               source.equals("RedefineRunningMethodsWithBacktrace.java") ||
+               source.equals("RedefineRunningMethodsWithBacktrace_B.java");
+    }
+
+    private static boolean matchLineNumber(int lineNumber) {
+        // Line number of the throw in the each version of the redefined class.
+        // The first version of this method is running so we have the line number,
+        // the second is cleaned up, so we don't, the third version is current so we do.
+        return lineNumber == 82 || lineNumber == -1 || lineNumber == 13;
+    }
 
     private static void touchRedefinedMethodInBacktrace(Throwable throwable) {
         System.out.println("touchRedefinedMethodInBacktrace: ");
@@ -131,8 +145,24 @@ public class RedefineRunningMethodsWithBacktrace {
         // Make sure that we can convert the backtrace, which is referring to
         // the redefined method, to a  StrackTraceElement[] without crashing.
         StackTraceElement[] stackTrace = throwable.getStackTrace();
-        for (int i = 0; i < stackTrace.length; i++) {
-            StackTraceElement frame = stackTrace[i];
+        StackTraceElement frame = stackTrace[0];
+        assertEquals(frame.getClassName(), "RedefineRunningMethodsWithBacktrace_B",
+              "\nTest failed: trace[0].getClassName() returned " + frame.getClassName());
+        assertEquals(frame.getMethodName(), "throwable",
+              "\nTest failed: trace[0].getMethodName() returned " + frame.getMethodName());
+        assertTrue(matchSource(frame.getFileName()),
+              "\nTest failed: trace[0].getFileName() returned " + frame.getFileName());
+        assertTrue(matchLineNumber(frame.getLineNumber()),
+              "\nTest failed: trace[0].getLineNumber() returned " + frame.getLineNumber());
+
+        frame = stackTrace[1];
+        assertEquals(frame.getClassName(), "RedefineRunningMethodsWithBacktrace",
+              "\nTest failed: trace[1].getClassName() returned " + frame.getClassName());
+        assertEquals(frame.getMethodName(), "getThrowableInB",
+              "\nTest failed: trace[1].getMethodName() returned " + frame.getMethodName());
+
+        for (int i = 2; i < stackTrace.length; i++) {
+            frame = stackTrace[i];
             assertNotNull(frame.getClassName(),
               "\nTest failed: trace[" + i + "].getClassName() returned null");
             assertNotNull(frame.getMethodName(),

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java
@@ -130,11 +130,15 @@ public class RedefineRunningMethodsWithBacktrace {
                source.equals("RedefineRunningMethodsWithBacktrace_B.java");
     }
 
+    static final int firstLineNumber = 82;
+    static final int cleanedupLineNumber = -1;
+    static final int rerunLineNumber = 13;
+
     private static boolean matchLineNumber(int lineNumber) {
         // Line number of the throw in the each version of the redefined class.
         // The first version of this method is running so we have the line number,
         // the second is cleaned up, so we don't, the third version is current so we do.
-        return lineNumber == 82 || lineNumber == -1 || lineNumber == 13;
+        return lineNumber == firstLineNumber || lineNumber == cleanedupLineNumber || lineNumber == rerunLineNumber;
     }
 
     private static void touchRedefinedMethodInBacktrace(Throwable throwable) {

--- a/test/jdk/com/sun/jdi/BacktraceFieldTest.java
+++ b/test/jdk/com/sun/jdi/BacktraceFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,12 +158,10 @@ public class BacktraceFieldTest extends TestScaffold {
                     println("BT: backTraceVal = " + backTraceVal);
 
                     printval(backTraceVal, 0);
-                    printval(backTraceVal, 1);
-                    printval(backTraceVal, 2);
-                    printval(backTraceVal, 3);  // backtrace has 4 elements
+                    printval(backTraceVal, 1);  // backtrace has 2 elements
 
                     try {
-                        printval(backTraceVal, 4);
+                        printval(backTraceVal, 2);
                     } catch (Exception e) {
                         println("Exception " + e);
                     }


### PR DESCRIPTION
This patch removes the work to save the Method name in the backtrace that was used for the case where redefinition could delete the method that was on the stack in the stack trace, but saved then deleted with redefinition later. RedefineClasses' ability to add/delete methods has been deprecated for many releases, so adding code and memory for this case is wasting space and time. This change speeds up Throwable microbenchmarks by about 10-30%, and speeds up DaCapo pmd by a bit.

Remerged with the change to factor out javaStackTraceClasses.

Tested with tier1-4.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384600](https://bugs.openjdk.org/browse/JDK-8384600): Improve java_lang_Throwable::fill_in_stack_trace (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [291a9cf7](https://git.openjdk.org/jdk/pull/32202/files/291a9cf70bf4ad898aac4e58dd69fd12fc03ede9)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32202/head:pull/32202` \
`$ git checkout pull/32202`

Update a local copy of the PR: \
`$ git checkout pull/32202` \
`$ git pull https://git.openjdk.org/jdk.git pull/32202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32202`

View PR using the GUI difftool: \
`$ git pr show -t 32202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32202.diff">https://git.openjdk.org/jdk/pull/32202.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32202#issuecomment-5182892849)
</details>
