### PR TITLE
8390049: Immutable zero-copy String views of a String's code units

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -29,11 +29,11 @@ import java.io.ObjectStreamField;
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Native;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
 import java.lang.constant.Constable;
 import java.lang.constant.ConstantDesc;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.*;
 import java.util.ArrayList;
@@ -53,6 +53,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import jdk.internal.foreign.SegmentFactories;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
@@ -63,6 +64,8 @@ import sun.nio.cs.ArrayEncoder;
 
 import sun.nio.cs.ISO_8859_1;
 import sun.nio.cs.US_ASCII;
+import sun.nio.cs.UTF_16BE;
+import sun.nio.cs.UTF_16LE;
 import sun.nio.cs.UTF_8;
 
 /**
@@ -2129,15 +2132,18 @@ public final class String
         return false;
     }
 
-    void copyToSegmentRaw(MemorySegment segment, long offset, int srcIndex, int srcLength) {
-        if (!isLatin1()) {
-            // This method is intended to be used together with bytesCompatible, which currently only supports
-            // latin1 strings. In the future, bytesCompatible could be updated to handle more cases, like
-            // UTF-16 strings (when the platform and charset endianness match, and the String doesn’t contain
-            // unpaired surrogates). If that happens, copyToSegmentRaw should also be updated.
-            throw new IllegalStateException("This string does not support copyToSegmentRaw");
-        }
-        MemorySegment.copy(value, srcIndex, segment, ValueLayout.JAVA_BYTE, offset, srcLength);
+    MemorySegment asReadOnlySegment(int srcIndex, int numChars) {
+        return SegmentFactories.ofString(value, coder, srcIndex, numChars);
+    }
+
+    MemorySegment asReadOnlySegment() {
+        return SegmentFactories.ofString(value);
+    }
+
+    Charset charset() {
+        return isLatin1() ? ISO_8859_1.INSTANCE
+                : (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? UTF_16BE.INSTANCE
+                : UTF_16LE.INSTANCE;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2350,8 +2350,18 @@ public final class System {
             }
 
             @Override
-            public void copyToSegmentRaw(String string, MemorySegment segment, long offset, int srcIndex, int srcLength) {
-                string.copyToSegmentRaw(segment, offset, srcIndex, srcLength);
+            public MemorySegment asReadOnlySegment(String string) {
+                return string.asReadOnlySegment();
+            }
+
+            @Override
+            public MemorySegment asReadOnlySegment(String string, int srcIndex, int numChars) {
+                return string.asReadOnlySegment(srcIndex, numChars);
+            }
+
+            @Override
+            public Charset stringCharset(String string) {
+                return string.charset();
             }
 
             @Override

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -25,10 +25,12 @@
 
 package java.lang.foreign;
 
+import jdk.internal.ValueBased;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.SegmentBulkOperations;
 import jdk.internal.foreign.SegmentFactories;
+import jdk.internal.foreign.StringSupport;
 import jdk.internal.javac.Restricted;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.vm.annotation.ForceInline;
@@ -2811,5 +2813,105 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
          */
         @Override
         int hashCode();
