### PR TITLE
Let's not branch a bunch

### DIFF
--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -566,13 +566,13 @@ void InlineKlass::Members::print_on(outputStream* st) const {
   st->print_cr(BULLET"unpack handler:                    " PTR_FORMAT, p2i(_unpack_handler));
   st->print_cr(BULLET"null reset offset:                 %d", _null_reset_value_offset);
   st->print_cr(BULLET"payload offset:                    %d", _payload_offset);
-  st->print_cr(BULLET"payload size (bytes):              %d", _payload_size_in_bytes);
+  st->print_cr(BULLET"payload size (bytes):              %d", layout_size_in_bytes(LayoutKind::BUFFERED));
   st->print_cr(BULLET"payload alignment:                 %d", _payload_alignment);
-  st->print_cr(BULLET"null-free non-atomic size (bytes): %d", _null_free_non_atomic_size_in_bytes);
+  st->print_cr(BULLET"null-free non-atomic size (bytes): %d", layout_size_in_bytes(LayoutKind::NULL_FREE_NON_ATOMIC_FLAT));
   st->print_cr(BULLET"null-free non-atomic alignment:    %d", _null_free_non_atomic_alignment);
-  st->print_cr(BULLET"null-free atomic size (bytes):     %d", _null_free_atomic_size_in_bytes);
-  st->print_cr(BULLET"nullable atomic size (bytes):      %d", _nullable_atomic_size_in_bytes);
-  st->print_cr(BULLET"nullable non-atomic size (bytes):  %d", _nullable_non_atomic_size_in_bytes);
+  st->print_cr(BULLET"null-free atomic size (bytes):     %d", layout_size_in_bytes(LayoutKind::NULL_FREE_ATOMIC_FLAT));
+  st->print_cr(BULLET"nullable atomic size (bytes):      %d", layout_size_in_bytes(LayoutKind::NULLABLE_ATOMIC_FLAT));
+  st->print_cr(BULLET"nullable non-atomic size (bytes):  %d", layout_size_in_bytes(LayoutKind::NULLABLE_NON_ATOMIC_FLAT));
   st->print_cr(BULLET"null marker offset:                %d", _null_marker_offset);
   st->print_cr(BULLET"fast acmp offset:                  %d", _fast_acmp_offset);
   st->print_cr(BULLET"fast acmp mask:                    " INT64_FORMAT_X_0, _fast_acmp_mask);

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -65,16 +65,16 @@ InlineKlass::Members::Members()
     _unpack_handler(nullptr),
     _null_reset_value_offset(0),
     _payload_offset(-1),
-    _payload_size_in_bytes(-1),
     _payload_alignment(-1),
-    _null_free_non_atomic_size_in_bytes(-1),
-    _null_free_non_atomic_alignment(-1),
-    _null_free_atomic_size_in_bytes(-1),
-    _nullable_atomic_size_in_bytes(-1),
-    _nullable_non_atomic_size_in_bytes(-1),
+    _layout_sizes(),
     _null_marker_offset(-1),
     _fast_acmp_offset(-1),
     _fast_acmp_mask(0) {
+  layout_size_in_bytes(LayoutKind::BUFFERED) = -1;
+  layout_size_in_bytes(LayoutKind::NULL_FREE_NON_ATOMIC_FLAT) = -1;
+  layout_size_in_bytes(LayoutKind::NULL_FREE_ATOMIC_FLAT) = -1;
+  layout_size_in_bytes(LayoutKind::NULLABLE_ATOMIC_FLAT) = -1;
+  layout_size_in_bytes(LayoutKind::NULLABLE_NON_ATOMIC_FLAT) = -1;
 }
 
 InlineKlass::InlineKlass() {

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -66,6 +66,7 @@ InlineKlass::Members::Members()
     _null_reset_value_offset(0),
     _payload_offset(-1),
     _payload_alignment(-1),
+    _null_free_non_atomic_alignment(-1),
     _layout_sizes(),
     _null_marker_offset(-1),
     _fast_acmp_offset(-1),

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -91,7 +91,7 @@ class InlineKlass: public InstanceKlass {
     int _payload_offset;           // offset of the beginning of the payload in a heap buffered instance
     int _payload_alignment;        // alignment required for payload
     int _null_free_non_atomic_alignment;     // alignment requirement for null-free non-atomic layout
-    // size of each LayoutKind. For null-free atomic, nullable atomic and nullable non-atomic, the size also acts as alignment.
+    // size of each LayoutKind. For atomic layouts, the size also acts as alignment.
     int _layout_sizes[static_cast<size_t>(LayoutKind::COUNT) - 1]; // REFERENCE has no size, accounting for -1
     int _null_marker_offset;       // expressed as an offset from the beginning of the object for a heap buffered value
                                    // payload_offset must be subtracted to get the offset from the beginning of the payload

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -89,13 +89,10 @@ class InlineKlass: public InstanceKlass {
 
     int _null_reset_value_offset;
     int _payload_offset;           // offset of the beginning of the payload in a heap buffered instance
-    int _payload_size_in_bytes;    // size of payload layout
     int _payload_alignment;        // alignment required for payload
-    int _null_free_non_atomic_size_in_bytes; // size of null-free non-atomic flat layout
     int _null_free_non_atomic_alignment;     // alignment requirement for null-free non-atomic layout
-    int _null_free_atomic_size_in_bytes;     // size and alignment requirement for a null-free atomic layout, -1 if no atomic flat layout is possible
-    int _nullable_atomic_size_in_bytes;      // size and alignment requirement for a nullable layout (always atomic), -1 if no nullable flat layout is possible
-    int _nullable_non_atomic_size_in_bytes;  // size and alignment requirement for a nullable non-atomic layout, -1 if not available
+    // size of each LayoutKind. For null-free atomic, nullable atomic and nullable non-atomic, the size also acts as alignment.
+    int _layout_sizes[static_cast<size_t>(LayoutKind::COUNT) - 1]; // REFERENCE has no size, accounting for -1
     int _null_marker_offset;       // expressed as an offset from the beginning of the object for a heap buffered value
                                    // payload_offset must be subtracted to get the offset from the beginning of the payload
 
@@ -117,6 +114,13 @@ class InlineKlass: public InstanceKlass {
     Members();
 
     void print_on(outputStream* st) const;
+
+    int& layout_size_in_bytes(LayoutKind lk) {
+      return _layout_sizes[static_cast<size_t>(lk)];
+    }
+    const int& layout_size_in_bytes(LayoutKind lk) const {
+      return _layout_sizes[static_cast<size_t>(lk)];
+    }
   };
 
   InlineKlass();
@@ -170,6 +174,10 @@ class InlineKlass: public InstanceKlass {
   }
   void set_null_reset_value_offset(int offset)                { members()._null_reset_value_offset = offset; }
 
+  bool has_layout(LayoutKind lk) const {
+    return members().layout_size_in_bytes(lk) != -1;
+  }
+
   int payload_offset() const {
     int offset = members()._payload_offset;
     assert(offset != 0, "Must be initialized before use");
@@ -177,29 +185,29 @@ class InlineKlass: public InstanceKlass {
   }
   void set_payload_offset(int offset)                         { members()._payload_offset = offset; }
 
-  int payload_size_in_bytes() const                           { return members()._payload_size_in_bytes; }
-  void set_payload_size_in_bytes(int payload_size)            { members()._payload_size_in_bytes = payload_size; }
+  int payload_size_in_bytes() const                           { return members().layout_size_in_bytes(LayoutKind::BUFFERED); }
+  void set_payload_size_in_bytes(int payload_size)            { members().layout_size_in_bytes(LayoutKind::BUFFERED) = payload_size; }
 
   int payload_alignment() const                               { return members()._payload_alignment; }
   void set_payload_alignment(int alignment)                   { members()._payload_alignment = alignment; }
 
-  int null_free_non_atomic_size_in_bytes() const              { return members()._null_free_non_atomic_size_in_bytes; }
-  void set_null_free_non_atomic_size_in_bytes(int size)       { members()._null_free_non_atomic_size_in_bytes = size; }
+  int null_free_non_atomic_size_in_bytes() const              { return members().layout_size_in_bytes(LayoutKind::NULL_FREE_NON_ATOMIC_FLAT); }
+  void set_null_free_non_atomic_size_in_bytes(int size)       { members().layout_size_in_bytes(LayoutKind::NULL_FREE_NON_ATOMIC_FLAT) = size; }
   bool has_null_free_non_atomic_layout() const                { return null_free_non_atomic_size_in_bytes() != -1; }
 
   int null_free_non_atomic_alignment() const                  { return members()._null_free_non_atomic_alignment; }
   void set_null_free_non_atomic_alignment(int alignment)      { members()._null_free_non_atomic_alignment = alignment; }
 
-  int null_free_atomic_size_in_bytes() const                  { return members()._null_free_atomic_size_in_bytes; }
-  void set_null_free_atomic_size_in_bytes(int size)           { members()._null_free_atomic_size_in_bytes = size; }
+  int null_free_atomic_size_in_bytes() const                  { return members().layout_size_in_bytes(LayoutKind::NULL_FREE_ATOMIC_FLAT); }
+  void set_null_free_atomic_size_in_bytes(int size)           { members().layout_size_in_bytes(LayoutKind::NULL_FREE_ATOMIC_FLAT) = size; }
   bool has_null_free_atomic_layout() const                    { return null_free_atomic_size_in_bytes() != -1; }
 
-  int nullable_atomic_size_in_bytes() const                   { return members()._nullable_atomic_size_in_bytes; }
-  void set_nullable_atomic_size_in_bytes(int size)            { members()._nullable_atomic_size_in_bytes = size; }
+  int nullable_atomic_size_in_bytes() const                   { return members().layout_size_in_bytes(LayoutKind::NULLABLE_ATOMIC_FLAT); }
+  void set_nullable_atomic_size_in_bytes(int size)            { members().layout_size_in_bytes(LayoutKind::NULLABLE_ATOMIC_FLAT) = size; }
   bool has_nullable_atomic_layout() const                     { return nullable_atomic_size_in_bytes() != -1; }
 
-  int nullable_non_atomic_size_in_bytes() const               { return members()._nullable_non_atomic_size_in_bytes; }
-  void set_nullable_non_atomic_size_in_bytes(int size)        { members()._nullable_non_atomic_size_in_bytes = size; }
+  int nullable_non_atomic_size_in_bytes() const               { return members().layout_size_in_bytes(LayoutKind::NULLABLE_NON_ATOMIC_FLAT); }
+  void set_nullable_non_atomic_size_in_bytes(int size)        { members().layout_size_in_bytes(LayoutKind::NULLABLE_NON_ATOMIC_FLAT) = size; }
   bool has_nullable_non_atomic_layout() const                 { return nullable_non_atomic_size_in_bytes() != -1; }
 
   int null_marker_offset() const                              { return members()._null_marker_offset; }

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -116,10 +116,12 @@ class InlineKlass: public InstanceKlass {
     void print_on(outputStream* st) const;
 
     int& layout_size_in_bytes(LayoutKind lk) {
-      return _layout_sizes[static_cast<size_t>(lk)];
+      // - 1 to ignore REFERENCE
+      return _layout_sizes[static_cast<size_t>(lk) - 1];
     }
     const int& layout_size_in_bytes(LayoutKind lk) const {
-      return _layout_sizes[static_cast<size_t>(lk)];
+      // - 1 to ignore REFERENCE
+      return _layout_sizes[static_cast<size_t>(lk) - 1];
     }
   };
 

--- a/src/hotspot/share/oops/inlineKlass.inline.hpp
+++ b/src/hotspot/share/oops/inlineKlass.inline.hpp
@@ -38,76 +38,22 @@ inline bool InlineKlass::layout_has_null_marker(LayoutKind lk) const {
 }
 
 inline bool InlineKlass::is_layout_supported(LayoutKind lk) const {
-  switch(lk) {
-    case LayoutKind::NULL_FREE_NON_ATOMIC_FLAT:
-      return has_null_free_non_atomic_layout();
-      break;
-    case LayoutKind::NULL_FREE_ATOMIC_FLAT:
-      return has_null_free_atomic_layout();
-      break;
-    case LayoutKind::NULLABLE_ATOMIC_FLAT:
-      return has_nullable_atomic_layout();
-      break;
-    case LayoutKind::NULLABLE_NON_ATOMIC_FLAT:
-      return has_nullable_non_atomic_layout();
-      break;
-    case LayoutKind::BUFFERED:
-      return true;
-      break;
-    default:
-      ShouldNotReachHere();
-  }
+  return has_layout(lk);
 }
 
-inline int InlineKlass::layout_size_in_bytes(LayoutKind kind) const {
-  switch(kind) {
-    case LayoutKind::NULL_FREE_NON_ATOMIC_FLAT:
-      assert(has_null_free_non_atomic_layout(), "Layout not available");
-      return null_free_non_atomic_size_in_bytes();
-      break;
-    case LayoutKind::NULL_FREE_ATOMIC_FLAT:
-      assert(has_null_free_atomic_layout(), "Layout not available");
-      return null_free_atomic_size_in_bytes();
-      break;
-    case LayoutKind::NULLABLE_ATOMIC_FLAT:
-      assert(has_nullable_atomic_layout(), "Layout not available");
-      return nullable_atomic_size_in_bytes();
-      break;
-    case LayoutKind::NULLABLE_NON_ATOMIC_FLAT:
-      assert(has_nullable_non_atomic_layout(), "Layout not available");
-      return nullable_non_atomic_size_in_bytes();
-      break;
-    case LayoutKind::BUFFERED:
-      return payload_size_in_bytes();
-      break;
-    default:
-      ShouldNotReachHere();
-  }
+inline int InlineKlass::layout_size_in_bytes(LayoutKind lk) const {
+  assert(has_layout(lk), "Layout not available");
+  return members().layout_size_in_bytes(lk);
 }
 
-inline int InlineKlass::layout_alignment(LayoutKind kind) const {
-  switch(kind) {
-    case LayoutKind::NULL_FREE_NON_ATOMIC_FLAT:
-      assert(has_null_free_non_atomic_layout(), "Layout not available");
-      return null_free_non_atomic_alignment();
-      break;
-    case LayoutKind::NULL_FREE_ATOMIC_FLAT:
-      assert(has_null_free_atomic_layout(), "Layout not available");
-      return null_free_atomic_size_in_bytes();
-      break;
-    case LayoutKind::NULLABLE_ATOMIC_FLAT:
-      assert(has_nullable_atomic_layout(), "Layout not available");
-      return nullable_atomic_size_in_bytes();
-      break;
-    case LayoutKind::NULLABLE_NON_ATOMIC_FLAT:
-      assert(has_nullable_non_atomic_layout(), "Layout not available");
-      return null_free_non_atomic_alignment();
-    break;
-    case LayoutKind::BUFFERED:
-      return payload_alignment();
-      break;
-    default:
-      ShouldNotReachHere();
+inline int InlineKlass::layout_alignment(LayoutKind lk) const {
+  assert(has_layout(lk), "Layout not available");
+  if (lk == LayoutKind::BUFFERED) {
+    return payload_alignment();
+  } else if (lk == LayoutKind::NULL_FREE_NON_ATOMIC_FLAT) {
+    return null_free_non_atomic_alignment();
+  } else {
+    return members().layout_size_in_bytes(lk);
   }
 }
 

--- a/src/hotspot/share/oops/inlineKlass.inline.hpp
+++ b/src/hotspot/share/oops/inlineKlass.inline.hpp
@@ -50,7 +50,8 @@ inline int InlineKlass::layout_alignment(LayoutKind lk) const {
   assert(has_layout(lk), "Layout not available");
   if (lk == LayoutKind::BUFFERED) {
     return payload_alignment();
-  } else if (lk == LayoutKind::NULL_FREE_NON_ATOMIC_FLAT) {
+  } else if (lk == LayoutKind::NULL_FREE_NON_ATOMIC_FLAT ||
+             lk == LayoutKind::NULLABLE_NON_ATOMIC_FLAT) {
     return null_free_non_atomic_alignment();
   } else {
     return members().layout_size_in_bytes(lk);

--- a/src/hotspot/share/oops/layoutKind.hpp
+++ b/src/hotspot/share/oops/layoutKind.hpp
@@ -86,13 +86,14 @@
 // of the java.lang.invoke.MemberName class relies on this property.
 
 enum class LayoutKind : uint32_t {
-  REFERENCE                 = 0,    // indirection to a heap allocated instance
-  BUFFERED                  = 1,    // layout used in heap allocated standalone instances
-  NULL_FREE_NON_ATOMIC_FLAT = 2,    // flat, null-free (no null marker), no guarantee of atomic updates
-  NULL_FREE_ATOMIC_FLAT     = 3,    // flat, null-free, size compatible with atomic updates, alignment requirement is equal to the size
-  NULLABLE_ATOMIC_FLAT      = 4,    // flat, include a null marker, plus same size/alignment properties as ATOMIC layout
-  NULLABLE_NON_ATOMIC_FLAT  = 5,    // flat, include a null marker, non-atomic, only used for strict final non-static fields
-  UNKNOWN                   = 6     // used for uninitialized fields of type LayoutKind
+  REFERENCE                 = 0,      // indirection to a heap allocated instance
+  BUFFERED                  = 1,      // layout used in heap allocated standalone instances
+  NULL_FREE_NON_ATOMIC_FLAT = 2,      // flat, null-free (no null marker), no guarantee of atomic updates
+  NULL_FREE_ATOMIC_FLAT     = 3,      // flat, null-free, size compatible with atomic updates, alignment requirement is equal to the size
+  NULLABLE_ATOMIC_FLAT      = 4,      // flat, include a null marker, plus same size/alignment properties as ATOMIC layout
+  NULLABLE_NON_ATOMIC_FLAT  = 5,      // flat, include a null marker, non-atomic, only used for strict final non-static fields
+  UNKNOWN                   = 6,      // used for uninitialized fields of type LayoutKind
+  COUNT                     = UNKNOWN
 };
 
 class outputStream;


### PR DESCRIPTION
Hi,

This code hasn't been tested other than being compiled so far.

This is a refactoring of the `Members` inner class of `InlineKlass`. We have this `LayoutKind` enum:

```
enum class LayoutKind : uint32_t {
  REFERENCE                 = 0,      // indirection to a heap allocated instance
  BUFFERED                  = 1,      // layout used in heap allocated standalone instances
  NULL_FREE_NON_ATOMIC_FLAT = 2,      // flat, null-free (no null marker), no guarantee of atomic updates
  NULL_FREE_ATOMIC_FLAT     = 3,      // flat, null-free, size compatible with atomic updates, alignment requirement is equal to the size
  NULLABLE_ATOMIC_FLAT      = 4,      // flat, include a null marker, plus same size/alignment properties as ATOMIC layout
  NULLABLE_NON_ATOMIC_FLAT  = 5,      // flat, include a null marker, non-atomic, only used for strict final non-static fields
  UNKNOWN                   = 6,      // used for uninitialized fields of type LayoutKind
  COUNT                     = UNKNOWN
};

```

All but `REFERENCE`, `UNKNOWN` and `COUNT` correspond to a size and alignment for an `InlineKlass`. We used to store each of these as a separate field in `Members`, and this requires us to switch on the `LayoutKind` value to get its respective size/alignment value. Instead, I propose that we store this in an array, this reduces the code to a single load, reducing both code size and CPU usage.

There are more places where we have this type of layout, so we should clean that up as well.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32251/head:pull/32251` \
`$ git checkout pull/32251`

Update a local copy of the PR: \
`$ git checkout pull/32251` \
`$ git pull https://git.openjdk.org/jdk.git pull/32251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32251`

View PR using the GUI difftool: \
`$ git pr show -t 32251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32251.diff">https://git.openjdk.org/jdk/pull/32251.diff</a>

</details>
