### PR TITLE
8388948: Javac crashes with NullPointerException in Types.intersect during method type inference of complex overlapping intersection bounds

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4112,8 +4112,8 @@ public class Types {
             //step 3 - for each element G in MEC, compute lci(Inv(G))
             List<Type> candidates = List.nil();
             for (Type erasedSupertype : mec) {
-                Type asSuperResult = asSuper(ts[startIdx], erasedSupertype.tsym);
-                List<Type> lci = asSuperResult != null ? List.of(asSuperResult) : List.nil();
+                Type firstSuperType = asSuper(ts[startIdx], erasedSupertype.tsym);
+                List<Type> lci = firstSuperType != null ? List.of(firstSuperType) : List.nil();
                 for (int i = startIdx + 1 ; i < ts.length ; i++) {
                     Type superType = asSuper(ts[i], erasedSupertype.tsym);
                     lci = intersect(lci, superType != null ? List.of(superType) : List.nil());

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4112,7 +4112,8 @@ public class Types {
             //step 3 - for each element G in MEC, compute lci(Inv(G))
             List<Type> candidates = List.nil();
             for (Type erasedSupertype : mec) {
-                List<Type> lci = List.of(asSuper(ts[startIdx], erasedSupertype.tsym));
+                Type asSuperResult = asSuper(ts[startIdx], erasedSupertype.tsym);
+                List<Type> lci = asSuperResult != null ? List.of(asSuperResult) : List.nil();
                 for (int i = startIdx + 1 ; i < ts.length ; i++) {
                     Type superType = asSuper(ts[i], erasedSupertype.tsym);
                     lci = intersect(lci, superType != null ? List.of(superType) : List.nil());

--- a/test/langtools/tools/javac/generics/typevars/NPEInTypeIntersectTest.java
+++ b/test/langtools/tools/javac/generics/typevars/NPEInTypeIntersectTest.java
@@ -1,0 +1,32 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8388948
+ * @summary javac crashes with NullPointerException in Types.intersect during method type inference of complex
+ *          overlapping intersection bounds
+ * @compile/fail/ref=NPEInTypeIntersectTest.out -XDrawDiagnostics NPEInTypeIntersectTest.java
+ */
+
+import java.util.function.Function;
+
+class NPEInTypeIntersectTest {
+    interface MyFunction<A, B> extends Function<A, B> {}
+
+    abstract class Container<T> {
+        abstract T get();
+    }
+
+    class NestedContainer<X> extends Container<NestedContainer<X>> {
+        @Override
+        public NestedContainer<X> get() {
+            return this;
+        }
+    }
+
+    void foo() {
+        NestedContainer<MyFunction<Integer[], String[]>> container = new NestedContainer<>();
+        process(container, container);
+    }
+
+    private static <A, B, C extends A & B, D extends A & C, E extends B & C, F extends D & E> void process(
+            Container<F> f, Container<E> e) {}
+}

--- a/test/langtools/tools/javac/generics/typevars/NPEInTypeIntersectTest.out
+++ b/test/langtools/tools/javac/generics/typevars/NPEInTypeIntersectTest.out
@@ -1,0 +1,5 @@
+NPEInTypeIntersectTest.java:30:41: compiler.err.type.var.may.not.be.followed.by.other.bounds
+NPEInTypeIntersectTest.java:30:58: compiler.err.type.var.may.not.be.followed.by.other.bounds
+NPEInTypeIntersectTest.java:30:75: compiler.err.type.var.may.not.be.followed.by.other.bounds
+NPEInTypeIntersectTest.java:30:92: compiler.err.type.var.may.not.be.followed.by.other.bounds
+4 errors


### PR DESCRIPTION
In Types.lub(), step 3 of the LUB algorithm:
```
    for (Type erasedSupertype : mec) {
        List<Type> lci = List.of(asSuper(ts[startIdx], erasedSupertype.tsym));  // asSuper() can return null
        for (int i = startIdx + 1; i < ts.length; i++) {
            Type superType = asSuper(ts[i], erasedSupertype.tsym);
            lci = intersect(lci, superType != null ? List.of(superType) : List.nil());  // the null can escape to intersect() and the NPE can be produced there
        }
        candidates = candidates.appendList(lci);
    }
```
the proposed fix is to check if the result of asSuper is null or not before creating list `lci`

TIA

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388948](https://bugs.openjdk.org/browse/JDK-8388948): Javac crashes with NullPointerException in Types.intersect during method type inference of complex overlapping intersection bounds (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32222/head:pull/32222` \
`$ git checkout pull/32222`

Update a local copy of the PR: \
`$ git checkout pull/32222` \
`$ git pull https://git.openjdk.org/jdk.git pull/32222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32222`

View PR using the GUI difftool: \
`$ git pr show -t 32222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32222.diff">https://git.openjdk.org/jdk/pull/32222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32222#issuecomment-5197312250)
</details>
