### PR TITLE
8389866: ZGC: Accepts an extremely negative ZAllocationSpikeTolerance value

### DIFF
--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -36,6 +36,7 @@
                                                                             \
   product(double, ZAllocationSpikeTolerance, 2.0,                           \
           "Allocation spike tolerance factor")                              \
+          range(0, INT_MAX)                                                 \
                                                                             \
   product(double, ZFragmentationLimit, 5.0,                                 \
           "Maximum allowed heap fragmentation")                             \

--- a/test/hotspot/jtreg/gc/z/TestZAllocationSpikeTolerance.java
+++ b/test/hotspot/jtreg/gc/z/TestZAllocationSpikeTolerance.java
@@ -46,7 +46,7 @@ public class TestZAllocationSpikeTolerance {
     private static void testInvalidValue() throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:+UseZGC",
-            "-XX:ZAllocationSpikeTolerance=-1", // invalid range 
+            "-XX:ZAllocationSpikeTolerance=-1", // invalid range
             "-version"
         );
 
@@ -67,7 +67,7 @@ public class TestZAllocationSpikeTolerance {
     private static void testValidValue() throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:+UseZGC",
-            "-XX:ZAllocationSpikeTolerance=1", // valid range 
+            "-XX:ZAllocationSpikeTolerance=1", // valid range
             "-version"
         );
 

--- a/test/hotspot/jtreg/gc/z/TestZAllocationSpikeTolerance.java
+++ b/test/hotspot/jtreg/gc/z/TestZAllocationSpikeTolerance.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestZAllocationSpikeTolerance
+ * @bug 8389866
+ * @summary Verifies TestZAllocationSpikeTolerance range
+ *          - fails gracefully for invalid value
+ *          - succeeds for valid value
+ * @library /test/lib
+ * @requires vm.gc.Z
+ * @run driver gc.z.TestZAllocationSpikeTolerance
+ */
+package gc.z;
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestZAllocationSpikeTolerance {
+    public static void main(String[] args) throws Exception {
+        testInvalidValue();
+        testValidValue();
+    }
+
+    private static void testInvalidValue() throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:+UseZGC",
+            "-XX:ZAllocationSpikeTolerance=-1", // invalid range 
+            "-version"
+        );
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+        // Ensure no crash (no assert failure)
+        output.shouldNotContain("assert");
+
+        // Expected graceful error output
+        output.shouldContain("ZAllocationSpikeTolerance");
+        output.shouldContain("outside the allowed range");
+        output.shouldContain("Error: A fatal exception has occurred. Program will exit.");
+
+        // Graceful exit with error code 1
+        output.shouldHaveExitValue(1);
+    }
+
+    private static void testValidValue() throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:+UseZGC",
+            "-XX:ZAllocationSpikeTolerance=1", // valid range 
+            "-version"
+        );
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+        output.shouldHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
ZAllocationSpikeTolerance doesn't have a range change. Passing negative value for ZAllocationSpikeTolerance could causes invalid allocation-rate calculations and may trigger premature GC cycles.
Current fix is to validate the range check between 1 to INT_MAX, that will avoid passing of negative values.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389866](https://bugs.openjdk.org/browse/JDK-8389866): ZGC: Accepts an extremely negative ZAllocationSpikeTolerance value (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32245/head:pull/32245` \
`$ git checkout pull/32245`

Update a local copy of the PR: \
`$ git checkout pull/32245` \
`$ git pull https://git.openjdk.org/jdk.git pull/32245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32245`

View PR using the GUI difftool: \
`$ git pr show -t 32245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32245.diff">https://git.openjdk.org/jdk/pull/32245.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32245#issuecomment-5209646231)
</details>
