### PR TITLE
8390053: Shenandoah: Entry point is beyond 64K with lots of scalarized args

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2976,7 +2976,7 @@ void CompiledEntrySignature::compute_calling_conventions(bool link_time) {
 
     // Limit the scalarized stack argument area to ensure that generated entry
     // points fit into nmethod's uint16_t *_entry_offset fields.
-    const int max_stack_slots = 128;
+    const int max_stack_slots = UseShenandoahGC ? 64 : 128;
     if (MAX2(_args_on_stack_cc, _args_on_stack_cc_ro) <= max_stack_slots) {
       return; // Success
     }


### PR DESCRIPTION
The newly added test from [JDK-8389379](https://bugs.openjdk.org/browse/JDK-8389379) reliably fails with Shenandoah on x86:

```
$ CONF=linux-x86_64-server-fastdebug make images test TEST=compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java TEST_VM_OPTS=-XX:+UseShenandoahGC

# Internal Error (/home/shade/trunks/jdk/src/hotspot/share/code/nmethod.cpp:1201), pid=48846, tid=48898
# guarantee(static_cast<int>(_verified_entry_offset) == (offsets->value(CodeOffsets::Verified_Entry))) failed: failed: 1296 != 66832
```

The immediate fix is to trim down the scalarized stack argument area (the tunable added in [JDK-8389379](https://bugs.openjdk.org/browse/JDK-8389379) itself) to accomodate larger Shenandoah barriers. We can trim it without `UseShenandoahGC`, if we think `64` is good enough for everything.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x] Linux x86_64 server fastdebug, `hotspot_valhalla jdk_valhalla` with `-XX:+UseShenandoahGC`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390053](https://bugs.openjdk.org/browse/JDK-8390053): Shenandoah: Entry point is beyond 64K with lots of scalarized args (**Bug** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32275/head:pull/32275` \
`$ git checkout pull/32275`

Update a local copy of the PR: \
`$ git checkout pull/32275` \
`$ git pull https://git.openjdk.org/jdk.git pull/32275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32275`

View PR using the GUI difftool: \
`$ git pr show -t 32275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32275.diff">https://git.openjdk.org/jdk/pull/32275.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32275#issuecomment-5239533229)
</details>
