### PR TITLE
8384108: Test Object.clone on a value object read from a flattened field

### DIFF
--- a/test/jdk/java/lang/Object/ValueObjects.java
+++ b/test/jdk/java/lang/Object/ValueObjects.java
@@ -75,6 +75,32 @@ class ValueObjects {
     }
 
     /**
+     * Test the Object.clone method on a value object read from a flattened
+     * field. The read materializes the value from the embedded payload and
+     * clone returns it.
+     */
+    @Test
+    void testCloneValueFromField() throws Exception {
+        value class V implements Cloneable {
+            int i;
+            V(int i) { this.i = i; }
+            @Override
+            protected V clone() throws CloneNotSupportedException {
+                return (V) super.clone();
+            }
+        }
+        class Holder {
+            V v = new V(42);
+        }
+        var holder = new Holder();
+        V read = holder.v;
+        V copy = read.clone();
+        assertSame(read, copy);
+        assertEquals(42, copy.i);
+        assertSame(holder.v, holder.v.clone());
+    }
+
+    /**
      * Test that the finalize method on a value class is not invoked by the GC.
      */
     @Test


### PR DESCRIPTION
Adds one case to the value objects test: cloning a value object read from a flattened field. The field read materializes the value from the embedded payload and clone returns it. Looks simple but the chain crosses the read materialization and buffering machinery, and optimization changes there can break it, so worth pinning.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384108](https://bugs.openjdk.org/browse/JDK-8384108): Test Object.clone on a value object read from a flattened field (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32284/head:pull/32284` \
`$ git checkout pull/32284`

Update a local copy of the PR: \
`$ git checkout pull/32284` \
`$ git pull https://git.openjdk.org/jdk.git pull/32284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32284`

View PR using the GUI difftool: \
`$ git pr show -t 32284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32284.diff">https://git.openjdk.org/jdk/pull/32284.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32284#issuecomment-5245298129)
</details>
