### PR TITLE
8389870: Object histogram in SA cannot identify FlatArrayKlass

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/FlatArrayKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/FlatArrayKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import sun.jvm.hotspot.utilities.Observer;
 
 // FlatArrayKlass is a proxy for FlatArrayKlass in the JVM
 
-public class FlatArrayKlass extends ArrayKlass {
+public class FlatArrayKlass extends ObjArrayKlass {
   static {
     VM.registerVMInitializedObserver(new Observer() {
         public void update(Observable o, Object data) {
@@ -54,6 +54,7 @@ public class FlatArrayKlass extends ArrayKlass {
   }
 
   public void printValueOn(PrintStream tty) {
-    tty.print("FlatArrayKlass");
+    tty.print("FlatArrayKlass for ");
+    getElementKlass().printValueOn(tty);
   }
 }


### PR DESCRIPTION
`jhisto` on CLHSDB and object histogram on HSDB cannot identify the object instantiated as `FlatArrayKlass` like following:

```
157: 1 32 * FlatArrayKlass
```

`FlatArrayKlass` inherits `ObjArrayKlass` in HotSpot, however it inherits `ArrayKlass` in SA. SA should follow HotSpot manner.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389870](https://bugs.openjdk.org/browse/JDK-8389870): Object histogram in SA cannot identify FlatArrayKlass (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32231/head:pull/32231` \
`$ git checkout pull/32231`

Update a local copy of the PR: \
`$ git checkout pull/32231` \
`$ git pull https://git.openjdk.org/jdk.git pull/32231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32231`

View PR using the GUI difftool: \
`$ git pr show -t 32231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32231.diff">https://git.openjdk.org/jdk/pull/32231.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32231#issuecomment-5201938030)
</details>
