### PR TITLE
8389674: Handle return values of GlobalLock

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
@@ -457,6 +457,9 @@ Java_sun_awt_windows_WClipboard_getClipboardData
             if (data != NULL) {
                 env->SetByteArrayRegion(bytes, 0, size, (jbyte *)data);
                 ::GlobalUnlock(handle);
+            } else {
+                JNU_ThrowIOException(env, "GlobalLock failed");
+                return NULL;
             }
         }
         break;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
@@ -245,14 +245,23 @@ Java_sun_awt_windows_WClipboard_publishClipboardData(JNIEnv *env,
         }
 
         LPMETAFILEPICT lpMfp = (LPMETAFILEPICT)::GlobalLock(hmfp);
-        lpMfp->mm = lpMfpOld->mm;
-        lpMfp->xExt = lpMfpOld->xExt;
-        lpMfp->yExt = lpMfpOld->yExt;
-        lpMfp->hMF = hmf;
-        ::GlobalUnlock(hmfp);
+        if (lpMfp != NULL) {
+            lpMfp->mm = lpMfpOld->mm;
+            lpMfp->xExt = lpMfpOld->xExt;
+            lpMfp->yExt = lpMfpOld->yExt;
+            lpMfp->hMF = hmf;
+            ::GlobalUnlock(hmfp);
+        } else {
+            env->ReleasePrimitiveArrayCritical(bytes, (LPVOID)lpbMfpBuffer, JNI_ABORT);
+            env->PopLocalFrame(NULL);
+            ::GlobalFree(hmfp);
+            return;
+        }
 
         env->ReleasePrimitiveArrayCritical(bytes, (LPVOID)lpbMfpBuffer, JNI_ABORT);
 
+        // where is hmfp freed (in 'normal' and error case) ?
+        // verify is only doing something in the debug case and not freeing anything
         VERIFY(::SetClipboardData((UINT)format, hmfp));
 
         return;
@@ -267,6 +276,10 @@ Java_sun_awt_windows_WClipboard_publishClipboardData(JNIEnv *env,
         throw std::bad_alloc();
     }
     char *dataout = (char *)::GlobalLock(hglobal);