+    }
+
+    /**
+     * {@return an immutable, zero-copy {@link StringView} of the given {@link String}}
+     *
+     * <p>Unlike {@link String#getBytes(Charset)} and {@link SegmentAllocator#allocateFrom(String, Charset)},
+     * no character replacement is performed. If the string contains ill-formed or unpaired
+     * surrogates, the corresponding code units are included in the result without replacement.
+     *
+     * <p>The returned segment is {@linkplain MemorySegment#isReadOnly() read-only}. The scope is an automatic
+     * scope that keeps the given string reachable. The returned segment is always accessible, from any
+     * thread.
+     *
+     * <p>The {@linkplain StringView#charset() charset} is implementation dependent.
+     *
+     * @implNote In this implementation, strings are currently stored using one of the following encodings:
+     *     <ol>
+     *       <li>{@link StandardCharsets#ISO_8859_1}, with elements accessed using {@link
+     *           ValueLayout#JAVA_BYTE}
+     *       <li>{@link StandardCharsets#UTF_16LE} or {@link StandardCharsets#UTF_16BE} (in platform
+     *           {@link ByteOrder#nativeOrder() native byte order}), with elements accessed using {@link
+     *           ValueLayout#JAVA_CHAR_UNALIGNED}
+     *     </ol>
+     *     Future implementations may use other charsets, such as {@link StandardCharsets#UTF_8}
+     * @param string the source string
+     * @throws NullPointerException if {@code string} is {@code null}
+     * @since 28
+     */
+    static StringView ofString(String string) {
+        Objects.requireNonNull(string);
+        return new StringView(
+                StringSupport.asReadOnlySegment(string),
+                StringSupport.stringCharset(string));
+    }
+
+    /**
+     * {@return an immutable, zero-copy {@link StringView} of a subrange of the given {@link String}}
+     *
+     * @param string   the source string
+     * @param srcIndex the starting character index in the source string
+     * @param numChars the number of characters to include in the view
+     * @see #ofString(String)
+     * @throws NullPointerException if {@code string} is {@code null}
+     * @throws IndexOutOfBoundsException if {@code srcIndex < 0}, {@code numChars < 0},
+     *                                   or {@code srcIndex > string.length() - numChars}
+     * @since 28
+     */
+    static StringView ofString(String string, int srcIndex, int numChars) {
+        Objects.requireNonNull(string);
+        Objects.checkFromIndexSize(srcIndex, numChars, string.length());
+        return new StringView(
+                StringSupport.asReadOnlySegment(string, srcIndex, numChars),
+                StringSupport.stringCharset(string));
+    }
+
+    /**
+     * An immutable, zero-copy view of a {@link String}'s storage code units and corresponding
+     * {@link Charset}.
+     *
+     * @see MemorySegment#ofString(String)
+     * @since 28
+     */
+    @ValueBased
+    final class StringView {
+        private final MemorySegment segment;
+        private final Charset charset;
+
+        StringView(MemorySegment segment, Charset charset) {
+            Objects.requireNonNull(segment);
+            Objects.requireNonNull(charset);
+            this.segment = segment;
+            this.charset = charset;
+        }
+
+        /** {@return the {@link MemorySegment} of the {@link String}'s storage code units} */
+        public MemorySegment segment() {
+            return segment;
+        }
+
+        /** {@return the {@link Charset} the {@link #segment()} is encoded in} */
+        public Charset charset() {
+            return charset;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof StringView stringView
+                    && segment.equals(stringView.segment)
+                    && charset.equals(stringView.charset);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(segment, charset);
+        }
+
+        @Override
+        public String toString() {
+            return "StringView[segment=" + segment + ", charset=" + charset + "]";
+        }
     }
 }

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -139,9 +139,10 @@ public interface SegmentAllocator {
         MemorySegment segment;
         int length;
         if (StringSupport.bytesCompatible(str, charset, 0, str.length())) {
-            length = str.length();
-            segment = allocateNoInit((long) length + termCharSize);
-            StringSupport.copyToSegmentRaw(str, segment, 0, 0, str.length());
+            MemorySegment src = MemorySegment.ofString(str).segment();
+            length = (int) src.byteSize();
+            segment = allocateNoInit(src.byteSize() + termCharSize);
+            MemorySegment.copy(src, 0, segment, 0, src.byteSize());
         } else {
             byte[] bytes = str.getBytes(charset);
             length = bytes.length;
@@ -192,8 +193,9 @@ public interface SegmentAllocator {
         Objects.checkFromIndexSize(srcIndex, numChars, str.length());
         MemorySegment segment;
         if (StringSupport.bytesCompatible(str, charset, srcIndex, numChars)) {
-            segment = allocateNoInit(numChars);
-            StringSupport.copyToSegmentRaw(str, segment, 0, srcIndex, numChars);
+            MemorySegment src = MemorySegment.ofString(str, srcIndex, numChars).segment();
+            segment = allocateNoInit(src.byteSize());
+            MemorySegment.copy(src, 0, segment, 0, src.byteSize());
         } else {
             byte[] bytes = str.substring(srcIndex, srcIndex + numChars).getBytes(charset);
             segment = allocateNoInit(bytes.length);

--- a/src/java.base/share/classes/java/nio/charset/StandardCharsets.java
+++ b/src/java.base/share/classes/java/nio/charset/StandardCharsets.java
@@ -62,18 +62,18 @@ public final class StandardCharsets {
     /**
      * Sixteen-bit UCS Transformation Format, big-endian byte order.
      */
-    public static final Charset UTF_16BE = new sun.nio.cs.UTF_16BE();
+    public static final Charset UTF_16BE = sun.nio.cs.UTF_16BE.INSTANCE;
 
     /**
      * Sixteen-bit UCS Transformation Format, little-endian byte order.
      */
-    public static final Charset UTF_16LE = new sun.nio.cs.UTF_16LE();
+    public static final Charset UTF_16LE = sun.nio.cs.UTF_16LE.INSTANCE;
 
     /**
      * Sixteen-bit UCS Transformation Format, byte order identified by an
      * optional byte-order mark.
      */
-    public static final Charset UTF_16 = new sun.nio.cs.UTF_16();
+    public static final Charset UTF_16 = sun.nio.cs.UTF_16.INSTANCE;
 
     /**
      * Thirty-two-bit UCS Transformation Format, big-endian byte order.

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -640,9 +640,19 @@ public interface JavaLangAccess {
     String getLoaderNameID(ClassLoader loader);
 
     /**
-     * Copy the string bytes to an existing segment, avoiding intermediate copies.
+     * Returns a read-only view of a subrange of the string bytes.
      */
-    void copyToSegmentRaw(String string, MemorySegment segment, long offset, int srcIndex, int srcLength);
+    MemorySegment asReadOnlySegment(String string, int srcIndex, int numChars);
+
+    /**
+     * Returns a read-only view of the string bytes.
+     */
+    MemorySegment asReadOnlySegment(String string);
+
+    /**
+     * The {@link Charset} of {@link #asReadOnlySegment(String)}.
+     */
+    Charset stringCharset(String string);
 
     /**
      * Are the string bytes compatible with the given charset?

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -139,6 +139,19 @@ public class SegmentFactories {
                 MemorySessionImpl.createHeap(arr));
     }
 
+    public static MemorySegment ofString(byte[] value, byte coder, int srcIndex, int numChars) {
+        ensureInitialized();
+        long byteOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + ((long) srcIndex << coder);
+        long byteLength = (long) numChars << coder;
+        return new OfByte(byteOffset, value, byteLength, true, MemorySessionImpl.GLOBAL_SESSION);
+    }
+
+    public static MemorySegment ofString(byte[] value) {
+        ensureInitialized();
+        return new OfByte(Unsafe.ARRAY_BYTE_BASE_OFFSET, value, value.length, true,
+                MemorySessionImpl.GLOBAL_SESSION);
+    }
+
     // Buffer conversion factories
 
     public static OfByte arrayOfByteSegment(Object base, long offset, long length,

--- a/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
@@ -30,14 +30,11 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.util.Architecture;
 import jdk.internal.util.ArraysSupport;
-import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.reflect.Array;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
-import java.util.Objects;
 
 import static java.lang.foreign.ValueLayout.*;
 
@@ -358,8 +355,9 @@ public final class StringSupport {
 
     public static int copyBytes(String string, MemorySegment segment, Charset charset, long offset, int srcIndex, int numChars) {
         if (bytesCompatible(string, charset, srcIndex, numChars)) {
-            copyToSegmentRaw(string, segment, offset, srcIndex, numChars);
-            return numChars;
+            MemorySegment src = asReadOnlySegment(string, srcIndex, numChars);
+            MemorySegment.copy(src, 0, segment, offset, src.byteSize());
+            return (int) src.byteSize();
         } else {
             byte[] bytes = string.substring(srcIndex, srcIndex + numChars).getBytes(charset);
             MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, offset, bytes.length);
@@ -367,7 +365,15 @@ public final class StringSupport {
         }
     }
 
-    public static void copyToSegmentRaw(String string, MemorySegment segment, long offset, int srcIndex, int srcLength) {
-        JAVA_LANG_ACCESS.copyToSegmentRaw(string, segment, offset, srcIndex, srcLength);
+    public static MemorySegment asReadOnlySegment(String string) {
+        return JAVA_LANG_ACCESS.asReadOnlySegment(string);
+    }
+
+    public static MemorySegment asReadOnlySegment(String string, int srcIndex, int numChars) {
+        return JAVA_LANG_ACCESS.asReadOnlySegment(string, srcIndex, numChars);
+    }
+
+    public static Charset stringCharset(String string) {
+        return JAVA_LANG_ACCESS.stringCharset(string);
     }
 }

--- a/src/java.base/share/classes/sun/nio/cs/UTF_16.java
+++ b/src/java.base/share/classes/sun/nio/cs/UTF_16.java
@@ -31,6 +31,7 @@ import java.nio.charset.CharsetEncoder;
 
 public class UTF_16 extends Unicode
 {
+    public static final UTF_16 INSTANCE = new UTF_16();
 
     public UTF_16() {
         super("UTF-16", StandardCharsets.aliases_UTF_16());

--- a/src/java.base/share/classes/sun/nio/cs/UTF_16BE.java
+++ b/src/java.base/share/classes/sun/nio/cs/UTF_16BE.java
@@ -31,6 +31,7 @@ import java.nio.charset.CharsetEncoder;
 
 public class UTF_16BE extends Unicode
 {
+    public static final UTF_16BE INSTANCE = new UTF_16BE();
 
     public UTF_16BE() {
         super("UTF-16BE", StandardCharsets.aliases_UTF_16BE());

--- a/src/java.base/share/classes/sun/nio/cs/UTF_16LE.java
+++ b/src/java.base/share/classes/sun/nio/cs/UTF_16LE.java
@@ -32,6 +32,8 @@ import java.nio.charset.CharsetEncoder;
 public class UTF_16LE extends Unicode
 {
 
+    public static final UTF_16LE INSTANCE = new UTF_16LE();
+
     public UTF_16LE() {
         super("UTF-16LE", StandardCharsets.aliases_UTF_16LE());
     }

--- a/test/jdk/java/foreign/TestStringView.java
+++ b/test/jdk/java/foreign/TestStringView.java
@@ -103,7 +103,7 @@ public class TestStringView {
     }
 
     @Test(dataProvider = "strings")
-    public void testStringViewRoundtrip(String string) {
+    public void testStringViewSubstringRoundtrip(String string) {
         for (int srcIndex = 0; srcIndex <= string.length(); srcIndex++) {
             for (int numChars = 0; numChars <= string.length() - srcIndex; numChars++) {
                 MemorySegment.StringView view = MemorySegment.ofString(string, srcIndex, numChars);

--- a/test/jdk/java/foreign/TestStringView.java
+++ b/test/jdk/java/foreign/TestStringView.java
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2026, Google LLC. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+import static org.testng.Assert.*;
+
+import org.testng.annotations.*;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/*
+ * @test
+ * @modules java.base/jdk.internal.foreign
+ * @run testng TestStringView
+ */
+public class TestStringView {
+
+    @Test(dataProvider = "strings")
+    public void testStringView(String string) {
+        MemorySegment.StringView view = MemorySegment.ofString(string);
+        MemorySegment segment = view.segment();
+        Charset charset = view.charset();
+        if (charset == StandardCharsets.ISO_8859_1) {
+            assertEquals(segment.byteSize(), string.length());
+            for (int i = 0; i < string.length(); i++) {
+                assertEquals(
+                        string.charAt(i),
+                        Byte.toUnsignedInt(segment.get(ValueLayout.JAVA_BYTE, i)));
+            }
+        } else if (charset == StandardCharsets.UTF_16LE || charset == StandardCharsets.UTF_16BE) {
+            assertEquals(segment.byteSize(), string.length() * 2);
+            for (int i = 0; i < string.length(); i++) {
+                assertEquals(string.charAt(i), segment.get(ValueLayout.JAVA_CHAR_UNALIGNED, i * 2));
+            }
+        } else {
+            throw new AssertionError(charset);
+        }
+    }
+
+    @Test(dataProvider = "strings")
+    public void testStringViewSubstring(String string) {
+        for (int srcIndex = 0; srcIndex <= string.length(); srcIndex++) {
+            for (int numChars = 0; numChars <= string.length() - srcIndex; numChars++) {
+                MemorySegment.StringView view = MemorySegment.ofString(string, srcIndex, numChars);
+                MemorySegment segment = view.segment();
+                Charset charset = view.charset();
+                if (charset == StandardCharsets.ISO_8859_1) {
+                    assertEquals(segment.byteSize(), numChars);
+                    for (int i = 0; i < numChars; i++) {
+                        assertEquals(
+                                string.charAt(srcIndex + i),
+                                Byte.toUnsignedInt(segment.get(ValueLayout.JAVA_BYTE, i)));
+                    }
+                } else if (charset == StandardCharsets.UTF_16LE
+                        || charset == StandardCharsets.UTF_16BE) {
+                    assertEquals(segment.byteSize(), numChars * 2);
+                    for (int i = 0; i < numChars; i++) {
+                        assertEquals(
+                                string.charAt(srcIndex + i),
+                                segment.get(ValueLayout.JAVA_CHAR_UNALIGNED, i * 2));
+                    }
+                } else {
+                    throw new AssertionError(charset);
+                }
+            }
+        }
+    }
+
+    @Test(dataProvider = "strings")
+    public void testStringViewRoundtrip(String string) {
+        MemorySegment.StringView view = MemorySegment.ofString(string);
+        MemorySegment segment = view.segment();
+        Charset charset = view.charset();
+        String roundtrip = segment.getString(0, charset, segment.byteSize());
+        if (charset.newEncoder().canEncode(string)) {
+            assertEquals(roundtrip, string);
+        } else {
+            assertEquals(roundtrip, new String(string.getBytes(charset), charset));
+        }
+    }
+
+    @Test(dataProvider = "strings")
+    public void testStringViewRoundtrip(String string) {
+        for (int srcIndex = 0; srcIndex <= string.length(); srcIndex++) {
+            for (int numChars = 0; numChars <= string.length() - srcIndex; numChars++) {
+                MemorySegment.StringView view = MemorySegment.ofString(string, srcIndex, numChars);
+                MemorySegment segment = view.segment();
+                Charset charset = view.charset();
+                String roundtrip = segment.getString(0, charset, segment.byteSize());
+                String substring = string.substring(srcIndex, srcIndex + numChars);
+                if (charset.newEncoder().canEncode(substring)) {
+                    assertEquals(roundtrip, substring);
+                } else {
+                    assertEquals(roundtrip, new String(substring.getBytes(charset), charset));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testStringViewThrows() {
+        assertThrows(NullPointerException.class, () -> MemorySegment.ofString(null));
+
+        String testString = "abc";
+        MemorySegment segment = MemorySegment.ofString(testString).segment();
+
+        assertTrue(segment.isReadOnly());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> segment.set(ValueLayout.JAVA_BYTE, 0, (byte) 0));
+    }
+
+    @Test
+    public void testEmptyStringViewSubstring() {
+        String testString = "abc";
+        assertEquals(
+                MemorySegment.ofString(testString, testString.length(), 0).segment().byteSize(), 0);
+    }
+
+    @Test
+    public void testStringViewSubstringThrows() {
+        assertThrows(NullPointerException.class, () -> MemorySegment.ofString(null, 0, 3));
+
+        String testString = "abc";
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> MemorySegment.ofString(testString, -1, testString.length()));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> MemorySegment.ofString(testString, 1, testString.length()));
+        assertThrows(
+                IndexOutOfBoundsException.class, () -> MemorySegment.ofString(testString, 0, -1));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> MemorySegment.ofString(testString, 0, Integer.MAX_VALUE));
+
+        MemorySegment segment =
+                MemorySegment.ofString(testString, 0, testString.length()).segment();
+        assertTrue(segment.isReadOnly());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> segment.set(ValueLayout.JAVA_BYTE, 0, (byte) 0));
+    }
+
+    @DataProvider
+    public static Object[][] strings() {
+        return new Object[][] {
+            {""},
+            {"hello world"},
+            {"123"},
+            {"section \u00A7"},
+            {"\u00E9"},
+            {"cartwheel \uD83E\uDD38"},
+            {"snowman \u26C4"},
+            {"cjk \u4E00\u4E8C"},
+            {"rainbow \uD83C\uDF08"},
+            {"\uD83D\uDE00"},
+            {"unpaired surrogate \uD83C"},
+            {"\uD83D"},
+            {"\uDC00"},
+            {"\uDC00\uD83C"},
+        };
+    }
+}


### PR DESCRIPTION
See

* [panama-dev@ thread 'String processing and Vector APIs'](https://mail.openjdk.org/archives/list/panama-dev@openjdk.org/thread/YSPX3TBXZTZEFZNXWDYOZCWLUQPC62P6/)
* [JDK-8390049: Immutable zero-copy String views of a String's code units](https://bugs.openjdk.org/browse/JDK-8390049)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8390049](https://bugs.openjdk.org/browse/JDK-8390049)

### Issue
 * [JDK-8390049](https://bugs.openjdk.org/browse/JDK-8390049): Zero-copy vector alternative to a scalar loop over charAt (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32272/head:pull/32272` \
`$ git checkout pull/32272`

Update a local copy of the PR: \
`$ git checkout pull/32272` \
`$ git pull https://git.openjdk.org/jdk.git pull/32272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32272`

View PR using the GUI difftool: \
`$ git pr show -t 32272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32272.diff">https://git.openjdk.org/jdk/pull/32272.diff</a>

</details>
