### PR TITLE
8390076: iList should be free'd after a failed C_GetInterfaceList() call in DEBUG mode

### DIFF
--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -135,6 +135,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
                 rv = C_GetInterfaceList(iList, &ulCount);
                 if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) {
                     TRACE0("Connect: error polling interface list\n");
+                    free(iList);
                     goto cleanup;
                 }
                 for (int i=0; i < (int)ulCount; i++) {


### PR DESCRIPTION
Could someone please help review this one-line fix?
This fixes a memory leak in the corner case where `C_GetInterfaceList()` fails after `iList` has been allocated.
Thanks,
Valerie

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390076](https://bugs.openjdk.org/browse/JDK-8390076): iList should be free'd after a failed C_GetInterfaceList() call in DEBUG mode (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32288/head:pull/32288` \
`$ git checkout pull/32288`

Update a local copy of the PR: \
`$ git checkout pull/32288` \
`$ git pull https://git.openjdk.org/jdk.git pull/32288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32288`

View PR using the GUI difftool: \
`$ git pr show -t 32288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32288.diff">https://git.openjdk.org/jdk/pull/32288.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32288#issuecomment-5247813841)
</details>