+    if (dataout == NULL) {
+        ::GlobalFree(hglobal);
+        return;
+    }
 
     if (format == CF_HDROP) {
         DROPFILES *dropfiles = (DROPFILES *)dataout;
@@ -278,6 +291,8 @@ Java_sun_awt_windows_WClipboard_publishClipboardData(JNIEnv *env,
     env->GetByteArrayRegion(bytes, 0, nBytes, (jbyte *)dataout);
     ::GlobalUnlock(hglobal);
 
+    // where is hglobal freed (in 'normal' and error case) ?
+    // verify is only doing something in the debug case and not freeing anything
     VERIFY(::SetClipboardData((UINT)format, hglobal));
 
     CATCH_BAD_ALLOC;
@@ -351,8 +366,12 @@ Java_sun_awt_windows_WClipboard_getClipboardData
 
         if (format == CF_METAFILEPICT) {
             HMETAFILEPICT hMetaFilePict = (HMETAFILEPICT)handle;
-            LPMETAFILEPICT lpMetaFilePict =
-                (LPMETAFILEPICT)::GlobalLock(hMetaFilePict);
+            LPMETAFILEPICT lpMetaFilePict = (LPMETAFILEPICT)::GlobalLock(hMetaFilePict);
+            if (lpMetaFilePict == NULL) {
+                JNU_ThrowIOException(env, "failed to get system clipboard data");
+                return NULL;
+            }
+
             UINT uSize = ::GetMetaFileBitsEx(lpMetaFilePict->hMF, 0, NULL);
             DASSERT(uSize != 0);
 
@@ -435,8 +454,10 @@ Java_sun_awt_windows_WClipboard_getClipboardData
 
         if (size != 0) {
             LPVOID data = ::GlobalLock(handle);
-            env->SetByteArrayRegion(bytes, 0, size, (jbyte *)data);
-            ::GlobalUnlock(handle);
+            if (data != NULL) {
+                env->SetByteArrayRegion(bytes, 0, size, (jbyte *)data);
+                ::GlobalUnlock(handle);
+            }
         }
         break;
     }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
@@ -260,8 +260,6 @@ Java_sun_awt_windows_WClipboard_publishClipboardData(JNIEnv *env,
 
         env->ReleasePrimitiveArrayCritical(bytes, (LPVOID)lpbMfpBuffer, JNI_ABORT);
 
-        // where is hmfp freed (in 'normal' and error case) ?
-        // verify is only doing something in the debug case and not freeing anything
         VERIFY(::SetClipboardData((UINT)format, hmfp));
 
         return;
@@ -291,8 +289,6 @@ Java_sun_awt_windows_WClipboard_publishClipboardData(JNIEnv *env,
     env->GetByteArrayRegion(bytes, 0, nBytes, (jbyte *)dataout);
     ::GlobalUnlock(hglobal);
 
-    // where is hglobal freed (in 'normal' and error case) ?
-    // verify is only doing something in the debug case and not freeing anything
     VERIFY(::SetClipboardData((UINT)format, hglobal));
 
     CATCH_BAD_ALLOC;

--- a/src/java.desktop/windows/native/libawt/windows/awt_DataTransferer.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DataTransferer.cpp
@@ -270,6 +270,9 @@ Java_sun_awt_windows_WDataTransferer_dragQueryFile
     try {
 
         bBytes = (jbyte*)::GlobalLock(hglobal);
+        if (bBytes == NULL) {
+            throw std::bad_alloc();
+        }
         env->GetByteArrayRegion(bytes, 0, size, bBytes);
 
         hdrop = (HDROP)bBytes;

--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDS.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDS.cpp
@@ -844,6 +844,11 @@ HRESULT AwtDragSource::GetData(FORMATETC __RPC_FAR *pFormatEtc,
         }
 
         char *dataout = (char *)::GlobalLock(copy);
+        if (dataout == NULL) {
+            env->PopLocalFrame(NULL);
+            ::GlobalFree(copy);
+            throw std::bad_alloc();
+        }
 
         if (matchedFormatEtc.cfFormat == CF_HDROP) {
             DROPFILES *dropfiles = (DROPFILES *)dataout;
@@ -914,6 +919,14 @@ HRESULT AwtDragSource::GetData(FORMATETC __RPC_FAR *pFormatEtc,
         }
 
         LPMETAFILEPICT lpMfp = (LPMETAFILEPICT)::GlobalLock(hmfp);
+        if (lpMfp == NULL) {
+            VERIFY(::DeleteMetaFile(hmf));
+            env->ReleasePrimitiveArrayCritical(bytes, (LPVOID)lpbMfpBuffer, JNI_ABORT);
+            env->PopLocalFrame(NULL);
+            ::GlobalFree(hmfp);
+            throw std::bad_alloc();
+        }
+
         lpMfp->mm = lpMfpOld->mm;
         lpMfp->xExt = lpMfpOld->xExt;
         lpMfp->yExt = lpMfpOld->yExt;
@@ -1016,6 +1029,10 @@ HRESULT AwtDragSource::GetDataHere(FORMATETC __RPC_FAR *pFormatEtc,
         }
 
         char *dataout = (char *)::GlobalLock(pmedium->hGlobal);
+        if (dataout == NULL) {
+            env->PopLocalFrame(NULL);
+            return E_UNEXPECTED;
+        }
 
         if (matchedFormatEtc.cfFormat == CF_HDROP) {
             DROPFILES *dropfiles = (DROPFILES *)dataout;
@@ -1083,7 +1100,9 @@ HRESULT AwtDragSource::SetData(FORMATETC __RPC_FAR *pFormatEtc, STGMEDIUM __RPC_
     AwtToolkit::GetInstance().eventNumber++;
     if (pFormatEtc->cfFormat == CF_PERFORMEDDROPEFFECT && pmedium->tymed == TYMED_HGLOBAL) {
         m_dwPerformedDropEffect = *(DWORD*)::GlobalLock(pmedium->hGlobal);
-        ::GlobalUnlock(pmedium->hGlobal);
+        if (m_dwPerformedDropEffect != NULL) {
+            ::GlobalUnlock(pmedium->hGlobal);
+        }
         if (fRelease) {
             ::ReleaseStgMedium(pmedium);
         }
@@ -1163,6 +1182,10 @@ HRESULT AwtDragSource::GetProcessId(FORMATETC __RPC_FAR *pFormatEtc, STGMEDIUM _
     }
 
     char *dataout = (char *)::GlobalLock(copy);
+    if (dataout == NULL) {
+        ::GlobalFree(copy);
+        throw std::bad_alloc();
+    }
 
     memcpy(dataout, &id, sizeof(id));
     ::GlobalUnlock(copy);

--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDS.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDS.cpp
@@ -1099,8 +1099,9 @@ HRESULT AwtDragSource::GetCanonicalFormatEtc(FORMATETC __RPC_FAR *pFormatEtcIn, 
 HRESULT AwtDragSource::SetData(FORMATETC __RPC_FAR *pFormatEtc, STGMEDIUM __RPC_FAR *pmedium, BOOL fRelease) {
     AwtToolkit::GetInstance().eventNumber++;
     if (pFormatEtc->cfFormat == CF_PERFORMEDDROPEFFECT && pmedium->tymed == TYMED_HGLOBAL) {
-        m_dwPerformedDropEffect = *(DWORD*)::GlobalLock(pmedium->hGlobal);
-        if (m_dwPerformedDropEffect != NULL) {
+        DWORD *dptr = (DWORD*)::GlobalLock(pmedium->hGlobal);
+        if (dptr != NULL) {
+            m_dwPerformedDropEffect = *dptr;
             ::GlobalUnlock(pmedium->hGlobal);
         }
         if (fRelease) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
@@ -957,7 +957,7 @@ jobject AwtDropTarget::ConvertMemoryMappedData(JNIEnv* env, jlong fmt, STGMEDIUM
                 OLE_HRT(E_INVALIDARG);
             }
             env->SetByteArrayRegion(bytes, 0, st.cbSize.LowPart, pFileListWithDoubleZeroTerminator);
-            ::GlobalUnlock(pFileListWithDoubleZeroTerminator);
+            ::GlobalUnlock(glob);
             retObj = bytes;
         }
         //std::bad_alloc could happen in JStringBuffer

--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
@@ -953,6 +953,9 @@ jobject AwtDropTarget::ConvertMemoryMappedData(JNIEnv* env, jlong fmt, STGMEDIUM
             HGLOBAL glob;
             OLE_HRT(GetHGlobalFromStream(spFileNames, &glob));
             jbyte *pFileListWithDoubleZeroTerminator = (jbyte *)::GlobalLock(glob);
+            if (pFileListWithDoubleZeroTerminator == NULL) {
+                OLE_HRT(E_INVALIDARG);
+            }
             env->SetByteArrayRegion(bytes, 0, st.cbSize.LowPart, pFileListWithDoubleZeroTerminator);
             ::GlobalUnlock(pFileListWithDoubleZeroTerminator);
             retObj = bytes;
@@ -1165,6 +1168,9 @@ BOOL AwtDropTarget::IsLocalDataObject(IDataObject __RPC_FAR *pDataObject) {
                 DWORD id = ::CoGetCurrentProcess();
 
                 LPVOID data = ::GlobalLock(stgmedium.hGlobal);
+                if (data == NULL) {
+                    return FALSE;
+                }
                 if (memcmp(data, &id, sizeof(id)) == 0) {
                     local = TRUE;
                 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.cpp
@@ -442,6 +442,9 @@ BOOL AwtPrintControl::CreateDevModeAndDevNames(PRINTDLG *ppd,
                 throw std::bad_alloc();
             }
             DEVMODE *devmode = (DEVMODE *)::GlobalLock(ppd->hDevMode);
+            if (devmode == NULL) {
+                throw std::bad_alloc();
+            }
             DASSERT(!::IsBadWritePtr(devmode, devmodeSize));
             memcpy(devmode, info2->pDevMode, devmodeSize);
             VERIFY(::GlobalUnlock(ppd->hDevMode) == 0);
@@ -475,8 +478,10 @@ BOOL AwtPrintControl::CreateDevModeAndDevNames(PRINTDLG *ppd,
             throw std::bad_alloc();
         }
 
-        DEVNAMES *devnames =
-            (DEVNAMES *)::GlobalLock(ppd->hDevNames);
+        DEVNAMES *devnames = (DEVNAMES*)::GlobalLock(ppd->hDevNames);
+        if (devnames == NULL) {
+            throw std::bad_alloc();
+        }
         DASSERT(!IsBadWritePtr(devnames, devnameSize));
         LPTSTR lpcDevnames = (LPTSTR)devnames;
 
@@ -681,14 +686,13 @@ BOOL AwtPrintControl::InitPrintDialog(JNIEnv *env,
                 printName = lpdevnames+devnames->wDeviceOffset;
 
                 if (!_tcscmp(printName, getName)) {
-
                     samePrinter = TRUE;
                     printName = _tcsdup(lpdevnames+devnames->wDeviceOffset);
                     portName = _tcsdup(lpdevnames+devnames->wOutputOffset);
-
                 }
+                ::GlobalUnlock(pd.hDevNames);
             }
-            ::GlobalUnlock(pd.hDevNames);
+
         }
         JNU_ReleaseStringPlatformChars(env, printerName, getName);
 
@@ -805,6 +809,15 @@ BOOL AwtPrintControl::InitPrintDialog(JNIEnv *env,
 
     if (pd.hDevMode != NULL) {
       DEVMODE *devmode = (DEVMODE *)::GlobalLock(pd.hDevMode);
+      if (devmode == NULL) {
+        if (printName != NULL) {
+          free(printName);
+        }
+        if (portName != NULL) {
+          free(portName);
+        }
+        return FALSE;
+      }
       DASSERT(!IsBadWritePtr(devmode, sizeof(DEVMODE)));
 
       WORD copies = (WORD)env->CallIntMethod(printCtrl,
@@ -1031,27 +1044,28 @@ BOOL AwtPrintControl::UpdateAttributes(JNIEnv *env,
     }
 
     if (pd.hDevNames != NULL) {
-        DEVNAMES *devnames = (DEVNAMES*)::GlobalLock(pd.hDevNames);
-        DASSERT(!IsBadReadPtr(devnames, sizeof(DEVNAMES)));
-        LPTSTR lpcNames = (LPTSTR)devnames;
-        LPCTSTR pbuf = (_tcslen(lpcNames + devnames->wDeviceOffset) == 0 ?
-                      TEXT("") : lpcNames + devnames->wDeviceOffset);
-        if (pbuf != NULL) {
-            jstring jstr = JNU_NewStringPlatform(env, pbuf);
-            env->CallVoidMethod(printCtrl,
-                                AwtPrintControl::setPrinterID,
-                                jstr);
-            env->DeleteLocalRef(jstr);
-        }
-        pbuf = (_tcslen(lpcNames + devnames->wOutputOffset) == 0 ?
-                      TEXT("") : lpcNames + devnames->wOutputOffset);
-        if (pbuf != NULL) {
-            if (wcscmp(pbuf, L"FILE:") == 0) {
-                pdFlags |= PD_PRINTTOFILE;
+        devnames = (DEVNAMES*)::GlobalLock(pd.hDevNames);
+        if (devnames != NULL) {
+            DASSERT(!IsBadReadPtr(devnames, sizeof(DEVNAMES)));
+            LPTSTR lpcNames = (LPTSTR)devnames;
+            LPCTSTR pbuf = (_tcslen(lpcNames + devnames->wDeviceOffset) == 0 ?
+                          TEXT("") : lpcNames + devnames->wDeviceOffset);
+            if (pbuf != NULL) {
+                jstring jstr = JNU_NewStringPlatform(env, pbuf);
+                env->CallVoidMethod(printCtrl,
+                                    AwtPrintControl::setPrinterID,
+                                    jstr);
+                env->DeleteLocalRef(jstr);
             }
+            pbuf = (_tcslen(lpcNames + devnames->wOutputOffset) == 0 ?
+                          TEXT("") : lpcNames + devnames->wOutputOffset);
+            if (pbuf != NULL) {
+                if (wcscmp(pbuf, L"FILE:") == 0) {
+                    pdFlags |= PD_PRINTTOFILE;
+                }
+            }
+            ::GlobalUnlock(pd.hDevNames);
         }
-        ::GlobalUnlock(pd.hDevNames);
-        devnames = NULL;
     }
 
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -4014,8 +4014,9 @@ static void matchPaperSize(HDC printDC, HGLOBAL hDevMode, HGLOBAL hDevNames,
                 }
                 ::GlobalUnlock(hDevMode);
             }
-            return;
         }
+        return;
+      }
     }
 
     /* begin trying to match papers */

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -424,37 +424,40 @@ Java_sun_awt_windows_WPrinterJob_showDocProperties(JNIEnv *env,
 
     if (hDevMode != NULL && hDevNames != NULL) {
         devmode = (DEVMODE *)::GlobalLock(hDevMode);
-        devnames = (DEVNAMES *)::GlobalLock(hDevNames);
+        if (devmode != NULL) {
+            devnames = (DEVNAMES *)::GlobalLock(hDevNames);
+            if (devnames != NULL) {
+                LPTSTR lpdevnames = (LPTSTR)devnames;
+                // No need to call _tcsdup as we won't unlock until we are done.
+                LPTSTR printerName = lpdevnames+devnames->wDeviceOffset;
+                LPTSTR portName = lpdevnames+devnames->wOutputOffset;
 
-        LPTSTR lpdevnames = (LPTSTR)devnames;
-        // No need to call _tcsdup as we won't unlock until we are done.
-        LPTSTR printerName = lpdevnames+devnames->wDeviceOffset;
-        LPTSTR portName = lpdevnames+devnames->wOutputOffset;
+                HANDLE hPrinter;
+                if (::OpenPrinter(printerName, &hPrinter, NULL) == TRUE) {
+                    devmode->dmFields |= dmFields;
+                    devmode->dmCopies = copies;
+                    devmode->dmCollate = collate;
+                    devmode->dmColor = color;
+                    devmode->dmDuplex = duplex;
+                    devmode->dmOrientation = orient;
+                    devmode->dmPrintQuality = xres_quality;
+                    devmode->dmYResolution = yres;
+                    devmode->dmPaperSize = paper;
+                    devmode->dmDefaultSource = bin;
 
-        HANDLE hPrinter;
-        if (::OpenPrinter(printerName, &hPrinter, NULL) == TRUE) {
-            devmode->dmFields |= dmFields;
-            devmode->dmCopies = copies;
-            devmode->dmCollate = collate;
-            devmode->dmColor = color;
-            devmode->dmDuplex = duplex;
-            devmode->dmOrientation = orient;
-            devmode->dmPrintQuality = xres_quality;
-            devmode->dmYResolution = yres;
-            devmode->dmPaperSize = paper;
-            devmode->dmDefaultSource = bin;
-
-            rval = ::DocumentProperties((HWND)hWndParent,
-                           hPrinter, printerName, devmode, devmode,
-                           DM_IN_BUFFER | DM_OUT_BUFFER | DM_IN_PROMPT);
-            if (rval == IDOK) {
-                UpdateJobAttributes(env, wJob, attrSet, devmode);
-                ret = JNI_TRUE;
+                    rval = ::DocumentProperties((HWND)hWndParent,
+                                   hPrinter, printerName, devmode, devmode,
+                                   DM_IN_BUFFER | DM_OUT_BUFFER | DM_IN_PROMPT);
+                    if (rval == IDOK) {
+                        UpdateJobAttributes(env, wJob, attrSet, devmode);
+                        ret = JNI_TRUE;
+                    }
+                    VERIFY(::ClosePrinter(hPrinter));
+                }
+                ::GlobalUnlock(hDevNames);
             }
-            VERIFY(::ClosePrinter(hPrinter));
+            ::GlobalUnlock(hDevMode);
         }
-        ::GlobalUnlock(hDevNames);
-        ::GlobalUnlock(hDevMode);
     }
 
     return ret;
@@ -653,8 +656,8 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
                 }
             }
             AwtPrintControl::setPrintDC(env, self, newDC);
+            ::GlobalUnlock(setup.hDevNames);
         }
-        ::GlobalUnlock(setup.hDevNames);
     }
 
     /* Get the Windows paper and margins description.
@@ -695,8 +698,8 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
                     return JNI_FALSE;
                 }
             }
+            ::GlobalUnlock(setup.hDevMode);
         }
-        ::GlobalUnlock(setup.hDevMode);
     }
 
     HGLOBAL oldG = AwtPrintControl::getPrintHDMode(env, self);
@@ -736,8 +739,8 @@ Java_sun_awt_windows_WPrinterJob_setNativeCopies(JNIEnv *env, jobject self,
           ? static_cast<short>(copies) : SHRT_MAX;
         devmode->dmCopies = nCopies;
         devmode->dmFields |= DM_COPIES;
+        ::GlobalUnlock(hDevMode);
       }
-      ::GlobalUnlock(hDevMode);
     }
 }
 
@@ -1457,8 +1460,8 @@ Java_sun_awt_windows_WPrinterJob__1startDoc(JNIEnv *env, jobject self,
                 } else if (ret < 0) {
                     success = false;
                 }
+                ::GlobalUnlock(hDevMode);
         }
-        ::GlobalUnlock(hDevMode);
         if (!success) {
             if (dest != NULL) {
                 JNU_ReleaseStringPlatformChars(env, dest, destination);
@@ -1666,11 +1669,10 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_WPrinterJob_deviceStartPage
                         RESTORE_CONTROLWORD
 
                         ::ClosePrinter(hPrinter);
-                        free ((char*)printerName);
                       }
+                      free ((char*)printerName);
+                      ::GlobalUnlock(hDevNames);
                     }
-
-                    ::GlobalUnlock(hDevNames);
                   } // sync
                   HDC res = ::ResetDC(printDC, devmode);
                   RESTORE_CONTROLWORD
@@ -3395,8 +3397,8 @@ static void pageFormatToSetup(JNIEnv *env, jobject job,
             devmode->dmPaperLength =
               (short)(convertFromPoints(paperSize.height, MM_LOMETRIC));
           }
+          ::GlobalUnlock(setup->hDevMode);
         }
-        ::GlobalUnlock(setup->hDevMode);
     }
 
     // When setting up these values, account for the orientation of the Paper
@@ -3428,10 +3430,12 @@ static WORD getOrientationFromDevMode2(HGLOBAL hDevMode) {
 
     if (hDevMode != NULL) {
         LPDEVMODE devMode = (LPDEVMODE) GlobalLock(hDevMode);
-        if ((devMode != NULL) && (devMode->dmFields & DM_ORIENTATION)) {
-            orient = devMode->dmOrientation;
+        if (devMode != NULL) {
+            if (devMode->dmFields & DM_ORIENTATION) {
+                orient = devMode->dmOrientation;
+            }
+            GlobalUnlock(hDevMode);
         }
-        GlobalUnlock(hDevMode);
     }
     return orient;
 }
@@ -3457,8 +3461,8 @@ static void setOrientationInDevMode(HGLOBAL hDevMode, jboolean isPortrait) {
                                     ? DMORIENT_PORTRAIT
                                     : DMORIENT_LANDSCAPE;
             devMode->dmFields |= DM_ORIENTATION;
+            GlobalUnlock(hDevMode);
         }
-        GlobalUnlock(hDevMode);
     }
 }
 
@@ -3855,8 +3859,8 @@ void setCapabilities(JNIEnv *env, jobject self, HDC printDC) {
                 SAVE_CONTROLWORD
                 ::ResetDC(printDC, devmode);
                 RESTORE_CONTROLWORD
+                GlobalUnlock(hDevMode);
             }
-            GlobalUnlock(hDevMode);
         }
     }
 
@@ -4003,14 +4007,15 @@ static void matchPaperSize(HDC printDC, HGLOBAL hDevMode, HGLOBAL hDevNames,
         *newHgt = origHgt;
 
         if (hDevMode != NULL) {
-          DEVMODE *devmode = (DEVMODE *)::GlobalLock(hDevMode);
-          if (devmode != NULL && (devmode->dmFields & DM_PAPERSIZE)) {
-            *paperSize = devmode->dmPaperSize;
-          }
-          ::GlobalUnlock(hDevMode);
+            DEVMODE *devmode = (DEVMODE *)::GlobalLock(hDevMode);
+            if (devmode != NULL) {
+                if (devmode->dmFields & DM_PAPERSIZE) {
+                    *paperSize = devmode->dmPaperSize;
+                }
+                ::GlobalUnlock(hDevMode);
+            }
+            return;
         }
-        return;
-      }
     }
 
     /* begin trying to match papers */
@@ -4022,8 +4027,8 @@ static void matchPaperSize(HDC printDC, HGLOBAL hDevMode, HGLOBAL hDevNames,
             LPTSTR lpdevnames = (LPTSTR)devnames;
             printer = _tcsdup(lpdevnames+devnames->wDeviceOffset);
             port = _tcsdup(lpdevnames+devnames->wOutputOffset);
+            ::GlobalUnlock(hDevNames);
         }
-        ::GlobalUnlock(hDevNames);
     }
 
     //REMIND: code duplicated in AwtPrintControl::getNearestMatchingPaper


### PR DESCRIPTION
GlobalLock has a return value that indicates errors; this should be handled.

While looking into this, in Java_sun_awt_windows_WPrinterJob_deviceStartPage  a free call was found that is not placed correctly and can lead to leaks.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389674](https://bugs.openjdk.org/browse/JDK-8389674): Handle return values of GlobalLock (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32206/head:pull/32206` \
`$ git checkout pull/32206`

Update a local copy of the PR: \
`$ git checkout pull/32206` \
`$ git pull https://git.openjdk.org/jdk.git pull/32206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32206`

View PR using the GUI difftool: \
`$ git pr show -t 32206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32206.diff">https://git.openjdk.org/jdk/pull/32206.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32206#issuecomment-5190990925)
</details>
