### PR TITLE
8390042: Test "javax/swing/JToolBar/RightLeftOrientation.java" fails on macOS because two tool bar are not mirror images of each other for "Mac OS X" look and feel

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaToolBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaToolBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,8 +120,11 @@ public final class AquaToolBarUI extends BasicToolBarUI implements SwingConstant
 
             if (((JToolBar)c).isFloatable()) {
                 if (((JToolBar)c).getOrientation() == HORIZONTAL) {
-                    borderInsets.left = 12;
-                    // We don't have to adjust for right-to-left
+                    if (((JToolBar)c).getComponentOrientation().isLeftToRight()) {
+                        borderInsets.left = 12;
+                    } else {
+                        borderInsets.right = 12;
+                    }
                 } else { // vertical
                     borderInsets.top = 12;
                 }

--- a/test/jdk/javax/swing/JToolBar/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JToolBar/RightLeftOrientation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 /*
  * @test
- * @bug 4214514
+ * @bug 4214514 8390042
  * @summary
  *     This test checks if tool bars lay out correctly when their
  *     ComponentOrientation property is set to RIGHT_TO_LEFT. This test is


### PR DESCRIPTION
Issue is for Aqua L&F, RTL mode rendering is not exactly same as LTR mode, as toolbar grip is not getting drawn or shown on right side.

Actually, JToolBar grip is getting painted in RTL mode too but its getBorderInsets() always reserves the extra handle space on the left, not on the right, so the right button overlaps the toolbar handle

The fix is made to reserve the handle inset on the leading side

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390042](https://bugs.openjdk.org/browse/JDK-8390042): Test "javax/swing/JToolBar/RightLeftOrientation.java" fails on macOS because two tool bar are not mirror images of each other for "Mac OS X" look and feel (**Bug** - P3)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32291/head:pull/32291` \
`$ git checkout pull/32291`

Update a local copy of the PR: \
`$ git checkout pull/32291` \
`$ git pull https://git.openjdk.org/jdk.git pull/32291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32291`

View PR using the GUI difftool: \
`$ git pr show -t 32291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32291.diff">https://git.openjdk.org/jdk/pull/32291.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32291#issuecomment-5249275147)
</details>
