### PR TITLE
8389480: GenerateJLIClassesPluginTest.java and IncludeLocalesPluginTest.java tests in tools/jlink/plugins/ fail due to AccessDeniedExceptions on Windows

### DIFF
--- a/test/jdk/tools/jlink/plugins/GenerateJLIClassesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/GenerateJLIClassesPluginTest.java
@@ -86,9 +86,16 @@ public class GenerateJLIClassesPluginTest {
     }
 
     @AfterMethod
-    public static void cleanup(ITestResult result) throws IOException {
+    public static void cleanup(ITestResult result) {
         if (result.isSuccess() && lastImageDir != null && Files.exists(lastImageDir)) {
-            FileUtils.deleteFileTreeWithRetry(lastImageDir);
+            // On Windows, the java.exe process spawned by test methods may
+            // hold open handles to files even after completion.
+            // Use a non-throwing cleanup method but tolerate failures. Just log them.
+            List<IOException> failures = FileUtils.deleteFileTreeUnchecked(lastImageDir);
+            if (!failures.isEmpty()) {
+                System.err.println("WARNING: cleanup of " + lastImageDir + " incomplete:");
+                failures.forEach(e -> System.err.println("  " + e));
+            }
         }
         lastImageDir = null;
     }

--- a/test/jdk/tools/jlink/plugins/IncludeLocalesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/IncludeLocalesPluginTest.java
@@ -466,9 +466,16 @@ public class IncludeLocalesPluginTest {
     }
 
     @AfterEach
-    public void cleanup() throws IOException {
+    public void cleanup() {
         if (testPassed && lastImageDir != null && Files.exists(lastImageDir)) {
-            FileUtils.deleteFileTreeWithRetry(lastImageDir);
+            // On Windows, the java.exe process spawned by testAvailableLocales() may
+            // hold open handles to files even after waitFor() returns.
+            // Use a non-throwing cleanup method but tolerate failures. Just log them.
+            List<IOException> failures = FileUtils.deleteFileTreeUnchecked(lastImageDir);
+            if (!failures.isEmpty()) {
+                System.err.println("WARNING: cleanup of " + lastImageDir + " incomplete:");
+                failures.forEach(e -> System.err.println("  " + e));
+            }
         }
     }
 


### PR DESCRIPTION
The newly added cleanup method in jdk/tools/jlink/plugins/IncludeLocalesPluginTest.java can fails on open file handles on Windows. Let's try to make the cleanup more fault tolerant.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389480](https://bugs.openjdk.org/browse/JDK-8389480): GenerateJLIClassesPluginTest.java and IncludeLocalesPluginTest.java tests in tools/jlink/plugins/ fail due to AccessDeniedExceptions on Windows (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32207/head:pull/32207` \
`$ git checkout pull/32207`

Update a local copy of the PR: \
`$ git checkout pull/32207` \
`$ git pull https://git.openjdk.org/jdk.git pull/32207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32207`

View PR using the GUI difftool: \
`$ git pr show -t 32207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32207.diff">https://git.openjdk.org/jdk/pull/32207.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32207#issuecomment-5191159661)
</details>
