### PR TITLE
8353624: C2: Re-enable malformed graph assert removed with JDK-8317998 to reduce noise

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4881,6 +4881,8 @@ bool Compile::final_graph_reshaping() {
 
       // Recheck with a better notion of 'required_outcnt'
       if (n->outcnt() != required_outcnt) {
+        DEBUG_ONLY(n->dump_bfs(3, nullptr, "-"););
+        assert(false, "malformed control flow");
         record_method_not_compilable("malformed control flow");
         return true;            // Not all targets reachable!
       }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4881,7 +4881,7 @@ bool Compile::final_graph_reshaping() {
 
       // Recheck with a better notion of 'required_outcnt'
       if (n->outcnt() != required_outcnt) {
-        DEBUG_ONLY(n->dump_bfs(3, nullptr, "-"););
+        DEBUG_ONLY(n->dump_bfs(3, nullptr, "-"));
         assert(false, "malformed control flow");
         record_method_not_compilable("malformed control flow");
         return true;            // Not all targets reachable!


### PR DESCRIPTION
https://github.com/openjdk/jdk/commit/7633a76607e264ce578f3c0e1d393c1016bc6b95 disabled a malformed graph assert to reduce noise in CI testing. Almost all of these issues could be traced back to missing Assertion Predicates ([JDK-8288981](https://bugs.openjdk.org/browse/JDK-8288981)). Now that this fix is complete, I ran testing again with the assert enabled and could not find any issues anymore. I therefore propose to re-enable it again.

Testing:
- t1-4,hs-comp-stress,valhalla-comp-stress: with and without enable preview
- t5-7: without enable preview

If we still find issues again in higher tiers, we could still reconsider again.

Thanks,
Christian 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8353624](https://bugs.openjdk.org/browse/JDK-8353624): C2: Re-enable malformed graph assert removed with JDK-8317998 to reduce noise (**Sub-task** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32299/head:pull/32299` \
`$ git checkout pull/32299`

Update a local copy of the PR: \
`$ git checkout pull/32299` \
`$ git pull https://git.openjdk.org/jdk.git pull/32299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32299`

View PR using the GUI difftool: \
`$ git pr show -t 32299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32299.diff">https://git.openjdk.org/jdk/pull/32299.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32299#issuecomment-5251763986)
</details>
