### PR TITLE
8387800: [lworld] PPC64 field flattening bugs in JEP 401

### DIFF
--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -2450,7 +2450,7 @@ void InterpreterMacroAssembler::write_flat_field(Register entry, Register tmp1, 
   payload_address(value, value, tmp1, tmp2);
 
   Register layout_info = field_offset;
-  lbz(tmp1, in_bytes(ResolvedFieldEntry::field_index_offset()), entry);
+  lhz(tmp1, in_bytes(ResolvedFieldEntry::field_index_offset()), entry);
   ld(tmp2, in_bytes(ResolvedFieldEntry::field_holder_offset()), entry);
   inline_layout_info(tmp2, tmp1, layout_info);
 

--- a/src/hotspot/cpu/ppc/jniFastGetField_ppc.cpp
+++ b/src/hotspot/cpu/ppc/jniFastGetField_ppc.cpp
@@ -99,7 +99,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->try_resolve_jobject_in_native(masm, Robj, R3_ARG1, R4_ARG2, Rtmp, slow);
 
-  __ srwi(Rtmp, R5_ARG3, jfieldIDWorkaround::offset_shift); // offset
+  __ srdi(Rtmp, R5_ARG3, jfieldIDWorkaround::offset_shift); // offset
 
   assert(count < LIST_CAPACITY, "LIST_CAPACITY too small");
   speculative_load_pclist[count] = __ pc();   // Used by the segfault handler

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -2609,7 +2609,8 @@ void TemplateTable::jvmti_post_field_access(Register Rcache, Register Rscratch, 
       // Restore object pointer.
       __ pop_ptr(R17_tos);
       __ verify_oop(R17_tos);
-    } else {
+    }
+    if (Rcache.is_volatile()) {
       // Cache is still needed to get class or obj.
       __ load_field_entry(Rcache, Rscratch);
     }
@@ -3322,7 +3323,7 @@ void TemplateTable::fast_storefield(TosState state) {
     {
       Label is_flat, done;
       __ test_field_is_flat(Rflags, is_flat);
-      __ null_check_throw(Rclass_or_obj, -1, Rscratch);
+      __ null_check_throw(R17_tos, -1, Rscratch);
       do_oop_store(_masm, Rclass_or_obj, Roffset, R17_tos, Rscratch, Rscratch2, Rscratch3, IN_HEAP);
       __ b(done);
       __ bind(is_flat);
@@ -3384,7 +3385,7 @@ void TemplateTable::fast_accessfield(TosState state) {
   Label LisVolatile;
   ByteSize cp_base_offset = ConstantPoolCache::base_offset();
 
-  const Register Rcache        = R3_ARG1,
+  const Register Rcache        = R31, // Needs to survive C call.
                  Rclass_or_obj = R17_tos,
                  Roffset       = R22_tmp2,
                  Rflags        = R23_tmp3,


### PR DESCRIPTION
I'm creating this pr on behalf of @TheRealMDoerr who isn't available until next week.
Martin has authored a fix for JDK-8387800 for which he opened https://github.com/openjdk/valhalla/pull/2630.
The pr could not be integrated because valhalla was in ramp-down.
I'd like to integrate now in order to falicitate further stabilization of valhalla implementation on ppc64.

The fix passed our CI testing:
Tier 1-4 of hotspot and jdk. All of langtools and jaxp. Renaissance Suite and SAP specific tests.
Testing was done on the main platforms and also on Linux/PPC64le and AIX.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387800](https://bugs.openjdk.org/browse/JDK-8387800): [lworld] PPC64 field flattening bugs in JEP 401 (**Bug** - P4)


### Reviewers
 * [David Briemann](https://openjdk.org/census#dbriemann) (@dbriemann - Committer)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32281/head:pull/32281` \
`$ git checkout pull/32281`

Update a local copy of the PR: \
`$ git checkout pull/32281` \
`$ git pull https://git.openjdk.org/jdk.git pull/32281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32281`

View PR using the GUI difftool: \
`$ git pr show -t 32281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32281.diff">https://git.openjdk.org/jdk/pull/32281.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32281#issuecomment-5251041620)
</details>
