### PR TITLE
8389759: ProblemList TestInstanceKlassSize.java and TestInstanceKlassSizeForInterface.java for --enable-preview

### DIFF
--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -41,3 +41,7 @@
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#default_gc 8382398 generic-all
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#parallel   8382398 generic-all
 runtime/cds/appcds/aotCode/AOTCodeFlags.java#Z          8382398 generic-all
+
+# Serviceability:
+serviceability/sa/TestInstanceKlassSize.java             8389759 generic-all
+serviceability/sa/TestInstanceKlassSizeForInterface.java 8389759 generic-all


### PR DESCRIPTION
We can see following errors when we run `make test` with `JTREG="VALUE_CLASS_PLUGIN=true;VM_OPTIONS=--enable-preview"`:

TestInstanceKlassSize
```
 stderr: [Exception in thread "main" java.lang.UnsupportedClassVersionError:
 Preview features are not enabled for jdk/test/whitebox/WhiteBox (class file
 version 72.65535). Try running with '--enable-preview'
        at java.base/java.lang.ClassLoader.findBootstrapClass(Native Method)
        at java.base/java.lang.ClassLoader.findBootstrapClassOrNull(ClassLoa
der.java:1244)
        at java.base/java.lang.System$1.findBootstrapClassOrNull(System.java
:2068)
        at java.base/jdk.internal.loader.ClassLoaders$BootClassLoader.loadCl
assOrNull(ClassLoaders.java:138)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(
BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(
BuiltinClassLoader.java:615)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(
BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(
BuiltinClassLoader.java:615)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Builti
nClassLoader.java:578)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:502)
        at TestInstanceKlassSize.<clinit>(TestInstanceKlassSize.java:65)
]
 exitValue = 1

java.lang.RuntimeException: Expected to get exit value of [0], exit value is
: [1]
        at jdk.test.lib.process.OutputAnalyzer.shouldHaveExitValue(OutputAna
lyzer.java:602)
        at TestInstanceKlassSize.startMeWithArgs(TestInstanceKlassSize.java:
100)
        at TestInstanceKlassSize.main(TestInstanceKlassSize.java:152)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(
DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:583)
        at com.sun.javatest.regtest.agent.MainMethodHelper.executeModernMain
Class(MainMethodHelper.java:55)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapp
er.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1527)
```

TestInstanceKlassSizeForInterface
```
 stderr: [Exception in thread "main" java.lang.UnsupportedClassVersionError: Preview features are not enabled for jdk/test/whitebox/WhiteBox (class file version 72.65535). Try running with '--enable-preview'
        at java.base/java.lang.ClassLoader.findBootstrapClass(Native Method)
        at java.base/java.lang.ClassLoader.findBootstrapClassOrNull(ClassLoader.java:1244)
        at java.base/java.lang.System$1.findBootstrapClassOrNull(System.java:2068)
        at java.base/jdk.internal.loader.ClassLoaders$BootClassLoader.loadClassOrNull(ClassLoaders.java:138)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:615)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:615)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:578)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:502)
        at TestInstanceKlassSizeForInterface.<clinit>(TestInstanceKlassSizeForInterface.java:61)
]
 exitValue = 1

java.lang.RuntimeException: Expected to get exit value of [0], exit value is: [1]
        at jdk.test.lib.process.OutputAnalyzer.shouldHaveExitValue(OutputAnalyzer.java:602)
        at TestInstanceKlassSizeForInterface.createAnotherToAttach(TestInstanceKlassSizeForInterface.java:121)
        at TestInstanceKlassSizeForInterface.main(TestInstanceKlassSizeForInterface.java:154)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:583)
        at com.sun.javatest.regtest.agent.MainMethodHelper.executeModernMainClass(MainMethodHelper.java:55)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1527)
```

In both case, new process would be kicked by `ProcessTools.createLimitedTestJavaProcessBuilder`. It intends `test.vm.opts` and `test.java.opts` are not added explicitly. Thus `--enable-preview` should not be added in this case. It means we cannot test both if `--enable-preview` is required.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ 8389759 is used in problem lists: [test/hotspot/jtreg/ProblemList-enable-preview.txt]

### Issue
 * [JDK-8389759](https://bugs.openjdk.org/browse/JDK-8389759): ProblemList TestInstanceKlassSize.java and TestInstanceKlassSizeForInterface.java for --enable-preview (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32210/head:pull/32210` \
`$ git checkout pull/32210`

Update a local copy of the PR: \
`$ git checkout pull/32210` \
`$ git pull https://git.openjdk.org/jdk.git pull/32210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32210`

View PR using the GUI difftool: \
`$ git pr show -t 32210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32210.diff">https://git.openjdk.org/jdk/pull/32210.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32210#issuecomment-5191565851)
</details>
