### PR TITLE
8372384: Remove unused local variable in MacroAssembler::sha512_update_sha_state on PPC

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc_sha.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc_sha.cpp
@@ -613,7 +613,6 @@ void MacroAssembler::sha512_update_sha_state(const Register state,
   VectorRegister ini_e = VR14;
   VectorRegister ini_g = VR16;
   static const VectorRegister inis[] = {ini_a, ini_c, ini_e, ini_g};
-  static const int total_inis = sizeof(inis)/sizeof(VectorRegister);
 
   Label state_save_aligned, after_state_save_aligned;
 


### PR DESCRIPTION

JBS Issue : [JDK-8372384](https://bugs.openjdk.org/browse/JDK-8372384)


MacroAssembler::sha512_update_sha_state in macroAssembler_ppc_sha.cpp defines a local constant:
static const int total_inis = sizeof(inis)/sizeof(VectorRegister);
which is never used. 

This patch removes the unused local variable total_inis and keeps the existing logic unchanged.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8372384](https://bugs.openjdk.org/browse/JDK-8372384): Remove unused local variable in MacroAssembler::sha512_update_sha_state on PPC (**Enhancement** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32215/head:pull/32215` \
`$ git checkout pull/32215`

Update a local copy of the PR: \
`$ git checkout pull/32215` \
`$ git pull https://git.openjdk.org/jdk.git pull/32215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32215`

View PR using the GUI difftool: \
`$ git pr show -t 32215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32215.diff">https://git.openjdk.org/jdk/pull/32215.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32215#issuecomment-5192211689)
</details>
