### PR TITLE
8389749: RISC-V: Optimize RVV string/array comparison with tiered approach

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2651,27 +2651,87 @@ void C2_MacroAssembler::java_round_double_v(VectorRegister dst, VectorRegister s
 }
 
 void C2_MacroAssembler::element_compare(Register a1, Register a2, Register result, Register cnt, Register tmp1, Register tmp2,
-                                        VectorRegister vr1, VectorRegister vr2, VectorRegister vrs, bool islatin, Label &DONE,
-                                        Assembler::LMUL lmul) {
-  Label loop;
+                                        bool islatin, Label &DONE, bool use_vcpop) {
   Assembler::SEW sew = islatin ? Assembler::e8 : Assembler::e16;
 
-  bind(loop);
-  vsetvli(tmp1, cnt, sew, lmul);
-  vlex_v(vr1, a1, sew);
-  vlex_v(vr2, a2, sew);
-  vmsne_vv(vrs, vr1, vr2);
-  vfirst_m(tmp2, vrs);
-  bgez(tmp2, DONE);
-  sub(cnt, cnt, tmp1);
-  if (!islatin) {
-    slli(tmp1, tmp1, 1); // get byte counts
-  }
-  add(a1, a1, tmp1);
-  add(a2, a2, tmp1);
-  bnez(cnt, loop);
+  Label loop, medium2, medium4, wide, same;
+  const VectorRegister va = v4;
+  const VectorRegister vb = v8;
+  const int elems_m1 = MaxVectorSize / (islatin ? 1 : 2);
+  const int elems_m4 = 4 * elems_m1;
+  const int bytes_m4 = 4 * MaxVectorSize;
 
-  mv(result, true);
+  beqz(cnt, same);
+
+  // Short input: one vl-bounded m1 compare, no loop.
+  mv(tmp1, elems_m1);
+  bgt(cnt, tmp1, medium2);
+  vsetvli(tmp1, cnt, sew, Assembler::m1, Assembler::ma, Assembler::ta);
+  vlex_v(va, a1, sew);
+  vlex_v(vb, a2, sew);
+  vmsne_vv(va, va, vb);
+  vfirst_m(tmp2, va);
+  bgez(tmp2, DONE);
+  j(same);
+
+  // Medium input: one vl-bounded m2 compare.
+  bind(medium2);
+  mv(tmp1, 2 * elems_m1);
+  bgt(cnt, tmp1, medium4);
+  vsetvli(tmp1, cnt, sew, Assembler::m2, Assembler::ma, Assembler::ta);
+  vlex_v(va, a1, sew);
+  vlex_v(vb, a2, sew);
+  vmsne_vv(va, va, vb);
+  vfirst_m(tmp2, va);
+  bgez(tmp2, DONE);
+  j(same);
+
+  // Medium input: one vl-bounded m4 compare.
+  bind(medium4);
+  mv(tmp1, elems_m4);
+  bgt(cnt, tmp1, wide);
+  vsetvli(tmp1, cnt, sew, Assembler::m4, Assembler::ma, Assembler::ta);
+  vlex_v(va, a1, sew);
+  vlex_v(vb, a2, sew);
+  vmsne_vv(va, va, vb);
+  vfirst_m(tmp2, va);
+  bgez(tmp2, DONE);
+  j(same);
+
+  // Long input: full m4 groups at fixed vl, then one vl-bounded
+  // compare covering the tail.
+  bind(wide);
+  vsetvli(tmp1, x0, sew, Assembler::m4, Assembler::ma, Assembler::ta);
+
+  bind(loop);
+  vlex_v(va, a1, sew);
+  vlex_v(vb, a2, sew);
+  vmsne_vv(va, va, vb);
+  if (use_vcpop) {
+    vcpop_m(tmp2, va);
+    bnez(tmp2, DONE);
+  } else {
+    vfirst_m(tmp2, va);
+    bgez(tmp2, DONE);
+  }
+  sub(cnt, cnt, tmp1);
+  addi(a1, a1, bytes_m4);
+  addi(a2, a2, bytes_m4);
+  bge(cnt, tmp1, loop);
+  beqz(cnt, same);
+
+  // Tail: one vl-bounded compare covers the rest.
+  vsetvli(tmp1, cnt, sew, Assembler::m4, Assembler::ma, Assembler::ta);
+  vlex_v(va, a1, sew);
+  vlex_v(vb, a2, sew);
+  vmsne_vv(va, va, vb);
+  vfirst_m(tmp2, va);
+  bgez(tmp2, DONE);
+
+  bind(same);
+  if (result != zr) {
+    mv(result, true);
+  }
 }
 
 void C2_MacroAssembler::string_equals_v(Register a1, Register a2, Register result, Register cnt) {
@@ -2683,7 +2743,7 @@ void C2_MacroAssembler::string_equals_v(Register a1, Register a2, Register resul
 
   mv(result, false);
 
-  element_compare(a1, a2, result, cnt, tmp1, tmp2, v2, v4, v2, true, DONE, Assembler::m2);
+  element_compare(a1, a2, result, cnt, tmp1, tmp2, true, DONE);
 
   bind(DONE);
   BLOCK_COMMENT("} string_equals_v");
@@ -2741,7 +2801,7 @@ void C2_MacroAssembler::arrays_equals_v(Register a1, Register a2, Register resul
   la(a1, Address(a1, base_offset));
   la(a2, Address(a2, base_offset));
 
-  element_compare(a1, a2, result, cnt1, tmp1, tmp2, v2, v4, v2, elem_size == 1, DONE, Assembler::m2);
+  element_compare(a1, a2, result, cnt1, tmp1, tmp2, elem_size == 1, DONE, true);
 
   bind(DONE);
 
@@ -2750,7 +2810,7 @@ void C2_MacroAssembler::arrays_equals_v(Register a1, Register a2, Register resul
 
 void C2_MacroAssembler::string_compare_v(Register str1, Register str2, Register cnt1, Register cnt2,
                                          Register result, Register tmp1, Register tmp2, int encForm) {
-  Label DIFFERENCE, DONE, L, loop;
+  Label DIFFERENCE, DONE, L, SMALL_STRING, SMALL_LOOP, SMALL_DIFFERENCE;
   bool encLL = encForm == StrIntrinsicNode::LL;
   bool encLU = encForm == StrIntrinsicNode::LU;
   bool encUL = encForm == StrIntrinsicNode::UL;
@@ -2776,17 +2836,14 @@ void C2_MacroAssembler::string_compare_v(Register str1, Register str2, Register 
   mv(cnt2, cnt1);
   bind(L);
 
+  mv(tmp1, minCharsInWord);
+  ble(cnt2, tmp1, SMALL_STRING);
+
   // We focus on the optimization of small sized string.
   // Please check below document for string size distribution statistics.
   // https://cr.openjdk.org/~shade/density/string-density-report.pdf
   if (str1_isL == str2_isL) { // LL or UU
-    // Below construction of v regs and lmul is based on test on 2 different boards,
-    // vlen == 128 and vlen == 256 respectively.
-    if (!encLL && MaxVectorSize == 16) { // UU
-      element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v4, v8, v4, encLL, DIFFERENCE, Assembler::m4);
-    } else { // UU + MaxVectorSize or LL
-      element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v2, v4, v2, encLL, DIFFERENCE, Assembler::m2);
-    }
+    element_compare(str1, str2, zr, cnt2, tmp1, tmp2, encLL, DIFFERENCE);
 
     j(DONE);
   } else { // LU or UL
@@ -2795,21 +2852,68 @@ void C2_MacroAssembler::string_compare_v(Register str1, Register str2, Register 
     VectorRegister vstr1 = encLU ? v8 : v4;
     VectorRegister vstr2 = encLU ? v4 : v8;
 
-    bind(loop);
-    vsetvli(tmp1, cnt2, Assembler::e8, Assembler::m2);
+    Label wide, fixed_loop;
+    const int elems_m2 = 2 * MaxVectorSize;
+
+    mv(tmp1, elems_m2);
+    bgt(cnt2, tmp1, wide);
+
+    // One vl-bounded compare covers the whole string.
+    vsetvli(tmp1, cnt2, Assembler::e8, Assembler::m2, Assembler::ma, Assembler::ta);
     vle8_v(vstr1, strL);
-    vsetvli(tmp1, cnt2, Assembler::e16, Assembler::m4);
+    vsetvli(tmp1, cnt2, Assembler::e16, Assembler::m4, Assembler::ma, Assembler::ta);
+    vzext_vf2(vstr2, vstr1);
+    vle16_v(vstr1, strU);
+    vmsne_vv(v4, vstr2, vstr1);
+    vfirst_m(tmp2, v4);
+    bgez(tmp2, DIFFERENCE);
+    j(DONE);
+
+    bind(wide);
+    vsetvli(tmp1, x0, Assembler::e8, Assembler::m2, Assembler::ma, Assembler::ta);
+
+    bind(fixed_loop);
+    vsetvli(zr, tmp1, Assembler::e8, Assembler::m2, Assembler::ma, Assembler::ta);
+    vle8_v(vstr1, strL);
+    vsetvli(zr, tmp1, Assembler::e16, Assembler::m4, Assembler::ma, Assembler::ta);
     vzext_vf2(vstr2, vstr1);
     vle16_v(vstr1, strU);
     vmsne_vv(v4, vstr2, vstr1);
     vfirst_m(tmp2, v4);
     bgez(tmp2, DIFFERENCE);
     sub(cnt2, cnt2, tmp1);
-    add(strL, strL, tmp1);
-    shadd(strU, tmp1, strU, tmp1, 1);
-    bnez(cnt2, loop);
+    beqz(cnt2, DONE);
+    addi(strL, strL, 2 * MaxVectorSize);
+    addi(strU, strU, 4 * MaxVectorSize);
+    bge(cnt2, tmp1, fixed_loop);
+
+    // Tail: one vl-bounded compare covers the rest.
+    vsetvli(tmp1, cnt2, Assembler::e8, Assembler::m2, Assembler::ma, Assembler::ta);
+    vle8_v(vstr1, strL);
+    vsetvli(tmp1, cnt2, Assembler::e16, Assembler::m4, Assembler::ma, Assembler::ta);
+    vzext_vf2(vstr2, vstr1);
+    vle16_v(vstr1, strU);
+    vmsne_vv(v4, vstr2, vstr1);
+    vfirst_m(tmp2, v4);
+    bgez(tmp2, DIFFERENCE);
     j(DONE);
   }
+
+  bind(SMALL_STRING);
+  beqz(cnt2, DONE);
+  bind(SMALL_LOOP);
+  str1_isL ? lbu(tmp1, Address(str1, 0)) : lhu(tmp1, Address(str1, 0));
+  str2_isL ? lbu(tmp2, Address(str2, 0)) : lhu(tmp2, Address(str2, 0));
+  bne(tmp1, tmp2, SMALL_DIFFERENCE);
+  addi(str1, str1, str1_isL ? 1 : 2);
+  addi(str2, str2, str2_isL ? 1 : 2);
+  subi(cnt2, cnt2, 1);
+  bnez(cnt2, SMALL_LOOP);
+  j(DONE);
+
+  bind(SMALL_DIFFERENCE);
+  sub(result, tmp1, tmp2);
+  j(DONE);
 
   bind(DIFFERENCE);
   slli(tmp1, tmp2, 1);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -35,9 +35,8 @@
   void element_compare(Register r1, Register r2,
                        Register result, Register cnt,
                        Register tmp1, Register tmp2,
-                       VectorRegister vr1, VectorRegister vr2,
-                       VectorRegister vrs,
-                       bool is_latin, Label& DONE, Assembler::LMUL lmul);
+                       bool is_latin, Label& DONE,
+                       bool use_vcpop = false);
 
   void string_compare_long_same_encoding(Register result, Register str1, Register str2,
                                   const bool isLL, Register cnt1, Register cnt2,

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -4055,12 +4055,17 @@ instruct vsqrt_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
 %}
 
 instruct vstring_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
-                         iRegI_R10 result, vReg_V2 v2,
-                         vReg_V3 v3, vReg_V4 v4, vReg_V5 v5, rFlagsReg cr)
+                         iRegI_R10 result, vReg_V4 v4, vReg_V5 v5,
+                         vReg_V6 v6, vReg_V7 v7, vReg_V8 v8,
+                         vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
+                         rFlagsReg cr)
 %{
   predicate(UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrEquals (Binary str1 str2) cnt));
-  effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP v2, TEMP v3, TEMP v4, TEMP v5, KILL cr);
+  effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt,
+         TEMP v4, TEMP v5, TEMP v6, TEMP v7,
+         TEMP v8, TEMP v9, TEMP v10, TEMP v11,
+         KILL cr);
 
   format %{ "String Equals $str1, $str2, $cnt -> $result\t#@string_equalsL" %}
   ins_encode %{
@@ -4072,11 +4077,17 @@ instruct vstring_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
 %}
 
 instruct varray_equalsB(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
-                        vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5, iRegP_R28 tmp, rFlagsReg cr)
+                        vReg_V4 v4, vReg_V5 v5,
+                        vReg_V6 v6, vReg_V7 v7, vReg_V8 v8,
+                        vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
+                        iRegP_R28 tmp, rFlagsReg cr)
 %{
   predicate(UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (AryEq ary1 ary2));
-  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v2, TEMP v3, TEMP v4, TEMP v5, KILL cr);
+  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2,
+         TEMP v4, TEMP v5, TEMP v6, TEMP v7,
+         TEMP v8, TEMP v9, TEMP v10, TEMP v11,
+         KILL cr);
 
   format %{ "Array Equals $ary1, ary2 -> $result\t#@array_equalsB // KILL $tmp" %}
   ins_encode %{
@@ -4087,11 +4098,17 @@ instruct varray_equalsB(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
 %}
 
 instruct varray_equalsC(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
-                        vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5, iRegP_R28 tmp, rFlagsReg cr)
+                        vReg_V4 v4, vReg_V5 v5,
+                        vReg_V6 v6, vReg_V7 v7, vReg_V8 v8,
+                        vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
+                        iRegP_R28 tmp, rFlagsReg cr)
 %{
   predicate(UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (AryEq ary1 ary2));
-  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v2, TEMP v3, TEMP v4, TEMP v5, KILL cr);
+  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2,
+         TEMP v4, TEMP v5, TEMP v6, TEMP v7,
+         TEMP v8, TEMP v9, TEMP v10, TEMP v11,
+         KILL cr);
 
   format %{ "Array Equals $ary1, ary2 -> $result\t#@array_equalsC // KILL $tmp" %}
   ins_encode %{
@@ -4123,37 +4140,17 @@ instruct varrays_hashcode(iRegP_R11 ary, iRegI_R12 cnt, iRegI_R10 result, immI b
   ins_pipe(pipe_class_memory);
 %}
 
-instruct vstring_compareU_128b(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
-                          vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
-                          iRegP_R28 tmp1, iRegL_R29 tmp2)
-%{
-  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU &&
-            MaxVectorSize == 16);
-  match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-        TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
-
-  format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
-  ins_encode %{
-    // Count is in 8-bit bytes; non-Compact chars are 16 bits.
-    __ string_compare_v($str1$$Register, $str2$$Register,
-                        $cnt1$$Register, $cnt2$$Register, $result$$Register,
-                        $tmp1$$Register, $tmp2$$Register,
-                        StrIntrinsicNode::UU);
-  %}
-  ins_pipe(pipe_class_memory);
-%}
-
 instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegI_R10 result, vReg_V4 v4, vReg_V5 v5,
