### PR TITLE
8377972: Provide a way for an application to opt-in to legacy Desktop.browse() behavior

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDesktopPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDesktopPeer.java
@@ -39,8 +39,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import sun.swing.SwingUtilities2;
-
 /**
  * Concrete implementation of the interface {@code DesktopPeer} for MacOS X
  *
@@ -81,7 +79,7 @@ public final class CDesktopPeer implements DesktopPeer {
 
     @Override
     public void browse(URI uri) throws IOException {
-         this.lsOpen(uri, SwingUtilities2.isBrowseInsecureAllowed(uri) ? OPEN : BROWSE);
+         this.lsOpen(uri, isBrowseInsecureAllowed(uri) ? OPEN : BROWSE);
     }
 
     @Override

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDesktopPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDesktopPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import java.lang.annotation.Native;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
+import java.util.Arrays;
 
 /**
  * Concrete implementation of the interface {@code DesktopPeer} for MacOS X
@@ -80,7 +80,19 @@ public final class CDesktopPeer implements DesktopPeer {
 
     @Override
     public void browse(URI uri) throws IOException {
-        this.lsOpen(uri, BROWSE);
+         this.lsOpen(uri, isBrowseInsecureAllowed(uri) ? OPEN : BROWSE);
+    }
+
+    private static boolean isBrowseInsecureAllowed(URI uri) {
+        String allowList = System.getProperty("awt.desktop.browse_insecure");
+        String scheme = uri.getScheme();
+
+        return scheme != null
+               && allowList != null
+               && (allowList.equals("*")
+                   || Arrays.stream(allowList.split(","))
+                            .map(String::trim)
+                            .anyMatch(allowed -> allowed.equalsIgnoreCase(scheme)));
     }
 
     @Override

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDesktopPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDesktopPeer.java
@@ -38,7 +38,8 @@ import java.lang.annotation.Native;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
+
+import sun.swing.SwingUtilities2;
 
 /**
  * Concrete implementation of the interface {@code DesktopPeer} for MacOS X
@@ -80,19 +81,7 @@ public final class CDesktopPeer implements DesktopPeer {
 
     @Override
     public void browse(URI uri) throws IOException {
-         this.lsOpen(uri, isBrowseInsecureAllowed(uri) ? OPEN : BROWSE);
-    }
-
-    private static boolean isBrowseInsecureAllowed(URI uri) {
-        String allowList = System.getProperty("awt.desktop.browse_insecure");
-        String scheme = uri.getScheme();
-
-        return scheme != null
-               && allowList != null
-               && (allowList.equals("*")
-                   || Arrays.stream(allowList.split(","))
-                            .map(String::trim)
-                            .anyMatch(allowed -> allowed.equalsIgnoreCase(scheme)));
+         this.lsOpen(uri, SwingUtilities2.isBrowseInsecureAllowed(uri) ? OPEN : BROWSE);
     }
 
     @Override

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
@@ -42,16 +42,18 @@ JNI_COCOA_ENTER(env);
 
     NSURL *urlToOpen = [NSURL URLWithString:JavaStringToNSString(env, uri)];
     NSURL *appURI = nil;
+    NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
 
-    if (action == sun_lwawt_macosx_CDesktopPeer_BROWSE) {
+    if (action == sun_lwawt_macosx_CDesktopPeer_OPEN) {
+        // Open with the app associated with the URI scheme
+        appURI = [workspace URLForApplicationToOpenURL:urlToOpen];
+    } else if (action == sun_lwawt_macosx_CDesktopPeer_BROWSE) {
         // To get the defaultBrowser
         NSURL *httpsURL = [NSURL URLWithString:@"https://"];
-        NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
         appURI = [workspace URLForApplicationToOpenURL:httpsURL];
     } else if (action == sun_lwawt_macosx_CDesktopPeer_MAIL) {
         // To get the default mailer
         NSURL *mailtoURL = [NSURL URLWithString:@"mailto://"];
-        NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
         appURI = [workspace URLForApplicationToOpenURL:mailtoURL];
     }
 

--- a/src/java.desktop/share/classes/java/awt/peer/DesktopPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/DesktopPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/peer/DesktopPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/DesktopPeer.java
@@ -38,6 +38,7 @@ import java.awt.desktop.SystemEventListener;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 
 import javax.swing.JMenuBar;
 
@@ -281,4 +282,25 @@ public interface DesktopPeer {
         return false;
     }
 
+    /**
+     * Returns whether or not Desktop.browse() will open URI in browser or
+     * in associated allowed app
+     *
+     * @param uri URI to be browsed
+     * @return whether or not associated app will be opened
+     */
+    default boolean isBrowseInsecureAllowed(URI uri) {
+        String allowList = System.getProperty("awt.desktop.browse_insecure");
+        String scheme = uri.getScheme();
+
+        // For http,https scheme URL should always open in browser
+        // For other schemes, it will depend on whether scheme is in allowList
+
+        return scheme != null && !(scheme.equals("http") || scheme.equals("https"))
+               && allowList != null
+               && (allowList.equals("*")
+                   || Arrays.stream(allowList.split(","))
+                            .map(String::trim)
+                            .anyMatch(allowed -> allowed.equalsIgnoreCase(scheme)));
+    }
 }

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -62,6 +62,8 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.util.Arrays;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
 import java.text.BreakIterator;
