### PR TITLE
8373348: Cache AdapterHandleEntry::_sig_cc field in AOTCache

### DIFF
--- a/src/hotspot/share/cds/cppVtables.cpp
+++ b/src/hotspot/share/cds/cppVtables.cpp
@@ -66,9 +66,11 @@
 // the virtual printing functions in AnyObj).
 
 using GrowableArray_ModuleEntry_ptr = GrowableArray<ModuleEntry*>;
+using GrowableArray_SigEntry = GrowableArray<SigEntry>;
 
 #define DEBUG_CPP_VTABLE_TYPES_DO(f) \
   f(GrowableArray_ModuleEntry_ptr) \
+  f(GrowableArray_SigEntry) \
 
 #endif
 

--- a/src/hotspot/share/memory/metaspaceClosureType.hpp
+++ b/src/hotspot/share/memory/metaspaceClosureType.hpp
@@ -35,6 +35,7 @@
   f(GrowableArray) \
   f(ModuleEntry) \
   f(PackageEntry) \
+  f(SigEntry) \
 
 #define METASPACE_CLOSURE_TYPE_DECLARE(name) name ## Type,
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -4193,7 +4193,3 @@ JRT_BLOCK_ENTRY(void, SharedRuntime::store_inline_type_fields_to_buf(JavaThread*
   JRT_BLOCK_END;
 }
 JRT_END
-
-void SigEntry::metaspace_pointers_do(MetaspaceClosure* it) {
-  it->push(&_name);
-}

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3381,8 +3381,6 @@ void AdapterHandlerEntry::remove_unshareable_info() {
 #endif // ASSERT
    _adapter_blob = nullptr;
    _linked = false;
-   _sig_cc = nullptr;
-   _sig_cc_ro = nullptr;
 }
 
 class CopyAdapterTableToArchive : StackObj {
@@ -3461,23 +3459,6 @@ void AdapterHandlerEntry::link() {
     if (_adapter_blob == nullptr) {
       log_warning(aot)("Failed to link AdapterHandlerEntry (fp=%s) to its code in the AOT code cache", _fingerprint->as_basic_args_string());
       generate_code = true;
-    }
-
-    if (get_sig_cc() == nullptr) {
-      // Calling conventions have to be regenerated at runtime and are accessed through method adapters,
-      // which are archived in the AOT code cache. If the adapters are not regenerated, the
-      // calling conventions should be regenerated here.
-      CompiledEntrySignature ces;
-      ces.initialize_from_fingerprint(_fingerprint);
-      if (ces.has_scalarized_args()) {
-        // Save a C heap allocated version of the scalarized signature and store it in the adapter
-        GrowableArray<SigEntry>* heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc()->length(), mtCode);
-        heap_sig->appendAll(ces.sig_cc());
-        set_sig_cc(heap_sig);
-        heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc_ro()->length(), mtCode);
-        heap_sig->appendAll(ces.sig_cc_ro());
-        set_sig_cc_ro(heap_sig);
-      }
     }
   } else {
     generate_code = true;
@@ -3570,6 +3551,8 @@ void AdapterHandlerEntry::metaspace_pointers_do(MetaspaceClosure* it) {
     lsh.cr();
   }
   it->push(&_fingerprint);
+  it->push(&_sig_cc);
+  it->push(&_sig_cc_ro);
 }
 
 AdapterHandlerEntry::~AdapterHandlerEntry() {
@@ -4210,3 +4193,7 @@ JRT_BLOCK_ENTRY(void, SharedRuntime::store_inline_type_fields_to_buf(JavaThread*
   JRT_BLOCK_END;
 }
 JRT_END
+
+void SigEntry::metaspace_pointers_do(MetaspaceClosure* it) {
+  it->push(&_name);
+}

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -741,8 +741,8 @@ class AdapterHandlerEntry : public MetaspaceObj {
   static const char *_entry_names[];
 
   // Support for scalarized inline type calling convention
-  const GrowableArray<SigEntry>* _sig_cc;
-  const GrowableArray<SigEntry>* _sig_cc_ro;
+  GrowableArray<SigEntry>* _sig_cc;
+  GrowableArray<SigEntry>* _sig_cc_ro;
 
 #ifdef ASSERT
   // Captures code and signature used to generate this adapter when
@@ -857,16 +857,16 @@ class AdapterHandlerEntry : public MetaspaceObj {
   bool is_linked() const { return _linked; }
 
   // Support for scalarized inline type calling convention
-  void set_sig_cc(const GrowableArray<SigEntry>* sig) {
+  void set_sig_cc(GrowableArray<SigEntry>* sig) {
     assert(_sig_cc == nullptr, "Already initialized");
     _sig_cc = sig;
   }
-  const GrowableArray<SigEntry>* get_sig_cc() const { return _sig_cc; }
-  void set_sig_cc_ro(const GrowableArray<SigEntry>* sig) {
+  GrowableArray<SigEntry>* get_sig_cc() const { return _sig_cc; }
+  void set_sig_cc_ro(GrowableArray<SigEntry>* sig) {
     assert(_sig_cc_ro == nullptr, "Already initialized");
     _sig_cc_ro = sig;
   }
-  const GrowableArray<SigEntry>* get_sig_cc_ro() const { return _sig_cc_ro; }
+  GrowableArray<SigEntry>* get_sig_cc_ro() const { return _sig_cc_ro; }
 
   uint id() const { return _id; }
   AdapterFingerPrint* fingerprint() const { return _fingerprint; }

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -736,6 +736,10 @@ TempNewSymbol SigEntry::create_symbol(const GrowableArray<SigEntry>* sig) {
   return SymbolTable::new_symbol(sig_str);
 }
 
+void SigEntry::metaspace_pointers_do(MetaspaceClosure* it) {
+  it->push(&_name);
+}
+
 void SigEntry::print_on(outputStream* st) const {
   st->print("SigEntry: type=%d offset=%d null_marker=%d ", _bt, _offset, _null_marker);
   if (_name != nullptr) {

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -28,7 +28,10 @@
 
 #include "classfile/symbolTable.hpp"
 #include "memory/allocation.hpp"
+#include "memory/metaspaceClosureType.hpp"
 #include "oops/method.hpp"
+
+class MetaspaceClosure;
 
 // Static routines and parsing loops for processing field and method
 // descriptors.  In the HotSpot sources we call them "signatures".
@@ -594,6 +597,11 @@ class SigEntry {
   static bool skip_value_delimiters(const GrowableArray<SigEntry>* sig, int i);
   static int fill_sig_bt(const GrowableArray<SigEntry>* sig, BasicType* sig_bt);
   static TempNewSymbol create_symbol(const GrowableArray<SigEntry>* sig);
+
+  void metaspace_pointers_do(MetaspaceClosure* it);
+  int size_in_heapwords() const { return (int)heap_word_size(sizeof(SigEntry)); }
+  MetaspaceClosureType type() const { return MetaspaceClosureType::SigEntryType; }
+  static bool is_read_only_by_default() { return true; }
 
   void print_on(outputStream* st) const;
 };

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -581,16 +581,17 @@ typedef GrowableArrayFilterIterator<SigEntry, SigEntryFilter> ExtendedSignature;
 class SigEntry {
  public:
   BasicType _bt;      // Basic type of the argument
-  int _offset;        // Offset of the field in its value class holder for scalarized arguments (-1 otherwise). Used for packing and unpacking.
-  Symbol* _name;      // Symbol for printing
   bool _null_marker;  // Is it a null marker? For printing
   bool _vt_oop;       // Is it a possibly null buffer
+  bool _padding;      // Dummy field initialized to zero for padding
+  int _offset;        // Offset of the field in its value class holder for scalarized arguments (-1 otherwise). Used for packing and unpacking.
+  Symbol* _name;      // Symbol for printing
 
   SigEntry()
-    : _bt(T_ILLEGAL), _offset(-1), _name(nullptr), _null_marker(false), _vt_oop(false) {}
+    : _bt(T_ILLEGAL), _null_marker(false), _vt_oop(false), _padding(0), _offset(-1), _name(nullptr)  {}
 
   SigEntry(BasicType bt, int offset, Symbol* name, bool null_marker, bool vt_oop)
-    : _bt(bt), _offset(offset), _name(name), _null_marker(null_marker), _vt_oop(vt_oop) {}
+    : _bt(bt), _null_marker(null_marker), _vt_oop(vt_oop), _padding(0), _offset(offset), _name(name) {}
 
   static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* name = nullptr, int offset = -1, bool null_marker = false, bool vt_oop = false);
   static void add_null_marker(GrowableArray<SigEntry>* sig, Symbol* name, int offset);


### PR DESCRIPTION
Signature calling conventions are regenerated at runtime as they were not being archived, so this patch now archives them and removes the regeneration code. Verified with tier 1-5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8373348](https://bugs.openjdk.org/browse/JDK-8373348): Cache AdapterHandleEntry::_sig_cc field in AOTCache (**Enhancement** - P4)


### Reviewers
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32219/head:pull/32219` \
`$ git checkout pull/32219`

Update a local copy of the PR: \
`$ git checkout pull/32219` \
`$ git pull https://git.openjdk.org/jdk.git pull/32219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32219`

View PR using the GUI difftool: \
`$ git pr show -t 32219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32219.diff">https://git.openjdk.org/jdk/pull/32219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32219#issuecomment-5195573479)
</details>
