### PR TITLE
8390104: Use correct bugid for test

### DIFF
--- a/test/jdk/javax/swing/JTable/TestJTableColWidth.java
+++ b/test/jdk/javax/swing/JTable/TestJTableColWidth.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8192888
+ * @bug 8375573
  * @key headful
  * @summary Verifies JTable doesn't ignore setPreferredWidth during
  *          initial layout when AUTO_RESIZE_LAST_COLUMN is enabled


### PR DESCRIPTION
The bugid used in
javax/swing/JTable/TestJTableColWidth.java
is wrong
It should use
8375573 instead of 8192888

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390104](https://bugs.openjdk.org/browse/JDK-8390104): Use correct bugid for test (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32293/head:pull/32293` \
`$ git checkout pull/32293`

Update a local copy of the PR: \
`$ git checkout pull/32293` \
`$ git pull https://git.openjdk.org/jdk.git pull/32293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32293`

View PR using the GUI difftool: \
`$ git pr show -t 32293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32293.diff">https://git.openjdk.org/jdk/pull/32293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32293#issuecomment-5249482313)
</details>