@@ -2118,5 +2120,28 @@ public class SwingUtilities2 {
         var newTx = newGC != null ? newGC.getDefaultTransform() : null;
         var oldTx = oldGC != null ? oldGC.getDefaultTransform() : null;
         return !Objects.equals(newTx, oldTx);
+    }
+
+    /**
+     * Returns whether or not Desktop.browse() will open URI in browser or
+     * in associated allowed app
+     *
+     * @param uri URI to be browsed
+     * @return whether or not associated app will be opened
+     * @since 28
+     */
+    public static boolean isBrowseInsecureAllowed(URI uri) {
+        String allowList = System.getProperty("awt.desktop.browse_insecure");
+        String scheme = uri.getScheme();
+
+        // For http,https scheme URL should always open in browser
+        // For other schemes, it will depend on whether scheme is in allowList
+
+        return scheme != null && !(scheme.equals("http") || scheme.equals("https"))
+               && allowList != null
+               && (allowList.equals("*")
+                   || Arrays.stream(allowList.split(","))
+                            .map(String::trim)
+                            .anyMatch(allowed -> allowed.equalsIgnoreCase(scheme)));
     }
 }

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -62,8 +62,6 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
-import java.net.URI;
-import java.util.Arrays;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
 import java.text.BreakIterator;
@@ -2122,26 +2120,4 @@ public class SwingUtilities2 {
         return !Objects.equals(newTx, oldTx);
     }
 
-    /**
-     * Returns whether or not Desktop.browse() will open URI in browser or
-     * in associated allowed app
-     *
-     * @param uri URI to be browsed
-     * @return whether or not associated app will be opened
-     * @since 28
-     */
-    public static boolean isBrowseInsecureAllowed(URI uri) {
-        String allowList = System.getProperty("awt.desktop.browse_insecure");
-        String scheme = uri.getScheme();
-
-        // For http,https scheme URL should always open in browser
-        // For other schemes, it will depend on whether scheme is in allowList
-
-        return scheme != null && !(scheme.equals("http") || scheme.equals("https"))
-               && allowList != null
-               && (allowList.equals("*")
-                   || Arrays.stream(allowList.split(","))
-                            .map(String::trim)
-                            .anyMatch(allowed -> allowed.equalsIgnoreCase(scheme)));
-    }
 }

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -2119,5 +2119,4 @@ public class SwingUtilities2 {
         var oldTx = oldGC != null ? oldGC.getDefaultTransform() : null;
         return !Objects.equals(newTx, oldTx);
     }
