### PR TITLE
8390014: TestInstanceKlassSize.java and TestInstanceKlassSizeForInterface.java failed when --enable-preview was passed

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jdk.internal.misc.PreviewFeatures;
+
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.JDKToolLauncher;
@@ -83,17 +85,21 @@ public class TestInstanceKlassSize {
         }
         try {
             // Run this app with the LingeredApp PID to get SA output from the LingeredApp
-            ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(
-                "--add-modules=jdk.hotspot.agent",
-                "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
-                "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED",
-                "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.oops=ALL-UNNAMED",
-                "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
-                "-XX:+UnlockDiagnosticVMOptions",
-                "-XX:+WhiteBoxAPI",
-                "-Xbootclasspath/a:.",
-                "TestInstanceKlassSize",
-                Long.toString(app.getPid()));
+            List<String> args = new ArrayList<>();
+            if (PreviewFeatures.isEnabled()) {
+                args.add("--enable-preview");
+            }
+            args.add("--add-modules=jdk.hotspot.agent");
+            args.add("--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED");
+            args.add("--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED");
+            args.add("--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.oops=ALL-UNNAMED");
+            args.add("--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED");
+            args.add("-XX:+UnlockDiagnosticVMOptions");
+            args.add("-XX:+WhiteBoxAPI");
+            args.add("-Xbootclasspath/a:.");
+            args.add("TestInstanceKlassSize");
+            args.add(Long.toString(app.getPid()));
+            ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(args);
             SATestUtils.addPrivilegesIfNeeded(processBuilder);
             output = ProcessTools.executeProcess(processBuilder);
             System.out.println(output.getOutput());

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
@@ -21,7 +21,10 @@
  * questions.
  */
 
+import java.util.ArrayList;
 import java.util.List;
+
+import jdk.internal.misc.PreviewFeatures;
 
 import sun.jvm.hotspot.HotSpotAgent;
 import sun.jvm.hotspot.utilities.SystemDictionaryHelper;
@@ -105,17 +108,21 @@ public class TestInstanceKlassSizeForInterface {
                             String[] instanceKlassNames,
                             int lingeredAppPid) throws Exception {
         // Start a new process to attach to the LingeredApp process to get SA info
-        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(
-            "--add-modules=jdk.hotspot.agent",
-            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
-            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED",
-            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.oops=ALL-UNNAMED",
-            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
-            "-XX:+UnlockDiagnosticVMOptions",
-            "-XX:+WhiteBoxAPI",
-            "-Xbootclasspath/a:.",
-            "TestInstanceKlassSizeForInterface",
-            Integer.toString(lingeredAppPid));
+        List<String> args = new ArrayList<>();
+        if (PreviewFeatures.isEnabled()) {
+            args.add("--enable-preview");
+        }
+        args.add("--add-modules=jdk.hotspot.agent");
+        args.add("--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED");
+        args.add("--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED");
+        args.add("--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.oops=ALL-UNNAMED");
+        args.add("--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED");
+        args.add("-XX:+UnlockDiagnosticVMOptions");
+        args.add("-XX:+WhiteBoxAPI");
+        args.add("-Xbootclasspath/a:.");
+        args.add("TestInstanceKlassSizeForInterface");
+        args.add(Integer.toString(lingeredAppPid));
+        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(args);
         SATestUtils.addPrivilegesIfNeeded(processBuilder);
         OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
         SAOutput.shouldHaveExitValue(0);


### PR DESCRIPTION
We can see following errors when we run `make test` with `JTREG="VALUE_CLASS_PLUGIN=true;VM_OPTIONS=--enable-preview"`:

TestInstanceKlassSize
```
 stderr: [Exception in thread "main" java.lang.UnsupportedClassVersionError:
 Preview features are not enabled for jdk/test/whitebox/WhiteBox (class file
 version 72.65535). Try running with '--enable-preview'
        at java.base/java.lang.ClassLoader.findBootstrapClass(Native Method)
        at java.base/java.lang.ClassLoader.findBootstrapClassOrNull(ClassLoa
der.java:1244)
        at java.base/java.lang.System$1.findBootstrapClassOrNull(System.java
:2068)
        at java.base/jdk.internal.loader.ClassLoaders$BootClassLoader.loadCl
assOrNull(ClassLoaders.java:138)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(
BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(
BuiltinClassLoader.java:615)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(
BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(
BuiltinClassLoader.java:615)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Builti
nClassLoader.java:578)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:502)
        at TestInstanceKlassSize.<clinit>(TestInstanceKlassSize.java:65)
]
 exitValue = 1

java.lang.RuntimeException: Expected to get exit value of [0], exit value is
: [1]
        at jdk.test.lib.process.OutputAnalyzer.shouldHaveExitValue(OutputAna
lyzer.java:602)
        at TestInstanceKlassSize.startMeWithArgs(TestInstanceKlassSize.java:
100)
        at TestInstanceKlassSize.main(TestInstanceKlassSize.java:152)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(
DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:583)
        at com.sun.javatest.regtest.agent.MainMethodHelper.executeModernMain
Class(MainMethodHelper.java:55)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapp
er.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1527)
```

TestInstanceKlassSizeForInterface
```
 stderr: [Exception in thread "main" java.lang.UnsupportedClassVersionError: Preview features are not enabled for jdk/test/whitebox/WhiteBox (class file version 72.65535). Try running with '--enable-preview'
        at java.base/java.lang.ClassLoader.findBootstrapClass(Native Method)
        at java.base/java.lang.ClassLoader.findBootstrapClassOrNull(ClassLoader.java:1244)
        at java.base/java.lang.System$1.findBootstrapClassOrNull(System.java:2068)
        at java.base/jdk.internal.loader.ClassLoaders$BootClassLoader.loadClassOrNull(ClassLoaders.java:138)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:615)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:615)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:578)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:502)
        at TestInstanceKlassSizeForInterface.<clinit>(TestInstanceKlassSizeForInterface.java:61)
]
 exitValue = 1

java.lang.RuntimeException: Expected to get exit value of [0], exit value is: [1]
        at jdk.test.lib.process.OutputAnalyzer.shouldHaveExitValue(OutputAnalyzer.java:602)
        at TestInstanceKlassSizeForInterface.createAnotherToAttach(TestInstanceKlassSizeForInterface.java:121)
        at TestInstanceKlassSizeForInterface.main(TestInstanceKlassSizeForInterface.java:154)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:583)
        at com.sun.javatest.regtest.agent.MainMethodHelper.executeModernMainClass(MainMethodHelper.java:55)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1527)
```

`--enable-preview` should be added when the test run with enabling preview mode.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390014](https://bugs.openjdk.org/browse/JDK-8390014): TestInstanceKlassSize.java and TestInstanceKlassSizeForInterface.java failed when --enable-preview was passed (**Bug** - P4)


### Reviewers
 * [Paul Hübner](https://openjdk.org/census#phubner) (@Arraying - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32262/head:pull/32262` \
`$ git checkout pull/32262`

Update a local copy of the PR: \
`$ git checkout pull/32262` \
`$ git pull https://git.openjdk.org/jdk.git pull/32262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32262`

View PR using the GUI difftool: \
`$ git pr show -t 32262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32262.diff">https://git.openjdk.org/jdk/pull/32262.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32262#issuecomment-5224789301)
</details>
