### PR TITLE
8390002: Windows AArch64 needs an additional yellow stack page (total 3)

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -42,7 +42,7 @@ define_pd_global(size_t, CodeCacheSegmentSize,   64);
 define_pd_global(uint, CodeEntryAlignment,       64);
 define_pd_global(intx, OptoLoopAlignment,        16);
 
-#define DEFAULT_STACK_YELLOW_PAGES (2)
+#define DEFAULT_STACK_YELLOW_PAGES (NOT_WINDOWS(2) WINDOWS_ONLY(3))
 #define DEFAULT_STACK_RED_PAGES (1)
 // Java_java_net_SocketOutputStream_socketWrite0() uses a 64k buffer on the
 // stack if compiled for unix and LP64. To pass stack overflow tests we need

--- a/test/hotspot/jtreg/runtime/StackGuardPages/TestWindowsStackYellowPages.java
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/TestWindowsStackYellowPages.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, Microsoft and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390002
+ * @summary Verifies that on Windows, there is are three yellow stack pages,
+ *          since Windows requires an additional yellow stack page for the
+ *          OS-managed stack-growth guard page
+ * @requires os.family == "windows"
+ * @library /test/lib
+ * @run driver TestWindowsStackYellowPages
+ */
+
+import jdk.test.lib.process.ProcessTools;
+
+public class TestWindowsStackYellowPages {
+    private static final String FLAG = "StackYellowPages";
+
+    public static void main(String[] args) throws Exception {
+        ProcessTools.executeTestJava("-XX:+PrintFlagsFinal", "-version")
+                    .shouldMatch(FLAG + "[ ]+=[ ]+3")
+                    .shouldHaveExitValue(0);
+
+        ProcessTools.executeTestJava("-XX:" + FLAG + "=2", "-version")
+                    .shouldContain(FLAG + "=2 is outside the allowed range")
+                    .shouldNotHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
On all Windows platforms, the default (and thus the minimum) number of
yellow stack pages needs to be 3 to accommodate Windows' stack-growth
guard page (see JBS issue for details).  The Windows/x64 implementation
has had this fix for a while now, but it was missing from the
Windows/ARM64 implementation.  This patch fixes the Windows/ARM64
default value and adds a test that applies to all Windows ports.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390002](https://bugs.openjdk.org/browse/JDK-8390002): Windows AArch64 needs an additional yellow stack page (total 3) (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32260/head:pull/32260` \
`$ git checkout pull/32260`

Update a local copy of the PR: \
`$ git checkout pull/32260` \
`$ git pull https://git.openjdk.org/jdk.git pull/32260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32260`

View PR using the GUI difftool: \
`$ git pr show -t 32260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32260.diff">https://git.openjdk.org/jdk/pull/32260.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32260#issuecomment-5220910722)
</details>
