### PR TITLE
8389666: C2: assert(false) failed: unexpected scalar opcode for integer DivV*

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1281,6 +1281,10 @@ Node* VectorNode::make_scalar(Compile* c, int vopc, BasicType bt, Node* control,
       return new AndINode(in1, in2);
     case Op_AndL:
       return new AndLNode(in1, in2);
+    case Op_DivI:
+      return new DivINode(control, in1, in2);
+    case Op_DivL:
+      return new DivLNode(control, in1, in2);
     case Op_DivF:
       return new DivFNode(control, in1, in2);
     case Op_DivD:

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorBroadcastTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorBroadcastTransforms.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8358521
+ * @bug 8358521 8389666
  * @summary Optimize vector operations by reassociating broadcasted inputs
  * @modules jdk.incubator.vector
  * @library /test/lib /
@@ -105,6 +105,41 @@ public class TestVectorBroadcastTransforms {
         int ib = R.nextInt();
         int ir = int_mul(ia, ib);
         Verify.checkEQ(ir, ia * ib);
+    }
+
+    // Integer vector DIV is currently matched on SVE. push_through_replicate
+    // must be able to scalarize DivVI via VectorNode::make_scalar(Op_DivI).
+    @Test
+    @IR(failOn = IRNode.DIV_VI,
+        applyIfCPUFeature = {"sve", "true"},
+        counts = { IRNode.DIV_I, ">= 1",
+                   IRNode.REPLICATE_I, IRNode.VECTOR_SIZE_ANY, ">= 1" })
+    static int int_div(int ia, int ib) {
+        return IntVector.broadcast(ISP, ia)
+                   .lanewise(VectorOperators.DIV, IntVector.broadcast(ISP, ib))
+                   .lane(0);
+    }
+
+    @Run(test = "int_div")
+    static void run_int_div() {
+        int ia = R.nextInt();
+        int ib = R.nextInt();
+        if (ib == 0) ib = 1;
+        int ir = int_div(ia, ib);
+        Verify.checkEQ(ir, ia / ib);
+    }
+
+    // Minimal crash reproducer from VectorExpressionFuzzer (constant broadcasts).
+    @Test
+    static int int_div_broadcast_constants() {
+        return IntVector.broadcast(IntVector.SPECIES_128, -4096)
+                   .div(IntVector.broadcast(IntVector.SPECIES_128, 1))
+                   .lane(0);
+    }
+
+    @Run(test = "int_div_broadcast_constants")
+    static void run_int_div_broadcast_constants() {
+        Verify.checkEQ(int_div_broadcast_constants(), -4096);
     }
 
     @Test
@@ -255,6 +290,26 @@ public class TestVectorBroadcastTransforms {
         long lb = R.nextLong();
         long lr = long_mul(la, lb);
         Verify.checkEQ(lr, la * lb);
+    }
+
+    @Test
+    @IR(failOn = IRNode.DIV_VL,
+        applyIfCPUFeature = {"sve", "true"},
+        counts = { IRNode.DIV_L, ">= 1",
+                   IRNode.REPLICATE_L, IRNode.VECTOR_SIZE_ANY, ">= 1" })
+    static long long_div(long la, long lb) {
+        return LongVector.broadcast(LSP, la)
+                   .div(LongVector.broadcast(LSP, lb))
+                   .lane(0);
+    }
+
+    @Run(test = "long_div")
+    static void run_long_div() {
+        long la = R.nextLong();
+        long lb = R.nextLong();
+        if (lb == 0L) lb = 1L;
+        long lr = long_div(la, lb);
+        Verify.checkEQ(lr, la / lb);
     }
 
     @Test
@@ -785,6 +840,26 @@ public class TestVectorBroadcastTransforms {
     }
 
     @Test
+    @IR(failOn = IRNode.DIV_VB,
+        applyIfCPUFeature = {"sve", "true"},
+        counts = { IRNode.DIV_I, ">= 1",
+                   IRNode.REPLICATE_B, IRNode.VECTOR_SIZE_ANY, ">= 1" })
+    static byte byte_div(byte ba, byte bb) {
+        return ByteVector.broadcast(BSP, ba)
+                   .div(ByteVector.broadcast(BSP, bb))
+                   .lane(0);
+    }
+
+    @Run(test = "byte_div")
+    static void run_byte_div() {
+        byte ba = (byte) R.nextInt();
+        byte bb = (byte) R.nextInt();
+        if (bb == 0) bb = 1;
+        byte br = byte_div(ba, bb);
+        Verify.checkEQ(br, (byte) (ba / bb));
+    }
+
+    @Test
     @IR(failOn = IRNode.AND_VB,
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"},
         counts = { IRNode.AND_I, ">= 1", IRNode.REPLICATE_B, IRNode.VECTOR_SIZE_ANY, ">= 1" })
@@ -1005,6 +1080,26 @@ public class TestVectorBroadcastTransforms {
         short sb = (short) R.nextInt();
         short sr = short_mul(sa, sb);
         Verify.checkEQ(sr, (short) (sa * sb));
+    }
+
+    @Test
+    @IR(failOn = IRNode.DIV_VS,
+        applyIfCPUFeature = {"sve", "true"},
+        counts = { IRNode.DIV_I, ">= 1",
+                   IRNode.REPLICATE_S, IRNode.VECTOR_SIZE_ANY, ">= 1" })
+    static short short_div(short sa, short sb) {
+        return ShortVector.broadcast(SSP, sa)
+                   .div(ShortVector.broadcast(SSP, sb))
+                   .lane(0);
+    }
+
+    @Run(test = "short_div")
+    static void run_short_div() {
+        short sa = (short) R.nextInt();
+        short sb = (short) R.nextInt();
+        if (sb == 0) sb = 1;
+        short sr = short_div(sa, sb);
+        Verify.checkEQ(sr, (short) (sa / sb));
     }
 
     @Test


### PR DESCRIPTION
JDK-8387594 added AArch64 SVE support for vector integer division (`DivVB/DivVS/DivVI/DivVL`), `VectorNode::scalar_opcode()` maps these nodes to `Op_DivI / Op_DivL`. That makes them eligible for `VectorNode::push_through_replicate()`, but `VectorNode::make_scalar()` was not updated to construct `DivINode / DivLNode`.

As a result, Idealizing a vector integer division whose inputs are both Replicate hits:
```
  assert(false) failed: unexpected scalar opcode
  at VectorNode::make_scalar
  at VectorNode::push_through_replicate
```

This was observed with VectorExpressionFuzzer, e.g.:
```
  IntVector.broadcast(SPECIES_128, -4096)
           .div(IntVector.broadcast(SPECIES_128, 1));
```

Reproduction:
```
make test TEST="test/hotspot/jtreg/compiler/vectorapi/VectorExpressionFuzzer.java" \
  TEST_VM_OPTS="-Djdk.test.lib.random.seed=-7741787539408201128"
```

This PR updates `Op_DivI / Op_DivL` in `VectorNode::make_scalar()` to fix this issue.

This PR also added some test cases for division in `test/hotspot/jtreg/compiler/vectorapi/TestVectorBroadcastTransforms.java`.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389666](https://bugs.openjdk.org/browse/JDK-8389666): C2: assert(false) failed: unexpected scalar opcode for integer DivV* (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32203/head:pull/32203` \
`$ git checkout pull/32203`

Update a local copy of the PR: \
`$ git checkout pull/32203` \
`$ git pull https://git.openjdk.org/jdk.git pull/32203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32203`

View PR using the GUI difftool: \
`$ git pr show -t 32203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32203.diff">https://git.openjdk.org/jdk/pull/32203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32203#issuecomment-5186800410)
</details>
