### PR TITLE
8390133: JFR: OngoingStream reads stale header

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/OngoingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/OngoingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,10 +167,11 @@ public final class OngoingStream extends EventByteStream {
         byte[] bytes = new byte[Math.max(HEADER_SIZE, size)];
         for (int attempts = 0; attempts < 25; attempts++) {
             // read twice and check files state to avoid simultaneous change by JVM
-            input.position(0);
-            input.readFully(bytes, 0, HEADER_SIZE);
-            input.position(0);
-            input.readFully(headerBytes);
+            input.positionPhysical(0);
+            input.readPhysicalFully(bytes, 0, HEADER_SIZE);
+            input.positionPhysical(0);
+            input.readPhysicalFully(headerBytes, 0, HEADER_SIZE);
+            input.position(HEADER_SIZE);
             if (bytes[HEADER_FILE_STATE_POSITION] != MODIFYING_STATE) {
                 if (bytes[HEADER_FILE_STATE_POSITION] == headerBytes[HEADER_FILE_STATE_POSITION]) {
                     ByteBuffer buffer = ByteBuffer.wrap(bytes);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,6 +108,10 @@ public final class RecordingInput implements DataInput, AutoCloseable {
 
     long readPhysicalLong() throws IOException {
         return file.readLong();
+    }
+
+    void readPhysicalFully(byte[] dest, int offset, int length) throws IOException {
+        file.readFully(dest, offset, length);
     }
 
     @Override


### PR DESCRIPTION
Could I have a review of PR that hopefully will make OngoingStream more stable?

Testing: jdk/jdk/jfr/

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390133](https://bugs.openjdk.org/browse/JDK-8390133): JFR: OngoingStream reads stale header (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32305/head:pull/32305` \
`$ git checkout pull/32305`

Update a local copy of the PR: \
`$ git checkout pull/32305` \
`$ git pull https://git.openjdk.org/jdk.git pull/32305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32305`

View PR using the GUI difftool: \
`$ git pr show -t 32305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32305.diff">https://git.openjdk.org/jdk/pull/32305.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32305#issuecomment-5255298818)
</details>
