### PR TITLE
8389806: [s390x] Parent reports exit status 1023 for child, even when child exited normally

### DIFF
--- a/src/hotspot/share/cds/aotMetaspace.cpp
+++ b/src/hotspot/share/cds/aotMetaspace.cpp
@@ -1337,7 +1337,7 @@ static int exec_jvm_with_java_tool_options(const char* java_launcher_path, TRAPS
   //
   // Note: the env variables are set only for the child process. They are not changed
   // for the current process. See java.lang.ProcessBuilder::environment().
-  JavaValue result(T_OBJECT);
+  JavaValue result(T_INT);
   JavaCallArguments javacall_args(2);
   javacall_args.push_oop(launcher);
   javacall_args.push_oop(launcher_args);


### PR DESCRIPTION
This is AOT related issue, caught by https://github.com/openjdk/jdk/pull/31496, but caused way long before that. Little bit more information & test failure log is present on JBS. 

Issue is that Launcher is return "int" type: https://github.com/openjdk/jdk/blob/52cd87fef6f3a4f017faf9efbdfa657413130862/src/java.base/share/classes/jdk/internal/misc/CDS.java#L522

But result is defined as "obj" type:
https://github.com/openjdk/jdk/blob/52cd87fef6f3a4f017faf9efbdfa657413130862/src/hotspot/share/cds/aotMetaspace.cpp#L1340-L1350

As java value is union: 
https://github.com/openjdk/jdk/blob/52cd87fef6f3a4f017faf9efbdfa657413130862/src/hotspot/share/utilities/globalDefinitions.hpp#L895-L902


We have issue on Big Endian/s390x. 

Initialisation is fine: 
```
(gdb) p result 
$1 = {
  _type = T_OBJECT,
  _value = {
    f = 0,
    d = 6.4758172331703867e-319,
    i = 0,
    l = 131072,
    h = 0x20000,
    o = 0x20000
  }
}
```

But once result returns, things change: 
```
(gdb) n
exec_jvm_with_java_tool_options (__the_thread__=0x433000290, java_launcher_path=<optimized out>) at /home/amit/jdk/src/hotspot/share/cds/aotMetaspace.cpp:1350
1350	  return result.get_jint();
(gdb) p result
$2 = {
  _type = T_OBJECT,
  _value = {
    f = 1.43352833e-42,
    d = 2.1708016941574736e-311,
    i = 1023,
    l = 4393751543808,
    h = 0x3ff00000000,
    o = 0x3ff00000000
  }
}
(gdb) step 
JavaValue::get_jint (this=0x3fff5bfce40) at /home/amit/jdk/src/hotspot/share/utilities/globalDefinitions.hpp:923
923	 jint get_jint() const { return _value.i; }
(gdb) p _value.i 
$4 = 1023
(gdb)
```

So even though the child process exits with 0 status (see the strace in JBS), 1023 is show, which is again way above the limit 255. 

```
With the proposed fix Test passes on s390x: 
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
   jtreg:./test/hotspot/jtreg/runtime/cds/PrintSharedArchiveAndExitNoHeap.java
                                                         1     1     0     0     0   
==============================
TEST SUCCESS
```



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389806](https://bugs.openjdk.org/browse/JDK-8389806): [s390x] Parent reports exit status 1023 for child, even when child exited normally (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32230/head:pull/32230` \
`$ git checkout pull/32230`

Update a local copy of the PR: \
`$ git checkout pull/32230` \
`$ git pull https://git.openjdk.org/jdk.git pull/32230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32230`

View PR using the GUI difftool: \
`$ git pr show -t 32230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32230.diff">https://git.openjdk.org/jdk/pull/32230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32230#issuecomment-5201215044)
</details>
