### PR TITLE
8386510: AArch64: MacroAssembler constructor undefined behaviour

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -457,17 +457,18 @@ class Address {
 
   Address(address target, relocInfo::relocType rtype = relocInfo::external_word_type);
 
-  Address(Register base, RegisterOrConstant index, extend ext = lsl()) {
+  Address(Register base, RegisterOrConstant index, extend ext = lsl(0)) {
     if (index.is_register()) {
       _mode = base_plus_offset_reg;
       new (&_nonliteral) Nonliteral(base, index.as_register(), 0, ext);
     } else {
       guarantee(ext.option() == ext::uxtx, "should be");
       assert(index.is_constant(), "should be");
+      assert(ext.shift() == 0, "must be");
       _mode = base_plus_offset;
       new (&_nonliteral) Nonliteral(base,
                                     noreg,
-                                    index.as_constant() << ext.shift());
+                                    index.as_constant());
     }
   }
 


### PR DESCRIPTION

JBS Issue : [JDK-8386510](https://bugs.openjdk.org/browse/JDK-8386510)

This implements the fix suggested by @theRealAph  in the JBS issue.

Address(Register base, RegisterOrConstant index, extend ext = lsl()) in the Constant case causes a left-shift operation with a negative shift, which is out of range, and therefore UB.


Fix

Default the extend to lsl(0) instead of lsl(), and assert that the constant path is only used with a zero shift.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386510](https://bugs.openjdk.org/browse/JDK-8386510): AArch64: MacroAssembler constructor undefined behaviour (**Bug** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32301/head:pull/32301` \
`$ git checkout pull/32301`

Update a local copy of the PR: \
`$ git checkout pull/32301` \
`$ git pull https://git.openjdk.org/jdk.git pull/32301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32301`

View PR using the GUI difftool: \
`$ git pr show -t 32301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32301.diff">https://git.openjdk.org/jdk/pull/32301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32301#issuecomment-5268725712)
</details>
