### PR TITLE
8389579: C2: Missed Ideal optimization opportunity in PhaseIterGVN for CompressBits and ExpandBits

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2703,8 +2703,15 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
   // If changed LShift inputs, check CompressBits users for
   // compress(x, 1 << n) and compress(x, -1 << n) optimizations.
   if (use_op == Op_LShiftI || use_op == Op_LShiftL) {
-    add_users_to_worklist_if(worklist, use, [=](Node* u) {
+    add_users_to_worklist_if(worklist, use, [&](Node* u) {
       return u->Opcode() == Op_CompressBits && u->in(2) == use;
+    });
+  }
+  // If changed ExpandBits inputs, check CompressBits users for
+  // compress(expand(x, m), m) optimization.
+  if (use_op == Op_ExpandBits) {
+    add_users_to_worklist_if(worklist, use, [&](Node* u) {
+      return u->Opcode() == Op_CompressBits && u->in(1) == use;
     });
   }
   // If changed AddI/SubI inputs, check CmpU for range check optimization.

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2700,6 +2700,13 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
       return u->Opcode() == Op_AndI || u->Opcode() == Op_AndL;
     });
   }
+  // If changed LShift inputs, check CompressBits users for
+  // compress(x, 1 << n) and compress(x, -1 << n) optimizations.
+  if (use_op == Op_LShiftI || use_op == Op_LShiftL) {
+    add_users_to_worklist_if(worklist, use, [=](Node* u) {
+      return u->Opcode() == Op_CompressBits && u->in(2) == use;
+    });
+  }
   // If changed AddI/SubI inputs, check CmpU for range check optimization.
   if (use_op == Op_AddI || use_op == Op_SubI) {
     add_users_to_worklist_if(worklist, use, [](Node* u) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2700,11 +2700,13 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
       return u->Opcode() == Op_AndI || u->Opcode() == Op_AndL;
     });
   }
-  // If changed LShift inputs, check CompressBits users for
-  // compress(x, 1 << n) and compress(x, -1 << n) optimizations.
+  // If changed LShift inputs, check CompressBits and ExpandBits users for
+  // compress(x, 1 << n), compress(x, -1 << n),
+  // expand(x, 1 << n), expand(x, -1 << n) optimizations.
   if (use_op == Op_LShiftI || use_op == Op_LShiftL) {
     add_users_to_worklist_if(worklist, use, [&](Node* u) {
-      return u->Opcode() == Op_CompressBits && u->in(2) == use;
+      return (u->Opcode() == Op_CompressBits || u->Opcode() == Op_ExpandBits) &&
+             u->in(2) == use;
     });
   }
   // If changed ExpandBits inputs, check CompressBits users for
@@ -2712,6 +2714,13 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
   if (use_op == Op_ExpandBits) {
     add_users_to_worklist_if(worklist, use, [&](Node* u) {
       return u->Opcode() == Op_CompressBits && u->in(1) == use;
+    });
+  }
+  // If changed CompressBits inputs, check ExpandBits users for
+  // expand(compress(x, m), m) optimization.
+  if (use_op == Op_CompressBits) {
+    add_users_to_worklist_if(worklist, use, [&](Node* u) {
+      return u->Opcode() == Op_ExpandBits && u->in(1) == use;
     });
   }
   // If changed AddI/SubI inputs, check CmpU for range check optimization.

--- a/test/hotspot/jtreg/compiler/c2/igvn/TestMissingCompressBitsAndExpandBitsIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/igvn/TestMissingCompressBitsAndExpandBitsIdeal.java
@@ -31,7 +31,7 @@ import jdk.test.lib.Utils;
  * @test
  * @bug 8389579
  * @key randomness
- * @summary Test missing Ideal optimization opportunity for CompressBits.
+ * @summary Test missing Ideal optimization opportunity for CompressBits and ExpandBits.
  * @library /test/lib /
  * @run main/othervm -Xcomp -XX:-TieredCompilation
  *      -XX:+IgnoreUnrecognizedVMOptions
