### PR TITLE
8341120: NPE message can be wrong for null restricted fields

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -1202,17 +1202,13 @@ bool ExceptionMessageBuilder::print_NPE_cause(outputStream* os, int bci, int slo
   address code_base = _method->constMethod()->code_base();
   Bytecodes::Code code = Bytecodes::java_code_at(_method, code_base + bci);
 
-  // Print null assignment to a null restricted type first, without finding the reference.
-  if (code == Bytecodes::_putfield && is_null_restricted_field(_method, code_base, bci)) {
-    int cp_index = Bytes::get_native_u2(code_base + bci + 1);
-    os->print(" because \"%s\" is a null restricted field and there's an attempt to store null in it",
-              get_field_name(_method, cp_index, code));
-    return true;
-  }
-
   if (print_NPE_cause0(os, bci, slot, _max_cause_detail, false, " because \"")) {
     if (code == Bytecodes::_aastore) {
       os->print("\" is null or is a null-free array and there's an attempt to store null in it");
+    } else if (code == Bytecodes::_putfield && is_null_restricted_field(_method, code_base, bci)) {
+      int cp_index = Bytes::get_native_u2(code_base + bci + 1);
+      os->print("\" is null or \"%s\" is a null restricted field and there's an attempt to store null in it",
+                get_field_name(_method, cp_index, code));
     } else if (code == Bytecodes::_putstatic) {
       os->print("\" cannot be stored into a null restricted field");
     } else {

--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -28,6 +28,9 @@
 #include "gc/shared/gcLocker.hpp"
 #include "interpreter/bytecodeUtils.hpp"
 #include "memory/resourceArea.hpp"
+#include "oops/constantPool.inline.hpp"
+#include "oops/resolvedFieldEntry.hpp"
+#include "runtime/fieldDescriptor.hpp"
 #include "runtime/safepointVerifiers.hpp"
 #include "runtime/signature.hpp"
 #include "utilities/events.hpp"
@@ -300,6 +303,30 @@ static void print_field_and_class(outputStream *os, Method* method, int cp_index
 static char const* get_field_name(Method* method, int cp_index, Bytecodes::Code bc) {
   Symbol* name = method->constants()->name_ref_at(cp_index, bc);
   return name->as_C_string();
+}
+
+static bool is_null_restricted_field(Method* method, address code_base, int bci) {
+  ConstantPool* cp = method->constants();
+  int cp_index = Bytes::get_native_u2(code_base + bci + 1);
+  ResolvedFieldEntry* field = cp->resolved_field_entry_at(cp_index);
+  const Bytecodes::Code bc = Bytecodes::_putfield;
+  bool is_resolved = field->is_resolved(bc);
+
+  if (is_resolved) {
+    return field->is_null_free_inline_type();
+  } else {
+    // This is more expensive but rare. C1 might not have resolved the field
+    // in the interpreter first.
+    fieldDescriptor fd;
+    Klass* klass = cp->resolved_klass_ref_at(cp_index, bc);
+    assert (klass != nullptr, "must be resolved if we got an NPE here");
+
+    Symbol* name  = cp->name_ref_at(cp_index, bc);
+    Symbol* sig  =  cp->signature_ref_at(cp_index, bc);
+    Klass* owner = InstanceKlass::cast(klass)->find_field(name, sig, false, &fd);
+    return owner != nullptr && fd.is_null_free_inline_type();
+  }
+  return false;
 }
 
 static void print_local_var(outputStream *os, unsigned int bci, Method* method, int slot, bool is_parameter) {
@@ -1111,6 +1138,7 @@ int ExceptionMessageBuilder::get_NPE_null_slot(int bci) {
     case Bytecodes::_monitorenter:
     case Bytecodes::_monitorexit:
     case Bytecodes::_checkcast:
+    case Bytecodes::_putstatic:
       return 0;
     case Bytecodes::_iaload:
     case Bytecodes::_faload:
@@ -1170,11 +1198,23 @@ int ExceptionMessageBuilder::get_NPE_null_slot(int bci) {
 }
 
 bool ExceptionMessageBuilder::print_NPE_cause(outputStream* os, int bci, int slot) {
+
+  address code_base = _method->constMethod()->code_base();
+  Bytecodes::Code code = Bytecodes::java_code_at(_method, code_base + bci);
+
+  // Print null assignment to a null restricted type first, without finding the reference.
+  if (code == Bytecodes::_putfield && is_null_restricted_field(_method, code_base, bci)) {
+    int cp_index = Bytes::get_native_u2(code_base + bci + 1);
+    os->print(" because \"%s\" is a null restricted field and there's an attempt to store null in it",
+              get_field_name(_method, cp_index, code));
+    return true;
+  }
+
   if (print_NPE_cause0(os, bci, slot, _max_cause_detail, false, " because \"")) {
-    address code_base = _method->constMethod()->code_base();
-    Bytecodes::Code code = Bytecodes::java_code_at(_method, code_base + bci);
     if (code == Bytecodes::_aastore) {
       os->print("\" is null or is a null-free array and there's an attempt to store null in it");
+    } else if (code == Bytecodes::_putstatic) {
+      os->print("\" cannot be stored into a null restricted field");
     } else {
       os->print("\" is null");
     }
@@ -1428,6 +1468,7 @@ void ExceptionMessageBuilder::print_NPE_failed_action(outputStream *os, int bci)
         os->print("Cannot read field \"%s\"", name->as_C_string());
       } break;
     case Bytecodes::_putfield: {
+    case Bytecodes::_putstatic:
         int cp_index = Bytes::get_native_u2(code_base + pos);
         os->print("Cannot assign field \"%s\"", get_field_name(_method, cp_index, code));
       } break;

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -580,7 +580,7 @@ class ConstantPool : public Metadata {
     return symbol_at(signature_index);
   }
 
-  // Returns a resolved klass without trying to resolve the class.
+  // Returns a resolved klass or nullptr if not resolved.  Does not trying to resolve the class.
   Klass* resolved_klass_ref_at(int which, Bytecodes::Code code) {
     jint ref_index = klass_ref_index_at(which, code);
     return resolved_klass_at(ref_index);

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -580,6 +580,12 @@ class ConstantPool : public Metadata {
     return symbol_at(signature_index);
   }
 
+  // Returns a resolved klass without trying to resolve the class.
+  Klass* resolved_klass_ref_at(int which, Bytecodes::Code code) {
+    jint ref_index = klass_ref_index_at(which, code);
+    return resolved_klass_at(ref_index);
+  }
+
   u2 klass_ref_index_at(int which, Bytecodes::Code code);
   u2 name_and_type_ref_index_at(int which, Bytecodes::Code code);
 

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -580,7 +580,7 @@ class ConstantPool : public Metadata {
     return symbol_at(signature_index);
   }
 
-  // Returns a resolved klass or nullptr if not resolved.  Does not trying to resolve the class.
+  // Returns a resolved klass or nullptr if not resolved.  Does not try to resolve the class.
   Klass* resolved_klass_ref_at(int which, Bytecodes::Code code) {
     jint ref_index = klass_ref_index_at(which, code);
     return resolved_klass_at(ref_index);

--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -46,6 +46,7 @@
 // the C++ compiler from potentially inserting random values in unused gaps.
 
 class InstanceKlass;
+class fieldDescriptor;
 
 class ResolvedFieldEntry {
   friend class VMStructs;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NPEInPreviewTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NPEInPreviewTest.java
@@ -75,10 +75,22 @@ public class NPEInPreviewTest {
     static MyValue nullStaticVal;
 
     static void testNullRestrictedFieldError() {
-        String expectedMessage = "Cannot assign field \"val\" because \"val\" is a null restricted field and there's an attempt to store null in it";
+        String expectedMessage = "Cannot assign field \"val\" because \"test\" is null or \"val\" is a null restricted field and there's an attempt to store null in it";
         try {
             var test = new NPEInPreviewTest();
             test.val = null;
+        } catch (NullPointerException npe) {
+            String message = npe.getMessage();
+            System.out.println("*** " + message);
+            Asserts.assertEquals(expectedMessage, message);
+        }
+    }
+
+    static void testNullRestrictedFieldStoredInNullError() {
+        String expectedMessage = "Cannot assign field \"val\" because \"test\" is null or \"val\" is a null restricted field and there's an attempt to store null in it";
+        try {
+            NPEInPreviewTest test = null;
+            test.val = new MyValue();
         } catch (NullPointerException npe) {
             String message = npe.getMessage();
             System.out.println("*** " + message);
@@ -165,6 +177,7 @@ public class NPEInPreviewTest {
     public static void main(String[] args) {
         c1Mode = args[0].equals("c1");
         testNullRestrictedFieldError();
+        testNullRestrictedFieldStoredInNullError();
         testActualNullFieldError();
         testNullRestrictedStaticFieldError();
         testNullRestrictedStaticFieldError2();

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NPEInPreviewTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NPEInPreviewTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test NullPointerException messages thrown in for NPE in null restricted type.
+ * @bug 8341120
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.misc
+ * @library /test/lib
+ * @enablePreview
+ * @compile -g NPEInPreviewTest.java
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+ShowCodeDetailsInExceptionMessages NPEInPreviewTest interpreter
+ * @run main/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:+UnlockDiagnosticVMOptions -XX:+ShowCodeDetailsInExceptionMessages NPEInPreviewTest c1
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+ShowCodeDetailsInExceptionMessages NPEInPreviewTest c2
+ */
+
+import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+import jdk.internal.value.ValueClass;
+import jdk.test.lib.Asserts;
+
+public class NPEInPreviewTest {
+
+    static boolean c1Mode;
+
+    @LooselyConsistentValue
+    static value class MyValue {
+        int i;
+        MyValue() { i = 0; }
+    }
+
+    static value class NotFlatValue {
+        int i;
+        int j;
+        int k;
+        NotFlatValue() { i = 5; j = 6; k = 7; }
+    }
+
+    @NullRestricted
+    MyValue val;
+
+    // Not null restricted.
+    MyValue nullVal;
+
+    NPEInPreviewTest() {
+      val = new MyValue();
+      super();
+    }
+
+    @NullRestricted
+    static MyValue staticVal;
+    // Not null restricted and null.
+    static MyValue nullStaticVal;
+
+    static void testNullRestrictedFieldError() {
+        String expectedMessage = "Cannot assign field \"val\" because \"val\" is a null restricted field and there's an attempt to store null in it";
+        try {
+            var test = new NPEInPreviewTest();
+            test.val = null;
+        } catch (NullPointerException npe) {
+            String message = npe.getMessage();
+            System.out.println("*** " + message);
+            Asserts.assertEquals(expectedMessage, message);
+        }
+    }
+
+    static void testActualNullFieldError() {
+        String expectedMessage = "Cannot assign field \"nullVal\" because \"self\" is null";
+
+        try {
+            NPEInPreviewTest self = null;
+            self.nullVal = null;
+        } catch (NullPointerException npe) {
+            String message = npe.getMessage();
+            System.out.println("*** " + message);
+            Asserts.assertEquals(expectedMessage, message);
+        }
+    }
+
+
+    // Should not get the message:
+    // There cannot be a NullPointerException at bci 4 of method void NPEInPreviewTest.testNullRestrictedStaticFieldError()
+    static void testNullRestrictedStaticFieldError() {
+        String expectedMessage = "Cannot assign field \"staticVal\" because \"null\" cannot be stored into a null restricted field";
+
+        try {
+            staticVal = null;
+        } catch (NullPointerException npe) {
+            String message = npe.getMessage();
+            System.out.println("*** " + message);
+            Asserts.assertEquals(expectedMessage, message);
+        }
+    }
+
+    static void testNullRestrictedStaticFieldError2() {
+        String expectedMessage = "Cannot assign field \"staticVal\" because \"NPEInPreviewTest.nullStaticVal\" cannot be stored into a null restricted field";
+
+        try {
+            staticVal = nullStaticVal;
+        } catch (NullPointerException npe) {
+            String message = npe.getMessage();
+            System.out.println("*** " + message);
+            Asserts.assertEquals(expectedMessage, message);
+        }
+    }
+
+    static void testNullRestrictedArrayError() {
+        // This message comes from the interpreter/runtime code so is not processed by Helpful NPE.
+        String expectedMessage = "Cannot store null in a null-restricted array";
+        // This message comes from the c1 null check, so is processed by Helpful NPE.
+        String c1ExpectedMessage = "Cannot store to object array because \"a\" is null or is a null-free array and there's an attempt to store null in it";
+
+        try {
+            var a = ValueClass.newNullRestrictedAtomicArray(MyValue.class, 10, new MyValue());
+            a[4] = null;
+        } catch (NullPointerException npe) {
+            String message = npe.getMessage();
+            System.out.println("*** " + message);
+            if (c1Mode) {
+                Asserts.assertEquals(c1ExpectedMessage, message);
+            } else {
+                Asserts.assertEquals(expectedMessage, message);
+            }
+        }
+    }
+
+    static void testNullRestrictedNotFlatArrayError() {
+        String expectedMessage = "Cannot store to object array because \"a\" is null or is a null-free array and there's an attempt to store null in it";
+        try {
+            var a = ValueClass.newNullRestrictedAtomicArray(NotFlatValue.class, 10, new NotFlatValue());
+            a[4] = null;
+        } catch (NullPointerException npe) {
+            String message = npe.getMessage();
+            System.out.println("*** " + message);
+            Asserts.assertEquals(expectedMessage, message);
+        }
+    }
+
+    static {
+        staticVal = new MyValue();
+    }
+
+    public static void main(String[] args) {
+        c1Mode = args[0].equals("c1");
+        testNullRestrictedFieldError();
+        testActualNullFieldError();
+        testNullRestrictedStaticFieldError();
+        testNullRestrictedStaticFieldError2();
+        testNullRestrictedArrayError();
+        testNullRestrictedNotFlatArrayError();
+    }
+}


### PR DESCRIPTION
Please review this change to improve the NPE messages for putfield/putstatic and a regression test.
Ran tier1-4.
Thanks,
Coleen

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8341120](https://bugs.openjdk.org/browse/JDK-8341120): NPE message can be wrong for null restricted fields (**Bug** - P4)


### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32274/head:pull/32274` \
`$ git checkout pull/32274`

Update a local copy of the PR: \
`$ git checkout pull/32274` \
`$ git pull https://git.openjdk.org/jdk.git pull/32274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32274`

View PR using the GUI difftool: \
`$ git pr show -t 32274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32274.diff">https://git.openjdk.org/jdk/pull/32274.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32274#issuecomment-5239488348)
</details>