+                          vReg_V6 v6, vReg_V7 v7, vReg_V8 v8,
+                          vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
-  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU &&
-            MaxVectorSize > 16);
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-        TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+         TEMP v4, TEMP v5, TEMP v6, TEMP v7,
+         TEMP v8, TEMP v9, TEMP v10, TEMP v11);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
   ins_encode %{
@@ -4167,13 +4164,16 @@ instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
 %}
 
 instruct vstring_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegI_R10 result, vReg_V4 v4, vReg_V5 v5,
+                          vReg_V6 v6, vReg_V7 v7, vReg_V8 v8,
+                          vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-        TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+         TEMP v4, TEMP v5, TEMP v6, TEMP v7,
+         TEMP v8, TEMP v9, TEMP v10, TEMP v11);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareL" %}
   ins_encode %{
@@ -4204,6 +4204,7 @@ instruct vstring_compareUL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI
   %}
   ins_pipe(pipe_class_memory);
 %}
+
 instruct vstring_compareLU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
                            iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
                            vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,


### PR DESCRIPTION
Hi, please consider.
The current RVV element_compare uses a single-LMUL loop for all input sizes. Since short strings dominate in practice [1], the per-iteration loop overhead is disproportionate for small inputs.
This patch replaces the loop with a tiered strategy: short inputs are handled by a single vl-bounded compare (m1/m2/m4 depending on size), long inputs use a fixed-stride m4 loop with a vl-bounded tail. For string_compare_v, strings shorter than one machine word fall back to a scalar loop to avoid RVV setup cost entirely.

