### PR TITLE
8323421: serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest.java fails with OOME

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest.java
@@ -30,7 +30,7 @@ package MyPackage;
  * @summary Verifies the JVMTI Heap Monitor Thread information sanity.
  * @requires vm.jvmti
  * @compile HeapMonitorThreadTest.java
- * @run main/othervm/native/timeout=480 -Xmx1g -agentlib:HeapMonitorTest MyPackage.HeapMonitorThreadTest
+ * @run main/othervm/native/timeout=480 -Xmx1g -Xlog:gc -agentlib:HeapMonitorTest MyPackage.HeapMonitorThreadTest
  */
 
 import java.util.List;

--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,7 +26,6 @@ package MyPackage;
 
 /**
  * @test
- * @bug 8323421
  * @build Frame HeapMonitor ThreadInformation
  * @summary Verifies the JVMTI Heap Monitor Thread information sanity.
  * @requires vm.jvmti

--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest.java
@@ -26,11 +26,12 @@ package MyPackage;
 
 /**
  * @test
+ * @bug 8323421
  * @build Frame HeapMonitor ThreadInformation
  * @summary Verifies the JVMTI Heap Monitor Thread information sanity.
  * @requires vm.jvmti
  * @compile HeapMonitorThreadTest.java
- * @run main/othervm/native/timeout=480 -Xmx512m -agentlib:HeapMonitorTest MyPackage.HeapMonitorThreadTest
+ * @run main/othervm/native/timeout=480 -Xmx1g -agentlib:HeapMonitorTest MyPackage.HeapMonitorThreadTest
  */
 
 import java.util.List;


### PR DESCRIPTION
The test fails intermittently with OutOfMemoryError under -Xcheck:jni -XX:+UseZGC (the original report also had -XX:+ZGenerational, which is gone since JEP 490). Reproduced at about 2%: 6 of 300 runs on four hosts, all
with the original signature.

GC logs from the failing runs show the 512m heap reaching 100% with ZGC in back-to-back allocation-stall collections that reclaim almost nothing, ending in the OOME while Allocator.helper grows its list. The sampling
agent holds jweaks on the sampled objects, which keeps the transient garbage alive until a major collection runs. The test's actual live set is only about 20MB.

Fix: bump the test heap from 512m to 1g.

Testing: 500 default-config runs at 1g all pass. The failing configuration at 1g (501 runs) had 2 OOME failures, about 0.4% vs 2% at 512m.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8323421](https://bugs.openjdk.org/browse/JDK-8323421): serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest.java fails with OOME (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) 🔄 Re-review required (review applies to [8c24fd30](https://git.openjdk.org/jdk/pull/32229/files/8c24fd3050f00e7a45ca1022d508dbae17c40cd4))
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32229/head:pull/32229` \
`$ git checkout pull/32229`

Update a local copy of the PR: \
`$ git checkout pull/32229` \
`$ git pull https://git.openjdk.org/jdk.git pull/32229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32229`

View PR using the GUI difftool: \
`$ git pr show -t 32229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32229.diff">https://git.openjdk.org/jdk/pull/32229.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32229#issuecomment-5207001466)
</details>
