### PR TITLE
8388592: C2: ShouldNotReachHere in loop stripmining scheduling verification

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -99,11 +99,9 @@ Node *PhaseIdealLoop::get_early_ctrl( Node *n ) {
   assert( !n->is_Phi() && !n->is_CFG(), "this code only handles data nodes" );
   uint i;
   Node *early;
-  // The control input of an expensive node is only a starting point:
-  // get_early_ctrl_for_expensive() below moves it up the dominator tree.
-  // That modifies the graph, so it is skipped when verifying:
-  // honor the control input here instead.
-  if (n->in(0) && (!n->is_expensive() || _verify_me || _verify_only)) {
+  // During verification we also get early control for expensive nodes here,
+  // as get_early_ctrl_for_expensive is skipped because it modifies the graph.
+  if (n->in(0) != nullptr && (!n->is_expensive() || _verify_me != nullptr || _verify_only)) {
     early = n->in(0);
     if (!early->is_CFG()) // Might be a non-CFG multi-def
       early = get_ctrl(early);        // So treat input as a straight data input

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -99,7 +99,11 @@ Node *PhaseIdealLoop::get_early_ctrl( Node *n ) {
   assert( !n->is_Phi() && !n->is_CFG(), "this code only handles data nodes" );
   uint i;
   Node *early;
-  if (n->in(0) && !n->is_expensive()) {
+  // The control input of an expensive node is only a starting point:
+  // get_early_ctrl_for_expensive() below moves it up the dominator tree.
+  // That modifies the graph, so it is skipped when verifying:
+  // honor the control input here instead.
+  if (n->in(0) && (!n->is_expensive() || _verify_me || _verify_only)) {
     early = n->in(0);
     if (!early->is_CFG()) // Might be a non-CFG multi-def
       early = get_ctrl(early);        // So treat input as a straight data input

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestExpensiveNodeInOuterStripMinedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestExpensiveNodeInOuterStripMinedLoop.java
@@ -29,8 +29,9 @@
  *          outer strip mined loop.
  *
  * @run main/othervm -Xbatch -XX:-TieredCompilation
- *                   -XX:CompileCommand=compileonly,TestExpensiveNodeInOuterStripMinedLoop::test
- *                   TestExpensiveNodeInOuterStripMinedLoop
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
  */
 
 /*
@@ -46,6 +47,8 @@
  * Only a debug VM verifies loop optimizations, so this test can only fail there.
  * The reduced shape comes from a JavaFuzzer test and needs OSR to trigger.
  */
+
+package compiler.loopstripmining;
 
 public class TestExpensiveNodeInOuterStripMinedLoop {
 

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestExpensiveNodeInOuterStripMinedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestExpensiveNodeInOuterStripMinedLoop.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8388592
+ * @summary The early control of an expensive node must not be computed above
+ *          its control input when verifying, otherwise it can end up in an
+ *          outer strip mined loop.
+ *
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,TestExpensiveNodeInOuterStripMinedLoop::test
+ *                   TestExpensiveNodeInOuterStripMinedLoop
+ */
+
+/*
+ * The Sqrt below is an expensive node pinned right after the strip mined loop
+ * nest. get_early_ctrl() ignores the control input of an expensive node because
+ * get_early_ctrl_for_expensive() normally adjusts it, but that adjustment
+ * modifies the graph and is therefore skipped when verifying. The early control
+ * was then taken from the data inputs only and could land inside the outer strip
+ * mined loop, above the control input. The Sqrt itself is pinned and so is not
+ * checked, but its ConvI2D input inherited that block and
+ * verify_strip_mined_scheduling() hit ShouldNotReachHere().
+ *
+ * Only a debug VM verifies loop optimizations, so this test can only fail there.
+ * The reduced shape comes from a JavaFuzzer test and needs OSR to trigger.
+ */
+
+public class TestExpensiveNodeInOuterStripMinedLoop {
+
+    short sFld;
+
+    public static void main(String[] args) {
+        TestExpensiveNodeInOuterStripMinedLoop t =
+            new TestExpensiveNodeInOuterStripMinedLoop();
+        for (int i = 0; i < 10_000; i++) {
+            t.test();
+        }
+    }
+
+    void test() {
+        int n = 8;
+        int m = 0;
+        int k = 2;
+        for (int i = 55; i > 8; --i) {
+            for (int j = 71; j > 8; j--) {
+                n = sFld;
+            }
+            do {
+                m = (int)(m - Math.sqrt(n));
+            } while (++k < 71);
+            for (int j = 6; 71 > j; ++j) {}
+        }
+    }
+}


### PR DESCRIPTION
The assert only fires in the verification pass, so this is debug builds only and there is no miscompilation.

`get_early_ctrl()` ignores the control input of an expensive node because `get_early_ctrl_for_expensive()` re-derives it afterwards, but that step is skipped when verifying since it modifies the graph (JDK-8040213). The pin is then lost: the `SqrtD` here is pinned outside the strip mined nest, yet verification places it inside the outer strip mined loop, above its own control input. Being pinned it is not checked itself, but its `ConvI2D` input inherits that block and `verify_strip_mined_scheduling()` reports it.

The fix honors the control input when verifying, like for any other pinned node, without modifying anything. That is what the real passes end up with anyway, since `get_early_ctrl_for_expensive()` rewires the control input to the block it picks.

The test is the reduced reproducer from the bug, credit to @mhaessig, who also did the bisect. It fails at `loopnode.cpp:7020` on fastdebug without the fix and passes with it.

Testing, all on linux-x86_64 fastdebug and re-run after the review changes:
- [x] the new test fails without the fix and passes with it
- [x] `Test_2133.java`, the original JavaFuzzer test from the bug, passes
- [x] `test/hotspot/jtreg/compiler/loopstripmining`, 37 tests, all passed
- [ ] `test/hotspot/jtreg:tier1` not completed yet, will update

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388592](https://bugs.openjdk.org/browse/JDK-8388592): C2: ShouldNotReachHere in loop stripmining scheduling verification (**Bug** - P3)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32226/head:pull/32226` \
`$ git checkout pull/32226`

Update a local copy of the PR: \
`$ git checkout pull/32226` \
`$ git pull https://git.openjdk.org/jdk.git pull/32226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32226`

View PR using the GUI difftool: \
`$ git pr show -t 32226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32226.diff">https://git.openjdk.org/jdk/pull/32226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32226#issuecomment-5198358950)
</details>
