### PR TITLE
8390077: Rebalance tier1_compiler test groups

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -192,17 +192,22 @@ tier1_compiler_2 = \
   compiler/inlining/ \
   compiler/integerArithmetic/ \
   compiler/interpreter/ \
-  -compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java \
-  -compiler/codecache/stress \
-  -compiler/codegen/aes \
-  -compiler/gcbarriers/PreserveFPRegistersTest.java \
-  -compiler/igvn/TestMaskedStoreIdealization.java
-
-tier1_compiler_3 = \
   compiler/intrinsics/ \
   compiler/jsr292/ \
   compiler/locks/ \
   compiler/loopopts/ \
+  -compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java \
+  -compiler/codecache/stress \
+  -compiler/codegen/aes \
+  -compiler/gcbarriers/PreserveFPRegistersTest.java \
+  -compiler/igvn/TestMaskedStoreIdealization.java \
+  -compiler/intrinsics/bmi \
+  -compiler/intrinsics/mathexact \
+  -compiler/intrinsics/sha \
+  -compiler/intrinsics/bigInteger/TestMultiplyToLen.java \
+  -compiler/intrinsics/zip/TestAdler32.java
+
+tier1_compiler_3 = \
   compiler/macronodes/ \
   compiler/memoryinitialization/ \
   compiler/osr/ \
@@ -218,11 +223,6 @@ tier1_compiler_3 = \
   compiler/unsafe/ \
   compiler/valhalla/ \
   compiler/vectorization/ \
-  -compiler/intrinsics/bmi \
-  -compiler/intrinsics/mathexact \
-  -compiler/intrinsics/sha \
-  -compiler/intrinsics/bigInteger/TestMultiplyToLen.java \
-  -compiler/intrinsics/zip/TestAdler32.java \
   -compiler/loopopts/Test7052494.java \
   -compiler/memoryinitialization/ZeroTLABTest.java \
   -compiler/runtime/Test6826736.java \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -163,19 +163,6 @@ tier1_compiler_1 = \
   compiler/blackhole/ \
   compiler/c1/ \
   compiler/c2/ \
-  -compiler/arraycopy/stress \
-  -compiler/c2/Test6850611.java \
-  -compiler/c2/cr6890943/Test6890943.java \
-  -compiler/c2/Test6905845.java \
-  -compiler/c2/cr6340864 \
-  -compiler/c2/cr6589834 \
-  -compiler/c2/cr8004867 \
-  -compiler/c2/stemmer \
-  -compiler/c2/Test6792161.java \
-  -compiler/c2/Test6603011.java \
-  -compiler/c2/Test6912517.java
-
-tier1_compiler_2 = \
   compiler/ccp/ \
   compiler/ciTypeFlow/ \
   compiler/classUnloading/ \
@@ -187,6 +174,22 @@ tier1_compiler_2 = \
   compiler/escapeAnalysis/ \
   compiler/exceptions/ \
   compiler/floatingpoint/ \
+  -compiler/arraycopy/stress \
+  -compiler/c2/Test6850611.java \
+  -compiler/c2/cr6890943/Test6890943.java \
+  -compiler/c2/Test6905845.java \
+  -compiler/c2/cr6340864 \
+  -compiler/c2/cr6589834 \
+  -compiler/c2/cr8004867 \
+  -compiler/c2/stemmer \
+  -compiler/c2/Test6792161.java \
+  -compiler/c2/Test6603011.java \
+  -compiler/c2/Test6912517.java \
+  -compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java \
+  -compiler/codecache/stress \
+  -compiler/codegen/aes
+  
+tier1_compiler_2 = \
   compiler/gcbarriers/ \
   compiler/igvn/ \
   compiler/inlining/ \
@@ -196,9 +199,8 @@ tier1_compiler_2 = \
   compiler/jsr292/ \
   compiler/locks/ \
   compiler/loopopts/ \
-  -compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java \
-  -compiler/codecache/stress \
-  -compiler/codegen/aes \
+  compiler/macronodes/ \
+  compiler/memoryinitialization/ \
   -compiler/gcbarriers/PreserveFPRegistersTest.java \
   -compiler/igvn/TestMaskedStoreIdealization.java \
   -compiler/intrinsics/bmi \
@@ -208,8 +210,6 @@ tier1_compiler_2 = \
   -compiler/intrinsics/zip/TestAdler32.java
 
 tier1_compiler_3 = \
-  compiler/macronodes/ \
-  compiler/memoryinitialization/ \
   compiler/osr/ \
   compiler/predicates/ \
   compiler/profiling \


### PR DESCRIPTION
Current GHA runs shows that tier1_compiler jobs became a bit unbalanced, with 3rd group taking disproportionate amount of time to execute. It is often the very last test job to finish, half an hour after all others.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390077](https://bugs.openjdk.org/browse/JDK-8390077): Rebalance tier1_compiler test groups (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32294/head:pull/32294` \
`$ git checkout pull/32294`

Update a local copy of the PR: \
`$ git checkout pull/32294` \
`$ git pull https://git.openjdk.org/jdk.git pull/32294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32294`

View PR using the GUI difftool: \
`$ git pr show -t 32294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32294.diff">https://git.openjdk.org/jdk/pull/32294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32294#issuecomment-5249972191)
</details>