-
 }

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDesktopPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDesktopPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,22 @@ final class WDesktopPeer implements DesktopPeer {
 
     @Override
     public void browse(URI uri) throws IOException {
-        this.launchUriInBrowser(uri);
+        String allowList = System.getProperty("awt.desktop.browse_insecure");
+        String scheme = uri.getScheme();
+
+        // For http,https scheme URL should always open in browser
+        // For other schemes, it will depend on whether scheme is in allowList
+        if (scheme != null && !(scheme.equals("http") || scheme.equals("https"))
+            && allowList != null
+            && (allowList.equals("*")
+                || Arrays.stream(allowList.split(","))
+                         .map(String::trim)
+                         .anyMatch(allowed -> allowed.equalsIgnoreCase(scheme)))) {
+            this.ShellExecute(uri, ACTION_OPEN_VERB);
+        } else {
+            // Fall back to opening the URI in browser
+            this.launchUriInBrowser(uri);
+        }
     }
 
     private void ShellExecute(File file, String verb) throws IOException {

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDesktopPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDesktopPeer.java
@@ -44,7 +44,6 @@ import java.util.List;
 import javax.swing.event.EventListenerList;
 
 import sun.awt.shell.ShellFolder;
-import sun.swing.SwingUtilities2;
 
 /**
  * Concrete implementation of the interface {@code DesktopPeer} for
@@ -106,7 +105,7 @@ final class WDesktopPeer implements DesktopPeer {
 
     @Override
     public void browse(URI uri) throws IOException {
-        if (SwingUtilities2.isBrowseInsecureAllowed(uri)) {
+        if (isBrowseInsecureAllowed(uri)) {
             this.ShellExecute(uri, ACTION_OPEN_VERB);
         } else {
             // Fall back to opening the URI in browser

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDesktopPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDesktopPeer.java
@@ -44,6 +44,7 @@ import java.util.List;
 import javax.swing.event.EventListenerList;
 
 import sun.awt.shell.ShellFolder;
+import sun.swing.SwingUtilities2;
 
 /**
  * Concrete implementation of the interface {@code DesktopPeer} for
@@ -105,17 +106,7 @@ final class WDesktopPeer implements DesktopPeer {
 
     @Override
     public void browse(URI uri) throws IOException {
-        String allowList = System.getProperty("awt.desktop.browse_insecure");
-        String scheme = uri.getScheme();
-
-        // For http,https scheme URL should always open in browser
-        // For other schemes, it will depend on whether scheme is in allowList
-        if (scheme != null && !(scheme.equals("http") || scheme.equals("https"))
-            && allowList != null
-            && (allowList.equals("*")
-                || Arrays.stream(allowList.split(","))
-                         .map(String::trim)
-                         .anyMatch(allowed -> allowed.equalsIgnoreCase(scheme)))) {
+        if (SwingUtilities2.isBrowseInsecureAllowed(uri)) {
             this.ShellExecute(uri, ACTION_OPEN_VERB);
         } else {
             // Fall back to opening the URI in browser


### PR DESCRIPTION
`JDK has the following API : java.awt.Desktop.browse(URI) "Launches the default browser to display a URI."

On Windows and macOS, the JDK used to call platform APIs to do this which would recognise some schemes as ones which would launch an associated application. For example on Windows "calculator:" is a scheme that windows may open the calculator, and on macOS "facetime:" may open the facetime application. 

Desktop.browse now always launches the browser directly, which is a problem for apps that took advantage of the previous behavior, since the browser itself may not re-direct to those applications.

The current behaviour is intentional to provide a secure-by-default behaviour.

The proposal here is to introduce an implementation system property ( **awt.desktop.browse_insecure**) which will allow apps to opt back into the old behaviour on Windows and macOS.

The end-user, or the application, can set this property as a comma separated list of allowed schemes :

-Dawt.desktop.browse_insecure=calculator,file 

where on Windows, the calculator and file scheme will be opened in open calc.exe and the File Explorer app respectively.

or -Dawt.desktop.browse_insecure=*

which allows all schemes.

If -Dawt.desktop.browse_insecure is set or the scheme is in the allowed list, then JDK will open the URI using platform APIs which may open an associated app instead of the browser
If -Dawt.desktop.browse_insecure is NOT set or scheme is NOT in the allowed list, the browser is explicitly launched and URI is handled by the browser - i.e. no change from current behaviour.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change requires CSR request [JDK-8389986](https://bugs.openjdk.org/browse/JDK-8389986) to be approved
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8377972](https://bugs.openjdk.org/browse/JDK-8377972): Provide a way for an application to opt-in to legacy Desktop.browse() behavior (**Bug** - P3)
 * [JDK-8389986](https://bugs.openjdk.org/browse/JDK-8389986): Provide a way for an application to opt-in to legacy Desktop.browse() behavior (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32247/head:pull/32247` \
`$ git checkout pull/32247`

Update a local copy of the PR: \
`$ git checkout pull/32247` \
`$ git pull https://git.openjdk.org/jdk.git pull/32247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32247`

View PR using the GUI difftool: \
`$ git pr show -t 32247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32247.diff">https://git.openjdk.org/jdk/pull/32247.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32247#issuecomment-5219866920)
</details>
