### PR TITLE
8389610: ARM32: native method wrapper unlocks a stale oop after GC relocates the object

### DIFF
--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -1201,6 +1201,9 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   Label slow_unlock, unlock_done;
   if (method->is_synchronized()) {
+    // Get locked oop from the handle we passed to jni
+    __ ldr(sync_obj, Address(sync_handle));
+
     log_trace(fastlock)("SharedRuntime unlock fast");
     __ fast_unlock(sync_obj, R2 /* t1 */, tmp /* t2 */, Rtemp /* t3 */,
                    7 /* savemask */, slow_unlock);


### PR DESCRIPTION
Hi,
fix for [JDK-8389610](https://bugs.openjdk.org/browse/JDK-8389610),

`generate_native_wrapper()` incorrectly generates arm32 unlocking code for native synchronized methods.
GC can relocate an object between the lock and the unlock (easily reproducible with Serial/Parallel GC).
We should reload the new address of the OOP from the handle before unlocking it.
 On all architectures we reload the address before unlock, except arm32.

Tested with a reproducer.

CI win-aarch64 test fail is not related to these changes, JDK upstream has the same CI issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389610](https://bugs.openjdk.org/browse/JDK-8389610): ARM32: native method wrapper unlocks a stale oop after GC relocates the object (**Bug** - P3)


### Reviewers
 * [Boris Ulasevich](https://openjdk.org/census#bulasevich) (@bulasevich - Committer)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32217/head:pull/32217` \
`$ git checkout pull/32217`

Update a local copy of the PR: \
`$ git checkout pull/32217` \
`$ git pull https://git.openjdk.org/jdk.git pull/32217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32217`

View PR using the GUI difftool: \
`$ git pr show -t 32217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32217.diff">https://git.openjdk.org/jdk/pull/32217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32217#issuecomment-5193419821)
</details>
