### PR TITLE
8390033: Disable stringop-overflow in shenandoahHeap.cpp

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -210,6 +210,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
     DISABLED_WARNINGS_gcc_safepointMechanism.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_shenandoahGenerationalHeap.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_shenandoahHeap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_shenandoahLock.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_stubGenerator_s390.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \


### PR DESCRIPTION
Hi, please consider.

I have been witnessing this build issue with GCC 14 after [JDK-8388880](https://bugs.openjdk.org/browse/JDK-8388880).
Similar to [JDK-8382522](https://bugs.openjdk.org/browse/JDK-8382522), seems that GCC 14's deeper inlining optimizations interact badly with stringop-overflow here.
This disables this warning for the affected file as well.

An explanation of why an issue on one platform should necessitate this change on all platforms: https://github.com/openjdk/jdk/pull/30823#issuecomment-4285519670

configure command:
```
sh configure --with-boot-jdk=/home/openeuler/jdk-bin/jdk-26+35 --with-debug-level=release --with-jvm-variants=server --with-native-debug-symbols=internal --disable-precompiled-headers --enable-unlimited-crypto
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390033](https://bugs.openjdk.org/browse/JDK-8390033): Disable stringop-overflow in shenandoahHeap.cpp (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32269/head:pull/32269` \
`$ git checkout pull/32269`

Update a local copy of the PR: \
`$ git checkout pull/32269` \
`$ git pull https://git.openjdk.org/jdk.git pull/32269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32269`

View PR using the GUI difftool: \
`$ git pr show -t 32269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32269.diff">https://git.openjdk.org/jdk/pull/32269.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32269#issuecomment-5231200135)
</details>