### Correctness Testing
- [x] Run tier1-tier3 test with release on SG2044

### Performance test with release on SG2044
```
make test TEST="micro:org.openjdk.bench.java.util.ArraysEquals" JTREG="TIMEOUT_FACTOR=16"

without this patch
Benchmark                                   (delta)  (size)  Mode  Cnt   Score   Error  Units
StringCompareToDifferentLength.compareToLL        2      24  avgt    9   1.773 ± 0.033  ms/op
StringCompareToDifferentLength.compareToLL        2      36  avgt    9   4.621 ± 0.096  ms/op
StringCompareToDifferentLength.compareToLL        2      72  avgt    9   4.848 ± 0.016  ms/op
StringCompareToDifferentLength.compareToLL        2     128  avgt    9   3.323 ± 1.114  ms/op
StringCompareToDifferentLength.compareToLL        2     256  avgt    9   4.374 ± 0.084  ms/op
StringCompareToDifferentLength.compareToLL        2     512  avgt    9  10.450 ± 0.033  ms/op
StringCompareToDifferentLength.compareToLU        2      24  avgt    9   1.771 ± 0.037  ms/op
StringCompareToDifferentLength.compareToLU        2      36  avgt    9   5.508 ± 0.318  ms/op
StringCompareToDifferentLength.compareToLU        2      72  avgt    9   5.767 ± 0.091  ms/op
StringCompareToDifferentLength.compareToLU        2     128  avgt    9   3.135 ± 0.023  ms/op
StringCompareToDifferentLength.compareToLU        2     256  avgt    9   5.980 ± 0.349  ms/op
StringCompareToDifferentLength.compareToLU        2     512  avgt    9  12.487 ± 0.382  ms/op
StringCompareToDifferentLength.compareToUL        2      24  avgt    9   2.152 ± 0.027  ms/op
StringCompareToDifferentLength.compareToUL        2      36  avgt    9   5.926 ± 0.194  ms/op
StringCompareToDifferentLength.compareToUL        2      72  avgt    9   6.008 ± 0.066  ms/op
StringCompareToDifferentLength.compareToUL        2     128  avgt    9   3.736 ± 0.011  ms/op
StringCompareToDifferentLength.compareToUL        2     256  avgt    9   5.988 ± 0.011  ms/op
StringCompareToDifferentLength.compareToUL        2     512  avgt    9  13.717 ± 0.114  ms/op
StringCompareToDifferentLength.compareToUU        2      24  avgt    9   1.784 ± 0.003  ms/op
StringCompareToDifferentLength.compareToUU        2      36  avgt    9   4.392 ± 0.008  ms/op
StringCompareToDifferentLength.compareToUU        2      72  avgt    9   4.736 ± 0.007  ms/op
StringCompareToDifferentLength.compareToUU        2     128  avgt    9   3.651 ± 0.273  ms/op
StringCompareToDifferentLength.compareToUU        2     256  avgt    9   6.541 ± 0.210  ms/op
StringCompareToDifferentLength.compareToUU        2     512  avgt    9  13.547 ± 0.366  ms/op
Finished running test 'micro:com.arm.benchmarks.intrinsics.StringCompareToDifferentLength'


with this patch
Benchmark                                   (delta)  (size)  Mode  Cnt   Score   Error  Units
StringCompareToDifferentLength.compareToLL        2      24  avgt    9   1.699 ± 0.053  ms/op
StringCompareToDifferentLength.compareToLL        2      36  avgt    9   2.117 ± 0.043  ms/op
StringCompareToDifferentLength.compareToLL        2      72  avgt    9   2.349 ± 0.097  ms/op
StringCompareToDifferentLength.compareToLL        2     128  avgt    9   2.157 ± 0.001  ms/op
StringCompareToDifferentLength.compareToLL        2     256  avgt    9   3.556 ± 0.005  ms/op
StringCompareToDifferentLength.compareToLL        2     512  avgt    9   6.462 ± 0.137  ms/op
StringCompareToDifferentLength.compareToLU        2      24  avgt    9   1.757 ± 0.096  ms/op
StringCompareToDifferentLength.compareToLU        2      36  avgt    9   3.472 ± 1.742  ms/op
StringCompareToDifferentLength.compareToLU        2      72  avgt    9   2.641 ± 0.079  ms/op
StringCompareToDifferentLength.compareToLU        2     128  avgt    9   3.325 ± 0.005  ms/op
StringCompareToDifferentLength.compareToLU        2     256  avgt    9   7.130 ± 0.098  ms/op
StringCompareToDifferentLength.compareToLU        2     512  avgt    9  11.474 ± 0.028  ms/op
StringCompareToDifferentLength.compareToUL        2      24  avgt    9   2.192 ± 0.078  ms/op
StringCompareToDifferentLength.compareToUL        2      36  avgt    9   3.714 ± 1.842  ms/op
StringCompareToDifferentLength.compareToUL        2      72  avgt    9   3.055 ± 0.001  ms/op
StringCompareToDifferentLength.compareToUL        2     128  avgt    9   4.005 ± 0.030  ms/op
StringCompareToDifferentLength.compareToUL        2     256  avgt    9   7.314 ± 2.766  ms/op
StringCompareToDifferentLength.compareToUL        2     512  avgt    9  11.758 ± 0.041  ms/op
StringCompareToDifferentLength.compareToUU        2      24  avgt    9   1.631 ± 0.003  ms/op
StringCompareToDifferentLength.compareToUU        2      36  avgt    9   2.403 ± 0.151  ms/op
StringCompareToDifferentLength.compareToUU        2      72  avgt    9   3.160 ± 0.101  ms/op
StringCompareToDifferentLength.compareToUU        2     128  avgt    9   3.546 ± 0.005  ms/op
StringCompareToDifferentLength.compareToUU        2     256  avgt    9   6.426 ± 0.062  ms/op
StringCompareToDifferentLength.compareToUU        2     512  avgt    9  13.218 ± 0.231  ms/op
Finished running test 'micro:com.arm.benchmarks.intrinsics.StringCompareToDifferentLength'
```

