### PR TITLE
8389901: [windows] CCombinedSegTable::GetEUDCFileName from awt_Font.cpp seems to miss RegCloseKey calls

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
@@ -1764,7 +1764,7 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
     if (m_fEUDCSubKeyExist == FALSE)
         return;
 
-    // get filename of typeface-specific TureType EUDC font
+    // get filename of typeface-specific TrueType EUDC font
     LPSTR lpszSubKey = GetCodePageSubkey();
     if (lpszSubKey == NULL) {
         m_fEUDCSubKeyExist = FALSE;
@@ -1802,10 +1802,13 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
 
     BOOL fUseDefault = FALSE;
     if (lStatus != ERROR_SUCCESS){ // try System default EUDC font
-        if (m_fTTEUDCFileExist == FALSE)
+        if (m_fTTEUDCFileExist == FALSE) {
+            RegCloseKey(hKey);
             return;
+        }
         if (wcslen(m_szDefaultEUDCFile) > 0) {
             StringCchCopy(lpszFileName, cchFileName, m_szDefaultEUDCFile);
+            RegCloseKey(hKey);
             return;
         }
         char szDefault[] = "SystemDefaultEUDCFont";
@@ -1816,6 +1819,7 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
             m_fTTEUDCFileExist = FALSE;
             // This font is associated with no EUDC font
             // and there is no system default EUDC font
+            RegCloseKey(hKey);
             return;
         }
     }
@@ -1824,6 +1828,7 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
         // This font is associated with no EUDC font
         // and the system default EUDC font is not TrueType
         m_fTTEUDCFileExist = FALSE;
+        RegCloseKey(hKey);
         return;
     }
 
@@ -1832,6 +1837,7 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
         (LPCSTR)szFileName, -1, lpszFileName, cchFileName) != 0);
     if (fUseDefault)
         StringCchCopy(m_szDefaultEUDCFile, _MAX_PATH, lpszFileName);
+    RegCloseKey(hKey);
 }
 
 void CCombinedSegTable::Create(LPCWSTR name)

--- a/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
@@ -1770,6 +1770,7 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
         m_fEUDCSubKeyExist = FALSE;
         return; // can not get codepage information
     }
+    DASSERT(strlen((LPCSTR)lpszSubKey) > 0);
     HKEY hRootKey = HKEY_CURRENT_USER;
     HKEY hKey;
     LONG lRet = ::RegOpenKeyExA(hRootKey, lpszSubKey, 0, KEY_READ, &hKey);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
@@ -1772,7 +1772,7 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
     }
     HKEY hRootKey = HKEY_CURRENT_USER;
     HKEY hKey;
-    LONG lRet = ::RegOpenKeyExA(hRootKey, lpszSubKey, 0, KEY_ALL_ACCESS, &hKey);
+    LONG lRet = ::RegOpenKeyExA(hRootKey, lpszSubKey, 0, KEY_READ, &hKey);
     if (lRet != ERROR_SUCCESS) {
         m_fEUDCSubKeyExist = FALSE;
         return; // no EUDC font


### PR DESCRIPTION
There is a RegOpenKeyExA call present, but we do not close the handle. This should be changed.
The MS docu says 
https://learn.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopenkeyexa
'A pointer to a variable that receives a handle to the opened key. If the key is not one of the predefined registry keys, call the [RegCloseKey](https://learn.microsoft.com/en-us/windows/desktop/api/winreg/nf-winreg-regclosekey) function after you have finished using the handle.'
And in this coding we call
`LONG lRet = ::RegOpenKeyExA(hRootKey, lpszSubKey, 0, KEY_ALL_ACCESS, &hKey);
`
with a non_NULL `lpszSubKey `so the RegCloseKey has to be done.

Also fixed a typo while at it.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389901](https://bugs.openjdk.org/browse/JDK-8389901): [windows] CCombinedSegTable::GetEUDCFileName from awt_Font.cpp seems to miss RegCloseKey calls (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32249/head:pull/32249` \
`$ git checkout pull/32249`

Update a local copy of the PR: \
`$ git checkout pull/32249` \
`$ git pull https://git.openjdk.org/jdk.git pull/32249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32249`

View PR using the GUI difftool: \
`$ git pr show -t 32249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32249.diff">https://git.openjdk.org/jdk/pull/32249.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32249#issuecomment-5215052043)
</details>
