### PR TITLE
8390132: Test runtime/cds/appcds/ClassPathAttrCircularReference.java "written dynamic archive" missing in output

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -467,6 +467,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/resolvedConstants \
  -runtime/cds/appcds/ArchiveRelocationTest.java \
  -runtime/cds/appcds/BadBSM.java \
+ -runtime/cds/appcds/ClassPathAttrCircularReference.java \
  -runtime/cds/appcds/CommandLineFlagCombo.java \
  -runtime/cds/appcds/CommandLineFlagComboNegative.java \
  -runtime/cds/appcds/DumpClassList.java \


### PR DESCRIPTION
Please review this trivial fix.

The ClassPathAttrCircularReference.java is not suitable for running in tier4, which runs `open/test/hotspot/jtreg:hotspot_appcds_dynamic` with `-Dtest.dynamic.cds.archive=true`. 

This test should be excluded from the `hotspot_appcds_dynamic` test group.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390132](https://bugs.openjdk.org/browse/JDK-8390132): Test runtime/cds/appcds/ClassPathAttrCircularReference.java "written dynamic archive" missing in output (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32307/head:pull/32307` \
`$ git checkout pull/32307`

Update a local copy of the PR: \
`$ git checkout pull/32307` \
`$ git pull https://git.openjdk.org/jdk.git pull/32307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32307`

View PR using the GUI difftool: \
`$ git pr show -t 32307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32307.diff">https://git.openjdk.org/jdk/pull/32307.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32307#issuecomment-5257477639)
</details>
