### PR TITLE
8390069: compiler/codegen/ShiftByZero.java fails in release config

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -26,7 +26,7 @@
  * @bug 8288445 8389892
  * @summary Test shift by 0
  * @run main/othervm -Xbatch -XX:-TieredCompilation ${test.main.class}
- * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:VerifyIterativeGVN=100000 ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:VerifyIterativeGVN=100000 ${test.main.class}
  */
 
 package compiler.codegen;


### PR DESCRIPTION
Trivial fix for a test bug.

Additional testing:
 - [x] Affected test passes in both `fastdebug` and `release` variants

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390069](https://bugs.openjdk.org/browse/JDK-8390069): compiler/codegen/ShiftByZero.java fails in release config (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32280/head:pull/32280` \
`$ git checkout pull/32280`

Update a local copy of the PR: \
`$ git checkout pull/32280` \
`$ git pull https://git.openjdk.org/jdk.git pull/32280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32280`

View PR using the GUI difftool: \
`$ git pr show -t 32280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32280.diff">https://git.openjdk.org/jdk/pull/32280.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32280#issuecomment-5241808452)
</details>
