### PR TITLE
8390429: Enable suspend001 jdb test to run with virtual threads

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -60,6 +60,9 @@ vmTestbase/nsk/jdb/where/where005/where005.java 8278470 generic-all
 
 vmTestbase/nsk/jdb/list/list003/list003.java        8300707 generic-all
 vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java  8300707 generic-all
+###
+# suspend001 hangs with virtual threads until the suspended-successor issue is fixed.
+vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java 8390031 generic-all
 
 ####
 ## NSK JDI tests failing with wrapper

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,7 @@ public class suspend001 extends JdbTest {
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
     static final String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK     = DEBUGGEE_CLASS + ".breakHere";
+    static final String THREAD_STARTED_BREAK = DEBUGGEE_CLASS + ".threadStarted";
 
     static final String SUSPENDED       = "Suspended";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + SUSPENDED;
@@ -94,9 +95,9 @@ public class suspend001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        waitForTestedThreadStarts(THREAD_STARTED_BREAK, 2);
         while (true) {
-            threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+            threads = jdb.getThreadIdsByName(SUSPENDED);
             if (threads.length != 1) {
                 log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);
                 log.complain("Found: " + threads.length);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
@@ -23,6 +23,8 @@
 
 package nsk.jdb.suspend.suspend001;
 
+import jdk.test.lib.thread.ThreadWrapper;
+
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
@@ -42,7 +44,10 @@ public class suspend001a {
 
     static void breakHere () {}
 
-    static Object lock                   = new Object();
+    static void threadStarted () {}
+
+    static Object lockSuspended          = new Object();
+    static Object lockMyThread           = new Object();
     static Object waitnotify             = new Object();
     public static volatile int notSuspended = 0;
 
@@ -50,11 +55,12 @@ public class suspend001a {
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
-        Thread suspended = new Suspended("Suspended");
-        Thread myThread = new MyThread("MyThread");
+        Thread suspended = new Suspended("Suspended").getThread();
+        Thread myThread = new MyThread("MyThread").getThread();
 
         // lock monitor to prevent threads from finishing after they started
-        synchronized (lock) {
+        synchronized (lockSuspended) {
+            synchronized (lockMyThread) {
             synchronized (waitnotify) {
                     suspended.start();
                     try {
@@ -73,6 +79,7 @@ public class suspend001a {
                     }
             }
             breakHere();  // a break to get thread ids and then to suspend Suspended thread.
+            }
         }
 
         // wait for MyThread completion
@@ -103,16 +110,16 @@ public class suspend001a {
     }
 }
 
-// This test uses a platform thread because suspending the tested virtual thread
-// and continuing causes jdb to stop responding.
-class Suspended extends Thread {
+class Suspended extends ThreadWrapper {
     String name;
 
     public Suspended (String n) {
+        super(n);
         name = n;
     }
 
     public void run() {
+        suspend001a.threadStarted();
         // Concatenate strings in advance to avoid lambda calculations later
         final String ThreadFinished = "Thread finished: " + this.name;
         suspend001a.log.display("Thread started: " + this.name);
@@ -121,7 +128,7 @@ class Suspended extends Thread {
             suspend001a.waitnotify.notify();
         }
         // prevent thread from early finish
-        synchronized (suspend001a.lock) {}
+        synchronized (suspend001a.lockSuspended) {}
 
         suspend001a.notSuspended++;
 
@@ -129,14 +136,16 @@ class Suspended extends Thread {
     }
 }
 
-class MyThread extends Thread {
+class MyThread extends ThreadWrapper {
     String name;
 
     public MyThread (String n) {
+        super(n);
         name = n;
     }
 
     public void run() {
+        suspend001a.threadStarted();
         // Concatenate strings in advance to avoid lambda calculations later
         final String ThreadFinished = "Thread finished: " + this.name;
         suspend001a.log.display("Thread started: " + this.name);
@@ -145,7 +154,7 @@ class MyThread extends Thread {
             suspend001a.waitnotify.notify();
         }
         // prevent thread from early finish
-        synchronized (suspend001a.lock) {}
+        synchronized (suspend001a.lockMyThread) {}
 
         suspend001a.notSuspended++;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
@@ -46,8 +46,7 @@ public class suspend001a {
 
     static void threadStarted () {}
 
-    static Object lockSuspended          = new Object();
-    static Object lockMyThread           = new Object();
+    static Object lock                   = new Object();
     static Object waitnotify             = new Object();
     public static volatile int notSuspended = 0;
 
@@ -59,8 +58,7 @@ public class suspend001a {
         Thread myThread = new MyThread("MyThread").getThread();
 
         // lock monitor to prevent threads from finishing after they started
-        synchronized (lockSuspended) {
-            synchronized (lockMyThread) {
+        synchronized (lock) {
             synchronized (waitnotify) {
                     suspended.start();
                     try {
@@ -79,7 +77,6 @@ public class suspend001a {
                     }
             }
             breakHere();  // a break to get thread ids and then to suspend Suspended thread.
-            }
         }
 
         // wait for MyThread completion
@@ -128,7 +125,7 @@ class Suspended extends ThreadWrapper {
             suspend001a.waitnotify.notify();
         }
         // prevent thread from early finish
-        synchronized (suspend001a.lockSuspended) {}
+        synchronized (suspend001a.lock) {}
 
         suspend001a.notSuspended++;
 
@@ -154,7 +151,7 @@ class MyThread extends ThreadWrapper {
             suspend001a.waitnotify.notify();
         }
         // prevent thread from early finish
-        synchronized (suspend001a.lockMyThread) {}
+        synchronized (suspend001a.lock) {}
 
         suspend001a.notSuspended++;
 


### PR DESCRIPTION
Converts suspend001 to the thread wrapper with the same start rendezvous the other converted jdb tests use, so it can run with virtual threads. With virtual threads the run still hangs on the jvm side issue with picking a suspended thread as the monitor successor, so the test is problem listed for virtual mode until that fix lands. the shared lock stays as is so the test keeps reproducing the scenario

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390429](https://bugs.openjdk.org/browse/JDK-8390429): Enable suspend001 jdb test to run with virtual threads (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32267/head:pull/32267` \
`$ git checkout pull/32267`

Update a local copy of the PR: \
`$ git checkout pull/32267` \
`$ git pull https://git.openjdk.org/jdk.git pull/32267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32267`

View PR using the GUI difftool: \
`$ git pr show -t 32267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32267.diff">https://git.openjdk.org/jdk/pull/32267.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32267#issuecomment-5243160976)
</details>
