### PR TITLE
8390065: TestDockerMemoryMetrics.java fails in MetricsMemoryTester failcount

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -69,52 +69,54 @@ public class MetricsMemoryTester {
         final long memAndSwapLimit = metrics.getMemoryAndSwapLimit();
         final long memLimit = metrics.getMemoryLimit();
 
+        final int M = 1024 * 1024;
+
         // We need swap to execute this test. Otherwise OOM killer acts with
         // SIGSEGV before we read the fail counter.
-        if (memAndSwapLimit <= memLimit) {
-            System.out.println("No swap memory limits. Ignoring test!");
-        } else {
-            final long count = metrics.getMemoryFailCount();
 
-            System.out.printf("Memory limit: %dMiB\n", memLimit / (1024 * 1024));
-            System.out.printf("Memory and swap limit: %dMiB\n", memAndSwapLimit / (1024 * 1024));
-            System.out.println("Initial memory fail count:" + count);
+        final long maxHeapSize = Runtime.getRuntime().maxMemory();
+         if (maxHeapSize <= memLimit || maxHeapSize >= memAndSwapLimit) {
+            throw new RuntimeException(
+                    "Expected memory limit < maximum heap < memory-and-swap limit: "
+                            + "memory=" + memLimit / M + "M, "
+                            + "heap=" + maxHeapSize / M + "M, "
+                            + "memory-and-swap=" + memAndSwapLimit / M + "M");
+        }
 
-            // Allocate 512M of data in 1M chunks per iteration
-            byte[][] bytes = new byte[64 * 8][];
-            int allocations = 0;
-            for (int i = 0; i < 64 * 8; i++) {
-                try {
-                    bytes[i] = new byte[1024 * 1024];
-                    allocations++;
-                    // Break out as soon as we see an increase in failcount
-                    // to avoid getting killed by the OOM killer.
-                    if (metrics.getMemoryFailCount() > count) {
-                        break;
-                    }
-                } catch (OutOfMemoryError e) {
-                    System.out.println("Allocation stopped after " + allocations
-                            + " MiB: " + e);
-                    break;
-                }
+        final long initialFailCount = metrics.getMemoryFailCount();
+
+        System.out.println("Initial memory fail count: " + initialFailCount);
+
+        // Allocate 512M of data in 1M chunks per iteration
+        byte[][] bytes = new byte[512][];
+
+        for (int i = 0; i < 512; i++) {
+            if (i % 8 == 0) {
+                System.out.printf("Allocated: %3dM, Memory usage: %3dM, Memory and swap: %3dM\n",
+                        i,
+                        metrics.getMemoryUsage() / M,
+                        metrics.getMemoryAndSwapUsage() / M);
+            } else {
+                System.out.print(".");
             }
-            if (allocations == 0) {
-                System.out.println("Allocation failed immediately. Ignoring test!");
-                return;
-            }
-            // Be sure bytes allocations don't get optimized out
-            System.out.println("DEBUG: Bytes allocation length 1: " + bytes[0].length);
-            final long newCount = metrics.getMemoryFailCount();
-            System.out.printf("Allocated memory: %dMiB\n", allocations);
-            System.out.printf("Memory usage: %dMiB\n", metrics.getMemoryUsage() / (1024 * 1024));
-            System.out.printf("Memory and swap usage: %dMiB\n", metrics.getMemoryAndSwapUsage() / (1024 * 1024));
-            System.out.println("Final memory fail count: " + newCount);
-            if (newCount <= count) {
-                throw new RuntimeException("Memory fail count : new : ["
-                        + newCount + "]"
-                        + ", old : [" + count + "]");
+            bytes[i] = new byte[M];
+            Arrays.fill(bytes[i], (byte) 1);  // dirty every page
+            // Break out as soon as we see an increase in failcount
+            if (metrics.getMemoryFailCount() > initialFailCount) {
+                break;
             }
         }
+
+        // Be sure bytes allocations don't get optimized out
+        System.out.println("\nDEBUG: Bytes allocation length 1: " + bytes[0].length);
+        final long newCount = metrics.getMemoryFailCount();
+        System.out.println("Final memory fail count: " + newCount);
+
+        if (newCount <= initialFailCount) {
+            throw new RuntimeException("Memory fail count did not increase: initial="
+                    + initialFailCount + ", final=" + newCount);
+        }
+
         System.out.println("TEST PASSED!!!");
     }
 

--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -75,7 +75,7 @@ public class MetricsMemoryTester {
         // SIGSEGV before we read the fail counter.
 
         final long maxHeapSize = Runtime.getRuntime().maxMemory();
-         if (maxHeapSize <= memLimit || maxHeapSize >= memAndSwapLimit) {
+        if (maxHeapSize <= memLimit || maxHeapSize >= memAndSwapLimit) {
             throw new RuntimeException(
                     "Expected memory limit < maximum heap < memory-and-swap limit: "
                             + "memory=" + memLimit / M + "M, "

--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -72,7 +72,7 @@ public class MetricsMemoryTester {
         final int M = 1024 * 1024;
 
         // We need swap to execute this test. Otherwise OOM killer acts with
-        // SIGSEGV before we read the fail counter.
+        // SIGKILL before we read the fail counter.
 
         final long maxHeapSize = Runtime.getRuntime().maxMemory();
         if (maxHeapSize <= memLimit || maxHeapSize >= memAndSwapLimit) {

--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -65,40 +65,53 @@ public class MetricsMemoryTester {
     }
 
     private static void testMemoryFailCount() {
-        long memAndSwapLimit = Metrics.systemMetrics().getMemoryAndSwapLimit();
-        long memLimit = Metrics.systemMetrics().getMemoryLimit();
+        final Metrics metrics = Metrics.systemMetrics();
+        final long memAndSwapLimit = metrics.getMemoryAndSwapLimit();
+        final long memLimit = metrics.getMemoryLimit();
 
-        // We need swap to execute this test or will SEGV
+        // We need swap to execute this test. Otherwise OOM killer acts with
+        // SIGSEGV before we read the fail counter.
         if (memAndSwapLimit <= memLimit) {
             System.out.println("No swap memory limits. Ignoring test!");
         } else {
-            long count = Metrics.systemMetrics().getMemoryFailCount();
+            final long count = metrics.getMemoryFailCount();
+
+            System.out.printf("Memory limit: %dMiB\n", memLimit / (1024 * 1024));
+            System.out.printf("Memory and swap limit: %dMiB\n", memAndSwapLimit / (1024 * 1024));
+            System.out.println("Initial memory fail count:" + count);
 
             // Allocate 512M of data in 1M chunks per iteration
             byte[][] bytes = new byte[64 * 8][];
-            boolean atLeastOneAllocationWorked = false;
+            int allocations = 0;
             for (int i = 0; i < 64 * 8; i++) {
                 try {
                     bytes[i] = new byte[1024 * 1024];
-                    atLeastOneAllocationWorked = true;
+                    allocations++;
                     // Break out as soon as we see an increase in failcount
                     // to avoid getting killed by the OOM killer.
-                    if (Metrics.systemMetrics().getMemoryFailCount() > count) {
+                    if (metrics.getMemoryFailCount() > count) {
                         break;
                     }
-                } catch (Error e) { // OOM error
+                } catch (OutOfMemoryError e) {
+                    System.out.println("Allocation stopped after " + allocations
+                            + " MiB: " + e);
                     break;
                 }
             }
-            if (!atLeastOneAllocationWorked) {
+            if (allocations == 0) {
                 System.out.println("Allocation failed immediately. Ignoring test!");
                 return;
             }
             // Be sure bytes allocations don't get optimized out
             System.out.println("DEBUG: Bytes allocation length 1: " + bytes[0].length);
-            if (Metrics.systemMetrics().getMemoryFailCount() <= count) {
+            final long newCount = metrics.getMemoryFailCount();
+            System.out.printf("Allocated memory: %dMiB\n", allocations);
+            System.out.printf("Memory usage: %dMiB\n", metrics.getMemoryUsage() / (1024 * 1024));
+            System.out.printf("Memory and swap usage: %dMiB\n", metrics.getMemoryAndSwapUsage() / (1024 * 1024));
+            System.out.println("Final memory fail count: " + newCount);
+            if (newCount <= count) {
                 throw new RuntimeException("Memory fail count : new : ["
-                        + Metrics.systemMetrics().getMemoryFailCount() + "]"
+                        + newCount + "]"
                         + ", old : [" + count + "]");
             }
         }

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -122,9 +122,9 @@ public class TestDockerMemoryMetrics {
         preOpts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/")
                 .addDockerOpts("--memory=" + memory)
                 .addDockerOpts("--memory-swap=" + memoryAndSwap)
-                .addDockerOpts("-XX:+AlwaysPreTouch")
-                .addDockerOpts("-Xms" + heap)
-                .addJavaOptsAppended("-Xmx" + heap);  // append so that this -Xms wins over externally set one
+                .addJavaOpts("-XX:+AlwaysPreTouch")
+                .addJavaOpts("-Xms" + heap)
+                .addJavaOptsAppended("-Xmx" + heap);
         OutputAnalyzer oa = DockerTestUtils.dockerRunJava(preOpts);
         String output = oa.getOutput();
         if (!output.contains("version")) {
@@ -144,9 +144,8 @@ public class TestDockerMemoryMetrics {
                 .addDockerOpts("--memory-swap=" + memoryAndSwap)
                 .addJavaOpts("-cp", "/test-classes/")
                 .addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED")
-                // flags set externally placed "after" the ones set with addJavaOpts() and thus win.
-                // Keep the required heap size after inherited jtreg options
-                .addJavaOptsAppended("-Xmx" + heap)  // append so that this -Xms wins over externally set one
+                // set the required heap size *after* inherited jtreg options
+                .addJavaOptsAppended("-Xmx" + heap)
                 .addClassOptions("failcount");
         oa = DockerTestUtils.dockerRunJava(opts);
         output = oa.getOutput();

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -108,7 +108,7 @@ public class TestDockerMemoryMetrics {
     private static void testMemoryFailCount(String memory, String heap, String memoryAndSwap) throws Exception {
         Common.logNewTestCase("testMemoryFailCount, memory = " + memory
                 + ", heap = " + heap
-                + ", memory and swap = " + memoryAndSwap);
+                + ", memory + swap = " + memoryAndSwap);
 
         // Check whether swapping really works for this test
         // On some systems there is no swap space enabled. And running
@@ -132,8 +132,8 @@ public class TestDockerMemoryMetrics {
         }
 
         //  0                   128                                                       1024
-        //  |---o----------------|---------------------------)----------------------------|
-        //      START            memory.max                  growth target                memory+swap limit
+        //  |---o----------------|---------------------------X--------------)-------------|
+        //      START            memory.max                  growth target  max heap      memory+swap limit
         //      o~~~~~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>  (growth)                         OOM
         //  failcount: 0          1 2 3 ..... N
         //

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -76,7 +76,7 @@ public class TestDockerMemoryMetrics {
             }
             testOomKillFlag("100m", true);
 
-            testMemoryFailCount("128m" /*memory*/, "512m" /*heap*/, "1024m" /*memory_n_swap*/);
+            testMemoryFailCount("128m" /*memory*/, "768m" /*heap*/, "1024m" /*memory_n_swap*/);
 
             testMemorySoftLimit("500m","200m");
 

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -76,7 +76,7 @@ public class TestDockerMemoryMetrics {
             }
             testOomKillFlag("100m", true);
 
-            testMemoryFailCount("128m");
+            testMemoryFailCount("128m" /*memory*/, "512m" /*heap*/, "1024m" /*memory_n_swap*/);
 
             testMemorySoftLimit("500m","200m");
 
@@ -105,36 +105,48 @@ public class TestDockerMemoryMetrics {
         DockerTestUtils.dockerRunJava(opts).shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
     }
 
-    private static void testMemoryFailCount(String value) throws Exception {
-        Common.logNewTestCase("testMemoryFailCount" + value);
+    private static void testMemoryFailCount(String memory, String heap, String memoryAndSwap) throws Exception {
+        Common.logNewTestCase("testMemoryFailCount, memory = " + memory
+                + ", heap = " + heap
+                + ", memory and swap = " + memoryAndSwap);
 
         // Check whether swapping really works for this test
         // On some systems there is no swap space enabled. And running
-        // 'java -Xms{mem-limit} -Xmx{mem-limit} -XX:+AlwaysPreTouch -version'
+        // 'java -Xms{heap} -Xmx{heap} -XX:+AlwaysPreTouch -version'
         // would fail due to swap space size being 0. Note that when swap is
-        // properly enabled on the system the container gets the same amount
-        // of swap as is configured for memory. Thus, 2x{mem-limit} is the actual
-        // memory and swap bound for this pre-test.
+        // properly enabled, the explicit memory-and-swap limit gives the JVM
+        // enough headroom to exceed the physical memory limit without being
+        // killed by the OOM killer.
         DockerRunOptions preOpts =
                 new DockerRunOptions(imageName, "/jdk/bin/java", "-version");
         preOpts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/")
-                .addDockerOpts("--memory=" + value)
-                .addJavaOpts("-XX:+AlwaysPreTouch")
-                .addJavaOpts("-Xms" + value)
-                .addJavaOpts("-Xmx" + value);
+                .addDockerOpts("--memory=" + memory)
+                .addDockerOpts("--memory-swap=" + memoryAndSwap)
+                .addDockerOpts("-XX:+AlwaysPreTouch")
+                .addDockerOpts("-Xms" + heap)
+                .addJavaOptsAppended("-Xmx" + heap);  // append so that this -Xms wins over externally set one
         OutputAnalyzer oa = DockerTestUtils.dockerRunJava(preOpts);
         String output = oa.getOutput();
         if (!output.contains("version")) {
             throw new SkippedException("Swapping doesn't work for this test.");
         }
 
+        //  0                   128                                                       1024
+        //  |---o----------------|---------------------------)----------------------------|
+        //      START            memory.max                  growth target                memory+swap limit
+        //      o~~~~~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>  (growth)                         OOM
+        //  failcount: 0          1 2 3 ..... N
+        //
         DockerRunOptions opts =
                 new DockerRunOptions(imageName, "/jdk/bin/java", "MetricsMemoryTester");
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/")
-                .addDockerOpts("--memory=" + value)
-                .addJavaOpts("-Xmx" + value)
+                .addDockerOpts("--memory=" + memory)
+                .addDockerOpts("--memory-swap=" + memoryAndSwap)
                 .addJavaOpts("-cp", "/test-classes/")
                 .addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED")
+                // flags set externally placed "after" the ones set with addJavaOpts() and thus win.
+                // Keep the required heap size after inherited jtreg options
+                .addJavaOptsAppended("-Xmx" + heap)  // append so that this -Xms wins over externally set one
                 .addClassOptions("failcount");
         oa = DockerTestUtils.dockerRunJava(opts);
         output = oa.getOutput();

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -76,7 +76,7 @@ public class TestDockerMemoryMetrics {
             }
             testOomKillFlag("100m", true);
 
-            testMemoryFailCount("128m" /*memory*/, "768m" /*heap*/, "1024m" /*memory_n_swap*/);
+            testMemoryFailCount("128m" /*memory*/, "768m" /*max_heap*/, "1024m" /*memory_n_swap*/);
 
             testMemorySoftLimit("500m","200m");
 

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -123,8 +123,8 @@ public class TestDockerMemoryMetrics {
                 .addDockerOpts("--memory=" + memory)
                 .addDockerOpts("--memory-swap=" + memoryAndSwap)
                 .addJavaOpts("-XX:+AlwaysPreTouch")
-                .addJavaOpts("-Xms" + heap)
-                .addJavaOptsAppended("-Xmx" + heap);
+                .addJavaOptsAppended("-XX:InitialHeapSize=" + heap)
+                .addJavaOptsAppended("-XX:MaxHeapSize=" + heap);
         OutputAnalyzer oa = DockerTestUtils.dockerRunJava(preOpts);
         String output = oa.getOutput();
         if (!output.contains("version")) {
@@ -133,9 +133,9 @@ public class TestDockerMemoryMetrics {
 
         //  0                   128                                                       1024
         //  |---o----------------|---------------------------X--------------)-------------|
-        //      START            memory.max                  growth target  max heap      memory+swap limit
-        //      o~~~~~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>  (growth)                         OOM
-        //  failcount: 0          1 2 3 ..... N
+        //      START            memory.max                  growth target  MaxHeapSize   memory+swap limit
+        //      o~~~~~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>~>  (growth)                          OOM
+        //  failcount: 0          1 2 3 . . . N
         //
         DockerRunOptions opts =
                 new DockerRunOptions(imageName, "/jdk/bin/java", "MetricsMemoryTester");
@@ -145,7 +145,7 @@ public class TestDockerMemoryMetrics {
                 .addJavaOpts("-cp", "/test-classes/")
                 .addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED")
                 // set the required heap size *after* inherited jtreg options
-                .addJavaOptsAppended("-Xmx" + heap)
+                .addJavaOptsAppended("-XX:MaxHeapSize=" + heap)
                 .addClassOptions("failcount");
         oa = DockerTestUtils.dockerRunJava(opts);
         output = oa.getOutput();


### PR DESCRIPTION
Please review this PR that makes "failcount" case of `TestDockerMemoryMetrics.java` more robust.
The "failcount" case is failing in some environments (OL9+ in my case).

With this change I am trying to address several issues:
* the test was not setting swap-space, and assumed OS will map mirror `--memory` in size. 128MiB for the test was not always enough for a successful run.
   * updated the test with additional `--memory-swap` flat to control the swap headroom in container so that failcount gets more chances to be incremented while main memory is full. It may also be that some OSes are more eager the others to update counters in cgroup-fs. This tweak helps.
*  the `new byte[1 MiB]` allocations alone reserves heap space for the application space but may leave the memory uncommitted. It can be that 512 MiB Java heap fills up and throws OutOfMemoryError before RSS crosses the 128MiB limit.
  * fix by dirtying the chunks after we allocate them.
* removed `catch`'ing `java.lang.OutOfMemoryError` errors to avoid secondary `OutOfMemoryError`.
* The test inherits JVM flags set externally and so `-Xmx` is often passed to the JVM running in a container.
  *  Make `-Xmx` flag set from within the test to *win* over the one set externally (e.g. by our make scripts for task definition).

* the additional logs help seeing the dynamics of the test, Example OL9:
```
Initial memory fail count: 0
Allocated:   0M, Memory usage:  42M, Memory and swap:  42M
.......Allocated:   8M, Memory usage:  72M, Memory and swap:  72M
.......Allocated:  16M, Memory usage:  88M, Memory and swap:  88M
.......Allocated:  24M, Memory usage: 106M, Memory and swap: 106M
.......Allocated:  32M, Memory usage: 123M, Memory and swap: 123M
.......Allocated:  40M, Memory usage: 127M, Memory and swap: 142M
.......Allocated:  48M, Memory usage: 127M, Memory and swap: 163M
.......Allocated:  56M, Memory usage:  97M, Memory and swap: 185M
.......Allocated:  64M, Memory usage: 113M, Memory and swap: 200M
.......Allocated:  72M, Memory usage: 127M, Memory and swap: 215M
.......Allocated:  80M, Memory usage: 127M, Memory and swap: 251M
.......Allocated:  88M, Memory usage: 127M, Memory and swap: 249M
.......Allocated:  96M, Memory usage: 127M, Memory and swap: 266M
.......Allocated: 104M, Memory usage: 125M, Memory and swap: 287M
.
DEBUG: Bytes allocation length 1: 1048576
Final memory fail count: 1
TEST PASSED!!!
``` 

Tested `TestDockerMemoryMetrics.java` on
* Ubuntu 24.04 x {Podman, Docker} 
* OL9,10 + Podman


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390065](https://bugs.openjdk.org/browse/JDK-8390065): TestDockerMemoryMetrics.java fails in MetricsMemoryTester failcount (**Bug** - P4)


### Reviewers
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32300/head:pull/32300` \
`$ git checkout pull/32300`

Update a local copy of the PR: \
`$ git checkout pull/32300` \
`$ git pull https://git.openjdk.org/jdk.git pull/32300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32300`

View PR using the GUI difftool: \
`$ git pr show -t 32300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32300.diff">https://git.openjdk.org/jdk/pull/32300.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32300#issuecomment-5263835855)
</details>
