### PR TITLE
8355572: Support HTTP Range requests in Simple Web Server

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/SimpleFileServer.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/SimpleFileServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,6 +90,19 @@ import sun.net.httpserver.simpleserver.OutputFilter;
  *    );
  * }</pre>
  *
+ * <h3>Range requests</h3>
+ *
+ * <p>The file server and {@linkplain #createFileHandler(Path) file handler} also support HTTP
+ * <i>range requests</i>, allowing clients to
+ * request partial file content using the {@code Range} request header, as specified in
+ * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-range-requests">RFC 9110</a>.
+ * Multiple ranges are sorted, and overlapping or adjacent ranges are merged.
+ * Requests containing an excessive number of ranges may be rejected.</p>
+ *
+ * <p>Conditional range requests with the {@code If-Range}
+ * request header are not supported. If {@code If-Range} is present,
+ * the server ignores the {@code Range} request header and returns the entire file.</p>
+ *
  * <h2>Output filter</h2>
  *
  * <p> The {@link #createOutputFilter(OutputStream, OutputLevel) createOutputFilter}
@@ -111,6 +124,8 @@ import sun.net.httpserver.simpleserver.OutputFilter;
  * {@code jwebserver} tool.
  *
  * @toolGuide jwebserver
+ * @spec https://www.rfc-editor.org/info/rfc9110
+ *       RFC 9110: HTTP Semantics
  *
  * @since 18
  */

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/Code.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ class Code {
     public static final int HTTP_ENTITY_TOO_LARGE = 413;
     public static final int HTTP_REQ_TOO_LONG = 414;
     public static final int HTTP_UNSUPPORTED_TYPE = 415;
+    public static final int HTTP_RANGE_NOT_SATISFIABLE = 416;
     public static final int HTTP_INTERNAL_ERROR = 500;
     public static final int HTTP_NOT_IMPLEMENTED = 501;
     public static final int HTTP_BAD_GATEWAY = 502;
@@ -97,6 +98,7 @@ class Code {
         case HTTP_ENTITY_TOO_LARGE: return " Request Entity Too Large";
         case HTTP_REQ_TOO_LONG: return " Request-URI Too Large";
         case HTTP_UNSUPPORTED_TYPE: return " Unsupported Media Type";
+        case HTTP_RANGE_NOT_SATISFIABLE: return " Range Not Satisfiable";
         case HTTP_INTERNAL_ERROR: return " Internal Server Error";
         case HTTP_NOT_IMPLEMENTED: return " Not Implemented";
         case HTTP_BAD_GATEWAY: return " Bad Gateway";

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/FileServerHandler.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/FileServerHandler.java
@@ -25,24 +25,32 @@
 
 package sun.net.httpserver.simpleserver;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.lang.System.Logger;
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.UnaryOperator;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpHandlers;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.sun.net.httpserver.HttpExchange.RSPBODY_CHUNKED;
 import static com.sun.net.httpserver.HttpExchange.RSPBODY_EMPTY;
 
 /**
@@ -60,6 +68,7 @@ public final class FileServerHandler implements HttpHandler {
     private static final String FAVICON_RESOURCE_PATH =
             "/sun/net/httpserver/simpleserver/resources/favicon.ico";
     private static final String FAVICON_LAST_MODIFIED = "Mon, 23 May 1995 11:11:11 GMT";
+    private static final int MAX_RANGES = 32;
 
     private final Path root;
     private final UnaryOperator<String> mimeTable;
@@ -268,22 +277,131 @@ public final class FileServerHandler implements HttpHandler {
         }
     }
 
+    private static final String rangePartHeader =
+            """
+            --%s\r
+            Content-Type: %s\r
+            Content-Range: bytes %s-%s/%s\r
+            \r
+            """;
 
     private void serveFile(HttpExchange exchange, Path path, boolean writeBody)
         throws IOException
     {
         var respHdrs = exchange.getResponseHeaders();
-        respHdrs.set("Content-Type", mediaType(path.toString()));
+        String contentType = mediaType(path.toString());
+
+        respHdrs.set("Content-Type", contentType);  // may be overridden by multipart/byteranges
         respHdrs.set("Last-Modified", getLastModified(path));
-        if (writeBody) {
-            exchange.sendResponseHeaders(200, Files.size(path));
-            try (InputStream fis = Files.newInputStream(path);
-                 OutputStream os = exchange.getResponseBody()) {
-                fis.transferTo(os);
-            }
-        } else {
-            respHdrs.set("Content-Length", Long.toString(Files.size(path)));
+        respHdrs.set("Accept-Ranges", "bytes");
+
+        long fileSize = Files.size(path);
+        if (!writeBody) {
+            respHdrs.set("Content-Length", Long.toString(fileSize));
             exchange.sendResponseHeaders(200, RSPBODY_EMPTY);
+            return;
+        }
+
+        if (fileSize == 0) {
+            respHdrs.set("Content-Length", "0");
+            exchange.sendResponseHeaders(200, RSPBODY_EMPTY);
+            return;
+        }
+
+        String hdrRange = exchange.getRequestHeaders().getFirst("Range");
+        String hdrIfRange = exchange.getRequestHeaders().getFirst("If-Range");
+        if (hdrRange == null
+                || hdrIfRange != null) {  // Conditional range requests are not supported.
+            sendFullFile(exchange, path, fileSize);
+            return;
+        }
+
+        Range[] ranges = parseRanges(hdrRange, fileSize);
+        if (ranges == null) {  // No Range header, or invalid/unsupported Range header
+            sendFullFile(exchange, path, fileSize);
+            return;
+        }
+
+        // Valid Range header, but no satisfiable ranges
+        if (ranges.length == 0) {
+            sendRangeNotSatisfiable(exchange, fileSize);
+            return;
+        }
+
+        // Single range.
+        if (ranges.length == 1) {
+            Range range = ranges[0];
+            respHdrs.set("Content-Range",
+                    "bytes %s-%s/%s".formatted(range.first(), range.last(), fileSize));
+            exchange.sendResponseHeaders(206, ranges[0].length());
+            try (SeekableByteChannel ch = Files.newByteChannel(path);
+                 OutputStream os = exchange.getResponseBody()) {
+                sendFileRanged(os, ch, range);
+            }
+            return;
+        }
+
+        // Multiple ranges, send as multipart/byteranges
+        String boundary = "range_" + UUID.randomUUID();
+        respHdrs.set("Content-Type", "multipart/byteranges; boundary=" + boundary);
+
+        exchange.sendResponseHeaders(206, RSPBODY_CHUNKED);
+        try (SeekableByteChannel ch = Files.newByteChannel(path);
+             OutputStream os = exchange.getResponseBody()) {
+            for (Range range : ranges) {
+                os.write(rangePartHeader.formatted(
+                        boundary,
+                        contentType,
+                        range.first(),
+                        range.last(),
+                        fileSize
+                ).getBytes(US_ASCII));
+
+                sendFileRanged(os, ch, range);
+
+                os.write("\r\n".getBytes(US_ASCII));
+            }
+
+            // end of multipart/byteranges
+            os.write(("--%s--\r\n".formatted(boundary)).getBytes(US_ASCII));
+        }
+    }
+
+    private static void sendFullFile(HttpExchange exchange, Path path, long fileSize)
+            throws IOException {
+        exchange.sendResponseHeaders(200, fileSize);
+        try (InputStream is = Files.newInputStream(path);
+             OutputStream os = exchange.getResponseBody()) {
+            is.transferTo(os);
+        }
+    }
+
+    private static void sendRangeNotSatisfiable(HttpExchange exchange, long fileSize)
+            throws IOException {
+        var respHdrs = exchange.getResponseHeaders();
+        respHdrs.remove("Content-Type");  // no body, so no content type
+        respHdrs.set("Content-Range", "bytes */" + fileSize);
+        exchange.sendResponseHeaders(416, RSPBODY_EMPTY);
+    }
+
+    private static void sendFileRanged(OutputStream os, SeekableByteChannel ch, Range range)
+            throws IOException {
+        ch.position(range.first());
+        long remaining = range.length();
+        ByteBuffer buffer = ByteBuffer.allocate(8 * 1024);
+        while (remaining > 0) {
+            buffer.clear();
+            if (remaining < buffer.capacity()) {
+                buffer.limit((int) remaining);
+            }
+
+            int bytesRead = ch.read(buffer);
+            if (bytesRead == -1) {
+                throw new EOFException("Unexpected end of file while reading range");
+            }
+
+            os.write(buffer.array(), 0, bytesRead);
+            remaining -= bytesRead;
         }
     }
 
@@ -413,6 +531,157 @@ public final class FileServerHandler implements HttpHandler {
                 exchange.setAttribute("request-path", "could not resolve request URI path");
                 handleNotFound(exchange);
             }
+        }
+    }
+
+    /**
+     * Parses the Range header value and returns an array of Range objects.
+     *
+     * Examples of valid Range header values:
+     * <ul>
+     *   <li>bytes=0-499: first 500 bytes</li>
+     *   <li>bytes=500-999: second 500 bytes</li>
+     *   <li>bytes=-500: last 500 bytes</li>
+     *   <li>bytes=500-: from byte 500 to end</li>
+     * </ul>
+     * Multiple ranges are sorted, and overlapping or adjacent ranges are merged:
+     * <ul>
+     *   <li>bytes=0-499,500-999: first 1000 bytes</li>
+     *   <li>bytes=500-999,0-499: first 1000 bytes</li>
+     *   <li>bytes=0-499,400-599: first 600 bytes</li>
+     * </ul>
+     * Requests containing an excessive number of range specs are rejected.
+     *
+     * @param header the value of the Range header
+     * @param fileSize the size of the file being requested
+     * @return {@code null} if the Range header is absent, invalid, or unsupported.
+     *         An empty array if the request cannot be satisfied or is rejected.
+     *         Otherwise, returns normalised byte ranges.
+     */
+    public static Range[] parseRanges(String header, long fileSize) {
+        if (header == null) {
+            return null;
+        }
+        if (fileSize == 0) {
+            return null;
+        }
+
+        String unit = "bytes=";  // Only bytes ranges are supported
+        if (!header.regionMatches(true, 0, unit, 0, unit.length())) {
+            return null;
+        }
+
+        String rangeSet = header.substring(unit.length()).trim();
+        if (rangeSet.isEmpty()) {
+            return null;
+        }
+
+        List<Range> ranges = new ArrayList<>();
+        String[] specs = rangeSet.split(",", MAX_RANGES + 1);
+        if (specs.length > MAX_RANGES) {
+            return new Range[0];  // Not satisfiable: too many ranges.
+        }
+        for (String spec : specs) {
+            Range range = parseRange(spec, fileSize);
+            if (range == null) {
+                return null;  // invalid range spec
+            }
+
+            if (range.length() != 0) {
+                ranges.add(range);
+            }
+        }
+
+        return mergeOverlappingRanges(ranges);
+    }
+
+    private static Range[] mergeOverlappingRanges(List<Range> ranges) {
+        List<Range> mergedRanges = new ArrayList<>();
+
+        ranges.sort(Comparator.comparingLong(Range::first));
+        for (Range range : ranges) {
+            if (mergedRanges.isEmpty()) {
+                mergedRanges.add(range);
+            } else {
+                Range last = mergedRanges.getLast();
+                if (range.first() <= last.last() + 1) {
+                    mergedRanges.set(mergedRanges.size() - 1,
+                            new Range(last.first(), Math.max(last.last(), range.last())));
+                } else {
+                    mergedRanges.add(range);
+                }
+            }
+        }
+
+        return mergedRanges.toArray(new Range[0]);
+    }
+
+    private static Range parseRange(String range, long fileSize) {
+        String[] parts = range.trim().split("-", -1);
+        if (parts.length != 2) {
+            return null;  // invalid range spec
+        }
+
+        try {
+            if (parts[0].isEmpty()) {
+                if (parts[1].isEmpty()) {
+                    return null;  // bytes=- (invalid)
+                }
+
+                // bytes=-N
+                if (parts[1].charAt(0) == '+') {
+                    // Long.parseLong accepts a leading '+' sign, but this is not valid in a Range header.
+                    return null;
+                }
+                long suffixLength = Long.parseLong(parts[1]);
+                if (suffixLength == 0) {
+                    return Range.EMPTY;
+                }
+
+                long first = Math.max(0, fileSize - suffixLength);
+                long last = fileSize - 1;
+
+                return new Range(first, last);
+            }
+
+            if (parts[0].charAt(0) == '+') {
+                return null;
+            }
+            long first = Long.parseLong(parts[0]);
+            if (first < 0) {
+                return null;
+            }
+
+            long last;
+            if (parts[1].isEmpty()) {
+                // bytes=n-
+                last = fileSize - 1;
+            } else {
+                // bytes=n-N
+                if (parts[1].charAt(0) == '+') {
+                    return null;
+                }
+                last = Long.parseLong(parts[1]);
+                if (last < first) {
+                    return null;
+                }
+            }
+
+            if (first >= fileSize) {
+                return Range.EMPTY;
+            }
+
+            return new Range(first, Math.min(last, fileSize - 1));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public record Range(long first, long last) {
+        static final Range EMPTY = new Range(0, -1);
+
+        long length() {
+            return last - first + 1;
         }
     }
 }

--- a/test/jdk/com/sun/net/httpserver/simpleserver/FileServerHandlerTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/FileServerHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Tests for FileServerHandler
+ * @modules jdk.httpserver/sun.net.httpserver.simpleserver
  * @run junit FileServerHandlerTest
  */
 
@@ -44,16 +45,126 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpPrincipal;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.SimpleFileServer;
+import sun.net.httpserver.simpleserver.FileServerHandler;
 
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class FileServerHandlerTest {
 
     static final Path CWD = Path.of(".").toAbsolutePath();
     static final Class<RuntimeException> RE = RuntimeException.class;
+
+    public static Arguments[] validRanges() {
+        return new Arguments[] {
+                Arguments.of("bytes=2-3", new FileServerHandler.Range[] {
+                        new FileServerHandler.Range(2, 3) }),
+                Arguments.of("bYTes=2-3", new FileServerHandler.Range[] {
+                        new FileServerHandler.Range(2, 3) }),
+                Arguments.of("bytes=2-", new FileServerHandler.Range[] {
+                        new FileServerHandler.Range(2, 14) }),
+                Arguments.of("bytes=-3", new FileServerHandler.Range[] {
+                        new FileServerHandler.Range(12, 14) }),
+                Arguments.of("bytes=0-100", new FileServerHandler.Range[] {
+                        new FileServerHandler.Range(0, 14) }),
+                Arguments.of("bytes=0-1,4-6", new FileServerHandler.Range[] {
+                        new FileServerHandler.Range(0, 1),
+                        new FileServerHandler.Range(4, 6) }),
+                Arguments.of("bytes=12-14,0-0,4-5", new FileServerHandler.Range[] {
+                        new FileServerHandler.Range(0, 0),
+                        new FileServerHandler.Range(4, 5),
+                        new FileServerHandler.Range(12, 14) }),
+                Arguments.of("bytes=0-4,3-6,5-7,9-13,12-15", new FileServerHandler.Range[] {
+                        new FileServerHandler.Range(0, 7),
+                        new FileServerHandler.Range(9, 14) }),
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("validRanges")
+    public void testParseValidRanges(String header, FileServerHandler.Range[] expected) {
+        assertArrayEquals(expected, FileServerHandler.parseRanges(header, 15L));
+    }
+
+    @Test
+    public void testParseDuplicateRanges() {
+        var expected = new FileServerHandler.Range[] {
+                new FileServerHandler.Range(0, 99),
+                new FileServerHandler.Range(200, 499)
+        };
+        var actual = FileServerHandler.parseRanges(
+                "bytes=0-99,200-399,0-99,400-499,200-499", 500L);
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testParseTooManyRanges() {
+        var header = new StringBuilder("bytes=");
+        for (int i = 0; i < 33; i++) {
+            if (i > 0) {
+                header.append(",");
+            }
+            header.append(i).append("-").append(i);
+        }
+
+        assertArrayEquals(new FileServerHandler.Range[0],
+                FileServerHandler.parseRanges(header.toString(), 100L));
+    }
+
+    public static Arguments[] unsatisfiableRangeHeaders() {
+        return new Arguments[] {
+                Arguments.of(15L, "bytes=15-20"),
+                Arguments.of(15L, "bytes=20-"),
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsatisfiableRangeHeaders")
+    public void testParseUnsatisfiableRanges(long fileSize, String header) {
+        assertArrayEquals(new FileServerHandler.Range[0],
+                FileServerHandler.parseRanges(header, fileSize));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "bytes=0-",
+            "bytes=-1",
+            "bytes=0-0"
+    })
+    public void testParseRangesIgnoredForNoContent(String header) {
+        assertNull(FileServerHandler.parseRanges(header, 0L));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {
+            "bytes=",
+            "bytes=-",
+            "bytes=meow-5",
+            "bytes=0-meow",
+            "meows=0-3",
+            "bytes=3-1",
+            "bytes=+2-5",
+            "bytes=2-+5",
+            "bytes=400--500",
+            "bytes=500-+600",
+            "bytes=500+-600",
+            "bytes=500-600+",
+            "bytes=--",
+            "bytes=-+1",
+            "bytes=+1-",
+            "bytes=400-500,",
+            "bytes=,400-500",
+            "bytes=400-500, "
+    })
+    public void testParseInvalidRanges(String header) {
+        assertNull(FileServerHandler.parseRanges(header, 15L));
+    }
 
     public static Object[][] notAllowedMethods() {
         var l = List.of("POST", "PUT", "DELETE", "TRACE", "OPTIONS");

--- a/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -109,8 +110,247 @@ public class SimpleFileServerTest {
             var response = client.send(request, BodyHandlers.ofString());
             assertEquals(200, response.statusCode());
             assertEquals("some text", response.body());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
             assertEquals("text/plain", response.headers().firstValue("content-type").get());
             assertEquals(expectedLength, response.headers().firstValue("content-length").get());
+            assertTrue(response.headers().firstValue("content-range").isEmpty());
+            assertEquals(lastModified, response.headers().firstValue("last-modified").get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testFileGETSingleRange() throws Exception {
+        var root = Files.createTempDirectory(TEST_DIR, "testFileGETSingleRange");
+        var file = Files.writeString(root.resolve("aFile.txt"), "123456789abcdef", CREATE);
+        var lastModified = getLastModified(file);
+        var expectedBody = "34";
+        var expectedLength = Integer.toString(expectedBody.getBytes(UTF_8).length);
+
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt"))
+                    .header("Range", "bytes=2-3").build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(206, response.statusCode());
+            assertEquals(expectedBody, response.body());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
+            assertEquals("text/plain", response.headers().firstValue("content-type").get());
+            assertEquals(expectedLength, response.headers().firstValue("content-length").get());
+            assertEquals(lastModified, response.headers().firstValue("last-modified").get());
+            assertEquals("bytes 2-3/15", response.headers().firstValue("content-range").get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testFileGETMergedRange() throws Exception {
+        var root = Files.createTempDirectory(TEST_DIR, "testFileGETMergedRange");
+        var file = Files.writeString(root.resolve("aFile.txt"), "123456789abcdef", CREATE);
+        var lastModified = getLastModified(file);
+        var expectedBody = "1234567";
+        var expectedLength = Integer.toString(expectedBody.getBytes(UTF_8).length);
+
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt"))
+                    .header("Range", "bytes=0-4,2-6").build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(206, response.statusCode());
+            assertEquals(expectedBody, response.body());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
+            assertEquals("text/plain", response.headers().firstValue("content-type").get());
+            assertEquals(expectedLength, response.headers().firstValue("content-length").get());
+            assertEquals(lastModified, response.headers().firstValue("last-modified").get());
+            assertEquals("bytes 0-6/15", response.headers().firstValue("content-range").get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testFileGETInvalidRangeIgnored() throws Exception {
+        var root = Files.createTempDirectory(TEST_DIR, "testFileGETInvalidRangeIgnored");
+        var file = Files.writeString(root.resolve("aFile.txt"), "123456789abcdef", CREATE);
+        var lastModified = getLastModified(file);
+        var expectedLength = Long.toString(Files.size(file));
+
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt"))
+                    .header("Range", "meows=3-").build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(200, response.statusCode());
+            assertEquals("123456789abcdef", response.body());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
+            assertEquals("text/plain", response.headers().firstValue("content-type").get());
+            assertEquals(expectedLength, response.headers().firstValue("content-length").get());
+            assertEquals(lastModified, response.headers().firstValue("last-modified").get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testFileGETUnsatisfiableRange() throws Exception {
+        var root = Files.createTempDirectory(TEST_DIR, "testFileGETUnsatisfiableRange");
+        var file = Files.writeString(root.resolve("aFile.txt"), "123456789abcdef", CREATE);
+        var lastModified = getLastModified(file);
+
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt"))
+                    .header("Range", "bytes=15-20").build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(416, response.statusCode());
+            assertEquals("", response.body());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
+            assertFalse(response.headers().firstValue("content-type").isPresent());
+            assertEquals("0", response.headers().firstValue("content-length").get());
+            assertEquals("bytes */15", response.headers().firstValue("content-range").get());
+            assertEquals(lastModified, response.headers().firstValue("last-modified").get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testFileGETNoContent() throws Exception {
+        var root = Files.createTempDirectory(TEST_DIR, "testFileGETNoContent");
+        var file = Files.writeString(root.resolve("aFile.txt"), "", CREATE);
+        var lastModified = getLastModified(file);
+        var expectedLength = Long.toString(Files.size(file));
+
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt"))
+                    .header("Range", "bytes=-1").build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(200, response.statusCode());
+            assertEquals("", response.body());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
+            assertEquals("text/plain", response.headers().firstValue("content-type").get());
+            assertEquals(expectedLength, response.headers().firstValue("content-length").get());
+            assertTrue(response.headers().firstValue("content-range").isEmpty());
+            assertEquals(lastModified, response.headers().firstValue("last-modified").get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testFileGETTooManyRanges() throws Exception {
+        var root = Files.createTempDirectory(TEST_DIR, "testFileGETTooManyRanges");
+        var file = Files.writeString(root.resolve("aFile.txt"), "123456789abcdef".repeat(5), CREATE);
+        var lastModified = getLastModified(file);
+        var rangeHeader = new StringBuilder("bytes=");
+        for (int i = 0; i < 33; i++) {
+            if (i > 0) {
+                rangeHeader.append(",");
+            }
+            rangeHeader.append(i * 3).append("-").append(i * 3 + 1);
+        }
+
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt"))
+                    .header("Range", rangeHeader.toString()).build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(416, response.statusCode());
+            assertEquals("", response.body());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
+            assertFalse(response.headers().firstValue("content-type").isPresent());
+            assertEquals("0", response.headers().firstValue("content-length").get());
+            assertEquals("bytes */75", response.headers().firstValue("content-range").get());
+            assertEquals(lastModified, response.headers().firstValue("last-modified").get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    record ExpectedRangePart(String contentRange, String body) { }
+
+    @Test
+    public void testFileGETMultipleRanges() throws Exception {
+        var root = Files.createTempDirectory(TEST_DIR, "testFileGETMultipleRanges");
+        var file = Files.writeString(root.resolve("aFile.txt"), "123456789abcdef", CREATE);
+        var lastModified = getLastModified(file);
+        var expectedParts = List.of(
+                new ExpectedRangePart("bytes 0-1/15", "12"),
+                new ExpectedRangePart("bytes 4-6/15", "567"));
+
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt"))
+                    .header("Range", "bytes=0-1,4-6")
+                    .build();
+
+            var response = client.send(request, BodyHandlers.ofString());
+
+            assertEquals(206, response.statusCode());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
+            assertEquals(lastModified, response.headers().firstValue("last-modified").get());
+
+            var contentType = response.headers().firstValue("content-type").get();
+            assertTrue(contentType.startsWith("multipart/byteranges; boundary="));
+
+            var boundary = contentType.substring("multipart/byteranges; boundary=".length());
+            var expectedBody = new StringBuilder();
+            for (var part : expectedParts) {
+                expectedBody.append("""
+                    --%s\r
+                    Content-Type: text/plain\r
+                    Content-Range: %s\r
+                    \r
+                    %s\r
+                    """.formatted(boundary, part.contentRange(), part.body()));
+            }
+            expectedBody.append("--%s--\r\n".formatted(boundary));
+
+            assertEquals(expectedBody.toString(), response.body());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testFileGETIfRangeIgnored() throws Exception {
+        var root = Files.createDirectory(TEST_DIR.resolve("testFileGETIfRangeIgnored"));
+        var file = Files.writeString(root.resolve("aFile.txt"), "123456789abcdef", CREATE);
+        var lastModified = getLastModified(file);
+        var expectedLength = Long.toString(Files.size(file));
+
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "aFile.txt"))
+                    .header("If-Range", lastModified)
+                    .header("Range", "bytes=2-3")
+                    .build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(200, response.statusCode());
+            assertEquals("123456789abcdef", response.body());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
+            assertEquals("text/plain", response.headers().firstValue("content-type").get());
+            assertEquals(expectedLength, response.headers().firstValue("content-length").get());
+            assertTrue(response.headers().firstValue("content-range").isEmpty());
             assertEquals(lastModified, response.headers().firstValue("last-modified").get());
         } finally {
             server.stop(0);
@@ -220,6 +460,7 @@ public class SimpleFileServerTest {
                     .method("HEAD", BodyPublishers.noBody()).build();
             var response = client.send(request, BodyHandlers.ofString());
             assertEquals(200, response.statusCode());
+            assertEquals("bytes", response.headers().firstValue("accept-ranges").get());
             assertEquals("text/plain", response.headers().firstValue("content-type").get());
             assertEquals(expectedLength, response.headers().firstValue("content-length").get());
             assertEquals(lastModified, response.headers().firstValue("last-modified").get());


### PR DESCRIPTION
Enhances `FileServerHandler` in the jdk.httpserver module to support the `Range` header.

This change contains:
1. A new constant `HTTP_RANGE_NOT_SATISFIABLE` to the `Code` to indicate unsatisifiable ranges.
2. `Accept-Ranges: bytes` for all file retrievals.
3. Single `bytes` ranges, returning `206 Partial Content` with `Content-Range`.
4. Multiple `bytes` ranges with `multipart/byteranges`.
5. Sorting and merging of overlapping or adjacent ranges.

As discussed in #28021, `If-Range` support is left out of scope for this change.
However, as required by [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.5-8), when `If-Range` is present, the `Range` header is ignored and the full content is returned.

`Range` parsing is tested in `FileServerHandlerTest`,
while `SimpleFileServerTest` tests the externally observable HTTP behavior.

This is a rework of #28021.
The earlier PR contains the previous review discussion and feedback that informed this version.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change requires a CSR request matching fixVersion 28 to be approved (needs to be created)
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8355572](https://bugs.openjdk.org/browse/JDK-8355572): Support HTTP Range requests in Simple Web Server (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32266/head:pull/32266` \
`$ git checkout pull/32266`

Update a local copy of the PR: \
`$ git checkout pull/32266` \
`$ git pull https://git.openjdk.org/jdk.git pull/32266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32266`

View PR using the GUI difftool: \
`$ git pr show -t 32266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32266.diff">https://git.openjdk.org/jdk/pull/32266.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32266#issuecomment-5227754389)
</details>
