### PR TITLE
8389765: Remove unused rtmp2 temp register from long_to_maskLE8_avx

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -24721,16 +24721,16 @@ instruct mask_not_imm(kReg dst, kReg src, immI_M1 cnt) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct long_to_maskLE8_avx(vec dst, rRegL src, rRegL rtmp1, rRegL rtmp2) %{
+instruct long_to_maskLE8_avx(vec dst, rRegL src, rRegL rtmp1) %{
   predicate(n->bottom_type()->isa_pvectmask() == nullptr && Matcher::vector_length(n) <= 8);
   match(Set dst (VectorLongToMask src));
-  effect(TEMP dst, TEMP rtmp1, TEMP rtmp2);
-  format %{ "long_to_mask_avx $dst, $src\t! using $rtmp1, $rtmp2" %}
+  effect(TEMP dst, TEMP rtmp1);
+  format %{ "long_to_mask_avx $dst, $src\t! using $rtmp1" %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);
     int vec_enc  = vector_length_encoding(mask_len);
     __ vector_long_to_maskvec($dst$$XMMRegister, $src$$Register, $rtmp1$$Register,
-                              $rtmp2$$Register, xnoreg, mask_len, vec_enc);
+                              noreg, xnoreg, mask_len, vec_enc);
   %}
   ins_pipe( pipe_slow );
 %}


### PR DESCRIPTION
JBS Issue : [JDK-8389765](https://bugs.openjdk.org/browse/JDK-8389765)

The long_to_maskLE8_avx instruct in src/hotspot/cpu/x86/x86.ad declares a temporary general-purpose register rtmp2 that is never used on the code path this instruct matches.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389765](https://bugs.openjdk.org/browse/JDK-8389765): Remove unused rtmp2 temp register from long_to_maskLE8_avx (**Enhancement** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32213/head:pull/32213` \
`$ git checkout pull/32213`

Update a local copy of the PR: \
`$ git checkout pull/32213` \
`$ git pull https://git.openjdk.org/jdk.git pull/32213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32213`

View PR using the GUI difftool: \
`$ git pr show -t 32213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32213.diff">https://git.openjdk.org/jdk/pull/32213.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32213#issuecomment-5192042291)
</details>
