### PR TITLE
8384606: HotCodeHeap tests require C2

### DIFF
--- a/test/hotspot/jtreg/compiler/hotcode/HotCodeCollectorMoveFunction.java
+++ b/test/hotspot/jtreg/compiler/hotcode/HotCodeCollectorMoveFunction.java
@@ -24,14 +24,15 @@
 
 /*
  * @test
+ * @summary Ensure the HotCodeCollector detects a very hot method and relocates
+ *          it to the HotCodeHeap. Sampling is best effort, so for reliability
+ *          we spawn a seperate test process to manage the VM flags.
+ * @requires vm.flagless
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -Xbatch -XX:-TieredCompilation -XX:+SegmentedCodeCache -XX:+UnlockExperimentalVMOptions -XX:+HotCodeHeap
- *                   -XX:+NMethodRelocation -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:HotCodeIntervalSeconds=0 -XX:HotCodeCallLevel=0
- *                   -XX:HotCodeSampleSeconds=5 -XX:HotCodeStablePercent=-1 -XX:HotCodeSamplePercent=100 -XX:HotCodeStartupDelaySeconds=0
- *                   -XX:CompileCommand=compileonly,compiler.hotcode.HotCodeCollectorMoveFunction::func
- *                   compiler.hotcode.HotCodeCollectorMoveFunction
+ * @run driver compiler.hotcode.HotCodeCollectorMoveFunction
  */
 
 package compiler.hotcode;
@@ -39,50 +40,78 @@ package compiler.hotcode;
 import java.lang.reflect.Method;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.whitebox.code.BlobType;
 import jdk.test.whitebox.code.NMethod;
 
 public class HotCodeCollectorMoveFunction {
 
-    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
-    private static final Method method;
-    private static final int C2_LEVEL = 4;
-    private static final int FUNC_RUN_MILLIS = 60_000;
-
-    static {
-        try {
-            method = HotCodeCollectorMoveFunction.class.getMethod("func");
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static void main(String[] args) throws Exception {
-        WHITE_BOX.testSetDontInlineMethod(method, true);
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xbootclasspath/a:.",
+            "-Xbatch",
+            "-XX:-TieredCompilation",
+            "-XX:+SegmentedCodeCache",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+HotCodeHeap",
+            "-XX:+NMethodRelocation",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+WhiteBoxAPI",
+            "-XX:HotCodeIntervalSeconds=0",
+            "-XX:HotCodeCallLevel=0",
+            "-XX:HotCodeSampleSeconds=5",
+            "-XX:HotCodeStablePercent=-1",
+            "-XX:HotCodeSamplePercent=100",
+            "-XX:HotCodeStartupDelaySeconds=0",
+            "-XX:CompileCommand=compileonly," + Runner.class.getName() + "::func",
+            Runner.class.getName()
+        );
 
-        compileFunc();
-
-        // Call function so collector samples and relocates
-        func();
-
-        // Function should now be in the Hot code heap after collector has had time to relocate
-        NMethod reloc_nm = NMethod.get(method, false);
-        Asserts.assertNotEquals(reloc_nm, null);
-        Asserts.assertEQ(reloc_nm.code_blob_type, BlobType.MethodHot);
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
     }
 
-    public static void compileFunc() {
-        WHITE_BOX.enqueueMethodForCompilation(method, C2_LEVEL);
+    static class Runner {
+        private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+        private static final Method method;
+        private static final int C2_LEVEL = 4;
+        private static final int FUNC_RUN_MILLIS = 60_000;
 
-        if (WHITE_BOX.getMethodCompilationLevel(method) != C2_LEVEL) {
-            throw new IllegalStateException("Method " + method + " is not compiled by C2.");
+        static {
+            try {
+                method = Runner.class.getMethod("func");
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public static void main(String[] args) {
+            WHITE_BOX.testSetDontInlineMethod(method, true);
+
+            compileFunc();
+
+            // Call function so collector samples and relocates
+            func();
+
+            // Function should now be in the Hot code heap after collector has had time to relocate
+            NMethod relocatedNMethod = NMethod.get(method, false);
+            Asserts.assertNotNull(relocatedNMethod);
+            Asserts.assertEQ(BlobType.MethodHot, relocatedNMethod.code_blob_type);
+        }
+
+        private static void compileFunc() {
+            WHITE_BOX.enqueueMethodForCompilation(method, C2_LEVEL);
+
+            if (WHITE_BOX.getMethodCompilationLevel(method) != C2_LEVEL) {
+                throw new IllegalStateException("Method " + method + " is not compiled by C2.");
+            }
+        }
+
+        public static void func() {
+            long start = System.currentTimeMillis();
+            while (System.currentTimeMillis() - start < FUNC_RUN_MILLIS) {}
         }
     }
-
-    public static void func() {
-        long start = System.currentTimeMillis();
-        while (System.currentTimeMillis() - start < FUNC_RUN_MILLIS) {}
-    }
-
 }

--- a/test/hotspot/jtreg/compiler/hotcode/StressHotCodeCollector.java
+++ b/test/hotspot/jtreg/compiler/hotcode/StressHotCodeCollector.java
@@ -26,11 +26,12 @@
 /*
  * @test
  * @key randomness
+ * @requires vm.compiler2.enabled & vm.opt.SegmentedCodeCache != false
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -Xcomp -XX:-TieredCompilation -XX:+UnlockExperimentalVMOptions -XX:+HotCodeHeap -XX:+NMethodRelocation
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:HotCodeIntervalSeconds=0 -XX:HotCodeSampleSeconds=10
+ * @run main/othervm -Xbootclasspath/a:. -Xcomp -XX:-TieredCompilation -XX:+SegmentedCodeCache -XX:+UnlockExperimentalVMOptions -XX:+HotCodeHeap
+ *                   -XX:+NMethodRelocation -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:HotCodeIntervalSeconds=0 -XX:HotCodeSampleSeconds=10
  *                   -XX:HotCodeStablePercent=-1 -XX:HotCodeSamplePercent=100 -XX:HotCodeStartupDelaySeconds=0
  *                   compiler.hotcode.StressHotCodeCollector
  */


### PR DESCRIPTION
Clean backport of [JDK-8384606](https://bugs.openjdk.org/browse/JDK-8384606)

This backport is clean and is low risk because it is testing only and for an experimental feature (`HotCodeHeap`).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384606](https://bugs.openjdk.org/browse/JDK-8384606): HotCodeHeap tests require C2 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32244/head:pull/32244` \
`$ git checkout pull/32244`

Update a local copy of the PR: \
`$ git checkout pull/32244` \
`$ git pull https://git.openjdk.org/jdk.git pull/32244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32244`

View PR using the GUI difftool: \
`$ git pr show -t 32244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32244.diff">https://git.openjdk.org/jdk/pull/32244.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32244#issuecomment-5209388444)
</details>
