### PR TITLE
8390136: ResourceMark needed for external_name calls in continuationFreezeThaw.cpp

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1747,6 +1747,8 @@ static void verify_frame_kind(frame& top, Continuation::preempt_kind preempt_kin
   Method* m;
   const char* code_name;
   int bci;
+  ResourceMark rm;
+
   if (preempt_kind == Continuation::monitorenter) {
     assert(top.is_interpreted_frame() || top.is_runtime_frame(), "unexpected %sframe",
       top.is_compiled_frame() ? "compiled " : top.is_native_frame() ? "native " : "");
@@ -1763,7 +1765,6 @@ static void verify_frame_kind(frame& top, Continuation::preempt_kind preempt_kin
       bci = at_sync_method ? -1 : top.interpreter_frame_bci();
     } else {
       JavaThread* current = JavaThread::current();
-      ResourceMark rm(current);
       CodeBlob* cb = top.cb();
       RegisterMap reg_map(current,
                   RegisterMap::UpdateMap::skip,


### PR DESCRIPTION
Seems we need a ResourceMark for some external_name calls in continuationFreezeThaw.cpp; fortunately it is only debug code.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390136](https://bugs.openjdk.org/browse/JDK-8390136): ResourceMark needed for external_name calls in continuationFreezeThaw.cpp (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32303/head:pull/32303` \
`$ git checkout pull/32303`

Update a local copy of the PR: \
`$ git checkout pull/32303` \
`$ git pull https://git.openjdk.org/jdk.git pull/32303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32303`

View PR using the GUI difftool: \
`$ git pr show -t 32303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32303.diff">https://git.openjdk.org/jdk/pull/32303.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32303#issuecomment-5255025732)
</details>
