### PR TITLE
8389910: [BACKOUT] Regression >6% on Crypto-MLDSA.sign on x64

### DIFF
--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -1139,31 +1139,17 @@ const char *InstructForm::mach_base_class(FormDict &globals)  const {
   return nullptr;
 }
 
-// Do the instruction predicates allow target_instr to be replaced by replacement_instr for cisc-spill optimzation.
-static bool hasPredicateSubset( const InstructForm *target_instr, const InstructForm *replacement_instr ) {
-  const Predicate *target_p  = target_instr->_predicate;
-  const Predicate *replacement_p  = replacement_instr->_predicate;
-  if( target_p == nullptr && replacement_p == nullptr ) {
+// Compare the instruction predicates for textual equality
+bool equivalent_predicates( const InstructForm *instr1, const InstructForm *instr2 ) {
+  const Predicate *pred1  = instr1->_predicate;
+  const Predicate *pred2  = instr2->_predicate;
+  if( pred1 == nullptr && pred2 == nullptr ) {
     // no predicates means they are identical
     return true;
   }
-
-  #ifdef AMD64
-  // A replacement_instr with no predicate handles a superset of the cases that target_instr handles.
-  // *Except* when target_instr has "predicate(false)", which shouldn't match anything.
-  // This is safe for x86 which only uses such predicates for instructions that should only be expanded
-  // as part of peephole optimizations. It's unclear if this is safe for s390 due to more complex predicates
-  // like "predicate(false && <more expressions>)". For now only enable for x86 (AMD64)
-  #define PREDICATE_FALSE_EXPR "#line 9\nfalse\n#line 9\n"
-
-  if( replacement_p == nullptr && !ADLParser::equivalent_expressions(target_p->_pred, PREDICATE_FALSE_EXPR) ) {
-    return true;
-  }
-  #endif /* AMD64 */
-
-  if( target_p != nullptr && replacement_p != nullptr ) {
+  if( pred1 != nullptr && pred2 != nullptr ) {
     // compare the predicates
-    if (ADLParser::equivalent_expressions(target_p->_pred, replacement_p->_pred)) {
+    if (ADLParser::equivalent_expressions(pred1->_pred, pred2->_pred)) {
       return true;
     }
   }
@@ -1184,7 +1170,7 @@ bool InstructForm::cisc_spills_to(ArchDesc &AD, InstructForm *instr) {
   const char *reg_type           = nullptr;
   FormDict   &globals            = AD.globalNames();
   cisc_spill_operand = _matrule->matchrule_cisc_spill_match(globals, AD.get_registers(), instr->_matrule, op_name, reg_type);
-  if( (cisc_spill_operand != Not_cisc_spillable) && (op_name != nullptr) && hasPredicateSubset(this, instr) ) {
+  if( (cisc_spill_operand != Not_cisc_spillable) && (op_name != nullptr) && equivalent_predicates(this, instr) ) {
     cisc_spill_operand = operand_position(op_name, Component::USE);
     int def_oper  = operand_position(op_name, Component::DEF);
     if( def_oper == NameList::Not_in_list && instr->num_opnds() == num_opnds()) {


### PR DESCRIPTION
Undo the changes in #31686 for [JDK-8386687](https://bugs.openjdk.org/browse/JDK-8386687) because they cause crashes on x86 with the UseAPX option.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389910](https://bugs.openjdk.org/browse/JDK-8389910): [BACKOUT] Regression &gt;6% on Crypto-MLDSA.sign on x64 (**Bug** - P3)


### Reviewers
 * [Derek White](https://openjdk.org/census#drwhite) (@dwhite-intel - Committer)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32241/head:pull/32241` \
`$ git checkout pull/32241`

Update a local copy of the PR: \
`$ git checkout pull/32241` \
`$ git pull https://git.openjdk.org/jdk.git pull/32241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32241`

View PR using the GUI difftool: \
`$ git pr show -t 32241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32241.diff">https://git.openjdk.org/jdk/pull/32241.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32241#issuecomment-5208697298)
</details>
