### PR TITLE
8389892: C2: VectorNode::Ideal modifies the node but returns nullptr

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1451,9 +1451,12 @@ Node* VectorNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     return n;
   }
 
+  bool inputs_have_been_swapped = false;
   // Sort inputs of commutative non-predicated vector operations to help value numbering.
   if (should_swap_inputs_to_help_global_value_numbering()) {
+    assert(in(1) != in(2), "it is useless to swap identical inputs");
     swap_edges(1, 2);
+    inputs_have_been_swapped = true;
   }
 
   n = push_through_replicate(phase);
@@ -1461,7 +1464,14 @@ Node* VectorNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     return n;
   }
 
-  return reassociate_vector_operation(phase);
+  n = reassociate_vector_operation(phase);
+  if (n != nullptr) {
+    return n;
+  }
+  if (inputs_have_been_swapped) {
+    return this;
+  }
+  return nullptr;
 }
 
 // Traverses a chain of VectorMaskCast and returns the first non VectorMaskCast node.

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -23,10 +23,10 @@
 
 /*
  * @test
- * @bug 8288445
+ * @bug 8288445 8389892
  * @summary Test shift by 0
- * @run main/othervm -Xbatch -XX:-TieredCompilation
- * compiler.codegen.ShiftByZero
+ * @run main/othervm -Xbatch -XX:-TieredCompilation ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:VerifyIterativeGVN=100000 ${test.main.class}
  */
 
 package compiler.codegen;


### PR DESCRIPTION
When using `-XX:VerifyIterativeGVN=100000`, we get (many) crashes on idealization of vector nodes. The cause is as simple as the fix:

https://github.com/openjdk/jdk/blob/c61f5b7ad8f6f9a00bf0161e4c2c6e6e5c6b3463/src/hotspot/share/opto/vectornode.cpp#L1454-L1464

Line 1456, we swap inputs, but `reassociate_vector_operation` can return `nullptr` as if nothing changed, for instance:

https://github.com/openjdk/jdk/blob/c61f5b7ad8f6f9a00bf0161e4c2c6e6e5c6b3463/src/hotspot/share/opto/vectornode.cpp#L1355-L1359

The fix is simply to return `this` if we have swapped input but `reassociate_vector_operation` would not change anything more.

Tested with tiers 1 to 4 and comp-stress. With verification, most of (or all?) failures left are due to [JDK-8389914](https://bugs.openjdk.org/browse/JDK-8389914). On the same set of tests, before this fix, we had >19k failures vs. ~100 after. That is a significant step toward [JDK-8389932](https://bugs.openjdk.org/browse/JDK-8389932).

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389892](https://bugs.openjdk.org/browse/JDK-8389892): C2: VectorNode::Ideal modifies the node but returns nullptr (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32250/head:pull/32250` \
`$ git checkout pull/32250`

Update a local copy of the PR: \
`$ git checkout pull/32250` \
`$ git pull https://git.openjdk.org/jdk.git pull/32250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32250`

View PR using the GUI difftool: \
`$ git pr show -t 32250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32250.diff">https://git.openjdk.org/jdk/pull/32250.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32250#issuecomment-5215967922)
</details>