@@ -41,10 +41,20 @@ import jdk.test.lib.Utils;
  * @run main ${test.main.class}
  */
 
-public class TestMissingCompressBitsIdeal {
+public class TestMissingCompressBitsAndExpandBitsIdeal {
     private static final Random R = Utils.getRandomInstance();
+    private static final int[] V = {43, 0x55555555};
+    private static final long[] L_V = {43L, 0x5555555555555555L};
 
     public static void main(String[] args) {
+        Asserts.assertEQ(testLShiftToExpand(), 1 << 11);
+        Asserts.assertEQ(testMinusOneLShiftToExpand(), 43 << 11);
+        Asserts.assertEQ(testLongLShiftToExpand(), 1L << 43);
+        Asserts.assertEQ(testLongMinusOneLShiftToExpand(), 43L << 43);
+
+        Asserts.assertEQ(testCompressToExpand(), 43 & 0x55555555);
+        Asserts.assertEQ(testLongCompressToExpand(), 43L & 0x5555555555555555L);
+
         for (int i = 0; i < 100; i++) {
             int intValue = R.nextInt();
             int intShift = R.nextInt(Integer.SIZE);
@@ -115,5 +125,67 @@ public class TestMissingCompressBitsIdeal {
         for (i = -10; i < -1; i++) { }
         long expandMask = i & mask;
         return Long.compress(Long.expand(val, expandMask), mask);
+    }
+
+    // expand(x, 1 << n) == (x & 1) << n
+    public static int testLShiftToExpand() {
+        int result = 0;
+        for (int i = 1; i >= 1; i--) {
+            int x = V[0];
+            result = Integer.expand(x, i << x);
+        }
+        return result;
+    }
+
+    // expand(x, -1 << n) == x << n
+    public static int testMinusOneLShiftToExpand() {
+        int result = 0;
+        for (int i = -1; i >= -1; i--) {
+            int x = V[0];
+            result = Integer.expand(x, i << x);
+        }
+        return result;
+    }
+
+     // expand(x, 1L << n) == (x & 1L) << n
+    public static long testLongLShiftToExpand() {
+        long result = 0;
+        for (long i = 1L; i >= 1L; i--) {
+            long x = L_V[0];
+            result = Long.expand(x, i << x);
+        }
+        return result;
+    }
+
+    // expand(x, -1L << n) == x << n
+    public static long testLongMinusOneLShiftToExpand() {
+        long result = 0;
+        for (long i = -1L; i >= -1L; i--) {
+            long x = L_V[0];
+            result = Long.expand(x, i << x);
+        }
+        return result;
+    }
+
+    // expand(compress(x, m), m) == x & m
+    public static int testCompressToExpand() {
+        int result = 0;
+        for (int i = 1; i >= 1; i--) {
+            int x = V[0];
+            int mask = V[1];
+            result = Integer.expand(Integer.compress(x, mask * i), mask);
+        }
+        return result;
+    }
+
+    // expand(compress(x, m), m) == x & m
+    public static long testLongCompressToExpand() {
+        long result = 0;
+        for (long i = 1L; i >= 1L; i--) {
+            long x = L_V[0];
+            long mask = L_V[1];
+            result = Long.expand(Long.compress(x, mask * i), mask);
+        }
+        return result;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/igvn/TestMissingCompressBitsAndExpandBitsIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/igvn/TestMissingCompressBitsAndExpandBitsIdeal.java
@@ -23,9 +23,9 @@
 
 package compiler.c2.igvn;
 
-import java.util.Random;
+import compiler.lib.generators.*;
+import compiler.lib.ir_framework.*;
 import jdk.test.lib.Asserts;
-import jdk.test.lib.Utils;
 
 /*
  * @test
@@ -33,159 +33,263 @@ import jdk.test.lib.Utils;
  * @key randomness
  * @summary Test missing Ideal optimization opportunity for CompressBits and ExpandBits.
  * @library /test/lib /
- * @run main/othervm -Xcomp -XX:-TieredCompilation
- *      -XX:+IgnoreUnrecognizedVMOptions
- *      -XX:VerifyIterativeGVN=100
- *      -XX:CompileCommand=compileonly,${test.main.class}::test*
- *      ${test.main.class}
- * @run main ${test.main.class}
+ * @run driver ${test.main.class}
  */
 
 public class TestMissingCompressBitsAndExpandBitsIdeal {
-    private static final Random R = Utils.getRandomInstance();
-    private static final int[] V = {43, 0x55555555};
-    private static final long[] L_V = {43L, 0x5555555555555555L};
+    private static final Generator<Integer> INTS = Generators.G.ints();
+    private static final Generator<Long> LONGS = Generators.G.longs();
+
+    private static final RestrictableGenerator<Integer> INT_SHIFTS = Generators.G.ints()
+                                                                               .restricted(1, Integer.SIZE - 1);
+    private static final RestrictableGenerator<Integer> LONG_SHIFTS = Generators.G.ints()
+                                                                                .restricted(1, Long.SIZE - 1);
 
     public static void main(String[] args) {
-        Asserts.assertEQ(testLShiftToExpand(), 1 << 11);
-        Asserts.assertEQ(testMinusOneLShiftToExpand(), 43 << 11);
-        Asserts.assertEQ(testLongLShiftToExpand(), 1L << 43);
-        Asserts.assertEQ(testLongMinusOneLShiftToExpand(), 43L << 43);
-
-        Asserts.assertEQ(testCompressToExpand(), 43 & 0x55555555);
-        Asserts.assertEQ(testLongCompressToExpand(), 43L & 0x5555555555555555L);
-
-        for (int i = 0; i < 100; i++) {
-            int intValue = R.nextInt();
-            int intShift = R.nextInt(Integer.SIZE);
-            Asserts.assertEQ(testIntCompressWithOneLeftShift(intValue, intShift),
-                             (intValue >>> intShift) & 1);
-            Asserts.assertEQ(testIntCompressWithMinusOneLeftShift(intValue, intShift),
-                             intValue >>> intShift);
-            int intMask = R.nextInt();
-            Asserts.assertEQ(testIntCompressExpandWithSameMask(intValue, intMask),
-                             intValue & Integer.compress(intMask, intMask));
-
-            long longValue = R.nextLong();
-            int longShift = R.nextInt(Long.SIZE);
-            Asserts.assertEQ(testLongCompressWithOneLeftShift(longValue, longShift),
-                             (longValue >>> longShift) & 1L);
-            Asserts.assertEQ(testLongCompressWithMinusOneLeftShift(longValue, longShift),
-                             longValue >>> longShift);
-            long longMask = R.nextLong();
-            Asserts.assertEQ(testLongCompressExpandWithSameMask(longValue, longMask),
-                             longValue & Long.compress(longMask, longMask));
-
-        }
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions",
+                                   "-XX:VerifyIterativeGVN=100");
     }
 
-    // compress(x, 1 << n) == (x >> n & 1)
-    public static int testIntCompressWithOneLeftShift(int val, int Lshift) {
+    // compress(x, 1 << n) == (x >> n) & 1
+    @Test
+    @IR(counts = {IRNode.COMPRESS_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.COMPRESS_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static int testIntCompressWithOneLeftShift(int value, int shift) {
         int i;
-        for (i = -10; i < 1; i++) { }
-        int mask = i << Lshift;
-        return Integer.compress(val, mask);
+        for (i = -10; i < 1; i++) {
+        }
+        int mask = i << shift;
+        return Integer.compress(value, mask);
     }
 
     // compress(x, -1 << n) == x >>> n
-    public static int testIntCompressWithMinusOneLeftShift(int val, int Lshift) {
+    @Test
+    @IR(counts = {IRNode.COMPRESS_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.COMPRESS_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static int testIntCompressWithMinusOneLeftShift(int value, int shift) {
         int i;
-        for (i = -10; i < -1; i++) { }
-        int mask = i << Lshift;
-        return Integer.compress(val, mask);
+        for (i = -10; i < -1; i++) {
+        }
+        int mask = i << shift;
+        return Integer.compress(value, mask);
     }
 
-    // compress(x, 1L << n) == (x >> n & 1L)
-    public static long testLongCompressWithOneLeftShift(long val, int Lshift) {
+    // compress(x, 1L << n) == (x >> n) & 1L
+    @Test
+    @IR(counts = {IRNode.COMPRESS_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.COMPRESS_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static long testLongCompressWithOneLeftShift(long value, int shift) {
         long i;
-        for (i = -10; i < 1; i++) { }
-        long mask = i << Lshift;
-        return Long.compress(val, mask);
+        for (i = -10; i < 1; i++) {
+        }
+        long mask = i << shift;
+        return Long.compress(value, mask);
     }
 
     // compress(x, -1L << n) == x >>> n
-    public static long testLongCompressWithMinusOneLeftShift(long val, int Lshift) {
+    @Test
+    @IR(counts = {IRNode.COMPRESS_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.COMPRESS_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static long testLongCompressWithMinusOneLeftShift(long value, int shift) {
         long i;
-        for (i = -10; i < -1; i++) { }
-        long mask = i << Lshift;
-        return Long.compress(val, mask);
+        for (i = -10; i < -1; i++) {
+        }
+        long mask = i << shift;
+        return Long.compress(value, mask);
     }
 
     // compress(expand(x, m), m) == x & compress(m, m)
-    public static int testIntCompressExpandWithSameMask(int val, int mask) {
+    @Test
+    @IR(counts = {IRNode.EXPAND_BITS, "> 0",
+                  IRNode.COMPRESS_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.EXPAND_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static int testIntCompressExpandWithSameMask(int value, int mask) {
         int i;
-        for (i = -10; i < -1; i++) { }
-        int expandMask = i & mask;
-        return Integer.compress(Integer.expand(val, expandMask), mask);
+        for (i = -10; i < 1; i++) {
+        }
+        int expandMask = mask * i;
+        return Integer.compress(Integer.expand(value, expandMask), mask);
     }
 
     // compress(expand(x, m), m) == x & compress(m, m)
-    public static long testLongCompressExpandWithSameMask(long val, long mask) {
+    @Test
+    @IR(counts = {IRNode.EXPAND_BITS, "> 0",
+                  IRNode.COMPRESS_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.EXPAND_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static long testLongCompressExpandWithSameMask(long value, long mask) {
         long i;
-        for (i = -10; i < -1; i++) { }
-        long expandMask = i & mask;
-        return Long.compress(Long.expand(val, expandMask), mask);
+        for (i = -10; i < 1; i++) {
+        }
+        long expandMask = mask * i;
+        return Long.compress(Long.expand(value, expandMask), mask);
     }
 
     // expand(x, 1 << n) == (x & 1) << n
-    public static int testLShiftToExpand() {
+    @Test
+    @IR(counts = {IRNode.EXPAND_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.EXPAND_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static int testIntExpandWithOneLeftShift(int value, int shift) {
         int result = 0;
         for (int i = 1; i >= 1; i--) {
-            int x = V[0];
-            result = Integer.expand(x, i << x);
+            int x = value;
+            result = Integer.expand(x, i << shift);
         }
         return result;
     }
 
     // expand(x, -1 << n) == x << n
-    public static int testMinusOneLShiftToExpand() {
+    @Test
+    @IR(counts = {IRNode.EXPAND_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.EXPAND_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static int testIntExpandWithMinusOneLeftShift(int value, int shift) {
         int result = 0;
         for (int i = -1; i >= -1; i--) {
-            int x = V[0];
-            result = Integer.expand(x, i << x);
+            int x = value;
+            result = Integer.expand(x, i << shift);
         }
         return result;
     }
 
-     // expand(x, 1L << n) == (x & 1L) << n
-    public static long testLongLShiftToExpand() {
+    // expand(x, 1L << n) == (x & 1L) << n
+    @Test
+    @IR(counts = {IRNode.EXPAND_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.EXPAND_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static long testLongExpandWithOneLeftShift(long value, int shift) {
         long result = 0;
         for (long i = 1L; i >= 1L; i--) {
-            long x = L_V[0];
-            result = Long.expand(x, i << x);
+            long x = value;
+            result = Long.expand(x, i << shift);
         }
         return result;
     }
 
     // expand(x, -1L << n) == x << n
-    public static long testLongMinusOneLShiftToExpand() {
+    @Test
+    @IR(counts = {IRNode.EXPAND_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.EXPAND_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static long testLongExpandWithMinusOneLeftShift(long value, int shift) {
         long result = 0;
         for (long i = -1L; i >= -1L; i--) {
-            long x = L_V[0];
-            result = Long.expand(x, i << x);
+            long x = value;
+            result = Long.expand(x, i << shift);
         }
         return result;
     }
 
     // expand(compress(x, m), m) == x & m
-    public static int testCompressToExpand() {
+    @Test
+    @IR(counts = {IRNode.COMPRESS_BITS, "> 0",
+                  IRNode.EXPAND_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.EXPAND_BITS, IRNode.COMPRESS_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static int testIntExpandCompressWithSameMask(int value, int mask) {
         int result = 0;
         for (int i = 1; i >= 1; i--) {
-            int x = V[0];
-            int mask = V[1];
+            int x = value;
             result = Integer.expand(Integer.compress(x, mask * i), mask);
         }
         return result;
     }
 
     // expand(compress(x, m), m) == x & m
-    public static long testLongCompressToExpand() {
+    @Test
+    @IR(counts = {IRNode.COMPRESS_BITS, "> 0",
+                  IRNode.EXPAND_BITS, "> 0"},
+        phase = {CompilePhase.AFTER_PARSING},
+        applyIfCPUFeature = {"bmi2", "true"})
+    @IR(failOn = {IRNode.EXPAND_BITS, IRNode.COMPRESS_BITS},
+        applyIfCPUFeature = {"bmi2", "true"})
+    public static long testLongExpandCompressWithSameMask(long value, long mask) {
         long result = 0;
         for (long i = 1L; i >= 1L; i--) {
-            long x = L_V[0];
-            long mask = L_V[1];
+            long x = value;
             result = Long.expand(Long.compress(x, mask * i), mask);
         }
         return result;
+    }
+
+    @Run(test = {"testIntCompressWithOneLeftShift",
+                 "testIntCompressWithMinusOneLeftShift",
+                 "testLongCompressWithOneLeftShift",
+                 "testLongCompressWithMinusOneLeftShift",
+                 "testIntCompressExpandWithSameMask",
+                 "testLongCompressExpandWithSameMask",
+                 "testIntExpandWithOneLeftShift",
+                 "testIntExpandWithMinusOneLeftShift",
+                 "testLongExpandWithOneLeftShift",
+                 "testLongExpandWithMinusOneLeftShift",
+                 "testIntExpandCompressWithSameMask",
+                 "testLongExpandCompressWithSameMask"})
+    public static void runTest() {
+        for (int i = 0; i < 100; i++) {
+            int intValue = INTS.next();
+            int intShift = INT_SHIFTS.next();
+            int intMask = INTS.next();
+            long longValue = LONGS.next();
+            int longShift = LONG_SHIFTS.next();
+            long longMask = LONGS.next();
+
+            Asserts.assertEQ(testIntCompressWithOneLeftShift(intValue, intShift),
+                             (intValue >> intShift) & 1);
+            Asserts.assertEQ(testIntCompressWithMinusOneLeftShift(intValue, intShift),
+                             intValue >>> intShift);
+
+            Asserts.assertEQ(testLongCompressWithOneLeftShift(longValue, longShift),
+                             (longValue >> longShift) & 1L);
+            Asserts.assertEQ(testLongCompressWithMinusOneLeftShift(longValue, longShift),
+                             longValue >>> longShift);
+
+            Asserts.assertEQ(testIntCompressExpandWithSameMask(intValue, intMask),
+                             intValue & Integer.compress(intMask, intMask));
+            Asserts.assertEQ(testLongCompressExpandWithSameMask(longValue, longMask),
+                             longValue & Long.compress(longMask, longMask));
+
+            Asserts.assertEQ(testIntExpandWithOneLeftShift(intValue, intShift),
+                             (intValue & 1) << intShift);
+            Asserts.assertEQ(testIntExpandWithMinusOneLeftShift(intValue, intShift),
+                             intValue << intShift);
+
+            Asserts.assertEQ(testLongExpandWithOneLeftShift(longValue, longShift),
+                             (longValue & 1L) << longShift);
+            Asserts.assertEQ(testLongExpandWithMinusOneLeftShift(longValue, longShift),
+                             longValue << longShift);
+
+            Asserts.assertEQ(testIntExpandCompressWithSameMask(intValue, intMask),
+                             intValue & intMask);
+            Asserts.assertEQ(testLongExpandCompressWithSameMask(longValue, longMask),
+                             longValue & longMask);
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/igvn/TestMissingCompressBitsIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/igvn/TestMissingCompressBitsIdeal.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.igvn;
+
+import java.util.Random;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/*
+ * @test
+ * @bug 8389579
+ * @summary Test missing Ideal optimization opportunity for CompressBits.
+ * @library /test/lib /
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:VerifyIterativeGVN=100
+ *      -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *      ${test.main.class}
+ */
+
+public class TestMissingCompressBitsIdeal {
+    private static final Random R = Utils.getRandomInstance();
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 100; i++) {
+            int intValue = R.nextInt();
+            int intShift = R.nextInt(Integer.SIZE);
+            Asserts.assertEQ(testIntCompressWithOneLeftShift(intValue, intShift),
+                             (intValue >>> intShift) & 1);
+            Asserts.assertEQ(testIntCompressWithMinusOneLeftShift(intValue, intShift),
+                             intValue >>> intShift);
+
+            long longValue = R.nextLong();
+            int longShift = R.nextInt(Long.SIZE);
+            Asserts.assertEQ(testLongCompressWithOneLeftShift(longValue, longShift),
+                             (longValue >>> longShift) & 1L);
+            Asserts.assertEQ(testLongCompressWithMinusOneLeftShift(longValue, longShift),
+                             longValue >>> longShift);
+        }
+    }
+
+    // compress(x, 1 << n) == (x >> n & 1)
+    public static int testIntCompressWithOneLeftShift(int val, int Lshift) {
+        int i;
+        for (i = -10; i < 1; i++) { }
+        int mask = i << Lshift;
+        return Integer.compress(val, mask);
+    }
+
+    // compress(x, -1 << n) == x >>> n
+    public static int testIntCompressWithMinusOneLeftShift(int val, int Lshift) {
+        int i;
+        for (i = -10; i < -1; i++) { }
+        int mask = i << Lshift;
+        return Integer.compress(val, mask);
+    }
+
+    // compress(x, 1L << n) == (x >> n & 1L)
+    public static long testLongCompressWithOneLeftShift(long val, int Lshift) {
+        long i;
+        for (i = -10; i < 1; i++) { }
+        long mask = i << Lshift;
+        return Long.compress(val, mask);
+    }
+
+    // compress(x, -1L << n) == x >>> n
+    public static long testLongCompressWithMinusOneLeftShift(long val, int Lshift) {
+        long i;
+        for (i = -10; i < -1; i++) { }
+        long mask = i << Lshift;
+        return Long.compress(val, mask);
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/igvn/TestMissingCompressBitsIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/igvn/TestMissingCompressBitsIdeal.java
@@ -30,6 +30,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8389579
+ * @key randomness
  * @summary Test missing Ideal optimization opportunity for CompressBits.
  * @library /test/lib /
  * @run main/othervm -Xcomp -XX:-TieredCompilation
@@ -37,6 +38,7 @@ import jdk.test.lib.Utils;
  *      -XX:VerifyIterativeGVN=100
  *      -XX:CompileCommand=compileonly,${test.main.class}::test*
  *      ${test.main.class}
+ * @run main ${test.main.class}
  */
 
 public class TestMissingCompressBitsIdeal {
@@ -50,6 +52,9 @@ public class TestMissingCompressBitsIdeal {
                              (intValue >>> intShift) & 1);
             Asserts.assertEQ(testIntCompressWithMinusOneLeftShift(intValue, intShift),
                              intValue >>> intShift);
+            int intMask = R.nextInt();
+            Asserts.assertEQ(testIntCompressExpandWithSameMask(intValue, intMask),
+                             intValue & Integer.compress(intMask, intMask));
 
             long longValue = R.nextLong();
             int longShift = R.nextInt(Long.SIZE);
@@ -57,6 +62,10 @@ public class TestMissingCompressBitsIdeal {
                              (longValue >>> longShift) & 1L);
             Asserts.assertEQ(testLongCompressWithMinusOneLeftShift(longValue, longShift),
                              longValue >>> longShift);
+            long longMask = R.nextLong();
+            Asserts.assertEQ(testLongCompressExpandWithSameMask(longValue, longMask),
+                             longValue & Long.compress(longMask, longMask));
+
         }
     }
 
@@ -90,5 +99,21 @@ public class TestMissingCompressBitsIdeal {
         for (i = -10; i < -1; i++) { }
         long mask = i << Lshift;
         return Long.compress(val, mask);
+    }
+
+    // compress(expand(x, m), m) == x & compress(m, m)
+    public static int testIntCompressExpandWithSameMask(int val, int mask) {
+        int i;
+        for (i = -10; i < -1; i++) { }
+        int expandMask = i & mask;
+        return Integer.compress(Integer.expand(val, expandMask), mask);
+    }
+
+    // compress(expand(x, m), m) == x & compress(m, m)
+    public static long testLongCompressExpandWithSameMask(long val, long mask) {
+        long i;
+        for (i = -10; i < -1; i++) { }
+        long expandMask = i & mask;
+        return Long.compress(Long.expand(val, expandMask), mask);
     }
 }


### PR DESCRIPTION
Please review this change. Thanks!

**Description:**

After IGVN simplification, the mask input of a CompressBits can become `1 << n or -1 << n`. `CompressBitsNode::Ideal()` can then replace `compress(x, 1 << n)` with `(x >> n) & 1`, or `compress(x, -1 << n)` with `x >>> n`. If the node is not reprocessed before `PhaseIterGVN::verify_Ideal_for()` checks the graph, `-XX:+VerifyIterativeGVN=100` can report a missed-Ideal optimization opportunity.

**Solution:**

Add handling in `PhaseIterGVN::add_users_of_use_to_worklist()` for `LShift` nodes used as the mask input of `CompressBits`. When an `LShift` node is the second input of a `CompressBits` node, add the `CompressBits` node back to the IGVN worklist so that `CompressBitsNode::Ideal()` can be applied.

**Test:**

GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389579](https://bugs.openjdk.org/browse/JDK-8389579): C2: Missed Ideal optimization opportunity in PhaseIterGVN for CompressBits and ExpandBits (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32235/head:pull/32235` \
`$ git checkout pull/32235`

Update a local copy of the PR: \
`$ git checkout pull/32235` \
`$ git pull https://git.openjdk.org/jdk.git pull/32235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32235`

View PR using the GUI difftool: \
`$ git pr show -t 32235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32235.diff">https://git.openjdk.org/jdk/pull/32235.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32235#issuecomment-5203302951)
</details>
