### PR TITLE
8389846: GenShen: ShenandoahScanRemembered::process_clusters may miss dirty cards when use write table

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -218,11 +218,16 @@ void ShenandoahScanRemembered::process_clusters(size_t first_cluster, size_t cou
           // for the next iteration of a dirty card loop.
           upper_bound = p;   // remember upper bound for next chunk
           if (p < start_addr) {
-            // if object starts in a previous slice, it'll be handled
-            // in its entirety by the thread processing that slice; we can
-            // skip over it and avoid an unnecessary extra scan.
             assert(obj == cast_to_oop(p), "Inconsistency detected");
-            p += obj->size();
+            if (use_write_table) {
+              // The head card may have become dirty after the worker
+              // responsible for the preceding slice passed it.
+              p += obj->oop_iterate_size(cl);
+            } else {
+              // The stable read table guarantees that the worker processing
+              // the preceding slice scanned this object in its entirety.
+              p += obj->size();
+            }
           } else {
             // the object starts in our slice, we scan it in its entirety
             assert(obj == cast_to_oop(p), "Inconsistency detected");


### PR DESCRIPTION
See the details in JBS bug, it seems a long existing bug in Genshen, which may cause heap corruption and lead to crashes. This is a minimal change to fix the bug.  

We have seem some crashes in our CI pipeline, but I haven't been able to reproduce the crash manually.  

Test:
- [x] hotspot_gc_shenandoah
- [x] Internal CI pipeline runs most of headless
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389846](https://bugs.openjdk.org/browse/JDK-8389846): GenShen: ShenandoahScanRemembered::process_clusters may miss dirty cards when use write table (**Bug** - P3)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32225/head:pull/32225` \
`$ git checkout pull/32225`

Update a local copy of the PR: \
`$ git checkout pull/32225` \
`$ git pull https://git.openjdk.org/jdk.git pull/32225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32225`

View PR using the GUI difftool: \
`$ git pr show -t 32225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32225.diff">https://git.openjdk.org/jdk/pull/32225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32225#issuecomment-5199376881)
</details>
