### PR TITLE
8389895: RISC-V: Fuse LoadN with DecodeN to eliminate redundant register moves

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -4616,6 +4616,22 @@ instruct loadN(iRegNNoSp dst, memory mem)
   ins_pipe(iload_reg_mem);
 %}
 
+instruct loadN_decode(iRegPNoSp dst, memory mem) %{
+  predicate(CompressedOops::shift() == 0 &&
+            CompressedOops::base() == nullptr &&
+            n->in(1)->as_Load()->barrier_data() == 0);
+  match(Set dst (DecodeN (LoadN mem)));
+
+  ins_cost(LOAD_COST);
+  format %{ "lwu  $dst, $mem\t# compressed ptr -> ptr, #@loadN_decode" %}
+
+  ins_encode %{
+    __ lwu(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
+  %}
+
+  ins_pipe(iload_reg_mem);
+%}
+
 // Load Klass Pointer
 instruct loadKlass(iRegPNoSp dst, memory mem)
 %{


### PR DESCRIPTION
Hi, please help review this small C2 match rule optimization for RISC-V.
When compressed oops run in zero-based unscaled mode (CompressedOops::base() == nullptr && CompressedOops::shift() == 0, i.e. heap size < 4GB), decoding a narrow oop is just a zero-extension. Since lwu already zero-extends its result, a LoadN followed by a DecodeN can be implemented by a single lwu into the pointer register.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389895](https://bugs.openjdk.org/browse/JDK-8389895): RISC-V: Fuse LoadN with DecodeN to eliminate redundant register moves (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32237/head:pull/32237` \
`$ git checkout pull/32237`

Update a local copy of the PR: \
`$ git checkout pull/32237` \
`$ git pull https://git.openjdk.org/jdk.git pull/32237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32237`

View PR using the GUI difftool: \
`$ git pr show -t 32237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32237.diff">https://git.openjdk.org/jdk/pull/32237.diff</a>

</details>
