### PR TITLE
8389583: Metal compiler invoked incorrectly on macOS can lead to spurious build failures

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -685,16 +685,16 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_EXTRA],
     UTIL_LOOKUP_TOOLCHAIN_PROGS(METAL, metal)
     if test "x$METAL" = x; then
       AC_MSG_CHECKING([if metal can be run using xcrun])
-      METAL="xcrun -sdk macosx metal"
+      METAL="xcrun metal"
       test_metal=`$METAL --version 2>&1`
       if test $? -ne 0; then
         AC_MSG_RESULT([no])
-        AC_MSG_NOTICE([A full XCode is required to build the JDK (not only command line tools)])
-        AC_MSG_NOTICE([If you have XCode installed, you might need to reset the Xcode active developer directory])
+        AC_MSG_NOTICE([A full Xcode is required to build the JDK (not only command line tools)])
+        AC_MSG_NOTICE([If you have Xcode installed, you might need to reset the Xcode active developer directory])
         AC_MSG_NOTICE([using 'sudo xcode-select -r'])
         AC_MSG_NOTICE([Starting with Xcode 26, the Metal toolchain is no longer bundled with Xcode.])
         AC_MSG_NOTICE([Try installing it with 'xcodebuild -downloadComponent MetalToolchain'])
-        AC_MSG_ERROR([XCode tool 'metal' neither found in path nor with xcrun])
+        AC_MSG_ERROR([Xcode tool 'metal' neither found in path nor with xcrun])
       else
         AC_MSG_RESULT([yes, will be using '$METAL'])
       fi
@@ -703,11 +703,11 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_EXTRA],
     UTIL_LOOKUP_TOOLCHAIN_PROGS(METALLIB, metallib)
     if test "x$METALLIB" = x; then
       AC_MSG_CHECKING([if metallib can be run using xcrun])
-      METALLIB="xcrun -sdk macosx metallib"
+      METALLIB="xcrun metallib"
       test_metallib=`$METALLIB --version 2>&1`
       if test $? -ne 0; then
         AC_MSG_RESULT([no])
-        AC_MSG_ERROR([XCode tool 'metallib' neither found in path nor with xcrun])
+        AC_MSG_ERROR([Xcode tool 'metallib' neither found in path nor with xcrun])
       else
         AC_MSG_RESULT([yes, will be using '$METALLIB'])
       fi


### PR DESCRIPTION
This also corrects the spelling of Xcode: capital X, lowercase c. [Authoritative reference](https://developer.apple.com/xcode/), [Wikipedia article](https://en.wikipedia.org/wiki/Xcode).

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389583](https://bugs.openjdk.org/browse/JDK-8389583): Metal compiler invoked incorrectly on macOS can lead to spurious build failures (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32243/head:pull/32243` \
`$ git checkout pull/32243`

Update a local copy of the PR: \
`$ git checkout pull/32243` \
`$ git pull https://git.openjdk.org/jdk.git pull/32243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32243`

View PR using the GUI difftool: \
`$ git pr show -t 32243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32243.diff">https://git.openjdk.org/jdk/pull/32243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32243#issuecomment-5346717574)
</details>
