### PR TITLE
8348872: jabswitch.cpp: regEnable and regDeleteValue leak reallocated data buffer

### DIFF
--- a/src/jdk.accessibility/windows/native/jabswitch/jabswitch.cpp
+++ b/src/jdk.accessibility/windows/native/jabswitch/jabswitch.cpp
@@ -282,12 +282,14 @@ void printVersion() {
     char* pVersionData = new char[nVersionSize];
     if (!GetFileVersionInfo(executableFileName, 0, nVersionSize, pVersionData)) {
         printf("Unable to get version info.\n");
+        delete[] pVersionData;
         return;
     }
     LPVOID pVersionInfo;
     UINT nSize;
     if (!VerQueryValue(pVersionData, _T("\\"), &pVersionInfo, &nSize)) {
         printf("Unable to query version value.\n");
+        delete[] pVersionData;
         return;
     }
     VS_FIXEDFILEINFO *pVSInfo = (VS_FIXEDFILEINFO *)pVersionInfo;
@@ -302,6 +304,7 @@ void printVersion() {
         "jabswitch enables or disables the Java Access Bridge.\n",
         versionString
     );
+    delete[] pVersionData;
 }
 
 int regEnable() {
@@ -323,9 +326,13 @@ int regEnable() {
         if (err == ERROR_SUCCESS) {
             err = _tcslwr_s(dataBuffer, DEFAULT_ALLOC);
             if (err) {
+                if (data != dataBuffer) delete[] data;
+                RegCloseKey(hKey);
                 return -1;
             }
             if (_tcsstr(dataBuffer, STR_ACCESSBRIDGE) != NULL) {
+                if (data != dataBuffer) delete[] data;
+                RegCloseKey(hKey);
                 return 0;  // This is OK, e.g. ran enable twice and the value is there.
             } else {
                 // add oracle_javaaccessbridge to Config key for HKCU
@@ -334,9 +341,11 @@ int regEnable() {
                 if (newStr != NULL) {
                     wsprintf(newStr, L"%s,%s", dataBuffer, STR_ACCESSBRIDGE);
                     RegSetValueEx(hKey, ACCESSIBILITY_CONFIG, 0, REG_SZ, (BYTE *)newStr, dataLength);
+                    delete[] newStr;
                 }
             }
         }
+        if (data != dataBuffer) delete[] data;
         RegCloseKey(hKey);
     }
     return err;
@@ -366,9 +375,13 @@ int regDeleteValue(HKEY hFamilyKey, LPCWSTR lpSubKey)
         if (err == ERROR_SUCCESS) {
             err = _tcslwr_s(dataBuffer, DEFAULT_ALLOC);
             if (err) {
+                if (data != dataBuffer) delete[] data;
+                RegCloseKey(hKey);
                 return -1;
             }
             if (_tcsstr(dataBuffer, STR_ACCESSBRIDGE) == NULL) {
+                if (data != dataBuffer) delete[] data;
+                RegCloseKey(hKey);
                 return 0;  // This is OK, e.g. ran disable twice and the value is not there.
             } else {
                 // remove oracle_javaaccessbridge from Config key
@@ -382,6 +395,9 @@ int regDeleteValue(HKEY hFamilyKey, LPCWSTR lpSubKey)
                     _tcscpy_s(searchBuffer, DEFAULT_ALLOC, tok);
                     err = _tcslwr_s(searchBuffer, DEFAULT_ALLOC);
                     if (err) {
+                        delete[] newStr;
+                        if (data != dataBuffer) delete[] data;
+                        RegCloseKey(hKey);
                         return -1;
                     }
                     if (_tcsstr(searchBuffer, STR_ACCESSBRIDGE) == NULL) {
@@ -395,8 +411,10 @@ int regDeleteValue(HKEY hFamilyKey, LPCWSTR lpSubKey)
                 }
                 dataLength = (_tcslen(newStr) + 1) * sizeof(TCHAR);
                 RegSetValueEx(hKey, ACCESSIBILITY_CONFIG, 0, REG_SZ, (BYTE *)newStr, dataLength);
+                delete[] newStr;
             }
         }
+        if (data != dataBuffer) delete[] data;
         RegCloseKey(hKey);
     }
     return err;


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8348872](https://bugs.openjdk.org/browse/JDK-8348872): jabswitch.cpp: regEnable and regDeleteValue leak reallocated data buffer (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32236/head:pull/32236` \
`$ git checkout pull/32236`

Update a local copy of the PR: \
`$ git checkout pull/32236` \
`$ git pull https://git.openjdk.org/jdk.git pull/32236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32236`

View PR using the GUI difftool: \
`$ git pr show -t 32236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32236.diff">https://git.openjdk.org/jdk/pull/32236.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32236#issuecomment-5206737841)
</details>
