### PR TITLE
8389914: C2: LoadNode::Ideal modifies the node but returns nullptr

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2211,7 +2211,6 @@ Node* LoadNode::Ideal_load_common(PhaseGVN* phase, bool can_reshape) {
     Node* opt_mem = MemNode::optimize_memory_chain(mem, addr_t, this, phase);
     if (opt_mem != mem) {
       set_req_X(MemNode::Memory, opt_mem, phase);
-      if (phase->type(opt_mem) == Type::TOP) { return NodeSentinel; }
       return this;
     }
     const TypeOopPtr* t_oop = addr_t->isa_oopptr();

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -563,7 +563,6 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
 
   if (mem != old_mem) {
     set_req_X(MemNode::Memory, mem, phase);
-    if (phase->type(mem) == Type::TOP) return NodeSentinel;
     return this;
   }
 


### PR DESCRIPTION
Sometimes, `LoadNode::Ideal` would perform changes, but return `nullptr`, causing failures with `VerifyIterativeGVN=100000`. The cause is simple, but somehow, I'm not sure of the fix.

In this code
https://github.com/openjdk/jdk/blob/4061f762d8386b715d97ff4d9ef3ed4eafe5f898/src/hotspot/share/opto/memnode.cpp#L2211-L2216

we clearly change `in(MemNode::Memory)`, but we would return `NodeSentinel` if the new input is `TOP` (that is bottom, empty). And of course, `NodeSentinel` means returning `nullptr` from `Ideal`:

https://github.com/openjdk/jdk/blob/4061f762d8386b715d97ff4d9ef3ed4eafe5f898/src/hotspot/share/opto/memnode.cpp#L2156-L2159

That cannot be! I think the fix is as simple as removing this special case: even if the input is `TOP`, a change was made, and we must return `this`. `LoadNode::Value` should take care of killing the node after:
https://github.com/openjdk/jdk/blob/4061f762d8386b715d97ff4d9ef3ed4eafe5f898/src/hotspot/share/opto/memnode.cpp#L2330-L2334

But where I doubt: why is this special case a thing at all. It was added by [JDK-6736417: Fastdebug C2 crashes in StoreBNode::Ideal](https://bugs.openjdk.org/browse/JDK-6736417) in commit https://github.com/openjdk/jdk/commit/37306315b207383ad39b9ee374ecb216b9ecb50e almost 18 years ago, in a few days! (Where were you, what were you doing 18 years ago, when this bug was fixed... Time flies...). Yet, it is not clear to me that the part of the fix I'm reverting now was really needed to fix the bug described in the issue.

So, since I couldn't find a reason my fix was wrong, I've tested. I've did tiers 1-4+stress with `VerifyIterativeGVN=100000`, and tiers 1-7+stress (no additional flags) without (related) failure. I've also tested tiers 1-4+stress with `VerifyIterativeGVN=1`, as gently suggested in https://github.com/openjdk/jdk/blob/4061f762d8386b715d97ff4d9ef3ed4eafe5f898/src/hotspot/share/opto/node.hpp#L1285-L1289. A lot of timeouts, but I couldn't find any verification failures. So... here is my fix. I'm not certain it won't reintroduced something alike [JDK-6736417](https://bugs.openjdk.org/browse/JDK-6736417), but I don't think the code I'm removing would be the right fix since it clearly doesn't respect the contract of `Ideal`. Also, so many things changed in 18 years, the real cause might be gone now.

As for adding a test... It's not quite easy since the only test failing with this verification enabled are some big Valhalla tests, such as TestLWorld.java, and I don't feel like adding a run of one of these already slow tests just for a corner case with extra-verification, when the current code is so clearly breaking the contract.

Thanks,
Marc

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389914](https://bugs.openjdk.org/browse/JDK-8389914): C2: LoadNode::Ideal modifies the node but returns nullptr (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32271/head:pull/32271` \
`$ git checkout pull/32271`

Update a local copy of the PR: \
`$ git checkout pull/32271` \
`$ git pull https://git.openjdk.org/jdk.git pull/32271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32271`

View PR using the GUI difftool: \
`$ git pr show -t 32271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32271.diff">https://git.openjdk.org/jdk/pull/32271.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32271#issuecomment-5237800040)
</details>
