### PR TITLE
8389379: [lworld] Calling convention mismatch when reaching stack argument limit

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -129,7 +129,7 @@ unsigned int CodeBlob::allocation_size(CodeBuffer* cb, int header_size) {
 }
 
 CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size, uint16_t header_size,
-                   int16_t frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments,
+                   int frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments,
                    int mutable_data_size) :
   _oop_maps(nullptr), // will be set by set_oop_maps() call
   _name(name),
@@ -141,9 +141,9 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size
   _data_offset(_content_offset + align_up(cb->total_content_size(), oopSize)),
   _frame_size(frame_size),
   _mutable_data_size(mutable_data_size),
+  _frame_complete_offset(frame_complete_offset),
   S390_ONLY(_ctable_offset(0) COMMA)
   _header_size(header_size),
-  _frame_complete_offset(frame_complete_offset),
   _kind(kind),
   _caller_must_gc_arguments(caller_must_gc_arguments)
 {
@@ -183,9 +183,9 @@ CodeBlob::CodeBlob(const char* name, CodeBlobKind kind, int size, uint16_t heade
   _data_offset(size),
   _frame_size(0),
   _mutable_data_size(0),
+  _frame_complete_offset(CodeOffsets::frame_never_safe),
   S390_ONLY(_ctable_offset(0) COMMA)
   _header_size(header_size),
-  _frame_complete_offset(CodeOffsets::frame_never_safe),
   _kind(kind),
   _caller_must_gc_arguments(false)
 {
@@ -321,7 +321,7 @@ RuntimeBlob::RuntimeBlob(
   CodeBuffer* cb,
   int         size,
   uint16_t    header_size,
-  int16_t     frame_complete,
+  int         frame_complete,
   int         frame_size,
   OopMapSet*  oop_maps,
   bool        caller_must_gc_arguments)
@@ -603,7 +603,7 @@ RuntimeStub::RuntimeStub(
   const char* name,
   CodeBuffer* cb,
   int         size,
-  int16_t     frame_complete,
+  int         frame_complete,
   int         frame_size,
   OopMapSet*  oop_maps,
   bool        caller_must_gc_arguments
@@ -615,7 +615,7 @@ RuntimeStub::RuntimeStub(
 
 RuntimeStub* RuntimeStub::new_runtime_stub(const char* stub_name,
                                            CodeBuffer* cb,
-                                           int16_t frame_complete,
+                                           int frame_complete,
                                            int frame_size,
                                            OopMapSet* oop_maps,
                                            bool caller_must_gc_arguments,

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -125,14 +125,14 @@ protected:
   int      _data_offset;           // offset to where data region begins
   int      _frame_size;            // size of stack frame in words (NOT slots. On x64 these are 64bit words)
   int      _mutable_data_size;
+  int      _frame_complete_offset; // instruction offsets in [0.._frame_complete_offset) have
+                                   // not finished setting up their frame. Beware of pc's in
+                                   // that range. There is a similar range(s) on returns
+                                   // which we don't detect.
 
   S390_ONLY(int _ctable_offset;)
 
   uint16_t _header_size;           // size of header (depends on subclass)
-  int16_t  _frame_complete_offset; // instruction offsets in [0.._frame_complete_offset) have
-                                   // not finished setting up their frame. Beware of pc's in
-                                   // that range. There is a similar range(s) on returns
-                                   // which we don't detect.
 
   CodeBlobKind _kind;              // Kind of this code blob
 
@@ -162,7 +162,7 @@ protected:
   const Vptr* vptr() const;
 
   CodeBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int size, uint16_t header_size,
-           int16_t frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments,
+           int frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments,
            int mutable_data_size);
 
   // Simple CodeBlob used for simple BufferBlob.
@@ -367,7 +367,7 @@ class RuntimeBlob : public CodeBlob {
     CodeBuffer* cb,
     int         size,
     uint16_t    header_size,
-    int16_t     frame_complete,
+    int         frame_complete,
     int         frame_size,
     OopMapSet*  oop_maps,
     bool        caller_must_gc_arguments = false
@@ -526,7 +526,7 @@ class RuntimeStub: public RuntimeBlob {
     const char* name,
     CodeBuffer* cb,
     int         size,
-    int16_t     frame_complete,
+    int         frame_complete,
     int         frame_size,
     OopMapSet*  oop_maps,
     bool        caller_must_gc_arguments
@@ -540,7 +540,7 @@ class RuntimeStub: public RuntimeBlob {
   static RuntimeStub* new_runtime_stub(
     const char* stub_name,
     CodeBuffer* cb,
-    int16_t     frame_complete,
+    int         frame_complete,
     int         frame_size,
     OopMapSet*  oop_maps,
     bool        caller_must_gc_arguments,

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1174,6 +1174,8 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
 
 // Fill in default values for various fields
 void nmethod::init_defaults(CodeBuffer *code_buffer, CodeOffsets* offsets) {
+  assert(frame_complete_offset() == offsets->value(CodeOffsets::Frame_Complete), "offset truncated?");
+
   // avoid uninitialized fields, even for short time periods
   _exception_cache            = nullptr;
   _gc_data                    = nullptr;

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1735,11 +1735,11 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
         }
       }
 
-      // Verify that there is sufficient space remaining. MachVEPNodes can be
-      // much larger because they unpack all scalarized arguments.
+      // Verify that there is sufficient space remaining
       uint required_size = MAX_inst_size;
       if (n->is_MachVEP()) {
-        required_size = MAX2(required_size, n->as_Mach()->size(C->regalloc()));
+        // MachVEPNodes can be much larger because they unpack all scalarized arguments.
+        required_size += n->as_Mach()->size(C->regalloc());
       }
       masm->code()->insts()->maybe_expand_to_ensure_remaining(required_size);
       if ((masm->code()->blob() == nullptr) || (!CompileBroker::should_compile_new_jobs())) {
@@ -3195,9 +3195,8 @@ void PhaseOutput::init_scratch_buffer_blob(int const_size) {
       if (UseShenandoahGC) {
         barrier_size += 700;
       } else if (UseZGC) {
-        // Covers the worst-case x64 APX save/restore of all extended general
-        // purpose registers, including the Windows calling sequence and the
-        // slow-path jump triggered by ForceUnreachable.
+        // Covers the worst-case x64 APX save/restore of all extended general purpose
+        // registers, including the slow-path jump triggered by ForceUnreachable.
         barrier_size += 400;
       }
       ciMethod* method = C->method();

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1735,8 +1735,13 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
         }
       }
 
-      // Verify that there is sufficient space remaining
-      masm->code()->insts()->maybe_expand_to_ensure_remaining(MAX_inst_size);
+      // Verify that there is sufficient space remaining. MachVEPNodes can be
+      // much larger because they unpack all scalarized arguments.
+      uint required_size = MAX_inst_size;
+      if (n->is_MachVEP()) {
+        required_size = MAX2(required_size, n->as_Mach()->size(C->regalloc()));
+      }
+      masm->code()->insts()->maybe_expand_to_ensure_remaining(required_size);
       if ((masm->code()->blob() == nullptr) || (!CompileBroker::should_compile_new_jobs())) {
         C->record_failure("CodeCache is full");
         return;
@@ -3181,26 +3186,35 @@ void PhaseOutput::init_scratch_buffer_blob(int const_size) {
     _scratch_const_size = const_size;
     int size = C2Compiler::initial_code_buffer_size(const_size);
     if (C->has_scalarized_args()) {
-      // Inline type entry points (MachVEPNodes) require lots of space for GC barriers and oop verification
-      // when loading object fields from the buffered argument. Increase scratch buffer size accordingly.
-      int barrier_size = 7;
+      // Inline type entry points (MachVEPNodes) require lots of space when
+      // unpacking fields from buffered arguments. Increase the scratch buffer
+      // for field moves, GC barriers and oop verification accordingly.
+      const int move_size = 32;
+      int barrier_size = 7; // Base oop load barrier
       DEBUG_ONLY(barrier_size += 37;)
       if (UseShenandoahGC) {
         barrier_size += 700;
       } else if (UseZGC) {
-        barrier_size += 200;
+        // Covers the worst-case x64 APX save/restore of all extended general
+        // purpose registers, including the Windows calling sequence and the
+        // slow-path jump triggered by ForceUnreachable.
+        barrier_size += 400;
       }
       ciMethod* method = C->method();
+      auto add_inline_arg_size = [&](ciInlineKlass* vk) {
+        size += vk->inline_arg_length() * move_size;
+        size += vk->oop_count() * barrier_size;
+      };
       int arg_num = 0;
       if (!method->is_static()) {
         if (method->is_scalarized_arg(arg_num)) {
-          size += method->holder()->as_inline_klass()->oop_count() * barrier_size;
+          add_inline_arg_size(method->holder()->as_inline_klass());
         }
         arg_num++;
       }
       for (ciSignatureStream str(method->signature()); !str.at_return_type(); str.next()) {
         if (method->is_scalarized_arg(arg_num)) {
-          size += str.type()->as_inline_klass()->oop_count() * barrier_size;
+          add_inline_arg_size(str.type()->as_inline_klass());
         }
         arg_num++;
       }

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1241,8 +1241,9 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
       }
     } else {
       assert(attached_method->has_scalarized_args(), "invalid use of attached method");
-      if (!attached_method->method_holder()->is_inline_klass() || attached_method->is_static()) {
-        // Ignore the attached method in this case to not confuse below code
+      if (attached_method->is_static() || !attached_method->is_scalarized_arg(0)) {
+        // Ignore the attached method if it is only needed to describe scalarized
+        // arguments. It remains attached to the call site for outgoing oop scanning.
         attached_method = methodHandle(current, nullptr);
       }
     }
@@ -2973,12 +2974,38 @@ void CompiledEntrySignature::compute_calling_conventions(bool link_time) {
     _c1_needs_stack_repair = (_args_on_stack_cc < _args_on_stack) || (_args_on_stack_cc_ro < _args_on_stack);
     _c2_needs_stack_repair = (_args_on_stack_cc > _args_on_stack) || (_args_on_stack_cc > _args_on_stack_cc_ro);
 
-    // Upper bound on stack arguments to avoid hitting the argument limit and
-    // bailing out of compilation ("unsupported incoming calling sequence").
-    // TODO 8281260 We need a reasonable limit (flag?) here
-    if (MAX2(_args_on_stack_cc, _args_on_stack_cc_ro) <= 75) {
+    // Limit the scalarized stack argument area to ensure that generated entry
+    // points fit into nmethod's uint16_t *_entry_offset fields.
+    const int max_stack_slots = 128;
+    if (MAX2(_args_on_stack_cc, _args_on_stack_cc_ro) <= max_stack_slots) {
       return; // Success
     }
+
+    // We exceeded the scalarized stack-slot limit. Check if not scalarizing the
+    // receiver would help. If so, use the receiver-as-oop convention for the
+    // method body but keep scalarizing the other arguments. This also preserves
+    // the convention used by calls through super methods.
+    if (_has_inline_recv && _args_on_stack_cc_ro <= max_stack_slots && _num_inline_args > 1) {
+      _sig_cc = _sig_cc_ro;
+      _args_on_stack_cc = SharedRuntime::java_calling_convention(_sig_cc, _regs_cc);
+      assert(_args_on_stack_cc == _args_on_stack_cc_ro, "calling conventions must match");
+      _has_inline_recv = false;
+      _num_inline_args--;
+      _c1_needs_stack_repair = _args_on_stack_cc < _args_on_stack;
+      _c2_needs_stack_repair = _args_on_stack_cc > _args_on_stack;
+      return; // Success
+    }
+
+#ifdef ASSERT
+    if (link_time) {
+      GrowableArray<Method*>* supers = get_supers();
+      for (int i = 0; i < supers->length(); ++i) {
+        Method* super_method = supers->at(i);
+        assert(super_method->mismatch() || !super_method->has_scalarized_args(),
+               "cannot fall back with a scalarized super method");
+      }
+    }
+#endif
   }
 
   // No scalarized args

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -498,7 +498,7 @@
   nonstatic_field(CodeBlob,                    _relocation_size,                              int)                                   \
   nonstatic_field(CodeBlob,                    _content_offset,                               int)                                   \
   nonstatic_field(CodeBlob,                    _code_offset,                                  int)                                   \
-  nonstatic_field(CodeBlob,                    _frame_complete_offset,                        int16_t)                               \
+  nonstatic_field(CodeBlob,                    _frame_complete_offset,                        int)                                   \
   nonstatic_field(CodeBlob,                    _data_offset,                                  int)                                   \
   nonstatic_field(CodeBlob,                    _frame_size,                                   int)                                   \
   nonstatic_field(CodeBlob,                    _oop_maps,                                     ImmutableOopMapSet*)                   \

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
@@ -147,7 +147,7 @@ public class TestScalarizedCallingConventionLimits {
             loop(fieldCount, i -> scope(
                "        Object f" + i + ";\n")),
                 """
-                
+
                         OopReceiver#fieldCount(Object[] values) {
                 """,
             loop(fieldCount, i -> scope(

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389379
+ * @key stress
+ * @summary Test scalarized calls and entry points around calling convention limits.
+ * @library /test/lib /
+ * @enablePreview
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:-UseBimorphicInlining
+ *                   -XX:CompileCommand=dontinline,*GeneratedScalarizedCallingConventionLimits$ValueImpl*::m
+ *                   -XX:CompileCommand=inline,*GeneratedScalarizedCallingConventionLimits$IdentityImpl*::m
+ *                   ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=dontinline,*GeneratedScalarizedCallingConventionLimits*::m
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+AbortVMOnCompilationFailure -XX:+VerifyOops -XX:+StressCodeBuffers -XX:+ForceUnreachable
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import compiler.lib.compile_framework.CompileFramework;
+import compiler.lib.template_framework.Template;
+
+import static compiler.lib.template_framework.Template.let;
+import static compiler.lib.template_framework.Template.scope;
+
+public class TestScalarizedCallingConventionLimits {
+    private static final String GENERATED_CLASS_NAME = "GeneratedScalarizedCallingConventionLimits";
+    private static final int ITERATIONS = 100_000;
+    private static final int MAX_ARGUMENT_COUNT = 30;
+    private static final int MAX_OOP_RECEIVER_FIELD_COUNT = 70;
+
+    private static String commaSeparated(int count, IntFunction<String> element) {
+        return IntStream.range(0, count).mapToObj(element).collect(Collectors.joining(", "));
+    }
+
+    private static String lines(int count, IntFunction<String> element) {
+        return IntStream.range(0, count).mapToObj(element).collect(Collectors.joining("\n"));
+    }
+
+    public static void main(String[] args) {
+        CompileFramework compileFramework = new CompileFramework();
+        compileFramework.addJavaSourceCode(GENERATED_CLASS_NAME, generateSource());
+        compileFramework.compile("--enable-preview", "--source", System.getProperty("java.specification.version"));
+        compileFramework.invoke(GENERATED_CLASS_NAME, "run", new Object[] {});
+    }
+
+    // Generate interfaces with value and identity-class implementations and a method
+    // with a varying number of arguments to stress test the calling convention.
+    private static final Template.OneArg<Integer> INTERFACE_CASE =
+            Template.make("argumentCount", (Integer argumentCount) -> {
+                String parameters = commaSeparated(argumentCount, i -> "Integer a" + i);
+                String parameterNames = commaSeparated(argumentCount, i -> "a" + i);
+                String arguments = commaSeparated(argumentCount, i -> Integer.toString(i + 1));
+
+                return scope(
+                        let("parameters", parameters),
+                        let("parameterNames", parameterNames),
+                        let("arguments", arguments),
+                        """
+                            interface I#argumentCount {
+                                int m(#parameters);
+                            }
+
+                            static value class ValueImpl#argumentCount implements I#argumentCount {
+                                int x, y, z;
+
+                                ValueImpl#argumentCount(int x, int y, int z) {
+                                    this.x = x;
+                                    this.y = y;
+                                    this.z = z;
+                                }
+
+                                @Override
+                                public int m(#parameters) {
+                                    return hash(x, y, z, hash(#parameterNames));
+                                }
+                            }
+
+                            static class IdentityImpl#argumentCount implements I#argumentCount {
+                                @Override
+                                public int m(#parameters) {
+                                    return hash(#parameterNames);
+                                }
+                            }
+
+                            static void test#argumentCount() {
+                                I#argumentCount value = new ValueImpl#argumentCount(42, 43, 44);
+                                I#argumentCount identity = new IdentityImpl#argumentCount();
+                                int argumentHash = hash(#arguments);
+                                int valueHash = hash(42, 43, 44, argumentHash);
+                                for (int i = 0; i < ITERATIONS; i++) {
+                                    I#argumentCount receiver = (i & 1) == 0 ? value : identity;
+                                    int actual = receiver.m(#arguments);
+                                    int expected = (i & 1) == 0 ? valueHash : argumentHash;
+                                    Asserts.assertEquals(expected, actual);
+                                }
+                            }
+
+                        """);
+            });
+
+    // Generate methods with a value class receiver with a varying number of oop fields to stress
+    // test code buffers during nmethod entry point generation (oops need GC barriers etc.)
+    private static final Template.OneArg<Integer> OOP_RECEIVER =
+            Template.make("fieldCount", (Integer fieldCount) -> {
+                String fields = lines(fieldCount, i -> "        Object f" + i + ";");
+                String assignments = lines(fieldCount, i -> "            this.f" + i + " = values[" + i + "];");
+                String arguments = commaSeparated(fieldCount, i -> "f" + i);
+
+                return scope(
+                        let("fields", fields),
+                        let("assignments", assignments),
+                        let("arguments", arguments),
+                        """
+                            static value class OopReceiver#fieldCount {
+                        #fields
+
+                                OopReceiver#fieldCount(Object[] values) {
+                        #assignments
+                                }
+
+                                int m() {
+                                    return hash(#arguments);
+                                }
+                            }
+
+                            static void testOopReceiver#fieldCount() {
+                                Object[] values = new Object[#fieldCount];
+                                for (int i = 0; i < values.length; i++) {
+                                    values[i] = i;
+                                }
+                                int valuesHash = hash(values);
+                                OopReceiver#fieldCount receiver = new OopReceiver#fieldCount(values);
+                                for (int i = 0; i < ITERATIONS; i++) {
+                                    Asserts.assertEquals(valuesHash, receiver.m());
+                                }
+                            }
+
+                        """);
+            });
+
+    private static String generateSource() {
+        String interfaceTestCalls = lines(MAX_ARGUMENT_COUNT, i -> "        test" + i + "();");
+        String oopReceiverTestCalls = lines(MAX_OOP_RECEIVER_FIELD_COUNT, i -> "        testOopReceiver" + i + "();");
+
+        Template.ZeroArgs classTemplate = Template.make(() -> scope(
+                let("generatedClassName", GENERATED_CLASS_NAME),
+                let("iterations", ITERATIONS),
+                """
+                import jdk.test.lib.Asserts;
+
+                public class #generatedClassName {
+                    static final int ITERATIONS = #iterations;
+
+                    static int hash(Object... values) {
+                        int result = 1;
+                        for (Object value : values) {
+                            result = 31 * result + (int)value;
+                        }
+                        return result;
+                    }
+
+                """,
+                IntStream.range(0, MAX_ARGUMENT_COUNT).mapToObj(INTERFACE_CASE::asToken).toList(),
+                IntStream.range(0, MAX_OOP_RECEIVER_FIELD_COUNT).mapToObj(OOP_RECEIVER::asToken).toList(),
+                let("interfaceTestCalls", interfaceTestCalls),
+                let("oopReceiverTestCalls", oopReceiverTestCalls),
+                """
+                    public static void run() {
+                #interfaceTestCalls
+                #oopReceiverTestCalls
+                    }
+                }
+                """
+        ));
+        return classTemplate.render();
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
@@ -57,8 +57,9 @@ import static compiler.lib.template_framework.Template.scope;
 public class TestScalarizedCallingConventionLimits {
     private static final String GENERATED_CLASS_NAME = "GeneratedScalarizedCallingConventionLimits";
     private static final int ITERATIONS = 100_000;
-    private static final int MAX_ARGUMENT_COUNT = 2;
-    private static final int MAX_OOP_RECEIVER_FIELD_COUNT = 3;
+    private static final int MAX_ARGUMENT_COUNT = 30;
+    private static final int MAX_OOP_RECEIVER_FIELD_COUNT = 70;
+
 
     public static void main(String[] args) {
         CompileFramework compileFramework = new CompileFramework();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
@@ -43,10 +43,12 @@
 package compiler.valhalla.inlinetypes;
 
 import java.util.function.IntFunction;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import compiler.lib.compile_framework.CompileFramework;
+import compiler.lib.template_framework.ScopeToken;
 import compiler.lib.template_framework.Template;
 
 import static compiler.lib.template_framework.Template.let;
@@ -55,16 +57,8 @@ import static compiler.lib.template_framework.Template.scope;
 public class TestScalarizedCallingConventionLimits {
     private static final String GENERATED_CLASS_NAME = "GeneratedScalarizedCallingConventionLimits";
     private static final int ITERATIONS = 100_000;
-    private static final int MAX_ARGUMENT_COUNT = 30;
-    private static final int MAX_OOP_RECEIVER_FIELD_COUNT = 70;
-
-    private static String commaSeparated(int count, IntFunction<String> element) {
-        return IntStream.range(0, count).mapToObj(element).collect(Collectors.joining(", "));
-    }
-
-    private static String lines(int count, IntFunction<String> element) {
-        return IntStream.range(0, count).mapToObj(element).collect(Collectors.joining("\n"));
-    }
+    private static final int MAX_ARGUMENT_COUNT = 2;
+    private static final int MAX_OOP_RECEIVER_FIELD_COUNT = 3;
 
     public static void main(String[] args) {
         CompileFramework compileFramework = new CompileFramework();
@@ -73,106 +67,8 @@ public class TestScalarizedCallingConventionLimits {
         compileFramework.invoke(GENERATED_CLASS_NAME, "run", new Object[] {});
     }
 
-    // Generate interfaces with value and identity-class implementations and a method
-    // with a varying number of arguments to stress test the calling convention.
-    private static final Template.OneArg<Integer> INTERFACE_CASE =
-            Template.make("argumentCount", (Integer argumentCount) -> {
-                String parameters = commaSeparated(argumentCount, i -> "Integer a" + i);
-                String parameterNames = commaSeparated(argumentCount, i -> "a" + i);
-                String arguments = commaSeparated(argumentCount, i -> Integer.toString(i + 1));
-
-                return scope(
-                        let("parameters", parameters),
-                        let("parameterNames", parameterNames),
-                        let("arguments", arguments),
-                        """
-                            interface I#argumentCount {
-                                int m(#parameters);
-                            }
-
-                            static value class ValueImpl#argumentCount implements I#argumentCount {
-                                int x, y, z;
-
-                                ValueImpl#argumentCount(int x, int y, int z) {
-                                    this.x = x;
-                                    this.y = y;
-                                    this.z = z;
-                                }
-
-                                @Override
-                                public int m(#parameters) {
-                                    return hash(x, y, z, hash(#parameterNames));
-                                }
-                            }
-
-                            static class IdentityImpl#argumentCount implements I#argumentCount {
-                                @Override
-                                public int m(#parameters) {
-                                    return hash(#parameterNames);
-                                }
-                            }
-
-                            static void test#argumentCount() {
-                                I#argumentCount value = new ValueImpl#argumentCount(42, 43, 44);
-                                I#argumentCount identity = new IdentityImpl#argumentCount();
-                                int argumentHash = hash(#arguments);
-                                int valueHash = hash(42, 43, 44, argumentHash);
-                                for (int i = 0; i < ITERATIONS; i++) {
-                                    I#argumentCount receiver = (i & 1) == 0 ? value : identity;
-                                    int actual = receiver.m(#arguments);
-                                    int expected = (i & 1) == 0 ? valueHash : argumentHash;
-                                    Asserts.assertEquals(expected, actual);
-                                }
-                            }
-
-                        """);
-            });
-
-    // Generate methods with a value class receiver with a varying number of oop fields to stress
-    // test code buffers during nmethod entry point generation (oops need GC barriers etc.)
-    private static final Template.OneArg<Integer> OOP_RECEIVER =
-            Template.make("fieldCount", (Integer fieldCount) -> {
-                String fields = lines(fieldCount, i -> "        Object f" + i + ";");
-                String assignments = lines(fieldCount, i -> "            this.f" + i + " = values[" + i + "];");
-                String arguments = commaSeparated(fieldCount, i -> "f" + i);
-
-                return scope(
-                        let("fields", fields),
-                        let("assignments", assignments),
-                        let("arguments", arguments),
-                        """
-                            static value class OopReceiver#fieldCount {
-                        #fields
-
-                                OopReceiver#fieldCount(Object[] values) {
-                        #assignments
-                                }
-
-                                int m() {
-                                    return hash(#arguments);
-                                }
-                            }
-
-                            static void testOopReceiver#fieldCount() {
-                                Object[] values = new Object[#fieldCount];
-                                for (int i = 0; i < values.length; i++) {
-                                    values[i] = i;
-                                }
-                                int valuesHash = hash(values);
-                                OopReceiver#fieldCount receiver = new OopReceiver#fieldCount(values);
-                                for (int i = 0; i < ITERATIONS; i++) {
-                                    Asserts.assertEquals(valuesHash, receiver.m());
-                                }
-                            }
-
-                        """);
-            });
-
     private static String generateSource() {
-        String interfaceTestCalls = lines(MAX_ARGUMENT_COUNT, i -> "        test" + i + "();");
-        String oopReceiverTestCalls = lines(MAX_OOP_RECEIVER_FIELD_COUNT, i -> "        testOopReceiver" + i + "();");
-
-        Template.ZeroArgs classTemplate = Template.make(() -> scope(
+        return Template.make(() -> scope(
                 let("generatedClassName", GENERATED_CLASS_NAME),
                 let("iterations", ITERATIONS),
                 """
@@ -190,19 +86,114 @@ public class TestScalarizedCallingConventionLimits {
                     }
 
                 """,
-                IntStream.range(0, MAX_ARGUMENT_COUNT).mapToObj(INTERFACE_CASE::asToken).toList(),
-                IntStream.range(0, MAX_OOP_RECEIVER_FIELD_COUNT).mapToObj(OOP_RECEIVER::asToken).toList(),
-                let("interfaceTestCalls", interfaceTestCalls),
-                let("oopReceiverTestCalls", oopReceiverTestCalls),
+            // Generate interfaces with value and identity-class implementations and a method
+            // with a varying number of arguments to stress test the calling convention.
+            loop(MAX_ARGUMENT_COUNT, argumentCount -> scope(
+                let("argumentCount", argumentCount),
+                let("classname", "ValueImpl" + argumentCount),
+                let("parameters", commaSeparated(argumentCount, i -> "Integer a" + i)),
+                let("parameterNames", commaSeparated(argumentCount, i -> "a" + i)),
+                let("arguments", commaSeparated(argumentCount, i -> Integer.toString(i + 1))),
+                """
+                    interface I#argumentCount {
+                        int m(#parameters);
+                    }
+
+                    static value class #classname implements I#argumentCount {
+                        int x, y, z;
+
+                        #classname(int x, int y, int z) {
+                            this.x = x;
+                            this.y = y;
+                            this.z = z;
+                        }
+
+                        @Override
+                        public int m(#parameters) {
+                            return hash(x, y, z, hash(#parameterNames));
+                        }
+                    }
+
+                    static class IdentityImpl#argumentCount implements I#argumentCount {
+                        @Override
+                        public int m(#parameters) {
+                            return hash(#parameterNames);
+                        }
+                    }
+
+                    static void test#argumentCount() {
+                        I#argumentCount value = new ValueImpl#argumentCount(42, 43, 44);
+                        I#argumentCount identity = new IdentityImpl#argumentCount();
+                        int argumentHash = hash(#arguments);
+                        int valueHash = hash(42, 43, 44, argumentHash);
+                        for (int i = 0; i < ITERATIONS; i++) {
+                            I#argumentCount receiver = (i & 1) == 0 ? value : identity;
+                            int actual = receiver.m(#arguments);
+                            int expected = (i & 1) == 0 ? valueHash : argumentHash;
+                            Asserts.assertEquals(expected, actual);
+                        }
+                    }
+
+                """)),
+            // Generate methods with a value class receiver with a varying number of oop fields to stress
+            // test code buffers during nmethod entry point generation (oops need GC barriers etc.)
+            loop(MAX_OOP_RECEIVER_FIELD_COUNT, fieldCount -> scope(
+                let("fieldCount", fieldCount),
+                let("arguments", commaSeparated(fieldCount, i -> "f" + i)),
+                """
+                    static value class OopReceiver#fieldCount {
+                """,
+            loop(fieldCount, i -> scope(
+               "        Object f" + i + ";\n")),
+                """
+                
+                        OopReceiver#fieldCount(Object[] values) {
+                """,
+            loop(fieldCount, i -> scope(
+               "            this.f" + i + " = values[" + i + "];\n")),
+                """
+                        }
+
+                        int m() {
+                            return hash(#arguments);
+                        }
+                    }
+
+                    static void testOopReceiver#fieldCount() {
+                        Object[] values = new Object[#fieldCount];
+                        for (int i = 0; i < values.length; i++) {
+                            values[i] = i;
+                        }
+                        int valuesHash = hash(values);
+                        OopReceiver#fieldCount receiver = new OopReceiver#fieldCount(values);
+                        for (int i = 0; i < ITERATIONS; i++) {
+                            Asserts.assertEquals(valuesHash, receiver.m());
+                        }
+                    }
+
+                """)),
                 """
                     public static void run() {
-                #interfaceTestCalls
-                #oopReceiverTestCalls
+                """,
+            loop(MAX_ARGUMENT_COUNT, i -> scope(
+               "        test" + i + "();\n")),
+            loop(MAX_OOP_RECEIVER_FIELD_COUNT, i -> scope(
+               "        testOopReceiver" + i + "();\n")),
+                """
                     }
                 }
                 """
-        ));
-        return classTemplate.render();
+        )).render();
+    }
+
+    private static String commaSeparated(int count, IntFunction<String> element) {
+        return IntStream.range(0, count).mapToObj(element).collect(Collectors.joining(", "));
+    }
+
+    private static List<ScopeToken> loop(int limit, IntFunction<ScopeToken> function) {
+        return IntStream.range(0, limit)
+                        .mapToObj(function)
+                        .toList();
     }
 }
 


### PR DESCRIPTION
We currently disable the scalarized calling convention when a method exceeds the 75 stack slots limit:
https://github.com/openjdk/jdk/blob/fc51e5e2f3497341ebe17ec31fadd57445224f71/src/hotspot/share/runtime/sharedRuntime.cpp#L2976-L2979

Now the problem is that a value class implementation can exceed this limit only because its receiver is scalarized, while the overridden interface method still uses scalarized arguments. Interface dispatch then uses incompatible calling conventions, causing incorrect results or crashes. Here's an example (see `INTERFACE_CASE` in the new test):

```
    interface I {
        int m(Integer a0, Integer a1, ...);
    }

    static value class ValueImpl implements I {
        int x, y, z;

        ValueImpl(int x, int y, int z) {
            this.x = x;
            this.y = y;
            this.z = z;
        }

        @Override
        public int m(Integer a0, Integer a1, ...) {
            ...
        }
    }
```

Method `m` would exceed the limit in `ValueImpl` due to the scalarized receiver but not in `I` where the receiver is non-scalarized. It could then be called with scalarized arguments through an interface call while not being able to handle those. The fix is to fall back to the non-scalarized calling convention for the receiver while still passing the other arguments in scalarized form, when only the calling convention with a scalarized receiver exceeds the limit.

As so often, this exposed another issue: C2 attaches the concrete `Method*` to calls with scalarized arguments so the GC can find the oop fields:
https://github.com/openjdk/jdk/blob/fc51e5e2f3497341ebe17ec31fadd57445224f71/src/hotspot/share/opto/graphKit.cpp#L2042-L2045

Runtime resolution also uses it because with a scalarized receiver no object is available:
https://github.com/openjdk/jdk/blob/fc51e5e2f3497341ebe17ec31fadd57445224f71/src/hotspot/share/runtime/sharedRuntime.cpp#L1279-L1282

In the new case where the receiver is now non-scalarized, runtime resolution incorrectly treated the attached method as the invokeinterface target, throwing an `IncompatibleClassChangeError`:
```
Caused by: java.lang.IncompatibleClassChangeError: Found class GeneratedScalarizedCallingConventionLimits$ValueImpl23, but interface was expected
	at GeneratedScalarizedCallingConventionLimits.test23(GeneratedScalarizedCallingConventionLimits.java:951)
	at GeneratedScalarizedCallingConventionLimits.run(GeneratedScalarizedCallingConventionLimits.java:7517)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
```

Runtime resolution now ignores an attached method unless its receiver is actually scalarized, while keeping it for oop scanning.

I also raised the scalarized calling convention limit to 128 slots because the 75 slot limit was rather arbitrary. The new limit is based on the nmethod's `uint16_t` `*_entry_offset` fields that would need to be made wider if we want to support a larger number of arguments.

When testing, I discovered yet another issue with stress flags like `-XX:+VerifyOops -XX:+StressCodeBuffers -XX:+ForceUnreachable` - we run out of CodeBuffer memory when generating code for the `MachVEPNode`:

```
#  Internal Error (/oracle/jdk/open/src/hotspot/share/asm/codeBuffer.hpp:208), pid=460261, tid=460276
#  assert(allocates2(pc)) failed: not in CodeBuffer memory: 0x00007f0cc1246560 <= 0x00007f0cc1246dd1 <= 0x00007f0cc1246dd0
#
# JRE version: Java(TM) SE Runtime Environment (28.0) (fastdebug build 28-internal-tohartma.open)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (fastdebug 28-internal-tohartma.open, mixed mode, compressed oops, compact obj headers, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x774084]  Assembler::push(Register)+0xd4

Stack: [0x00007f0cb7002000,0x00007f0cb7102000],  sp=0x00007f0cb70fcf38,  free space=1003k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x774084]  Assembler::push(Register)+0xd4  (codeBuffer.hpp:208)
V  [libjvm.so+0x167df51]  MacroAssembler::_verify_oop(Register, char const*, char const*, int)+0x3e1  (macroAssembler_x86.cpp:342)
V  [libjvm.so+0xece0bb]  G1BarrierSetAssembler::load_at(MacroAssembler*, unsigned long, BasicType, Register, Address, Register)+0xbb  (g1BarrierSetAssembler_x86.cpp:148)
V  [libjvm.so+0x1680586]  MacroAssembler::access_load_at(BasicType, unsigned long, Register, Address, Register)+0x106  (macroAssembler_x86.cpp:5625)
V  [libjvm.so+0x16821ae]  MacroAssembler::unpack_inline_helper(GrowableArray<SigEntry> const*, int&, VMRegImpl*, int&, VMRegPair*, int, int&, MacroAssembler::RegState*)+0xe3e  (macroAssembler_x86.cpp:5664)
V  [libjvm.so+0x16323ac]  MacroAssembler::unpack_inline_args(Compile*, bool)+0x58c  (macroAssembler_common.cpp:184)
V  [libjvm.so+0x3c5d59]  MachVEPNode::emit(C2_MacroAssembler*, PhaseRegAlloc*) const+0x49  (x86.ad:2605)
V  [libjvm.so+0x1860be4]  PhaseOutput::fill_buffer(C2_MacroAssembler*, unsigned int*)+0x5c4  (output.cpp:1755)
V  [libjvm.so+0x18643dc]  PhaseOutput::Output()+0xd7c  (output.cpp:383)
V  [libjvm.so+0xc11a19]  Compile::Code_Gen()+0xa39  (compile.cpp:3919)
```

I fixed this by improving the computation of the required size and also had to widen the `_frame_complete*` fields which would silently truncate and then lead to spurious failures like this one:

```
#  Internal Error (/oracle/jdk/open/src/hotspot/cpu/x86/gc/shared/barrierSetNMethod_x86.cpp:79), pid=632665, tid=632703
#  assert(check_barrier(msg)) failed: Addr: 0x00007faa89622488 Code: 0xfa expected 0x41
#
# JRE version: Java(TM) SE Runtime Environment (28.0) (fastdebug build 28-internal-tohartma.open)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (fastdebug 28-internal-tohartma.open, mixed mode, compact obj headers, z gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x86dc8a]  NativeNMethodCmpBarrier::verify() const+0x11a

Stack: [0x00007faa90a94000,0x00007faa90b94000],  sp=0x00007faa90b8f5c0,  free space=1005k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x86dc8a]  NativeNMethodCmpBarrier::verify() const+0x11a  (barrierSetNMethod_x86.cpp:79)
V  [libjvm.so+0x86cfbb]  BarrierSetNMethod::set_guard_value(nmethod*, int, int)+0x6b  (barrierSetNMethod_x86.cpp:169)
V  [libjvm.so+0x1ea9295]  ZNMethod::register_nmethod(nmethod*)+0xc5  (zNMethod.cpp:240)
V  [libjvm.so+0x17e0d75]  nmethod::post_init()+0x75  (nmethod.cpp:1217)
V  [libjvm.so+0x17e1afe]  nmethod::nmethod(Method*, CompilerType, int, int, int, int, int, unsigned char*, CodeOffsets*, int, DebugInformationRecorder*, Dependencies*, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, CompLevel, nmethod::Flags)+0x45e  (nmethod.cpp:1733)
V  [libjvm.so+0x17e2282]  nmethod::new_nmethod(methodHandle const&, int, int, CodeOffsets*, int, DebugInformationRecorder*, Dependencies*, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, CompLevel, nmethod::Flags)+0x262  (nmethod.cpp:1138)
V  [libjvm.so+0xac4087]  ciEnv::register_method(ciMethod*, int, CodeOffsets*, int, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, bool, bool, bool, bool, int)+0x3a7  (ciEnv.cpp:1072)
V  [libjvm.so+0x1893e88]  PhaseOutput::install_code(ciMethod*, int, AbstractCompiler*, bool, bool)+0x178  (output.cpp:3352)
```

To guard against this, I added an assert to `nmethod::init_defaults` that would catch truncation in the future.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389379](https://bugs.openjdk.org/browse/JDK-8389379): [lworld] Calling convention mismatch when reaching stack argument limit (**Bug** - P3)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32212/head:pull/32212` \
`$ git checkout pull/32212`

Update a local copy of the PR: \
`$ git checkout pull/32212` \
`$ git pull https://git.openjdk.org/jdk.git pull/32212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32212`

View PR using the GUI difftool: \
`$ git pr show -t 32212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32212.diff">https://git.openjdk.org/jdk/pull/32212.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32212#issuecomment-5200600394)
</details>
