### PR TITLE
8385672: SunEC NONEwithECDSA Signature.update(ByteBuffer) rejects an input of exactly 64 bytes, while update(byte[]) accepts it

### DIFF
--- a/src/java.base/share/classes/sun/security/ec/ECDSASignature.java
+++ b/src/java.base/share/classes/sun/security/ec/ECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,7 +157,7 @@ abstract class ECDSASignature extends SignatureSpi {
         @Override
         protected void engineUpdate(byte[] b, int off, int len)
         throws SignatureException {
-            if (offset >= precomputedDigest.length) {
+            if (len > precomputedDigest.length - offset) {
                 offset = RAW_ECDSA_MAX + 1;
                 return;
             }
@@ -172,7 +172,7 @@ abstract class ECDSASignature extends SignatureSpi {
             if (len <= 0) {
                 return;
             }
-            if (len >= precomputedDigest.length - offset) {
+            if (len > precomputedDigest.length - offset) {
                 offset = RAW_ECDSA_MAX + 1;
                 return;
             }

--- a/src/java.base/share/classes/sun/security/ec/ECDSASignature.java
+++ b/src/java.base/share/classes/sun/security/ec/ECDSASignature.java
@@ -157,6 +157,8 @@ abstract class ECDSASignature extends SignatureSpi {
         @Override
         protected void engineUpdate(byte[] b, int off, int len)
         throws SignatureException {
+            // Check capacity. If precomputedDigest is already full, this
+            // condition effectively becomes 'len > -1' and will always be true
             if (len > precomputedDigest.length - offset) {
                 offset = RAW_ECDSA_MAX + 1;
                 return;

--- a/test/jdk/sun/security/ec/NONEwithECDSAOffsetTest.java
+++ b/test/jdk/sun/security/ec/NONEwithECDSAOffsetTest.java
@@ -25,7 +25,6 @@ import java.nio.ByteBuffer;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.Provider;
-import java.security.SecureRandom;
 import java.security.Security;
 import java.security.Signature;
 import java.security.SignatureException;

--- a/test/jdk/sun/security/ec/NONEwithECDSAOffsetTest.java
+++ b/test/jdk/sun/security/ec/NONEwithECDSAOffsetTest.java
@@ -36,7 +36,6 @@ import jtreg.SkippedException;
 /*
  * @test
  * @bug 8385672
- * @key randomness
  * @summary This test validates the length checks in SunEC's NONEwithECDSA
  *         implementation
  * @library /test/lib/

--- a/test/jdk/sun/security/ec/NONEwithECDSAOffsetTest.java
+++ b/test/jdk/sun/security/ec/NONEwithECDSAOffsetTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.ByteBuffer;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Arrays;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8385672
+ * @key randomness
+ * @summary This test validates the length checks in SunEC's NONEwithECDSA
+ *         implementation
+ * @library /test/lib/
+ */
+
+public class NONEwithECDSAOffsetTest {
+
+    private static Signature s;
+    private static PrivateKey pk;
+
+    public static void main(String[] args) throws Exception {
+        Provider prov = Security.getProvider("SunEC");
+        if (prov == null) {
+            throw new SkippedException("Skip test - no SunEC provider found");
+        }
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", prov);
+        kpg.initialize(new ECGenParameterSpec("secp521r1"));
+        pk = kpg.generateKeyPair().getPrivate();
+        s = Signature.getInstance("NONEwithECDSA", prov);
+
+        test(48, true);
+        test(64, true);
+        test(65, false);
+    }
+
+    private static void test(int dataLen, boolean shouldPass) throws Exception {
+        System.out.println("Testing " + dataLen + ", shouldPass = " +
+                shouldPass);
+        byte[] data = new byte[dataLen];
+        Arrays.fill(data, (byte) dataLen);
+
+        int testNum = 1;
+        boolean done = false;
+        while (!done) {
+            String testId = String.format("Test#%d", testNum);
+            s.initSign(pk);
+            try {
+                switch (testNum++) {
+                    case 1: // update(byte)
+                        byte i = 0;
+                        while (i++ < dataLen) {
+                            s.update(i);
+                        }
+                        break;
+                    case 2: // update(byte[])
+                        s.update(data);
+                        break;
+                    case 3: // update(byte[], int, int)
+                        int firstPart = data.length/2;
+                        s.update(data, 0, firstPart);
+                        s.update(data, firstPart, data.length - firstPart);
+                        break;
+                    case 4: // update(ByteBuffer)
+                        s.update(ByteBuffer.wrap(data));
+                        done = true;
+                        break;
+                    default:
+                        throw new AssertionError("Error: Unsupported testNum"
+                                + testNum);
+                }
+                s.sign();
+                if (!shouldPass) {
+                    done = true;
+                    throw new AssertionError(testId +
+                            " should throw SignatureException");
+                }
+            } catch (SignatureException se) {
+                if (shouldPass) {
+                    done = true;
+                    throw new AssertionError(testId +
+                            ": Unexpected SignatureException", se);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes 2 problematic if-checks inside the NONwithECDSA signature impl of SunEC provider.

Thanks in advance for the review~
Valerie


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385672](https://bugs.openjdk.org/browse/JDK-8385672): SunEC NONEwithECDSA Signature.update(ByteBuffer) rejects an input of exactly 64 bytes, while update(byte[]) accepts it (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32308/head:pull/32308` \
`$ git checkout pull/32308`

Update a local copy of the PR: \
`$ git checkout pull/32308` \
`$ git pull https://git.openjdk.org/jdk.git pull/32308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32308`

View PR using the GUI difftool: \
`$ git pr show -t 32308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32308.diff">https://git.openjdk.org/jdk/pull/32308.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32308#issuecomment-5259484037)
</details>
