### PR TITLE
8389659: Cannot invoke "com.sun.tools.javac.code.Type.getTag()" because "type" is null on invalid LHS

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Kinds.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Kinds.java
@@ -174,6 +174,7 @@ public class Kinds {
         public static final KindSelector MDL = new KindSelector(0x40);
         public static final KindSelector ERR = new KindSelector(0x7f);
         public static final KindSelector ASG = new KindSelector(0x84);
+        public static final KindSelector ASG_OP = new KindSelector(0x184);
 
         //common derived selectors
         public static final KindSelector TYP_PCK = of(TYP, PCK);
@@ -182,14 +183,14 @@ public class Kinds {
         public static final KindSelector VAL_TYP = of(VAL, TYP);
         public static final KindSelector VAL_TYP_PCK = of(VAL, TYP, PCK);
 
-        private final byte data;
+        private final int data;
 
         private KindSelector(int data) {
-            this.data = (byte) data;
+            this.data = data;
         }
 
         public static KindSelector of(KindSelector... kindSelectors) {
-            byte newData = 0;
+            int newData = 0;
             for (KindSelector kindSel : kindSelectors) {
                 newData |= kindSel.data;
             }
@@ -205,7 +206,7 @@ public class Kinds {
         }
 
         public boolean isAssignment() {
-            return ASG.subset(this) && !VAL.subset(this);
+            return ASG.subset(this) && !ASG_OP.subset(this);
         }
 
         /** A set of KindName(s) representing a set of symbol's kinds. */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -180,7 +180,7 @@ public class Attr extends JCTree.Visitor {
 
         statInfo = new ResultInfo(KindSelector.NIL, Type.noType);
         varAssignmentInfo = new ResultInfo(KindSelector.ASG, Type.noType);
-        varAssignmentOpInfo = new ResultInfo(KindSelector.of(KindSelector.VAL, KindSelector.ASG), Type.noType);
+        varAssignmentOpInfo = new ResultInfo(KindSelector.ASG_OP, Type.noType);
         unknownExprInfo = new ResultInfo(KindSelector.VAL, Type.noType);
         methodAttrInfo = new MethodAttrInfo();
         unknownTypeInfo = new ResultInfo(KindSelector.TYP, Type.noType);

--- a/test/langtools/tools/javac/SuperInit/InitAssignOp.java
+++ b/test/langtools/tools/javac/SuperInit/InitAssignOp.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389659
+ * @summary Verify assign op is handled correctly in the constructor prologue
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.file
+ *      jdk.compiler/com.sun.tools.javac.main
+ *      jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit ${test.main.class}
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import toolbox.JavaTask;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class InitAssignOp {
+
+    private final ToolBox tb = new ToolBox();
+    private Path base;
+
+    @Test
+    void testInitAssignOp() throws Exception {
+        record TestCase(String source, List<String> expectedCompilationOutput) {}
+        TestCase[] tests = new TestCase[] {
+            new TestCase("""
+                         public class Test {
+                             private int i;
+
+                             public Test() {
+                                 ++this.i;
+                                 super();
+                             }
+                             public static void main(String... args) {
+                                 System.out.println(new Test().i);
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:5:15: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.value.classes)",
+                             "1 error"
+                         )),
+            new TestCase("""
+                         public class Test {
+                             private int i;
+
+                             public Test() {
+                                 this.i++;
+                                 super();
+                             }
+                             public static void main(String... args) {
+                                 System.out.println(new Test().i);
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:5:13: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.value.classes)",
+                             "1 error"
+                         )),
+            new TestCase("""
+                         public class Test {
+                             private int i;
+
+                             public Test() {
+                                 this.i += 1;
+                                 super();
+                             }
+                             public static void main(String... args) {
+                                 System.out.println(new Test().i);
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:5:13: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.value.classes)",
+                             "1 error"
+                         )),
+        };
+        for (TestCase test : tests) {
+            Path classes = base.resolve("classes");
+            Files.createDirectories(classes);
+            List<String> out;
+
+            out =
+                new JavacTask(tb)
+                        .options("-XDrawDiagnostics")
+                        .outdir(classes)
+                        .sources(test.source())
+                        .run(Task.Expect.FAIL)
+                        .writeAll()
+                        .getOutputLines(Task.OutputKind.DIRECT);
+            Assertions.assertEquals(test.expectedCompilationOutput(), out);
+            new JavacTask(tb)
+                    .options("--enable-preview", "--release", System.getProperty("java.specification.version"))
+                    .outdir(classes)
+                    .sources(test.source())
+                    .run()
+                    .writeAll();
+
+            out =
+                new JavaTask(tb)
+                        .vmOptions("--enable-preview")
+                        .classpath(classes.toString())
+                        .className("Test")
+                        .run()
+                        .getOutputLines(Task.OutputKind.STDOUT);
+            List<String> expectedRunOutput = List.of(
+                "1"
+            );
+            Assertions.assertEquals(expectedRunOutput, out);
+        }
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+
+}

--- a/test/langtools/tools/javac/SuperInit/InitAssignOp.java
+++ b/test/langtools/tools/javac/SuperInit/InitAssignOp.java
@@ -145,6 +145,142 @@ public class InitAssignOp {
         }
     }
 
+    @Test
+    void testInitAssignOpErrors() throws Exception {
+        record TestCase(String source, List<String> expectedCompilationOutput) {}
+        TestCase[] tests = new TestCase[] {
+            new TestCase("""
+                         public class Test {
+                             public Test() {
+                                 ++0;
+                                 super();
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:11: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+            new TestCase("""
+                         public class Test {
+                             public Test() {
+                                 ++test();
+                                 super();
+                             }
+                             private static int test() { return 1; }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:15: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+            new TestCase("""
+                         public class Test {
+                             public Test(int i) {
+                                 ++(i + 1);
+                                 super();
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:14: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+
+            new TestCase("""
+                         public class Test {
+                             public Test() {
+                                 0++;
+                                 super();
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:9: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+            new TestCase("""
+                         public class Test {
+                             public Test() {
+                                 test()++;
+                                 super();
+                             }
+                             private static int test() { return 1; }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:13: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+            new TestCase("""
+                         public class Test {
+                             public Test(int i) {
+                                 (i + 1)++;
+                                 super();
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:12: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+
+            new TestCase("""
+                         public class Test {
+                             public Test() {
+                                 0 += 1;
+                                 super();
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:9: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+            new TestCase("""
+                         public class Test {
+                             public Test() {
+                                 test() += 1;
+                                 super();
+                             }
+                             private static int test() { return 1; }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:13: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+            new TestCase("""
+                         public class Test {
+                             public Test(int i) {
+                                 (i + 1) += 1;
+                                 super();
+                             }
+                         }
+                         """,
+                         List.of(
+                             "Test.java:3:12: compiler.err.unexpected.type: kindname.variable, kindname.value",
+                             "1 error"
+                         )),
+        };
+        for (TestCase test : tests) {
+            Path classes = base.resolve("classes");
+            Files.createDirectories(classes);
+            List<String> out;
+
+            out =
+                new JavacTask(tb)
+                        .options("-XDrawDiagnostics",
+                                 "--enable-preview", "--release", System.getProperty("java.specification.version"))
+                        .outdir(classes)
+                        .sources(test.source())
+                        .run(Task.Expect.FAIL)
+                        .writeAll()
+                        .getOutputLines(Task.OutputKind.DIRECT);
+            Assertions.assertEquals(test.expectedCompilationOutput(), out);
+        }
+    }
+
     @BeforeEach
     public void setUp(TestInfo info) {
         base = Paths.get(".")


### PR DESCRIPTION
Consider code like:
```
public class X {
    void test() {
        0 += 0;
    }
}
```

Current JDK mainline javac will compile this code without any compile-time errors:
```
$ cat /tmp/T.java 
public class T {
    void test() {
        0 += 0;
    }
}
$ ./build/linux-x86_64-server-release/jdk/bin/javac /tmp/T.java 
$
```

This is obviously wrong: the LHS of `+=` must be a variable. The exact outcome differs based on the exact LHS expresion, it may crash javac, or produce wrong code.

The issue is that, as of recently, this is used as the result info for the LHS:
```
varAssignmentOpInfo = new ResultInfo(KindSelector.of(KindSelector.VAL, KindSelector.ASG), Type.noType);
```

The kind selector includes `VAL`, which means values are accepted. Before, it was simply `ASG`, but we currently need to recognize the difference between assignment and assignment-operation.

The proposed solution is to take another bit for kind selector to differentiate between assignment and assignment op.

With this patch, the outcome is back to the JDK 27 behavior:
```
$ javac /tmp/T.java
/tmp/T.java:3: error: unexpected type
        0 += 0;
        ^
  required: variable
  found:    value
1 error
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389659](https://bugs.openjdk.org/browse/JDK-8389659): Cannot invoke "com.sun.tools.javac.code.Type.getTag()" because "type" is null on invalid LHS (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32204/head:pull/32204` \
`$ git checkout pull/32204`

Update a local copy of the PR: \
`$ git checkout pull/32204` \
`$ git pull https://git.openjdk.org/jdk.git pull/32204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32204`

View PR using the GUI difftool: \
`$ git pr show -t 32204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32204.diff">https://git.openjdk.org/jdk/pull/32204.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32204#issuecomment-5189116676)
</details>
