### PR TITLE
8390132: Test runtime/cds/appcds/ClassPathAttrCircularReference.java written dynamic archive missing in output

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -467,6 +467,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/resolvedConstants \
  -runtime/cds/appcds/ArchiveRelocationTest.java \
  -runtime/cds/appcds/BadBSM.java \
+ -runtime/cds/appcds/ClassPathAttrCircularReference.java \
  -runtime/cds/appcds/CommandLineFlagCombo.java \
  -runtime/cds/appcds/CommandLineFlagComboNegative.java \
  -runtime/cds/appcds/DumpClassList.java \


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8390132](https://bugs.openjdk.org/browse/JDK-8390132)

### Issue
 * [JDK-8390132](https://bugs.openjdk.org/browse/JDK-8390132): Test runtime/cds/appcds/ClassPathAttrCircularReference.java "written dynamic archive" missing in output (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32306/head:pull/32306` \
`$ git checkout pull/32306`

Update a local copy of the PR: \
`$ git checkout pull/32306` \
`$ git pull https://git.openjdk.org/jdk.git pull/32306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32306`

View PR using the GUI difftool: \
`$ git pr show -t 32306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32306.diff">https://git.openjdk.org/jdk/pull/32306.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32306#issuecomment-5256460234)
</details>