```
make test TEST="micro:openjdk.bench.java.lang.StringEquals" JTREG="TIMEOUT_FACTOR=16"

without this patch
Benchmark                      Mode  Cnt   Score   Error  Units
StringEquals.almostEqual       avgt   15  14.655 ± 0.011  ns/op
StringEquals.almostEqualUTF16  avgt   15  14.671 ± 0.042  ns/op
StringEquals.different         avgt   15   9.238 ± 0.001  ns/op
StringEquals.differentCoders   avgt   15   6.927 ± 0.001  ns/op
StringEquals.equal             avgt   15  14.642 ± 0.014  ns/op
StringEquals.equalsUTF16       avgt   15  14.651 ± 0.024  ns/op
Finished running test 'micro:openjdk.bench.java.lang.StringEquals'

with this patch
Benchmark                      Mode  Cnt   Score    Error  Units
StringEquals.almostEqual       avgt   15  11.554 ±  0.004  ns/op
StringEquals.almostEqualUTF16  avgt   15  11.553 ±  0.003  ns/op
StringEquals.different         avgt   15   9.238 ±  0.005  ns/op
StringEquals.differentCoders   avgt   15   6.927 ±  0.001  ns/op
StringEquals.equal             avgt   15  11.563 ±  0.033  ns/op
StringEquals.equalsUTF16       avgt   15  11.551 ±  0.002  ns/op
Finished running test 'micro:openjdk.bench.java.lang.StringEquals'
```

