### PR TITLE
8389478: Crash with missing symbol in serializable lambda: AssertionError: isSubtype PACKAGE

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2960,7 +2960,7 @@ public class Check {
 
     private void checkAccessFromSerializableElementInner(final JCTree tree, boolean isLambda) {
         Symbol sym = TreeInfo.symbol(tree);
-        if (!sym.kind.matches(KindSelector.VAL_MTH)) {
+        if (!sym.kind.matches(KindSelector.VAL_MTH) || sym.kind == ERR) {
             return;
         }
 

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 8301580 8322159 8333107 8332230 8338678 8351260 8366196 8372336 8373094 8384229 8387865
+ * @bug 8301580 8322159 8333107 8332230 8338678 8351260 8366196 8372336 8373094 8384229
+ *      8387865 8389478
  * @summary Verify error recovery w.r.t. Attr
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -882,6 +883,41 @@ public class AttrRecovery {
                 "C.java:3:13: compiler.err.cant.resolve: kindname.variable, unknown, , ",
                 "C.java:3:24: compiler.err.cant.resolve.location: kindname.variable, unknown, , , (compiler.misc.location: kindname.class, C, null)",
                 "2 errors"
+        );
+
+        assertEquals(expected, actual);
+    }
+
+    @Test //JDK-8389478
+    public void testCheckAccessFromSerializableElement() throws Exception {
+        String code = """
+                      import java.io.Serializable;
+
+                      public class Test {
+                          interface SerializableFunction<T, R> extends Serializable {
+                              R apply(T t);
+                          }
+
+                          public static void main(String[] args) {
+                              SerializableFunction<String, Object> f = (x) -> {
+                                  // Map is not imported
+                                  return Map.Entry.FIELD;
+                              };
+                          }
+                      }
+                      """;
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev",
+                         "-XDshould-stop.at=WARN", "-Xlint:all")
+                .sources(code)
+                .outdir(base)
+                .run(Expect.FAIL)
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "Test.java:11:23: compiler.err.doesnt.exist: Map",
+                "1 error"
         );
 
         assertEquals(expected, actual);


### PR DESCRIPTION
Consider code like:
```
                      import java.io.Serializable;
                      public class Test {
                          interface SerializableFunction<T, R> extends Serializable {
                              R apply(T t);
                          }
                          public static void main(String[] args) {
                              SerializableFunction<String, Object> f = (x) -> {
                                  // Map is not imported
                                  return Map.Entry.FIELD;
                              };
                          }
                      }
```

The unimported `Map` gets attributed as a package, and `Map.Entry` is a `ClassSymbol`, marked as `ERR`. Since it is an `ERR`, it will go through the `!sym.kind.matches(KindSelector.VAL_MTH)` check in `checkAccessFromSerializableElementInner`, and later there's `types.isSubtype(sym.owner.type, syms.serializableType)`, which will crash, since `sym.owner.type` is a package type (for `Map`), for which `isSubtype` does not work.

The proposal here is to skip the checks when the symbol is erroneous, avoiding the problem.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389478](https://bugs.openjdk.org/browse/JDK-8389478): Crash with missing symbol in serializable lambda: AssertionError: isSubtype PACKAGE (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32208/head:pull/32208` \
`$ git checkout pull/32208`

Update a local copy of the PR: \
`$ git checkout pull/32208` \
`$ git pull https://git.openjdk.org/jdk.git pull/32208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32208`

View PR using the GUI difftool: \
`$ git pr show -t 32208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32208.diff">https://git.openjdk.org/jdk/pull/32208.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32208#issuecomment-5191305508)
</details>
