### PR TITLE
8388490: Assert in VectorUnboxNode::Ideal because value input is TOP

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -2333,6 +2333,9 @@ Node* VectorUnboxNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
       if (in_vt->length() == out_vt->length()) {
         Node* value = vbox->in(VectorBoxNode::Value);
+        if (phase->type(value) == Type::TOP) {
+          return nullptr;
+        }
 
         bool is_vector_mask = vbox_klass->is_subclass_of(ciEnv::current()->vector_VectorMask_klass());
         if (is_vector_mask) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,8 +71,6 @@ compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java 8387392 windows-aarch6
 
 compiler/vectorapi/VectorStoreMaskIdentityTest.java 8388281 generic-all
 
-compiler/igvn/TestMaskedStoreIdealization.java 8388490 generic-all
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/igvn/TestMaskedStoreIdealization.java
+++ b/test/hotspot/jtreg/compiler/igvn/TestMaskedStoreIdealization.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8387073
+ * @bug 8387073 8388490
  * @key randomness
  * @summary Narrower stores preceding masked vector stores must not be eliminated.
  * @modules jdk.incubator.vector
@@ -65,9 +65,6 @@ public class TestMaskedStoreIdealization {
             "--add-opens", "jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED"
         ));
         vmArgs.addAll(Arrays.asList(args)); // Forward args
-        // Temporarily disable stress flag due to unrelated test failures.
-        // TODO: Remove when JDK-8388490 is fixed.
-        vmArgs.addAll(List.of("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-StressReflectiveCode"));
         String[] vmArgsArray = vmArgs.toArray(new String[0]);
 
         comp.invoke(PACKAGE + "." + CLASS_NAME, "main", new Object[] { vmArgsArray });

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorUnboxTopInput.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorUnboxTopInput.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8388490
+ * @key randomness
+ * @summary VectorUnboxNode::Ideal must handle a TOP value during IGVN
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @modules jdk.incubator.vector
+ * @library /test/lib
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+StressReflectiveCode
+ *                   -XX:-UseLoopPredicate -XX:+StressIGVN -XX:StressSeed=93 -XX:MaxVectorSize=16
+ *                   ${test.main.class}
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+import jdk.test.lib.Asserts;
+
+public class TestVectorUnboxTopInput {
+    private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_128;
+    private static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_128;
+
+    private static int LENGTH = I_SPECIES.length();
+    private static boolean[] ma;
+    private static boolean[] mb;
+    private static boolean[] mr;
+
+    static {
+        ma = new boolean[LENGTH];
+        mb = new boolean[LENGTH];
+        mr = new boolean[LENGTH];
+
+        for (int i = 0; i < LENGTH; i++) {
+            long lb = i;
+            ma[i] = (lb & 1) == 0;
+            mb[i] = (lb & 2) == 0;
+        }
+    }
+
+    public static void testSingleMaskAllI() {
+        VectorMask<Integer> avm = VectorMask.fromArray(I_SPECIES, ma, 0);
+        VectorMask<Integer> bvm = VectorMask.fromArray(I_SPECIES, mb, 0);
+        avm.not().or(bvm.not()).intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Foo.assertEquals(!ma[i] | !mb[i], mr[i]);
+        }
+    }
+
+    public static void testSingleMaskAllL() {
+        VectorMask<Long> avm = VectorMask.fromArray(L_SPECIES, ma, 0);
+        VectorMask<Long> bvm = VectorMask.fromArray(L_SPECIES, mb, 0);
+        avm.not().or(bvm.not()).intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Foo.assertEquals(!ma[i] | !mb[i], mr[i]);
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            testSingleMaskAllL();
+        }
+        for (int i = 0; i < 10_000; i++) {
+            testSingleMaskAllI();
+        }
+    }
+}
+
+class Foo {
+    static void assertEquals(Object lhs, Object rhs) {
+        Asserts.assertEquals(lhs, rhs, "Unexpected mask result");
+    }
+}


### PR DESCRIPTION
Depending on the IGVN worklist order, `VectorUnboxNode::Ideal` can encounter a `TOP` input for `VectorBoxNode::Value` on a dead path and then assert when calling `value->bottom_type()->is_vect()` on it. We need an explicit check here.

As discussed in the JBS issue, there might be more paths that need such checks. I did some research with Codex and it supports this theory but couldn't come up with a reproducer. I also tried manually but failed. Let's only fix this path for now and see if our test generators find more issues in the future instead of blindly adding top-checks.

I added the simplified test provided by @chhagedorn (simplified a little further) but other existing tests trigger this as well.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388490](https://bugs.openjdk.org/browse/JDK-8388490): Assert in VectorUnboxNode::Ideal because value input is TOP (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)

### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32279/head:pull/32279` \
`$ git checkout pull/32279`

Update a local copy of the PR: \
`$ git checkout pull/32279` \
`$ git pull https://git.openjdk.org/jdk.git pull/32279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32279`

View PR using the GUI difftool: \
`$ git pr show -t 32279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32279.diff">https://git.openjdk.org/jdk/pull/32279.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32279#issuecomment-5241053785)
</details>