```
make test TEST="micro:org.openjdk.bench.java.util.ArraysEquals"

without this patch
Benchmark                            Mode  Cnt   Score   Error  Units
ArraysEquals.testByteFalseBeginning  avgt   12  10.277 ± 0.027  ns/op
ArraysEquals.testByteFalseEnd        avgt   12  38.500 ± 0.021  ns/op
ArraysEquals.testByteFalseMid        avgt   12  12.824 ± 0.019  ns/op
ArraysEquals.testByteTrue            avgt   12  38.889 ± 0.041  ns/op
ArraysEquals.testCharFalseBeginning  avgt   12  10.263 ± 0.001  ns/op
ArraysEquals.testCharFalseEnd        avgt   12  25.403 ± 0.008  ns/op
ArraysEquals.testCharFalseMid        avgt   12  16.761 ± 0.084  ns/op
ArraysEquals.testCharTrue            avgt   12  25.412 ± 0.050  ns/op
Finished running test 'micro:org.openjdk.bench.java.util.ArraysEquals'

with this patch
Benchmark                            Mode  Cnt   Score   Error  Units
ArraysEquals.testByteFalseBeginning  avgt   12  11.458 ± 0.100  ns/op
ArraysEquals.testByteFalseEnd        avgt   12  15.532 ± 0.092  ns/op
ArraysEquals.testByteFalseMid        avgt   12  11.418 ± 0.043  ns/op
ArraysEquals.testByteTrue            avgt   12  16.172 ± 0.012  ns/op
ArraysEquals.testCharFalseBeginning  avgt   12  11.416 ± 0.079  ns/op
ArraysEquals.testCharFalseEnd        avgt   12  25.260 ± 0.021  ns/op
ArraysEquals.testCharFalseMid        avgt   12  17.456 ± 0.849  ns/op
ArraysEquals.testCharTrue            avgt   12  26.067 ± 0.480  ns/op
Finished running test 'micro:org.openjdk.bench.java.util.ArraysEquals'
```


[1] https://cr.openjdk.org/~shade/density/string-density-report.pdf

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389749](https://bugs.openjdk.org/browse/JDK-8389749): RISC-V: Optimize RVV string/array comparison with tiered approach (**Enhancement** - P4)


### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32205/head:pull/32205` \
`$ git checkout pull/32205`

Update a local copy of the PR: \
`$ git checkout pull/32205` \
`$ git pull https://git.openjdk.org/jdk.git pull/32205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32205`

View PR using the GUI difftool: \
`$ git pr show -t 32205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32205.diff">https://git.openjdk.org/jdk/pull/32205.diff</a>

</details>
