### PR TITLE
8389966: Remove dangling bootstrap compile reason name

### DIFF
--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -71,9 +71,9 @@ class CompileTask : public CHeapObj<mtCompiler> {
       "tiered",
       "replay",
       "whitebox",
-      "must_be_compiled",
-      "bootstrap"
+      "must_be_compiled"
     };
+    STATIC_ASSERT(ARRAY_SIZE(reason_names) == Reason_Count);
     return reason_names[compile_reason];
   }
 


### PR DESCRIPTION
Removes `"bootstrap"` from `reason_names`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389966](https://bugs.openjdk.org/browse/JDK-8389966): Remove dangling bootstrap compile reason name (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32256/head:pull/32256` \
`$ git checkout pull/32256`

Update a local copy of the PR: \
`$ git checkout pull/32256` \
`$ git pull https://git.openjdk.org/jdk.git pull/32256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32256`

View PR using the GUI difftool: \
`$ git pr show -t 32256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32256.diff">https://git.openjdk.org/jdk/pull/32256.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32256#issuecomment-5217906361)
</details>
