### PR TITLE
8336666: Investigate why AIX needs more metaspace in test serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+// This test has two variants with different MaxMetaspaceSize values depending on CDS availability.
+// With CDS enabled: 17m is sufficient because core JDK classes are mapped from CDS shared
+// archive into separate shared class space and do not count against MaxMetaspaceSize.
+// Without CDS (e.g. AIX): all classes are allocated in classic metaspace, requiring a
+// larger MaxMetaspaceSize of 25m.
+
 /*
  * @test id=nocds
  * @bug 8308762
@@ -51,11 +57,6 @@
  * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=17m -XX:MaxMetaspaceSize=17m RedefineLeakThrowable
  */
 
-// This test has two variants with different MaxMetaspaceSize values depending on CDS availability.
-// With CDS enabled: 17m is sufficient because core JDK classes are mapped from CDS shared
-// archive into separate shared class space and do not count against MaxMetaspaceSize.
-// Without CDS (e.g. AIX): all classes are allocated in classic metaspace, requiring a
-// larger MaxMetaspaceSize of 25m.
 class Tester {
     void test() {
         try {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -44,7 +44,7 @@
  * @requires vm.jvmti
  * @requires vm.flagless
  * @requires vm.cds
- * @modules java.base./jdk.internal.misc
+ * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  *          java.compiler
  * @run main RedefineClassHelper

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -22,12 +22,13 @@
  */
 
 /*
- * @test
+ * @test id=nocds
  * @bug 8308762
  * @library /test/lib
  * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
  * @requires vm.jvmti
  * @requires vm.flagless
+ * @requires !vm.cds
  * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  *          java.compiler
@@ -35,7 +36,26 @@
  * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=25m -XX:MaxMetaspaceSize=25m RedefineLeakThrowable
  */
 
-// MaxMetaspaceSize=25m allows InMemoryJavaCompiler to load even if CDS is off.
+/*
+ * @test id=cds
+ * @bug 8308762
+ * @library /test/lib
+ * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
+ * @requires vm.jvmti
+ * @requires vm.flagless
+ * @requires vm.cds
+ * @modules java.base./jdk.internal.misc
+ * @modules java.instrument
+ *          java.compiler
+ * @run main RedefineClassHelper
+ * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=17m -XX:MaxMetaspaceSize=17m RedefineLeakThrowable
+ */
+
+// This test has two variants with different MaxMetaspaceSize values depending on CDS availability.
+// With CDS enabled: 17m is sufficient because core JDK classes are mapped from CDS shared
+// archive into separate shared class space and do not count against MaxMetaspaceSize.
+// Without CDS (e.g. AIX): all classes are allocated in classic metaspace, requiring a
+// larger MaxMetaspaceSize of 25m.
 class Tester {
     void test() {
         try {


### PR DESCRIPTION
The test was using a fixed -XX:MaxMetaspaceSize=25m for all platforms. Investigation (via jcmd VM.metaspace) revealed that the higher limit is needed only on platforms where CDS is unavailable (e.g. AIX). Without CDS, all 3,340 classes are allocated in classic metaspace (~23.4 MB committed), whereas on Linux with CDS active, 1,364 core JDK classes are mapped from the shared archive into a separate "Shared Class Space" that does not count against -XX:MaxMetaspaceSize, keeping classic metaspace usage at ~13.6 MB.

This was validated by running the test on Linux with -Xshare:off -XX:MaxMetaspaceSize=17m, which reproduces the same OOM as AIX. When running with 25m, the usage is very similar to AIX.

This change splits the test into two variants based on CDS availability:

> id=cds (@requires vm.cds): runs with -XX:MaxMetaspaceSize=17m
id=nocds (@requires !vm.cds): runs with -XX:MaxMetaspaceSize=25m

An explanatory comment is also included so the reasoning is clear to future readers.

JBS Issue: [JDK-8336666](https://bugs.openjdk.org/browse/JDK-8336666)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8336666](https://bugs.openjdk.org/browse/JDK-8336666): Investigate why AIX needs more metaspace in test serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [9aa4b2f4](https://git.openjdk.org/jdk/pull/32254/files/9aa4b2f4390bb2a44eda0916fd8ba397d44edd60)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32254/head:pull/32254` \
`$ git checkout pull/32254`

Update a local copy of the PR: \
`$ git checkout pull/32254` \
`$ git pull https://git.openjdk.org/jdk.git pull/32254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32254`

View PR using the GUI difftool: \
`$ git pr show -t 32254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32254.diff">https://git.openjdk.org/jdk/pull/32254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32254#issuecomment-5216598720)
</details>
