### PR TITLE
8389573: InputStreamReader.readAllAsString() should override the generic Reader default implementation to avoid unnecessary buffer copies

### DIFF
--- a/src/java.base/share/classes/java/io/InputStreamReader.java
+++ b/src/java.base/share/classes/java/io/InputStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,6 +181,11 @@ public class InputStreamReader extends Reader {
      */
     public int read(char[] cbuf, int off, int len) throws IOException {
         return sd.read(cbuf, off, len);
+    }
+
+    @Override
+    public String readAllAsString() throws IOException {
+        return sd.readAllAsString();
     }
 
     /**

--- a/src/java.base/share/classes/java/io/InputStreamReader.java
+++ b/src/java.base/share/classes/java/io/InputStreamReader.java
@@ -185,7 +185,8 @@ public class InputStreamReader extends Reader {
 
     @Override
     public String readAllAsString() throws IOException {
-        return sd.readAllAsString();
+        String s = sd.tryReadAllAsString();
+        return (s != null) ? s : super.readAllAsString();
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -117,10 +117,7 @@ public class StreamDecoder extends Reader {
     }
 
     public int read() throws IOException {
-        synchronized (lock) {
-            readCalled = true;
-            return read0();
-        }
+        return read0();
     }
 
     @SuppressWarnings("fallthrough")
@@ -313,8 +310,6 @@ public class StreamDecoder extends Reader {
     }
 
     int implRead(char[] cbuf, int off, int end) throws IOException {
-        readCalled = true;
-
         // In order to handle surrogate pairs, this method requires that
         // the invoker attempt to read at least two characters.  Saving the
         // extra character, if any, at a higher level is easier than trying

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -49,7 +49,7 @@ public class StreamDecoder extends Reader {
     private static final int MIN_BYTE_BUFFER_SIZE = 32;
     private static final int DEFAULT_BYTE_BUFFER_SIZE = 8192;
 
-    private volatile boolean havePulledFromInputStream;
+    private volatile boolean decoderContainsBytes;
     private volatile boolean closed;
 
     private void ensureOpen() throws IOException {
@@ -207,10 +207,15 @@ public class StreamDecoder extends Reader {
 
             byte[] remaining = in.readAllBytes();
 
-            if (!havePulledFromInputStream)
+            if (!decoderContainsBytes
+                    && decoder.malformedInputAction() == CodingErrorAction.REPLACE
+                    && decoder.unmappableCharacterAction() == CodingErrorAction.REPLACE
+                    && decoder.getClass() == cs.newDecoder().getClass())
                 return new String(remaining, cs);
 
-            int estimateSize = (haveLeftoverChar ? 1 : 0) + (int) Math.ceil((bb.remaining() + remaining.length) * decoder.maxCharsPerByte());
+            int estimateSize = (haveLeftoverChar ? 1 : 0)
+                    + (int) Math.ceil((bb.remaining() + remaining.length)
+                    * decoder.maxCharsPerByte());
             int initialSize = Math.max(estimateSize, DEFAULT_BYTE_BUFFER_SIZE);
             CharBuffer cb = CharBuffer.allocate(initialSize);
 
@@ -219,21 +224,41 @@ public class StreamDecoder extends Reader {
                 haveLeftoverChar = false;
             }
 
-            while (bb.hasRemaining()) {
-                CoderResult cr = decoder.decode(bb, cb, false);
-                if (cr.isError())
-                    cr.throwException();
-                if (cr.isOverflow())
-                    cb = ensureFree(cb, bb.remaining());
-            }
+            if (bb.hasRemaining() || remaining.length > 0) {
+                while (bb.hasRemaining()) {
+                    CoderResult cr = decoder.decode(bb, cb, remaining.length == 0);
+                    if (cr.isError())
+                        cr.throwException();
+                    if (cr.isOverflow())
+                        cb = ensureFree(cb, bb.remaining());
+                    if (cr.isUnderflow())
+                        break;
+                }
 
-            ByteBuffer bbuf = ByteBuffer.wrap(remaining);
-            while (bbuf.hasRemaining()) {
-                CoderResult cr = decoder.decode(bbuf, cb, false);
+                ByteBuffer bbuf = !bb.hasRemaining()
+                        ? ByteBuffer.wrap(remaining)
+                        : bb.capacity() - bb.remaining() >= remaining.length
+                        ? bb.compact().put(remaining).flip()
+                        : ByteBuffer.allocate(bb.remaining() + remaining.length)
+                                .put(bb).put(remaining).flip();
+
+                while (bbuf.hasRemaining()) {
+                    CoderResult cr = decoder.decode(bbuf, cb, true);
+                    if (cr.isError())
+                        cr.throwException();
+                    if (cr.isOverflow())
+                        cb = ensureFree(cb, bbuf.remaining());
+                    if (cr.isUnderflow())
+                        break;
+                }
+
+                CoderResult cr = decoder.flush(cb);
+                while (cr.isOverflow()) {
+                    cb = ensureFree(cb, 1);
+                    cr = decoder.flush(cb);
+                }
                 if (cr.isError())
                     cr.throwException();
-                if (cr.isOverflow())
-                    cb = ensureFree(cb, bbuf.remaining());
             }
 
             return cb.flip().toString();
@@ -331,7 +356,7 @@ public class StreamDecoder extends Reader {
                     throw new IOException("Underlying input stream returned zero bytes");
                 assert (n <= rem) : "n = " + n + ", rem = " + rem;
                 bb.position(pos + n);
-                havePulledFromInputStream = true;
+                decoderContainsBytes = true;
             }
         } finally {
             // Flip even when an IOException is thrown,

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ public class StreamDecoder extends Reader {
     private static final int MIN_BYTE_BUFFER_SIZE = 32;
     private static final int DEFAULT_BYTE_BUFFER_SIZE = 8192;
 
+    private volatile boolean havePulledFromInputStream;
     private volatile boolean closed;
 
     private void ensureOpen() throws IOException {
@@ -192,6 +193,53 @@ public class StreamDecoder extends Reader {
         }
     }
 
+    private static CharBuffer ensureFree(CharBuffer cb, int minFree) {
+        return cb.remaining() < minFree ? CharBuffer.allocate(cb.position() + minFree).put(cb.flip()) : cb;
+    }
+
+    @Override
+    public String readAllAsString() throws IOException {
+        synchronized (lock) {
+            ensureOpen();
+
+            if (in == null)
+                return super.readAllAsString();
+
+            byte[] remaining = in.readAllBytes();
+
+            if (!havePulledFromInputStream)
+                return new String(remaining, cs);
+
+            int estimateSize = (haveLeftoverChar ? 1 : 0) + (int) Math.ceil((bb.remaining() + remaining.length) * decoder.maxCharsPerByte());
+            int initialSize = Math.max(estimateSize, DEFAULT_BYTE_BUFFER_SIZE);
+            CharBuffer cb = CharBuffer.allocate(initialSize);
+
+            if (haveLeftoverChar) {
+                cb.put(leftoverChar);
+                haveLeftoverChar = false;
+            }
+
+            while (bb.hasRemaining()) {
+                CoderResult cr = decoder.decode(bb, cb, false);
+                if (cr.isError())
+                    cr.throwException();
+                if (cr.isOverflow())
+                    cb = ensureFree(cb, bb.remaining());
+            }
+
+            ByteBuffer bbuf = ByteBuffer.wrap(remaining);
+            while (bbuf.hasRemaining()) {
+                CoderResult cr = decoder.decode(bbuf, cb, false);
+                if (cr.isError())
+                    cr.throwException();
+                if (cr.isOverflow())
+                    cb = ensureFree(cb, bbuf.remaining());
+            }
+
+            return cb.flip().toString();
+        }
+    }
+
     public boolean ready() throws IOException {
         synchronized (lock) {
             ensureOpen();
@@ -283,6 +331,7 @@ public class StreamDecoder extends Reader {
                     throw new IOException("Underlying input stream returned zero bytes");
                 assert (n <= rem) : "n = " + n + ", rem = " + rem;
                 bb.position(pos + n);
+                havePulledFromInputStream = true;
             }
         } finally {
             // Flip even when an IOException is thrown,

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -49,7 +49,7 @@ public class StreamDecoder extends Reader {
     private static final int MIN_BYTE_BUFFER_SIZE = 32;
     private static final int DEFAULT_BYTE_BUFFER_SIZE = 8192;
 
-    private volatile boolean readCalled;
+    private boolean readCalled;
     private volatile boolean closed;
 
     private void ensureOpen() throws IOException {
@@ -117,12 +117,17 @@ public class StreamDecoder extends Reader {
     }
 
     public int read() throws IOException {
-        return read0();
+        synchronized (lock) {
+            readCalled = true;
+            return read0();
+        }
     }
 
     @SuppressWarnings("fallthrough")
     private int read0() throws IOException {
         synchronized (lock) {
+            readCalled = true;
+
             // Return the leftover char, if there is one
             if (haveLeftoverChar) {
                 haveLeftoverChar = false;
@@ -150,6 +155,7 @@ public class StreamDecoder extends Reader {
 
     public int read(char[] cbuf, int offset, int length) throws IOException {
         synchronized (lock) {
+            readCalled = true;
             int off = offset;
             int len = length;
 
@@ -191,10 +197,6 @@ public class StreamDecoder extends Reader {
             // indicating EOF, then we don't return their sum as this loses data.
             return (nr < 0) ? (n == 1 ? 1 : nr) : (n + nr);
         }
-    }
-
-    private static CharBuffer ensureFree(CharBuffer cb, int minFree) {
-        return cb.remaining() < minFree ? CharBuffer.allocate(cb.position() + minFree).put(cb.flip()) : cb;
     }
 
     public boolean ready() throws IOException {
@@ -278,7 +280,6 @@ public class StreamDecoder extends Reader {
     }
 
     private int readBytes() throws IOException {
-        readCalled = true;
         bb.compact();
         try {
             if (ch != null) {
@@ -312,6 +313,7 @@ public class StreamDecoder extends Reader {
     }
 
     int implRead(char[] cbuf, int off, int end) throws IOException {
+        readCalled = true;
 
         // In order to handle surrogate pairs, this method requires that
         // the invoker attempt to read at least two characters.  Saving the
@@ -392,9 +394,12 @@ public class StreamDecoder extends Reader {
     }
 
     public String tryReadAllAsString() throws IOException {
+        if (in == null || !decoderFromCharset) {
+            return null;
+        }
         synchronized (lock) {
             ensureOpen();
-            if (in != null && decoderFromCharset && !readCalled) {
+            if (!readCalled) {
                 return new String(in.readAllBytes(), cs);
             }
         }

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -222,40 +222,46 @@ public class StreamDecoder extends Reader {
             }
 
             if (bb.hasRemaining() || remaining.length > 0) {
-                while (bb.hasRemaining()) {
-                    CoderResult cr = decoder.decode(bb, cb, remaining.length == 0);
+                try {
+                    while (bb.hasRemaining()) {
+                        CoderResult cr = decoder.decode(bb, cb, remaining.length == 0);
+                        if (cr.isError())
+                            cr.throwException();
+                        if (cr.isOverflow())
+                            cb = ensureFree(cb, bb.remaining());
+                        if (cr.isUnderflow())
+                            break;
+                    }
+
+                    ByteBuffer bbuf = !bb.hasRemaining()
+                            ? ByteBuffer.wrap(remaining)
+                            : bb.capacity() - bb.remaining() >= remaining.length
+                            ? bb.compact().put(remaining).flip()
+                            : ByteBuffer.allocate(bb.remaining() + remaining.length)
+                                    .put(bb).put(remaining).flip();
+
+                    while (bbuf.hasRemaining()) {
+                        CoderResult cr = decoder.decode(bbuf, cb, true);
+                        if (cr.isError())
+                            cr.throwException();
+                        if (cr.isOverflow())
+                            cb = ensureFree(cb, bbuf.remaining());
+                        if (cr.isUnderflow())
+                            break;
+                    }
+
+                    CoderResult cr = decoder.flush(cb);
+                    while (cr.isOverflow()) {
+                        cb = ensureFree(cb, 1);
+                        cr = decoder.flush(cb);
+                    }
                     if (cr.isError())
                         cr.throwException();
-                    if (cr.isOverflow())
-                        cb = ensureFree(cb, bb.remaining());
-                    if (cr.isUnderflow())
-                        break;
+                } finally {
+                    decoder.reset();
+                    decoderContainsBytes = false;
+                    bb.clear().flip();
                 }
-
-                ByteBuffer bbuf = !bb.hasRemaining()
-                        ? ByteBuffer.wrap(remaining)
-                        : bb.capacity() - bb.remaining() >= remaining.length
-                        ? bb.compact().put(remaining).flip()
-                        : ByteBuffer.allocate(bb.remaining() + remaining.length)
-                                .put(bb).put(remaining).flip();
-
-                while (bbuf.hasRemaining()) {
-                    CoderResult cr = decoder.decode(bbuf, cb, true);
-                    if (cr.isError())
-                        cr.throwException();
-                    if (cr.isOverflow())
-                        cb = ensureFree(cb, bbuf.remaining());
-                    if (cr.isUnderflow())
-                        break;
-                }
-
-                CoderResult cr = decoder.flush(cb);
-                while (cr.isOverflow()) {
-                    cb = ensureFree(cb, 1);
-                    cr = decoder.flush(cb);
-                }
-                if (cr.isError())
-                    cr.throwException();
             }
 
             return cb.flip().toString();

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -207,10 +207,7 @@ public class StreamDecoder extends Reader {
 
             byte[] remaining = in.readAllBytes();
 
-            if (!decoderContainsBytes
-                    && decoder.malformedInputAction() == CodingErrorAction.REPLACE
-                    && decoder.unmappableCharacterAction() == CodingErrorAction.REPLACE
-                    && decoder.getClass() == cs.newDecoder().getClass())
+            if (decoderFromCharset && !decoderContainsBytes)
                 return new String(remaining, cs);
 
             int estimateSize = (haveLeftoverChar ? 1 : 0)
@@ -305,19 +302,28 @@ public class StreamDecoder extends Reader {
     private final InputStream in;
     private final ReadableByteChannel ch;
 
+    // true if decoder was created from cs, false if decoder was provided externally
+    private final boolean decoderFromCharset;
+
     StreamDecoder(InputStream in, Object lock, Charset cs) {
-        this(in, lock,
+        this(in, lock, cs,
             cs.newDecoder()
                 .onMalformedInput(CodingErrorAction.REPLACE)
-                .onUnmappableCharacter(CodingErrorAction.REPLACE));
+                .onUnmappableCharacter(CodingErrorAction.REPLACE),
+            true);
     }
 
     StreamDecoder(InputStream in, Object lock, CharsetDecoder dec) {
+        this(in, lock, dec.charset(), dec, false);
+    }
+
+    private StreamDecoder(InputStream in, Object lock, Charset cs, CharsetDecoder dec, boolean decoderFromCharset) {
         super(lock);
-        this.cs = dec.charset();
+        this.cs = cs;
         this.decoder = dec;
         this.in = in;
         this.ch = null;
+        this.decoderFromCharset = decoderFromCharset;
         this.bb = ByteBuffer.allocate(DEFAULT_BYTE_BUFFER_SIZE);
         bb.flip();                      // So that bb is initially empty
     }
@@ -327,6 +333,7 @@ public class StreamDecoder extends Reader {
         this.ch = ch;
         this.decoder = dec;
         this.cs = dec.charset();
+        this.decoderFromCharset = false;
         this.bb = ByteBuffer.allocate(mbc < 0
                                   ? DEFAULT_BYTE_BUFFER_SIZE
                                   : (mbc < MIN_BYTE_BUFFER_SIZE

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -49,7 +49,7 @@ public class StreamDecoder extends Reader {
     private static final int MIN_BYTE_BUFFER_SIZE = 32;
     private static final int DEFAULT_BYTE_BUFFER_SIZE = 8192;
 
-    private volatile boolean decoderContainsBytes;
+    private volatile boolean readCalled;
     private volatile boolean closed;
 
     private void ensureOpen() throws IOException {
@@ -197,77 +197,6 @@ public class StreamDecoder extends Reader {
         return cb.remaining() < minFree ? CharBuffer.allocate(cb.position() + minFree).put(cb.flip()) : cb;
     }
 
-    @Override
-    public String readAllAsString() throws IOException {
-        synchronized (lock) {
-            ensureOpen();
-
-            if (in == null)
-                return super.readAllAsString();
-
-            byte[] remaining = in.readAllBytes();
-
-            if (decoderFromCharset && !decoderContainsBytes)
-                return new String(remaining, cs);
-
-            int estimateSize = (haveLeftoverChar ? 1 : 0)
-                    + (int) Math.ceil((bb.remaining() + remaining.length)
-                    * decoder.maxCharsPerByte());
-            int initialSize = Math.max(estimateSize, DEFAULT_BYTE_BUFFER_SIZE);
-            CharBuffer cb = CharBuffer.allocate(initialSize);
-
-            if (haveLeftoverChar) {
-                cb.put(leftoverChar);
-                haveLeftoverChar = false;
-            }
-
-            if (bb.hasRemaining() || remaining.length > 0) {
-                try {
-                    while (bb.hasRemaining()) {
-                        CoderResult cr = decoder.decode(bb, cb, remaining.length == 0);
-                        if (cr.isError())
-                            cr.throwException();
-                        if (cr.isOverflow())
-                            cb = ensureFree(cb, bb.remaining());
-                        if (cr.isUnderflow())
-                            break;
-                    }
-
-                    ByteBuffer bbuf = !bb.hasRemaining()
-                            ? ByteBuffer.wrap(remaining)
-                            : bb.capacity() - bb.remaining() >= remaining.length
-                            ? bb.compact().put(remaining).flip()
-                            : ByteBuffer.allocate(bb.remaining() + remaining.length)
-                                    .put(bb).put(remaining).flip();
-
-                    while (bbuf.hasRemaining()) {
-                        CoderResult cr = decoder.decode(bbuf, cb, true);
-                        if (cr.isError())
-                            cr.throwException();
-                        if (cr.isOverflow())
-                            cb = ensureFree(cb, bbuf.remaining());
-                        if (cr.isUnderflow())
-                            break;
-                    }
-
-                    CoderResult cr = decoder.flush(cb);
-                    while (cr.isOverflow()) {
-                        cb = ensureFree(cb, 1);
-                        cr = decoder.flush(cb);
-                    }
-                    if (cr.isError())
-                        cr.throwException();
-                } finally {
-                    decoder.reset();
-                    decoderContainsBytes = false;
-                    bb.clear().flip();
-                }
-            }
-
-            return cb.flip().toString();
-        }
-    }
-
     public boolean ready() throws IOException {
         synchronized (lock) {
             ensureOpen();
@@ -349,6 +278,7 @@ public class StreamDecoder extends Reader {
     }
 
     private int readBytes() throws IOException {
+        readCalled = true;
         bb.compact();
         try {
             if (ch != null) {
@@ -369,7 +299,6 @@ public class StreamDecoder extends Reader {
                     throw new IOException("Underlying input stream returned zero bytes");
                 assert (n <= rem) : "n = " + n + ", rem = " + rem;
                 bb.position(pos + n);
-                decoderContainsBytes = true;
             }
         } finally {
             // Flip even when an IOException is thrown,
@@ -460,5 +389,15 @@ public class StreamDecoder extends Reader {
         } else {
             in.close();
         }
+    }
+
+    public String tryReadAllAsString() throws IOException {
+        synchronized (lock) {
+            ensureOpen();
+            if (in != null && decoderFromCharset && !readCalled) {
+                return new String(in.readAllBytes(), cs);
+            }
+        }
+        return null;
     }
 }

--- a/test/jdk/java/io/Reader/ReadAll.java
+++ b/test/jdk/java/io/Reader/ReadAll.java
@@ -196,26 +196,26 @@ public class ReadAll {
         }
         assertEquals(stringExpected.substring(n), string);
 
-        // InputStreamReader implementation: Called directly after construction (Fast Path)
+        // InputStreamReader implementation: Called directly after construction
         try (InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(stringExpected.getBytes()))) {
             string = isr.readAllAsString();
         }
         assertEquals(stringExpected, string);
 
-        // InputStreamReader implementation: Called on empty stream (Fast Path)
+        // InputStreamReader implementation: Called on empty stream
         try (InputStreamReader isr = new InputStreamReader(InputStream.nullInputStream())) {
             string = isr.readAllAsString();
         }
         assertEquals("", string);
 
-        // InputStreamReader implementation: Stream ends mid-character (here: last byte of three-byte UTF-8 character missing) (Fast Path)
+        // InputStreamReader implementation: Stream ends mid-character (here: last byte of three-byte UTF-8 character missing)
         try (InputStreamReader isr = new InputStreamReader(
                 new ByteArrayInputStream(new byte[] { (byte) 0xE2, (byte) 0x82 }), StandardCharsets.UTF_8)) {
             string = isr.readAllAsString();
         }
         assertEquals("\uFFFD", string);
 
-        // InputStreamReader implementation: Complete character + incomplete sequence (Slow Path)
+        // InputStreamReader implementation: Complete character + incomplete sequence
         try (InputStreamReader isr = new InputStreamReader(
                 new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0xE2 }),
                 StandardCharsets.UTF_8)) {
@@ -224,7 +224,7 @@ public class ReadAll {
         }
         assertEquals("\uFFFD", string);
 
-        // InputStreamReader implementation: Two Complete characters + incomplete sequence (Slow Path)
+        // InputStreamReader implementation: Two Complete characters + incomplete sequence
         try (InputStreamReader isr = new InputStreamReader(
                 new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42, (byte) 0xE2 }),
                 StandardCharsets.UTF_8)) {
@@ -233,7 +233,7 @@ public class ReadAll {
         }
         assertEquals("B\uFFFD", string);
 
-        // InputStreamReader implementation: Three Complete characters + incomplete sequence (Slow Path)
+        // InputStreamReader implementation: Three Complete characters + incomplete sequence
         try (InputStreamReader isr = new InputStreamReader(
                 new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42, (byte) 0x43, (byte) 0xE2 }),
                 StandardCharsets.UTF_8)) {
@@ -243,7 +243,7 @@ public class ReadAll {
         }
         assertEquals("C\uFFFD", string);
 
-        // InputStreamReader implementation: Four Complete characters (Slow Path)
+        // InputStreamReader implementation: Four Complete characters
         try (InputStreamReader isr = new InputStreamReader(
                 new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42, (byte) 0x43, (byte) 0x44 }),
                 StandardCharsets.UTF_8)) {
@@ -253,7 +253,7 @@ public class ReadAll {
         }
         assertEquals("CD", string);
 
-        // InputStreamReader implementation: 8K+ Complete characters (Slow Path)
+        // InputStreamReader implementation: 8K+ Complete characters
         int plen = PHRASE.length();
         String p8192 = PHRASE.repeat((8192 + plen - 1) / plen);
         try (InputStreamReader isr = new InputStreamReader(new SequenceInputStream(
@@ -266,14 +266,14 @@ public class ReadAll {
         }
         assertEquals("CD" + p8192, string);
 
-        // InputStreamReader implementation: read() after readAllString() (Slow path)
+        // InputStreamReader implementation: read() after readAllString()
         try (InputStreamReader isr = new InputStreamReader(
                 new ByteArrayInputStream(stringExpected.getBytes()))) {
             assertEquals(stringExpected, isr.readAllAsString());
             assertEquals(-1, isr.read()); // must not throw but return -1
         }
 
-        // InputStreamReader implementation: readAllAsString() after readAllString() (Slow path)
+        // InputStreamReader implementation: readAllAsString() after readAllString()
         try (InputStreamReader isr = new InputStreamReader(
                 new ByteArrayInputStream(stringExpected.getBytes()))) {
             assertEquals(stringExpected, isr.readAllAsString());

--- a/test/jdk/java/io/Reader/ReadAll.java
+++ b/test/jdk/java/io/Reader/ReadAll.java
@@ -265,5 +265,19 @@ public class ReadAll {
             string = isr.readAllAsString();
         }
         assertEquals("CD" + p8192, string);
+
+        // InputStreamReader implementation: read() after readAllString() (Slow path)
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(stringExpected.getBytes()))) {
+            assertEquals(stringExpected, isr.readAllAsString());
+            assertEquals(-1, isr.read()); // must not throw but return -1
+        }
+
+        // InputStreamReader implementation: readAllAsString() after readAllString() (Slow path)
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(stringExpected.getBytes()))) {
+            assertEquals(stringExpected, isr.readAllAsString());
+            assertEquals("", isr.readAllAsString());
+        }
     }
 }

--- a/test/jdk/java/io/Reader/ReadAll.java
+++ b/test/jdk/java/io/Reader/ReadAll.java
@@ -279,5 +279,75 @@ public class ReadAll {
             assertEquals(stringExpected, isr.readAllAsString());
             assertEquals("", isr.readAllAsString());
         }
+
+        // InputStreamReader implementation: Internal decoder, empty stream but decoder has bytes
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41 }),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            assertEquals("", isr.readAllAsString());
+        }
+
+        // InputStreamReader implementation: Internal decoder, with leftover char
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42 }),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            assertEquals("B", isr.readAllAsString());
+        }
+
+        // InputStreamReader implementation: Internal decoder, readAllAsString() called twice
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41 }),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            assertEquals("", isr.readAllAsString());
+            assertEquals("", isr.readAllAsString());
+        }
+
+        // InputStreamReader implementation: Internal decoder, with leftover then readAllAsString() again
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42 }),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            assertEquals("B", isr.readAllAsString());
+            assertEquals("", isr.readAllAsString());
+        }
+
+        // InputStreamReader implementation: External decoder, on empty input stream
+        try (InputStreamReader isr = new InputStreamReader(
+                InputStream.nullInputStream(),
+                StandardCharsets.UTF_8.newDecoder())) {
+            assertEquals("", isr.readAllAsString());
+        }
+
+        // InputStreamReader implementation: External decoder, empty stream but decoder has bytes
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41 }),
+                StandardCharsets.UTF_8.newDecoder())) {
+            assertEquals('A', isr.read());
+            assertEquals("", isr.readAllAsString());
+            assertEquals(-1, isr.read());
+        }
+
+        // InputStreamReader implementation: External decoder, without leftover, then readAllAsString() twice
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41 }),
+                StandardCharsets.UTF_8.newDecoder())) {
+            assertEquals('A', isr.read());
+            assertEquals("", isr.readAllAsString());
+            assertEquals("", isr.readAllAsString());
+            assertEquals(-1, isr.read());
+        }
+
+        // InputStreamReader implementation: External decoder, with leftover then readAllAsString() again
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42 }),
+                StandardCharsets.UTF_8.newDecoder())) {
+            assertEquals('A', isr.read());
+            assertEquals("B", isr.readAllAsString());
+            assertEquals("", isr.readAllAsString());
+            assertEquals(-1, isr.read());
+        }
     }
 }

--- a/test/jdk/java/io/Reader/ReadAll.java
+++ b/test/jdk/java/io/Reader/ReadAll.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.SequenceInputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -201,24 +202,68 @@ public class ReadAll {
         }
         assertEquals(stringExpected, string);
 
-        // InputStreamReader implementation: Called after previous read() call (Slow Path)
-        try (InputStreamReader isr = new InputStreamReader(
-                new ByteArrayInputStream("A€B".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8)) {
-            string = (char) isr.read() + isr.readAllAsString();
-        }
-        assertEquals("A€B", string);
-
-        // InputStreamReader implementation: Called on empty stream
+        // InputStreamReader implementation: Called on empty stream (Fast Path)
         try (InputStreamReader isr = new InputStreamReader(InputStream.nullInputStream())) {
             string = isr.readAllAsString();
         }
         assertEquals("", string);
 
-        // InputStreamReader implementation: Stream ends mid-character (here: last byte of three-byte UTF-8 character missing)
+        // InputStreamReader implementation: Stream ends mid-character (here: last byte of three-byte UTF-8 character missing) (Fast Path)
         try (InputStreamReader isr = new InputStreamReader(
                 new ByteArrayInputStream(new byte[] { (byte) 0xE2, (byte) 0x82 }), StandardCharsets.UTF_8)) {
             string = isr.readAllAsString();
         }
         assertEquals("\uFFFD", string);
+
+        // InputStreamReader implementation: Complete character + incomplete sequence (Slow Path)
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0xE2 }),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            string = isr.readAllAsString();
+        }
+        assertEquals("\uFFFD", string);
+
+        // InputStreamReader implementation: Two Complete characters + incomplete sequence (Slow Path)
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42, (byte) 0xE2 }),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            string = isr.readAllAsString();
+        }
+        assertEquals("B\uFFFD", string);
+
+        // InputStreamReader implementation: Three Complete characters + incomplete sequence (Slow Path)
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42, (byte) 0x43, (byte) 0xE2 }),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            assertEquals('B', isr.read());
+            string = isr.readAllAsString();
+        }
+        assertEquals("C\uFFFD", string);
+
+        // InputStreamReader implementation: Four Complete characters (Slow Path)
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42, (byte) 0x43, (byte) 0x44 }),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            assertEquals('B', isr.read());
+            string = isr.readAllAsString();
+        }
+        assertEquals("CD", string);
+
+        // InputStreamReader implementation: 8K+ Complete characters (Slow Path)
+        int plen = PHRASE.length();
+        String p8192 = PHRASE.repeat((8192 + plen - 1) / plen);
+        try (InputStreamReader isr = new InputStreamReader(new SequenceInputStream(
+                new ByteArrayInputStream(new byte[] { (byte) 0x41, (byte) 0x42, (byte) 0x43, (byte) 0x44 }),
+                new ByteArrayInputStream(p8192.getBytes(StandardCharsets.UTF_8))),
+                StandardCharsets.UTF_8)) {
+            assertEquals('A', isr.read());
+            assertEquals('B', isr.read());
+            string = isr.readAllAsString();
+        }
+        assertEquals("CD" + p8192, string);
     }
 }

--- a/test/jdk/java/io/Reader/ReadAll.java
+++ b/test/jdk/java/io/Reader/ReadAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,11 +30,15 @@
  * @key randomness
  */
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -190,5 +194,31 @@ public class ReadAll {
             string = r.readAllAsString();
         }
         assertEquals(stringExpected.substring(n), string);
+
+        // InputStreamReader implementation: Called directly after construction (Fast Path)
+        try (InputStreamReader isr = new InputStreamReader(new ByteArrayInputStream(stringExpected.getBytes()))) {
+            string = isr.readAllAsString();
+        }
+        assertEquals(stringExpected, string);
+
+        // InputStreamReader implementation: Called after previous read() call (Slow Path)
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream("A€B".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8)) {
+            string = (char) isr.read() + isr.readAllAsString();
+        }
+        assertEquals("A€B", string);
+
+        // InputStreamReader implementation: Called on empty stream
+        try (InputStreamReader isr = new InputStreamReader(InputStream.nullInputStream())) {
+            string = isr.readAllAsString();
+        }
+        assertEquals("", string);
+
+        // InputStreamReader implementation: Stream ends mid-character (here: last byte of three-byte UTF-8 character missing)
+        try (InputStreamReader isr = new InputStreamReader(
+                new ByteArrayInputStream(new byte[] { (byte) 0xE2, (byte) 0x82 }), StandardCharsets.UTF_8)) {
+            string = isr.readAllAsString();
+        }
+        assertEquals("\uFFFD", string);
     }
 }


### PR DESCRIPTION
This Pull Request provides an implementation for [JDK-8389573](https://bugs.openjdk.org/browse/JDK-8389573): 'InputStreamReader.readAllAsString() should override the generic Reader default implementation to avoid unnecessary buffer copies'.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389573](https://bugs.openjdk.org/browse/JDK-8389573): InputStreamReader.readAllAsString() should override the generic Reader default implementation to avoid unnecessary buffer copies (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32264/head:pull/32264` \
`$ git checkout pull/32264`

Update a local copy of the PR: \
`$ git checkout pull/32264` \
`$ git pull https://git.openjdk.org/jdk.git pull/32264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32264`

View PR using the GUI difftool: \
`$ git pr show -t 32264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32264.diff">https://git.openjdk.org/jdk/pull/32264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32264#issuecomment-5226908033)
</details>
