### PR TITLE
8390102: RISC-V: Support AOT Code Cache

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -36,6 +36,7 @@
 #include "ci/ciInlineKlass.hpp"
 #include "ci/ciInstance.hpp"
 #include "ci/ciObjArrayKlass.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "nativeInst_riscv.hpp"
@@ -43,6 +44,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "runtime/threadIdentifier.hpp"
 #include "utilities/powerOfTwo.hpp"
 #include "vmreg_riscv.inline.hpp"
 
@@ -441,6 +443,19 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 
     case T_LONG:
       assert(patch_code == lir_patch_none, "no patching handled here");
+#if INCLUDE_CDS
+      if (AOTCodeCache::is_on_for_dump()) {
+        address b = c->as_pointer();
+        if (b == (address)ThreadIdentifier::unsafe_offset()) {
+          __ la(dest->as_register_lo(), ExternalAddress(b));
+          break;
+        }
+        if (AOTRuntimeConstants::contains(b)) {
+          __ load_aotrc_address(dest->as_register_lo(), b);
+          break;
+        }
+      }
+#endif
       __ mv(dest->as_register_lo(), (intptr_t)c->as_jlong());
       break;
 

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
@@ -69,7 +69,7 @@ private:
     _call_stub_size = 11 * MacroAssembler::instruction_size +
                       1 * MacroAssembler::instruction_size + wordSize,
     // See emit_exception_handler for detail
-    _exception_handler_size = DEBUG_ONLY(256) NOT_DEBUG(32), // or smaller
+    _exception_handler_size = DEBUG_ONLY(1*K) NOT_DEBUG(175), // or smaller
     // See emit_deopt_handler for detail
     // far_call (2) + j (1)
     _deopt_handler_size = 1 * MacroAssembler::instruction_size +

--- a/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/g1/g1BarrierSetAssembler_riscv.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "asm/macroAssembler.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "gc/g1/g1BarrierSet.hpp"
 #include "gc/g1/g1BarrierSetAssembler.hpp"
 #include "gc/g1/g1BarrierSetRuntime.hpp"
@@ -250,9 +251,22 @@ static void generate_post_barrier(MacroAssembler* masm,
   assert(thread == xthread, "must be");
   assert_different_registers(store_addr, new_val, thread, tmp1, tmp2, noreg);
   // Does store cross heap regions?
-  __ xorr(tmp1, store_addr, new_val);                    // tmp1 := store address ^ new value
-  __ srli(tmp1, tmp1, G1HeapRegion::LogOfHRGrainBytes);  // tmp1 := ((store address ^ new value) >> LogOfHRGrainBytes)
-  __ beqz(tmp1, done);
+#if INCLUDE_CDS
+  // AOT code needs to load the barrier grain shift from the aot
+  // runtime constants area in the code cache otherwise we can compile
+  // it as an immediate operand
+  if (AOTCodeCache::is_on_for_dump()) {
+    __ xorr(tmp1, store_addr, new_val);
+    __ lwu(tmp2, ExternalAddress(AOTRuntimeConstants::grain_shift_address()));
+    __ srl(tmp1, tmp1, tmp2);
+    __ beqz(tmp1, done);
+  } else
+#endif
+  {
+    __ xorr(tmp1, store_addr, new_val);                    // tmp1 := store address ^ new value
+    __ srli(tmp1, tmp1, G1HeapRegion::LogOfHRGrainBytes);  // tmp1 := ((store address ^ new value) >> LogOfHRGrainBytes)
+    __ beqz(tmp1, done);
+  }
 
   // Crosses regions, storing null?
   if (new_val_may_be_null) {

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -219,8 +219,14 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
 
   // Test for in-cset
   if (is_strong) {
-    __ mv(t1, ShenandoahHeap::in_cset_fast_test_addr());
-    __ srli(t0, x10, ShenandoahHeapRegion::region_size_bytes_shift_jint());
+    if (AOTCodeCache::is_on_for_dump()) {
+      __ ld(t1, ExternalAddress(AOTRuntimeConstants::cset_base_address()));
+      __ lwu(t0, ExternalAddress(AOTRuntimeConstants::grain_shift_address()));
+      __ srl(t0, x10, t0);
+    } else {
+      __ mv(t1, ShenandoahHeap::in_cset_fast_test_addr());
+      __ srli(t0, x10, ShenandoahHeapRegion::region_size_bytes_shift_jint());
+    }
     __ add(t1, t1, t0);
     __ lbu(t1, Address(t1));
     __ test_bit(t0, t1, 0);
@@ -815,8 +821,14 @@ void ShenandoahBarrierStubC2::lrb(MacroAssembler& masm) {
     __ mv(_tmp2, _obj);
   }
 
-  __ mv(_tmp1, ShenandoahHeap::in_cset_fast_test_addr());
-  __ srli(_tmp2, _tmp2, ShenandoahHeapRegion::region_size_bytes_shift_jint());
+  if (AOTCodeCache::is_on_for_dump()) {
+    __ lwu(_tmp1, ExternalAddress(AOTRuntimeConstants::grain_shift_address()));
+    __ srl(_tmp2, _tmp2, _tmp1);
+    __ ld(_tmp1, ExternalAddress(AOTRuntimeConstants::cset_base_address()));
+  } else {
+    __ mv(_tmp1, ShenandoahHeap::in_cset_fast_test_addr());
+    __ srli(_tmp2, _tmp2, ShenandoahHeapRegion::region_size_bytes_shift_jint());
+  }
   __ add(_tmp1, _tmp1, _tmp2);
   __ lbu(_tmp1, Address(_tmp1, 0));
   maybe_far_jump_if_zero(masm, _tmp1);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -917,14 +917,7 @@ void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        int number_of_arguments,
                                        Label *retaddr) {
   push_reg(RegSet::of(t1, xmethod), sp);   // push << t1 & xmethod >> to sp
-  // Use a relocation so that the target address can be fixed up when
-  // this code is loaded from the AOT code cache in a new JVM instance.
-  RuntimeAddress target(entry_point);
-  relocate(target.rspec(), [&] {
-    int32_t offset;
-    movptr(t1, target.target(), offset, t0);
-    jalr(t1, offset);
-  });
+  rt_call(entry_point, t1, t0);
   if (retaddr != nullptr) {
     bind(*retaddr);
   }
@@ -1174,16 +1167,16 @@ void MacroAssembler::jalr(Register Rs, int32_t offset) {
   Assembler::jalr(x1, Rs, offset);
 }
 
-void MacroAssembler::rt_call(address dest, Register tmp) {
-  assert(tmp != x5, "tmp register must not be x5.");
+void MacroAssembler::rt_call(address dest, Register tmp1, Register tmp2) {
+  assert(tmp1 != x5, "tmp register must not be x5.");
   RuntimeAddress target(dest);
   if (CodeCache::contains(dest)) {
-    far_call(target, tmp);
+    far_call(target, tmp1);
   } else {
     relocate(target.rspec(), [&] {
       int32_t offset;
-      movptr(tmp, target.target(), offset);
-      jalr(tmp, offset);
+      movptr(tmp1, target.target(), offset, tmp2);
+      jalr(tmp1, offset);
     });
   }
 }
@@ -5399,14 +5392,7 @@ void MacroAssembler::get_thread(Register thread) {
                       RegSet::range(x28, x31) + ra - thread;
   push_reg(saved_regs, sp);
 
-  // Use a relocation so that the target address can be fixed up when
-  // this code is loaded from the AOT code cache in a new JVM instance.
-  RuntimeAddress target(CAST_FROM_FN_PTR(address, Thread::current));
-  relocate(target.rspec(), [&] {
-    int32_t offset;
-    movptr(t1, target.target(), offset, t0);
-    jalr(t1, offset);
-  });
+  rt_call(CAST_FROM_FN_PTR(address, Thread::current), t1, t0);
   if (thread != c_rarg0) {
     mv(thread, c_rarg0);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -26,6 +26,7 @@
 
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
+#include "cds/archiveBuilder.hpp"
 #include "ci/ciInlineKlass.hpp"
 #include "code/compiledIC.hpp"
 #include "compiler/disassembler.hpp"
@@ -879,9 +880,13 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
 }
 
 void MacroAssembler::stop(const char* msg) {
-  BLOCK_COMMENT(msg);
+  // Skip AOT caching C strings in scratch buffer.
+  const char* str = (code_section()->scratch_emit()) ? msg : AOTCodeCache::add_C_string(msg);
+  BLOCK_COMMENT(str);
+  // load msg into a0 so we can access it from the signal handler
+  // ExternalAddress enables saving and restoring via the code cache
+  la(c_rarg0, ExternalAddress((address) str));
   illegal_instruction(Assembler::csr::time);
-  emit_int64((uintptr_t)msg);
 }
 
 void MacroAssembler::unimplemented(const char* what) {
@@ -911,10 +916,15 @@ void MacroAssembler::emit_static_call_stub() {
 void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        int number_of_arguments,
                                        Label *retaddr) {
-  int32_t offset = 0;
   push_reg(RegSet::of(t1, xmethod), sp);   // push << t1 & xmethod >> to sp
-  movptr(t1, entry_point, offset, t0);
-  jalr(t1, offset);
+  // Use a relocation so that the target address can be fixed up when
+  // this code is loaded from the AOT code cache in a new JVM instance.
+  RuntimeAddress target(entry_point);
+  relocate(target.rspec(), [&] {
+    int32_t offset;
+    movptr(t1, target.target(), offset, t0);
+    jalr(t1, offset);
+  });
   if (retaddr != nullptr) {
     bind(*retaddr);
   }
@@ -3054,7 +3064,7 @@ int MacroAssembler::patch_oop(address insn_addr, address o) {
 
 void MacroAssembler::reinit_heapbase() {
   if (UseCompressedOops) {
-    if (Universe::is_fully_initialized()) {
+    if (Universe::is_fully_initialized() && !AOTCodeCache::is_on_for_dump()) {
       mv(xheapbase, CompressedOops::base());
     } else {
       ld(xheapbase, ExternalAddress(CompressedOops::base_addr()));
@@ -3935,18 +3945,27 @@ void MacroAssembler::decode_klass_not_null(Register dst, Register src, Register 
   assert_different_registers(dst, tmp);
   assert_different_registers(src, tmp);
 
-  if (CompressedKlassPointers::base() == nullptr) {
+  Register xbase = tmp;
+
+  if (AOTCodeCache::is_on_for_dump()) {
+    // We are generating code during AOT buildup that will run in *future* processes
+    // with likely different encoding settings. Therefore, we have to load the
+    // encoding base dynamically, we cannot just bake it in as immediate.
+    // Note that we only need to do this for base. The encoding shift would be the
+    // same between build time and runtime: the standard precomputed shift.
+    assert(CompressedKlassPointers::shift() == ArchiveBuilder::precomputed_narrow_klass_shift(),
+           "unexpected compressed klass shift!");
+    ld(xbase, ExternalAddress(CompressedKlassPointers::base_addr()));
+  } else if (CompressedKlassPointers::base() == nullptr) {
     if (CompressedKlassPointers::shift() != 0) {
       slli(dst, src, CompressedKlassPointers::shift());
     } else {
       mv(dst, src);
     }
     return;
+  } else {
+    mv(xbase, (uintptr_t)CompressedKlassPointers::base());
   }
-
-  Register xbase = tmp;
-
-  mv(xbase, (uintptr_t)CompressedKlassPointers::base());
 
   if (CompressedKlassPointers::shift() != 0) {
     // dst = (src << shift) + xbase
@@ -3962,6 +3981,28 @@ void MacroAssembler::encode_klass_not_null(Register r, Register tmp) {
 }
 
 void MacroAssembler::encode_klass_not_null(Register dst, Register src, Register tmp) {
+  Register xbase = dst;
+  if (dst == src) {
+    xbase = tmp;
+  }
+
+  if (AOTCodeCache::is_on_for_dump()) {
+    // We are generating code during AOT buildup that will run in *future* processes
+    // with likely different encoding settings. Therefore, we have to load the
+    // encoding base dynamically and must not take the base-value dependent zext
+    // short cut below. Note that we only need to do this for base; the encoding
+    // shift is the same at build and run time: the standard precomputed shift.
+    assert(CompressedKlassPointers::shift() == ArchiveBuilder::precomputed_narrow_klass_shift(),
+           "unexpected compressed klass shift!");
+    assert_different_registers(src, xbase);
+    ld(xbase, ExternalAddress(CompressedKlassPointers::base_addr()));
+    sub(dst, src, xbase);
+    if (CompressedKlassPointers::shift() != 0) {
+      srli(dst, dst, CompressedKlassPointers::shift());
+    }
+    return;
+  }
+
   if (CompressedKlassPointers::base() == nullptr) {
     if (CompressedKlassPointers::shift() != 0) {
       srli(dst, src, CompressedKlassPointers::shift());
@@ -3975,11 +4016,6 @@ void MacroAssembler::encode_klass_not_null(Register dst, Register src, Register 
       CompressedKlassPointers::shift() == 0) {
     zext(dst, src, 32);
     return;
-  }
-
-  Register xbase = dst;
-  if (dst == src) {
-    xbase = tmp;
   }
 
   assert_different_registers(src, xbase);
@@ -5363,8 +5399,14 @@ void MacroAssembler::get_thread(Register thread) {
                       RegSet::range(x28, x31) + ra - thread;
   push_reg(saved_regs, sp);
 
-  mv(t1, CAST_FROM_FN_PTR(address, Thread::current));
-  jalr(t1);
+  // Use a relocation so that the target address can be fixed up when
+  // this code is loaded from the AOT code cache in a new JVM instance.
+  RuntimeAddress target(CAST_FROM_FN_PTR(address, Thread::current));
+  relocate(target.rspec(), [&] {
+    int32_t offset;
+    movptr(t1, target.target(), offset, t0);
+    jalr(t1, offset);
+  });
   if (thread != c_rarg0) {
     mv(thread, c_rarg0);
   }
@@ -5374,10 +5416,31 @@ void MacroAssembler::get_thread(Register thread) {
 }
 
 void MacroAssembler::load_byte_map_base(Register reg) {
+#if INCLUDE_CDS
+  if (AOTCodeCache::is_on_for_dump()) {
+    address byte_map_base_adr = AOTRuntimeConstants::card_table_base_address();
+    ld(reg, ExternalAddress(byte_map_base_adr));
+    return;
+  }
+#endif
   CardTableBarrierSet* ctbs = CardTableBarrierSet::barrier_set();
   // Strictly speaking the card table base isn't an address at all, and it might
   // even be negative. It is thus materialised as a constant.
   mv(reg, (uint64_t)ctbs->card_table_base_const());
+}
+
+void MacroAssembler::load_aotrc_address(Register reg, address a) {
+#if INCLUDE_CDS
+  assert(AOTRuntimeConstants::contains(a), "address out of range for data area");
+  if (AOTCodeCache::is_on_for_dump()) {
+    // all aotrc field addresses should be registered in the AOTCodeCache address table
+    la(reg, ExternalAddress(a));
+  } else {
+    mv(reg, (intptr_t)a);
+  }
+#else
+  ShouldNotReachHere();
+#endif
 }
 
 void MacroAssembler::build_frame(int framesize) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1168,7 +1168,8 @@ void MacroAssembler::jalr(Register Rs, int32_t offset) {
 }
 
 void MacroAssembler::rt_call(address dest, Register tmp1, Register tmp2) {
-  assert(tmp1 != x5, "tmp register must not be x5.");
+  assert_different_registers(tmp1, x5);
+  assert_different_registers(tmp1, tmp2);
   RuntimeAddress target(dest);
   if (CodeCache::contains(dest)) {
     far_call(target, tmp1);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -28,6 +28,7 @@
 #define CPU_RISCV_MACROASSEMBLER_RISCV_HPP
 
 #include "asm/assembler.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/vmreg.hpp"
 #include "metaprogramming/enableIf.hpp"
 #include "oops/compressedOops.hpp"
@@ -1290,6 +1291,9 @@ public:
   }
 
   void load_byte_map_base(Register reg);
+
+  // Load a constant address in the AOT Runtime Constants area
+  void load_aotrc_address(Register reg, address a);
 
   void bang_stack_with_offset(int offset) {
     // stack grows down, caller passes positive offset

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -771,7 +771,7 @@ class MacroAssembler: public Assembler {
   // is used to keep the entry address for jalr/movptr.
   // Uses call() for intra code cache, else movptr + jalr.
   // Clobebrs t1
-  void rt_call(address dest, Register tmp = t1);
+  void rt_call(address dest, Register tmp1 = t1, Register tmp2 = noreg);
 
   // ret: jalr x0, 0(x1)
   inline void ret() {

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2400,14 +2400,7 @@ encode %{
       // Make the anchor frame walkable
       __ la(t0, retaddr);
       __ sd(t0, Address(xthread, JavaThread::last_Java_pc_offset()));
-      // Use a relocation so that the target address can be fixed up when
-      // this code is loaded from the AOT code cache in a new JVM instance.
-      RuntimeAddress target(entry);
-      __ relocate(target.rspec(), [&] {
-        int32_t offset = 0;
-        __ movptr(t1, target.target(), offset, t0); // lui + lui + slli + add
-        __ jalr(t1, offset);
-      });
+      __ rt_call(entry, t1, t0);
       __ bind(retaddr);
       __ post_call_nop();
     }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2400,10 +2400,14 @@ encode %{
       // Make the anchor frame walkable
       __ la(t0, retaddr);
       __ sd(t0, Address(xthread, JavaThread::last_Java_pc_offset()));
-      int32_t offset = 0;
-      // No relocation needed
-      __ movptr(t1, entry, offset, t0); // lui + lui + slli + add
-      __ jalr(t1, offset);
+      // Use a relocation so that the target address can be fixed up when
+      // this code is loaded from the AOT code cache in a new JVM instance.
+      RuntimeAddress target(entry);
+      __ relocate(target.rspec(), [&] {
+        int32_t offset = 0;
+        __ movptr(t1, target.target(), offset, t0); // lui + lui + slli + add
+        __ jalr(t1, offset);
+      });
       __ bind(retaddr);
       __ post_call_nop();
     }
@@ -2793,6 +2797,18 @@ operand immP0()
 operand immP_1()
 %{
   predicate(n->get_ptr() == 1);
+  match(ConP);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+// AOT Runtime Constants Address
+operand immAOTRuntimeConstantsAddress()
+%{
+  // Check if the address is in the range of AOT Runtime Constants
+  predicate(AOTRuntimeConstants::contains((address)(n->get_ptr())));
   match(ConP);
 
   op_cost(0);
@@ -4757,6 +4773,20 @@ instruct loadConP1(iRegPNoSp dst, immP_1 con)
   format %{ "mv  $dst, $con\t# load ptr constant one, #@loadConP1" %}
 
   ins_encode(riscv_enc_mov_p1(dst));
+
+  ins_pipe(ialu_imm);
+%}
+
+instruct loadAOTRCAddress(iRegPNoSp dst, immAOTRuntimeConstantsAddress con)
+%{
+  match(Set dst con);
+
+  ins_cost(ALU_COST);
+  format %{ "la  $dst, $con\t# aotrc, #@loadAOTRCAddress" %}
+
+  ins_encode %{
+    __ load_aotrc_address($dst$$Register, (address)$con$$constant);
+  %}
 
   ins_pipe(ialu_imm);
 %}

--- a/src/hotspot/cpu/riscv/runtime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/runtime_riscv.cpp
@@ -26,6 +26,7 @@
 #ifdef COMPILER2
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/vmreg.hpp"
 #include "interpreter/interpreter.hpp"
 #include "opto/runtime.hpp"
@@ -58,10 +59,15 @@ public:
 
 //------------------------------generate_uncommon_trap_blob--------------------
 UncommonTrapBlob* OptoRuntime::generate_uncommon_trap_blob() {
+  const char* name = OptoRuntime::stub_name(StubId::c2_uncommon_trap_id);
+  CodeBlob* blob = AOTCodeCache::load_code_blob(AOTCodeEntry::C2Blob, BlobId::c2_uncommon_trap_id);
+  if (blob != nullptr) {
+    return blob->as_uncommon_trap_blob();
+  }
+
   // Allocate space for the code
   ResourceMark rm;
   // Setup code generation tools
-  const char* name = OptoRuntime::stub_name(StubId::c2_uncommon_trap_id);
   CodeBuffer buffer(name, 2048, 1024);
   if (buffer.blob() == nullptr) {
     return nullptr;
@@ -243,8 +249,10 @@ UncommonTrapBlob* OptoRuntime::generate_uncommon_trap_blob() {
   // Make sure all code is generated
   masm->flush();
 
-  return UncommonTrapBlob::create(&buffer, oop_maps,
-                                                  SimpleRuntimeFrame::framesize >> 1);
+  UncommonTrapBlob* ut_blob = UncommonTrapBlob::create(&buffer, oop_maps,
+                                                       SimpleRuntimeFrame::framesize >> 1);
+  AOTCodeCache::store_code_blob(*ut_blob, AOTCodeEntry::C2Blob, BlobId::c2_uncommon_trap_id);
+  return ut_blob;
 }
 
 //------------------------------generate_exception_blob---------------------------
@@ -278,10 +286,15 @@ ExceptionBlob* OptoRuntime::generate_exception_blob() {
 
   assert(SimpleRuntimeFrame::framesize % 4 == 0, "sp not 16-byte aligned");
 
+  const char* name = OptoRuntime::stub_name(StubId::c2_exception_id);
+  CodeBlob* blob = AOTCodeCache::load_code_blob(AOTCodeEntry::C2Blob, BlobId::c2_exception_id);
+  if (blob != nullptr) {
+    return blob->as_exception_blob();
+  }
+
   // Allocate space for the code
   ResourceMark rm;
   // Setup code generation tools
-  const char* name = OptoRuntime::stub_name(StubId::c2_exception_id);
   CodeBuffer buffer(name, 2048, 1024);
   if (buffer.blob() == nullptr) {
     return nullptr;
@@ -380,6 +393,8 @@ ExceptionBlob* OptoRuntime::generate_exception_blob() {
   masm->flush();
 
   // Set exception blob
-  return ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
+  ExceptionBlob* ex_blob = ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
+  AOTCodeCache::store_code_blob(*ex_blob, AOTCodeEntry::C2Blob, BlobId::c2_exception_id);
+  return ex_blob;
 }
 #endif // COMPILER2

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -27,6 +27,7 @@
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
 #include "classfile/symbolTable.hpp"
+#include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "code/debugInfoRec.hpp"
 #include "code/vtableStubs.hpp"
@@ -2123,6 +2124,12 @@ void SharedRuntime::generate_deopt_blob() {
   // Setup code generation tools
   int pad = 0;
   const char* name = SharedRuntime::stub_name(StubId::shared_deopt_id);
+  CodeBlob* blob = AOTCodeCache::load_code_blob(AOTCodeEntry::SharedBlob, BlobId::shared_deopt_id);
+  if (blob != nullptr) {
+    _deopt_blob = blob->as_deoptimization_blob();
+    return;
+  }
+
   CodeBuffer buffer(name, 2048 + pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words = -1;
@@ -2427,6 +2434,8 @@ void SharedRuntime::generate_deopt_blob() {
   _deopt_blob = DeoptimizationBlob::create(&buffer, oop_maps, 0, exception_offset, reexecute_offset, frame_size_in_words);
   assert(_deopt_blob != nullptr, "create deoptimization blob fail!");
   _deopt_blob->set_unpack_with_exception_in_tls_offset(exception_in_tls_offset);
+
+  AOTCodeCache::store_code_blob(*_deopt_blob, AOTCodeEntry::SharedBlob, BlobId::shared_deopt_id);
 }
 
 // Number of stack slots between incoming argument block and the start of
@@ -2453,13 +2462,18 @@ VMReg SharedRuntime::thread_register() {
 SafepointBlob* SharedRuntime::generate_handler_blob(StubId id, address call_ptr) {
   assert(is_polling_page_id(id), "expected a polling page stub id");
 
+  const char* name = SharedRuntime::stub_name(id);
+  CodeBlob* blob = AOTCodeCache::load_code_blob(AOTCodeEntry::SharedBlob, StubInfo::blob(id));
+  if (blob != nullptr) {
+    return blob->as_safepoint_blob();
+  }
+
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
   assert_cond(oop_maps != nullptr);
   OopMap* map = nullptr;
 
   // Allocate space for the code.  Setup code generation tools.
-  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   assert_cond(masm != nullptr);
@@ -2564,7 +2578,10 @@ SafepointBlob* SharedRuntime::generate_handler_blob(StubId id, address call_ptr)
   masm->flush();
 
   // Fill-out other meta info
-  return SafepointBlob::create(&buffer, oop_maps, frame_size_in_words);
+  SafepointBlob* sp_blob = SafepointBlob::create(&buffer, oop_maps, frame_size_in_words);
+
+  AOTCodeCache::store_code_blob(*sp_blob, AOTCodeEntry::SharedBlob, StubInfo::blob(id));
+  return sp_blob;
 }
 
 //
@@ -2579,10 +2596,15 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(StubId id, address destination
   assert(StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
   assert(is_resolve_id(id), "expected a resolve stub id");
 
+  const char* name = SharedRuntime::stub_name(id);
+  CodeBlob* blob = AOTCodeCache::load_code_blob(AOTCodeEntry::SharedBlob, StubInfo::blob(id));
+  if (blob != nullptr) {
+    return blob->as_runtime_stub();
+  }
+
   // allocate space for the code
   ResourceMark rm;
 
-  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   assert_cond(masm != nullptr);
@@ -2653,7 +2675,10 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(StubId id, address destination
   masm->flush();
 
   // return the  blob
-  return RuntimeStub::new_runtime_stub(name, &buffer, frame_complete, frame_size_in_words, oop_maps, true);
+  RuntimeStub* rs_blob = RuntimeStub::new_runtime_stub(name, &buffer, frame_complete, frame_size_in_words, oop_maps, true);
+
+  AOTCodeCache::store_code_blob(*rs_blob, AOTCodeEntry::SharedBlob, StubInfo::blob(id));
+  return rs_blob;
 }
 
 // Continuation point for throwing of implicit exceptions that are
@@ -2697,6 +2722,11 @@ RuntimeStub* SharedRuntime::generate_throw_exception(StubId id, address runtime_
   ResourceMark rm;
   const char* timer_msg = "SharedRuntime generate_throw_exception";
   TraceTime timer(timer_msg, TRACETIME_LOG(Info, startuptime));
+
+  CodeBlob* blob = AOTCodeCache::load_code_blob(AOTCodeEntry::SharedBlob, StubInfo::blob(id));
+  if (blob != nullptr) {
+    return blob->as_runtime_stub();
+  }
 
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps  = new OopMapSet();
@@ -2756,6 +2786,8 @@ RuntimeStub* SharedRuntime::generate_throw_exception(StubId id, address runtime_
                                   (framesize >> (LogBytesPerWord - LogBytesPerInt)),
                                   oop_maps, false);
   assert(stub != nullptr, "create runtime stub fail!");
+
+  AOTCodeCache::store_code_blob(*stub, AOTCodeEntry::SharedBlob, StubInfo::blob(id));
   return stub;
 }
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -67,6 +67,109 @@
 
 #define BIND(label) bind(label); BLOCK_COMMENT(#label ":")
 
+alignas(64) static const char _encodeBlock_toBase64[64] = {
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+  'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+  'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+};
+
+alignas(64) static const char _encodeBlock_toBase64URL[64] = {
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+  'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+  'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
+};
+
+static const uint8_t _decodeBlock_fromBase64[256] = {
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,  62u, 255u, 255u, 255u,  63u,
+    52u,  53u,  54u,  55u,  56u,  57u,  58u,  59u,  60u,  61u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u,   0u,   1u,   2u,   3u,   4u,   5u,   6u,   7u,   8u,   9u,  10u,  11u,  12u,  13u,  14u,
+    15u,  16u,  17u,  18u,  19u,  20u,  21u,  22u,  23u,  24u,  25u, 255u, 255u, 255u, 255u, 255u,
+    255u,  26u,  27u,  28u,  29u,  30u,  31u,  32u,  33u,  34u,  35u,  36u,  37u,  38u,  39u,  40u,
+    41u,  42u,  43u,  44u,  45u,  46u,  47u,  48u,  49u,  50u,  51u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+};
+
+static const uint8_t _decodeBlock_fromBase64URL[256] = {
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,  62u, 255u, 255u,
+    52u,  53u,  54u,  55u,  56u,  57u,  58u,  59u,  60u,  61u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u,   0u,   1u,   2u,   3u,   4u,   5u,   6u,   7u,   8u,   9u,  10u,  11u,  12u,  13u,  14u,
+    15u,  16u,  17u,  18u,  19u,  20u,  21u,  22u,  23u,  24u,  25u, 255u, 255u, 255u, 255u,  63u,
+    255u,  26u,  27u,  28u,  29u,  30u,  31u,  32u,  33u,  34u,  35u,  36u,  37u,  38u,  39u,  40u,
+    41u,  42u,  43u,  44u,  45u,  46u,  47u,  48u,  49u,  50u,  51u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+    255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
+};
+
+alignas(64) static const uint32_t _sha256_round_consts[64] = {
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+  0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+  0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+  0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+  0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+  0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+alignas(64) static const uint64_t _sha512_round_consts[80] = {
+  0x428a2f98d728ae22l, 0x7137449123ef65cdl, 0xb5c0fbcfec4d3b2fl,
+  0xe9b5dba58189dbbcl, 0x3956c25bf348b538l, 0x59f111f1b605d019l,
+  0x923f82a4af194f9bl, 0xab1c5ed5da6d8118l, 0xd807aa98a3030242l,
+  0x12835b0145706fbel, 0x243185be4ee4b28cl, 0x550c7dc3d5ffb4e2l,
+  0x72be5d74f27b896fl, 0x80deb1fe3b1696b1l, 0x9bdc06a725c71235l,
+  0xc19bf174cf692694l, 0xe49b69c19ef14ad2l, 0xefbe4786384f25e3l,
+  0x0fc19dc68b8cd5b5l, 0x240ca1cc77ac9c65l, 0x2de92c6f592b0275l,
+  0x4a7484aa6ea6e483l, 0x5cb0a9dcbd41fbd4l, 0x76f988da831153b5l,
+  0x983e5152ee66dfabl, 0xa831c66d2db43210l, 0xb00327c898fb213fl,
+  0xbf597fc7beef0ee4l, 0xc6e00bf33da88fc2l, 0xd5a79147930aa725l,
+  0x06ca6351e003826fl, 0x142929670a0e6e70l, 0x27b70a8546d22ffcl,
+  0x2e1b21385c26c926l, 0x4d2c6dfc5ac42aedl, 0x53380d139d95b3dfl,
+  0x650a73548baf63del, 0x766a0abb3c77b2a8l, 0x81c2c92e47edaee6l,
+  0x92722c851482353bl, 0xa2bfe8a14cf10364l, 0xa81a664bbc423001l,
+  0xc24b8b70d0f89791l, 0xc76c51a30654be30l, 0xd192e819d6ef5218l,
+  0xd69906245565a910l, 0xf40e35855771202al, 0x106aa07032bbd1b8l,
+  0x19a4c116b8d2d0c8l, 0x1e376c085141ab53l, 0x2748774cdf8eeb99l,
+  0x34b0bcb5e19b48a8l, 0x391c0cb3c5c95a63l, 0x4ed8aa4ae3418acbl,
+  0x5b9cca4f7763e373l, 0x682e6ff3d6b2b8a3l, 0x748f82ee5defb2fcl,
+  0x78a5636f43172f60l, 0x84c87814a1f0ab72l, 0x8cc702081a6439ecl,
+  0x90befffa23631e28l, 0xa4506cebde82bde9l, 0xbef9a3f7b2c67915l,
+  0xc67178f2e372532bl, 0xca273eceea26619cl, 0xd186b8c721c0c207l,
+  0xeada7dd6cde0eb1el, 0xf57d4f7fee6ed178l, 0x06f067aa72176fbal,
+  0x0a637dc5a2c898a6l, 0x113f9804bef90dael, 0x1b710b35131c471bl,
+  0x28db77f523047d84l, 0x32caab7b40c72493l, 0x3c9ebe0a15c9bebcl,
+  0x431d67c49c100d4cl, 0x4cc5d4becb3e42b6l, 0x597f299cfc657e2al,
+  0x5fcb6fab3ad6faecl, 0x6c44198c4a475817l
+};
+
 // Stub Code definitions
 
 class StubGenerator: public StubCodeGenerator {
@@ -208,8 +311,17 @@ class StubGenerator: public StubCodeGenerator {
            "adjust this code");
 
     StubId stub_id = StubId::stubgen_call_stub_id;
+    GrowableArray<address> entries;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 2, "sanity check");
+    address start = load_archive_data(stub_id, &entries);
+    if (start != nullptr) {
+      assert(entries.length() == 1, "expected 1 extra entry");
+      return_address = entries.at(0);
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     const Address sp_after_call (fp, sp_after_call_off  * wordSize);
 
@@ -357,6 +469,7 @@ class StubGenerator: public StubCodeGenerator {
     // save current address for use by exception handling code
 
     return_address = __ pc();
+    entries.append(return_address);
 
     // store result depending on type (everything that is not
     // T_OBJECT, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
@@ -460,6 +573,9 @@ class StubGenerator: public StubCodeGenerator {
     __ fsd(j_farg0, Address(j_rarg2, 0), t0);
     __ j(exit);
 
+    // record the stub entry and end plus the auxiliary entry
+    store_archive_data(stub_id, start, __ pc(), &entries);
+
     return start;
   }
 
@@ -477,8 +593,14 @@ class StubGenerator: public StubCodeGenerator {
 
   address generate_catch_exception() {
     StubId stub_id = StubId::stubgen_catch_exception_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     // same as in generate_call_stub():
     const Address thread(fp, thread_off * wordSize);
@@ -501,7 +623,9 @@ class StubGenerator: public StubCodeGenerator {
     __ verify_oop(x10);
 
     __ sd(x10, Address(xthread, Thread::pending_exception_offset()));
-    __ mv(t0, (address)__FILE__);
+    // special case -- add file name string to AOT address table
+    address file = (address)AOTCodeCache::add_C_string(__FILE__);
+    __ la(t0, ExternalAddress(file));
     __ sd(t0, Address(xthread, Thread::exception_file_offset()));
     __ mv(t0, (int)__LINE__);
     __ sw(t0, Address(xthread, Thread::exception_line_offset()));
@@ -510,6 +634,9 @@ class StubGenerator: public StubCodeGenerator {
     assert(StubRoutines::_call_stub_return_address != nullptr,
            "_call_stub_return_address must have been generated before");
     __ j(RuntimeAddress(StubRoutines::_call_stub_return_address));
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -530,8 +657,14 @@ class StubGenerator: public StubCodeGenerator {
 
   address generate_forward_exception() {
     StubId stub_id = StubId::stubgen_forward_exception_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     // Upon entry, RA points to the return address returning into
     // Java (interpreted or compiled) code; i.e., the return address
@@ -598,6 +731,9 @@ class StubGenerator: public StubCodeGenerator {
     __ verify_oop(x10);
     __ jr(x9);
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -617,8 +753,14 @@ class StubGenerator: public StubCodeGenerator {
   address generate_verify_oop() {
 
     StubId stub_id = StubId::stubgen_verify_oop_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     Label exit, error;
 
@@ -658,6 +800,9 @@ class StubGenerator: public StubCodeGenerator {
     __ rt_call(CAST_FROM_FN_PTR(address, MacroAssembler::debug64));
     __ ebreak();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -673,14 +818,20 @@ class StubGenerator: public StubCodeGenerator {
   //      x29 < MacroAssembler::zero_words_block_size.
 
   address generate_zero_blocks() {
+    StubId stub_id = StubId::stubgen_zero_blocks_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, stub_id);
     Label done;
 
     const Register base = x28, cnt = x29, tmp1 = x30, tmp2 = x31;
 
-    __ align(CodeEntryAlignment);
-    StubId stub_id = StubId::stubgen_zero_blocks_id;
-    StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     if (UseBlockZeroing) {
       int zicboz_block_size = VM_Version::zicboz_block_size.value();
@@ -711,6 +862,9 @@ class StubGenerator: public StubCodeGenerator {
 
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -733,6 +887,12 @@ class StubGenerator: public StubCodeGenerator {
   // s and d are adjusted to point to the remaining words to copy
   //
   address generate_copy_longs(StubId stub_id, Register s, Register d, Register count) {
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     BasicType type;
     copy_direction direction;
     switch (stub_id) {
@@ -762,7 +922,7 @@ class StubGenerator: public StubCodeGenerator {
     Label again, drain;
     StubCodeMark mark(this, stub_id);
     __ align(CodeEntryAlignment);
-    address start = __ pc();
+    start = __ pc();
 
     if (direction == copy_forwards) {
       __ sub(s, s, bias);
@@ -878,6 +1038,9 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -1196,18 +1359,43 @@ class StubGenerator: public StubCodeGenerator {
       break;
     }
 
+    // all stubs provide a 2nd entry which omits the frame push for
+    // use when bailing out from a conjoint copy. However we may also
+    // need some extra addressses for memory access protection.
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 2, "sanity check");
+    assert(nopush_entry != nullptr, "all disjoint copy stubs export a nopush entry");
+
+    bool add_extras = !is_oop && (!aligned || sizeof(jlong) == size);
+    int extra_count = ((add_extras ? 1 : 0) * UnsafeMemoryAccess::COLUMN_COUNT);
+    GrowableArray<address> entries;
+    GrowableArray<address> extras;
+    GrowableArray<address> *extras_ptr = (extra_count > 0 ? &extras : nullptr);
+    address start = load_archive_data(stub_id, &entries, extras_ptr);
+    if (start != nullptr) {
+      assert(entries.length() == entry_count - 1,
+             "unexpected entries count %d", entries.length());
+      *nopush_entry = entries.at(0);
+      assert(extras.length() == extra_count,
+             "unexpected extra count %d", extras.length());
+      if (add_extras) {
+        // register one handler at offset 0
+        register_unsafe_access_handlers(extras, 0, 1);
+      }
+      return start;
+    }
+
     const Register s = c_rarg0, d = c_rarg1, count = c_rarg2;
     RegSet saved_reg = RegSet::of(s, d, count);
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
-    if (nopush_entry != nullptr) {
-     *nopush_entry = __ pc();
-      // caller can pass a 64-bit byte count here (from Unsafe.copyMemory)
-      BLOCK_COMMENT("Entry:");
-    }
+    *nopush_entry = __ pc();
+    entries.append(*nopush_entry);
+    // caller can pass a 64-bit byte count here (from Unsafe.copyMemory)
+    BLOCK_COMMENT("Entry:");
 
     DecoratorSet decorators = IN_HEAP | IS_ARRAY | ARRAYCOPY_DISJOINT;
     if (dest_uninitialized) {
@@ -1227,8 +1415,7 @@ class StubGenerator: public StubCodeGenerator {
 
     {
       // UnsafeMemoryAccess page error: continue after unsafe access
-      bool add_entry = !is_oop && (!aligned || sizeof(jlong) == size);
-      UnsafeMemoryAccessMark umam(this, add_entry, true);
+      UnsafeMemoryAccessMark umam(this, add_extras, true);
       copy_memory(decorators, is_oop ? T_OBJECT : T_BYTE, aligned, s, d, count, size);
     }
 
@@ -1244,6 +1431,20 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ mv(x10, zr); // return 0
     __ ret();
+
+    address end = __ pc();
+
+    if (add_extras) {
+      // retrieve the registered handler addresses
+      retrieve_unsafe_access_handlers(start, end, extras);
+      assert(extras.length() == extra_count,
+             "incorrect handlers count %d", extras.length());
+    }
+
+    // record the stub entry and end plus the no_push entry and any
+    // extra handler addresses
+    store_archive_data(stub_id, start, end, &entries, extras_ptr);
+
     return start;
   }
 
@@ -1272,8 +1473,6 @@ class StubGenerator: public StubCodeGenerator {
   //   used by some other conjoint copy method
   //
   address generate_conjoint_copy(StubId stub_id, address nooverlap_target, address *nopush_entry) {
-    const Register s = c_rarg0, d = c_rarg1, count = c_rarg2;
-    RegSet saved_regs = RegSet::of(s, d, count);
     int size;
     bool aligned;
     bool is_oop;
@@ -1354,12 +1553,45 @@ class StubGenerator: public StubCodeGenerator {
       ShouldNotReachHere();
     }
 
+    // only some conjoint stubs generate a 2nd entry
+    int entry_count = StubInfo::entry_count(stub_id);
+    int expected_entry_count = (nopush_entry == nullptr ? 1 : 2);
+    assert(entry_count == expected_entry_count,
+           "expected entry count %d does not match declared entry count %d for stub %s",
+           expected_entry_count, entry_count, StubInfo::name(stub_id));
+
+    // We need to protect memory accesses in certain cases
+    bool add_extras = !is_oop && (!aligned || sizeof(jlong) == size);
+    int extra_count = ((add_extras ? 1 : 0) * UnsafeMemoryAccess::COLUMN_COUNT);
+    GrowableArray<address> entries;
+    GrowableArray<address> extras;
+    GrowableArray<address> *entries_ptr = (nopush_entry != nullptr ? &entries : nullptr);
+    GrowableArray<address> *extras_ptr = (extra_count > 0 ? &extras : nullptr);
+    address start = load_archive_data(stub_id, entries_ptr, extras_ptr);
+    if (start != nullptr) {
+      assert(entries.length() == expected_entry_count - 1,
+             "unexpected entries count %d", entries.length());
+      assert(extras.length() == extra_count,
+             "unexpected extra count %d", extras.length());
+      if (nopush_entry != nullptr) {
+        *nopush_entry = entries.at(0);
+      }
+      if (add_extras) {
+        // register one handler at offset 0
+        register_unsafe_access_handlers(extras, 0, 1);
+      }
+      return start;
+    }
+
+    const Register s = c_rarg0, d = c_rarg1, count = c_rarg2;
+    RegSet saved_regs = RegSet::of(s, d, count);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
     if (nopush_entry != nullptr) {
       *nopush_entry = __ pc();
+      entries.append(*nopush_entry);
       // caller can pass a 64-bit byte count here (from Unsafe.copyMemory)
       BLOCK_COMMENT("Entry:");
     }
@@ -1390,8 +1622,7 @@ class StubGenerator: public StubCodeGenerator {
 
     {
       // UnsafeMemoryAccess page error: continue after unsafe access
-      bool add_entry = !is_oop && (!aligned || sizeof(jlong) == size);
-      UnsafeMemoryAccessMark umam(this, add_entry, true);
+      UnsafeMemoryAccessMark umam(this, add_extras, true);
       copy_memory(decorators, is_oop ? T_OBJECT : T_BYTE, aligned, s, d, count, -size);
     }
 
@@ -1405,6 +1636,20 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ mv(x10, zr); // return 0
     __ ret();
+
+    address end = __ pc();
+
+    if (add_extras) {
+      // retrieve the registered handler addresses
+      retrieve_unsafe_access_handlers(start, end, extras);
+      assert(extras.length() == extra_count,
+             "incorrect handlers count %d", extras.length());
+    }
+
+    // record the stub entry and end plus any no_push entry and/or
+    // extra handler addresses
+    store_archive_data(stub_id, start, end, entries_ptr, extras_ptr);
+
     return start;
   }
 
@@ -1457,6 +1702,27 @@ class StubGenerator: public StubCodeGenerator {
       ShouldNotReachHere();
     }
 
+    // The normal stub provides a 2nd entry which omits the frame push
+    // for use when bailing out from a disjoint copy.
+    // Only some conjoint stubs generate a 2nd entry
+    int entry_count = StubInfo::entry_count(stub_id);
+    int expected_entry_count = (nopush_entry == nullptr ? 1 : 2);
+    GrowableArray<address> entries;
+    GrowableArray<address> *entries_ptr = (expected_entry_count == 1 ? nullptr : &entries);
+    assert(entry_count == expected_entry_count,
+           "expected entry count %d does not match declared entry count %d for stub %s",
+           expected_entry_count, entry_count, StubInfo::name(stub_id));
+    address start = load_archive_data(stub_id, entries_ptr);
+    if (start != nullptr) {
+      assert(entries.length() + 1 == expected_entry_count,
+             "expected entry count %d does not match return entry count %d for stub %s",
+             expected_entry_count, entries.length() + 1, StubInfo::name(stub_id));
+      if (nopush_entry != nullptr) {
+        *nopush_entry = entries.at(0);
+      }
+      return start;
+    }
+
     Label L_load_element, L_store_element, L_do_card_marks, L_done, L_done_pop;
 
     // Input registers (after setup_arg_regs)
@@ -1489,13 +1755,14 @@ class StubGenerator: public StubCodeGenerator {
 
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     __ enter(); // required for proper stackwalking of RuntimeStub frame
 
     // Caller of this entry point must set up the argument registers.
     if (nopush_entry != nullptr) {
       *nopush_entry = __ pc();
+      entries.append(*nopush_entry);
       BLOCK_COMMENT("Entry:");
     }
 
@@ -1598,6 +1865,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret();
 
+    // record the stub entry and end plus any no_push entry
+    store_archive_data(stub_id, start, __ pc(), entries_ptr);
+
     return start;
   }
 
@@ -1633,10 +1903,23 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   address generate_unsafecopy_common_error_exit() {
-    address start = __ pc();
+    StubId stub_id = StubId::stubgen_unsafecopy_common_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, stub_id);
+    start = __ pc();
     __ mv(x10, 0);
     __ leave();
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -1651,10 +1934,22 @@ class StubGenerator: public StubCodeGenerator {
   //    c_rarg2   - byte value
   //
   address generate_unsafe_setmemory() {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_unsafe_setmemory_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    // we expect one set of extra unsafememory access handler entries
+    GrowableArray<address> extras;
+    int extra_count = 1 * UnsafeMemoryAccess::COLUMN_COUNT;
+    address start = load_archive_data(stub_id, nullptr, &extras);
+    if (start != nullptr) {
+      assert(extras.length() == extra_count,
+             "unexpected extra entry count %d", extras.length());
+      register_unsafe_access_handlers(extras, 0, 1);
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     // bump this on entry, not on exit:
     // inc_counter_np(SharedRuntime::_unsafe_set_memory_ctr);
@@ -1668,6 +1963,7 @@ class StubGenerator: public StubCodeGenerator {
     const Register tmp_reg   = x29; // temp register
 
     // Mark remaining code as such which performs Unsafe accesses.
+    {
     UnsafeMemoryAccessMark umam(this, true, false);
 
     __ enter(); // required for proper stackwalking of RuntimeStub frame
@@ -1748,6 +2044,17 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(L_exit);
     __ leave();
     __ ret();
+    // have to exit the block and destroy the UnsafeMemoryAccessMark
+    // in order to retrieve the handler end address
+    }
+
+    // install saved handler addresses in extras
+    address end = __ pc();
+    retrieve_unsafe_access_handlers(start, end, extras);
+    assert(extras.length() == extra_count,
+           "incorrect handlers count %d", extras.length());
+    // record the stub entry and end plus the extras
+    store_archive_data(stub_id, start, end, nullptr, &extras);
 
     return start;
   }
@@ -1771,13 +2078,19 @@ class StubGenerator: public StubCodeGenerator {
                                address long_copy_entry) {
     assert_cond(byte_copy_entry != nullptr && short_copy_entry != nullptr &&
                 int_copy_entry != nullptr && long_copy_entry != nullptr);
+    StubId stub_id = StubId::stubgen_unsafe_arraycopy_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     Label L_long_aligned, L_int_aligned, L_short_aligned;
     const Register s = c_rarg0, d = c_rarg1, count = c_rarg2;
 
     __ align(CodeEntryAlignment);
-    StubId stub_id = StubId::stubgen_unsafe_arraycopy_id;
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
     __ enter(); // required for proper stackwalking of RuntimeStub frame
 
     // bump this on entry, not on exit:
@@ -1804,6 +2117,9 @@ class StubGenerator: public StubCodeGenerator {
     __ srli(count, count, LogBytesPerLong);   // size => long_count
     __ j(RuntimeAddress(long_copy_entry));
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -1827,6 +2143,13 @@ class StubGenerator: public StubCodeGenerator {
     assert_cond(byte_copy_entry != nullptr && short_copy_entry != nullptr &&
                 int_copy_entry != nullptr && oop_copy_entry != nullptr &&
                 long_copy_entry != nullptr && checkcast_copy_entry != nullptr);
+    StubId stub_id = StubId::stubgen_generic_arraycopy_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     Label L_failed, L_failed_0, L_objArray;
     Label L_copy_bytes, L_copy_shorts, L_copy_ints, L_copy_longs;
 
@@ -1842,10 +2165,9 @@ class StubGenerator: public StubCodeGenerator {
 
     __ align(CodeEntryAlignment);
 
-    StubId stub_id = StubId::stubgen_generic_arraycopy_id;
     StubCodeMark mark(this, stub_id);
 
-    address start = __ pc();
+    start = __ pc();
 
     __ enter(); // required for proper stackwalking of RuntimeStub frame
 
@@ -2095,6 +2417,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();   // required for proper stackwalking of RuntimeStub frame
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -2140,9 +2465,15 @@ class StubGenerator: public StubCodeGenerator {
       ShouldNotReachHere();
     };
 
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     BLOCK_COMMENT("Entry:");
 
@@ -2295,6 +2626,9 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(L_exit);
     __ leave();
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -2476,8 +2810,14 @@ class StubGenerator: public StubCodeGenerator {
   address generate_aescrypt_encryptBlock() {
     assert(UseAESIntrinsics, "need AES instructions (Zvkned extension) support");
 
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_aescrypt_encryptBlock_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
     Label L_aes128, L_aes192;
@@ -2493,7 +2833,7 @@ class StubGenerator: public StubCodeGenerator {
     };
     const VectorRegister res   = v19;
 
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
     __ lwu(keylen, Address(key, arrayOopDesc::length_offset_in_bytes() - arrayOopDesc::base_offset_in_bytes(T_INT)));
@@ -2532,6 +2872,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -2555,8 +2898,14 @@ class StubGenerator: public StubCodeGenerator {
   address generate_aescrypt_decryptBlock() {
     assert(UseAESIntrinsics, "need AES instructions (Zvkned extension) support");
 
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_aescrypt_decryptBlock_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
     Label L_aes128, L_aes192;
@@ -2572,7 +2921,7 @@ class StubGenerator: public StubCodeGenerator {
     };
     const VectorRegister res   = v19;
 
-    address start = __ pc();
+    start = __ pc();
     __ enter(); // required for proper stackwalking of RuntimeStub frame
 
     __ lwu(keylen, Address(key, arrayOopDesc::length_offset_in_bytes() - arrayOopDesc::base_offset_in_bytes(T_INT)));
@@ -2610,6 +2959,9 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(c_rarg0, 0);
     __ leave();
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -2664,8 +3016,14 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_cipherBlockChaining_encryptAESCrypt() {
     assert(UseAESIntrinsics, "need AES instructions (Zvkned extension) support");
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_cipherBlockChaining_encryptAESCrypt_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
     const Register from       = c_rarg0;
@@ -2676,7 +3034,7 @@ class StubGenerator: public StubCodeGenerator {
 
     const Register keylen     = x28;
 
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
     Label L_aes128, L_aes192;
@@ -2697,6 +3055,9 @@ class StubGenerator: public StubCodeGenerator {
     // Note: the following function performs key += 13*16
     __ bind(L_aes192);
     cipherBlockChaining_encryptAESCrypt(13, from, to, key, rvec, input_len);
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -2753,8 +3114,14 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_cipherBlockChaining_decryptAESCrypt() {
     assert(UseAESIntrinsics, "need AES instructions (Zvkned extension) support");
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_cipherBlockChaining_decryptAESCrypt_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
     const Register from        = c_rarg0;
@@ -2765,7 +3132,7 @@ class StubGenerator: public StubCodeGenerator {
 
     const Register keylen      = x28;
 
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
     Label L_aes128, L_aes192, L_aes128_loop, L_aes192_loop, L_aes256_loop;
@@ -2786,6 +3153,9 @@ class StubGenerator: public StubCodeGenerator {
     // Note: the following function performs key += 13*16
     __ bind(L_aes192);
     cipherBlockChaining_decryptAESCrypt(13, from, to, key, rvec, input_len);
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -2958,8 +3328,14 @@ class StubGenerator: public StubCodeGenerator {
   address generate_counterMode_AESCrypt() {
     assert(UseAESCTRIntrinsics, "need AES instructions (Zvkned extension) and Zbb extension support");
 
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_counterMode_AESCrypt_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
     const Register in                  = c_rarg0;
@@ -2972,7 +3348,7 @@ class StubGenerator: public StubCodeGenerator {
 
     const Register keylen              = c_rarg7; // temporary register
 
-    const address start = __ pc();
+    start = __ pc();
     __ enter();
 
     Label L_exit;
@@ -3001,6 +3377,9 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(x10, input_len);
     __ leave();
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -3048,11 +3427,17 @@ class StubGenerator: public StubCodeGenerator {
   address generate_ghash_processBlocks() {
     assert(UseGHASHIntrinsics, "need GHASH instructions (Zvkg extension) and Zvbb support");
 
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_ghash_processBlocks_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
     Register state   = c_rarg0;
@@ -3068,6 +3453,9 @@ class StubGenerator: public StubCodeGenerator {
 
     __ leave();
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -3133,8 +3521,14 @@ class StubGenerator: public StubCodeGenerator {
     assert(UseGHASHIntrinsics, "need GHASH instructions (Zvkg extension) and Zvbb support");
     assert(UseAESCTRIntrinsics, "need AES instructions (Zvkned extension) and Zbb extension support");
 
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_galoisCounterMode_AESCrypt_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
     const Register in         = c_rarg0;
@@ -3158,7 +3552,7 @@ class StubGenerator: public StubCodeGenerator {
     VectorRegister vtmp2      = v17;
     VectorRegister vtmp3      = v18;
 
-    const address start = __ pc();
+    start = __ pc();
     __ enter();
 
     Label L_exit;
@@ -3192,6 +3586,9 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(x10, input_len);
     __ leave();
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -3251,6 +3648,12 @@ class StubGenerator: public StubCodeGenerator {
     default:
       ShouldNotReachHere();
     };
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
@@ -3335,17 +3738,27 @@ class StubGenerator: public StubCodeGenerator {
       __ sub(result, tmp1, tmp2);
     __ bind(DONE);
       __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
   address generate_method_entry_barrier() {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_method_entry_barrier_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
     Label deoptimize_label;
 
-    address start = __ pc();
+    start = __ pc();
 
     BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
 
@@ -3399,6 +3812,9 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(sp, t0);
     __ jr(t1);
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -3423,6 +3839,12 @@ class StubGenerator: public StubCodeGenerator {
     default:
       ShouldNotReachHere();
     };
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
@@ -3519,6 +3941,10 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(LENGTH_DIFF);
       __ pop_reg(spilled_regs, sp);
       __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
@@ -3555,6 +3981,12 @@ class StubGenerator: public StubCodeGenerator {
       ShouldNotReachHere();
     };
 
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
@@ -3778,6 +4210,10 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(DONE);
     __ pop_reg(spilled_regs, sp);
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
@@ -3791,6 +4227,20 @@ class StubGenerator: public StubCodeGenerator {
 #ifdef COMPILER2
   void generate_lookup_secondary_supers_table_stub() {
     StubId stub_id = StubId::stubgen_lookup_secondary_supers_table_id;
+    GrowableArray<address> entries;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == Klass::SECONDARY_SUPERS_TABLE_SIZE, "sanity check");
+    address start = load_archive_data(stub_id, &entries);
+    if (start != nullptr) {
+      assert(entries.length() == Klass::SECONDARY_SUPERS_TABLE_SIZE - 1,
+             "unexpected extra entry count %d", entries.length());
+      StubRoutines::_lookup_secondary_supers_table_stubs[0] = start;
+      for (int slot = 1; slot < Klass::SECONDARY_SUPERS_TABLE_SIZE; slot++) {
+        StubRoutines::_lookup_secondary_supers_table_stubs[slot] = entries.at(slot - 1);
+      }
+      return;
+    }
+
     StubCodeMark mark(this, stub_id);
 
     const Register
@@ -3803,7 +4253,13 @@ class StubGenerator: public StubCodeGenerator {
       r_bitmap       = x16;
 
     for (int slot = 0; slot < Klass::SECONDARY_SUPERS_TABLE_SIZE; slot++) {
-      StubRoutines::_lookup_secondary_supers_table_stubs[slot] = __ pc();
+      address next_entry = __ pc();
+      StubRoutines::_lookup_secondary_supers_table_stubs[slot] = next_entry;
+      if (slot == 0) {
+        start = next_entry;
+      } else {
+        entries.append(next_entry);
+      }
       Label L_success;
       __ enter();
       __ lookup_secondary_supers_table_const(r_sub_klass, r_super_klass, result,
@@ -3812,14 +4268,22 @@ class StubGenerator: public StubCodeGenerator {
       __ leave();
       __ ret();
     }
+    // record the stub entry and end plus all the auxiliary entries
+    store_archive_data(stub_id, start, __ pc(), &entries);
   }
 
   // Slow path implementation for UseSecondarySupersTable.
   address generate_lookup_secondary_supers_table_slow_path_stub() {
     StubId stub_id = StubId::stubgen_lookup_secondary_supers_table_slow_path_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
 
-    address start = __ pc();
+    start = __ pc();
     const Register
       r_super_klass  = x10,        // argument
       r_array_base   = x11,        // argument
@@ -3832,13 +4296,22 @@ class StubGenerator: public StubCodeGenerator {
     __ lookup_secondary_supers_table_slow_path(r_super_klass, r_array_base, r_array_index, r_bitmap, result, temp1);
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
   address generate_mulAdd()
   {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_mulAdd_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
     address entry = __ pc();
@@ -3856,6 +4329,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
@@ -3871,8 +4347,14 @@ class StubGenerator: public StubCodeGenerator {
    */
   address generate_multiplyToLen()
   {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_multiplyToLen_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
 
@@ -3897,13 +4379,22 @@ class StubGenerator: public StubCodeGenerator {
     __ leave(); // required for proper stackwalking of RuntimeStub frame
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
   address generate_squareToLen()
   {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_squareToLen_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
 
@@ -3930,6 +4421,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
@@ -3943,8 +4437,14 @@ class StubGenerator: public StubCodeGenerator {
   //   c_rarg4   - numIter
   //
   address generate_bigIntegerLeftShift() {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_bigIntegerLeftShiftWorker_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
 
@@ -3982,6 +4482,9 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(exit);
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
@@ -3995,8 +4498,14 @@ class StubGenerator: public StubCodeGenerator {
   //   c_rarg4   - numIter
   //
   address generate_bigIntegerRightShift() {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_bigIntegerRightShiftWorker_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
 
@@ -4036,6 +4545,9 @@ class StubGenerator: public StubCodeGenerator {
 
     __ bind(exit);
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
 
     return entry;
   }
@@ -4824,9 +5336,19 @@ class StubGenerator: public StubCodeGenerator {
     if (!Continuations::enabled()) return nullptr;
 
     StubId stub_id = StubId::stubgen_cont_thaw_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
     generate_cont_thaw(Continuation::thaw_top);
+
+    // record the stub start and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -4835,10 +5357,19 @@ class StubGenerator: public StubCodeGenerator {
 
     // TODO: will probably need multiple return barriers depending on return type
     StubId stub_id = StubId::stubgen_cont_returnBarrier_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     generate_cont_thaw(Continuation::thaw_return_barrier);
+
+    // record the stub start and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -4847,10 +5378,19 @@ class StubGenerator: public StubCodeGenerator {
     if (!Continuations::enabled()) return nullptr;
 
     StubId stub_id = StubId::stubgen_cont_returnBarrierExc_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     generate_cont_thaw(Continuation::thaw_return_barrier_exception);
+
+    // record the stub start and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -4858,8 +5398,14 @@ class StubGenerator: public StubCodeGenerator {
   address generate_cont_preempt_stub() {
     if (!Continuations::enabled()) return nullptr;
     StubId stub_id = StubId::stubgen_cont_preempt_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     __ reset_last_Java_frame(true);
 
@@ -4882,6 +5428,9 @@ class StubGenerator: public StubCodeGenerator {
     __ la(t1, ExternalAddress(ContinuationEntry::thaw_call_pc_address()));
     __ ld(t1, Address(t1));
     __ jr(t1);
+
+    // record the stub start and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -5033,53 +5582,6 @@ class StubGenerator: public StubCodeGenerator {
     //   c_rarg3   - int     limit
     //
     address generate_sha2_implCompress(Assembler::SEW vset_sew, StubId stub_id) {
-      alignas(64) static const uint32_t round_consts_256[64] = {
-        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
-        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
-        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
-        0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
-        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
-      };
-      alignas(64) static const uint64_t round_consts_512[80] = {
-        0x428a2f98d728ae22l, 0x7137449123ef65cdl, 0xb5c0fbcfec4d3b2fl,
-        0xe9b5dba58189dbbcl, 0x3956c25bf348b538l, 0x59f111f1b605d019l,
-        0x923f82a4af194f9bl, 0xab1c5ed5da6d8118l, 0xd807aa98a3030242l,
-        0x12835b0145706fbel, 0x243185be4ee4b28cl, 0x550c7dc3d5ffb4e2l,
-        0x72be5d74f27b896fl, 0x80deb1fe3b1696b1l, 0x9bdc06a725c71235l,
-        0xc19bf174cf692694l, 0xe49b69c19ef14ad2l, 0xefbe4786384f25e3l,
-        0x0fc19dc68b8cd5b5l, 0x240ca1cc77ac9c65l, 0x2de92c6f592b0275l,
-        0x4a7484aa6ea6e483l, 0x5cb0a9dcbd41fbd4l, 0x76f988da831153b5l,
-        0x983e5152ee66dfabl, 0xa831c66d2db43210l, 0xb00327c898fb213fl,
-        0xbf597fc7beef0ee4l, 0xc6e00bf33da88fc2l, 0xd5a79147930aa725l,
-        0x06ca6351e003826fl, 0x142929670a0e6e70l, 0x27b70a8546d22ffcl,
-        0x2e1b21385c26c926l, 0x4d2c6dfc5ac42aedl, 0x53380d139d95b3dfl,
-        0x650a73548baf63del, 0x766a0abb3c77b2a8l, 0x81c2c92e47edaee6l,
-        0x92722c851482353bl, 0xa2bfe8a14cf10364l, 0xa81a664bbc423001l,
-        0xc24b8b70d0f89791l, 0xc76c51a30654be30l, 0xd192e819d6ef5218l,
-        0xd69906245565a910l, 0xf40e35855771202al, 0x106aa07032bbd1b8l,
-        0x19a4c116b8d2d0c8l, 0x1e376c085141ab53l, 0x2748774cdf8eeb99l,
-        0x34b0bcb5e19b48a8l, 0x391c0cb3c5c95a63l, 0x4ed8aa4ae3418acbl,
-        0x5b9cca4f7763e373l, 0x682e6ff3d6b2b8a3l, 0x748f82ee5defb2fcl,
-        0x78a5636f43172f60l, 0x84c87814a1f0ab72l, 0x8cc702081a6439ecl,
-        0x90befffa23631e28l, 0xa4506cebde82bde9l, 0xbef9a3f7b2c67915l,
-        0xc67178f2e372532bl, 0xca273eceea26619cl, 0xd186b8c721c0c207l,
-        0xeada7dd6cde0eb1el, 0xf57d4f7fee6ed178l, 0x06f067aa72176fbal,
-        0x0a637dc5a2c898a6l, 0x113f9804bef90dael, 0x1b710b35131c471bl,
-        0x28db77f523047d84l, 0x32caab7b40c72493l, 0x3c9ebe0a15c9bebcl,
-        0x431d67c49c100d4cl, 0x4cc5d4becb3e42b6l, 0x597f299cfc657e2al,
-        0x5fcb6fab3ad6faecl, 0x6c44198c4a475817l
-      };
       const int const_add = vset_sew == Assembler::e32 ? 16 : 32;
 
       bool multi_block;
@@ -5103,9 +5605,15 @@ class StubGenerator: public StubCodeGenerator {
       default:
         ShouldNotReachHere();
       };
+      int entry_count = StubInfo::entry_count(stub_id);
+      assert(entry_count == 1, "sanity check");
+      address start = _cgen->load_archive_data(stub_id);
+      if (start != nullptr) {
+        return start;
+      }
       __ align(CodeEntryAlignment);
       StubCodeMark mark(_cgen, stub_id);
-      address start = __ pc();
+      start = __ pc();
 
       Register buf   = c_rarg0;
       Register state = c_rarg1;
@@ -5129,7 +5637,7 @@ class StubGenerator: public StubCodeGenerator {
 
       __ enter();
 
-      address constant_table = vset_sew == Assembler::e32 ? (address)round_consts_256 : (address)round_consts_512;
+      address constant_table = vset_sew == Assembler::e32 ? (address)_sha256_round_consts : (address)_sha512_round_consts;
       la(consts, ExternalAddress(constant_table));
 
       // Register use in this function:
@@ -5279,6 +5787,9 @@ class StubGenerator: public StubCodeGenerator {
 
       __ leave();
       __ ret();
+
+      // record the stub entry and end
+      _cgen->store_archive_data(stub_id, start, __ pc());
 
       return start;
     }
@@ -5452,7 +5963,6 @@ class StubGenerator: public StubCodeGenerator {
   //   x30     t5  buf6
   //   x31     t6  buf7
   address generate_md5_implCompress(StubId stub_id) {
-    __ align(CodeEntryAlignment);
     bool multi_block;
     switch (stub_id) {
     case StubId::stubgen_md5_implCompress_id:
@@ -5464,8 +5974,15 @@ class StubGenerator: public StubCodeGenerator {
     default:
       ShouldNotReachHere();
     };
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     // rotation constants
     const int S11 = 7;
@@ -5668,6 +6185,9 @@ class StubGenerator: public StubCodeGenerator {
     __ pop_reg(saved_regs, sp);
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return (address) start;
   }
 
@@ -5715,14 +6235,19 @@ class StubGenerator: public StubCodeGenerator {
    *   N depends on single vector register length.
    */
   address generate_chacha20Block() {
-    Label L_Rounds;
-
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_chacha20Block_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
+    Label L_Rounds;
     const int states_len = 16;
     const int step = 4;
     const Register state = c_rarg0;
@@ -5804,6 +6329,9 @@ class StubGenerator: public StubCodeGenerator {
 
     __ leave();
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return (address) start;
   }
@@ -6030,10 +6558,16 @@ class StubGenerator: public StubCodeGenerator {
       default:
         ShouldNotReachHere();
       };
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
     RegSet saved_regs = RegSet::range(x18, x27);
@@ -6156,6 +6690,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return (address) start;
   }
 
@@ -6224,26 +6761,16 @@ class StubGenerator: public StubCodeGenerator {
    *  c_rarg5   - isURL, Base64 or URL character set
    */
   address generate_base64_encodeBlock() {
-    alignas(64) static const char toBase64[64] = {
-      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-      'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-      'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
-    };
-
-    alignas(64) static const char toBase64URL[64] = {
-      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-      'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-      'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
-    };
-
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_base64_encodeBlock_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
     Register src    = c_rarg0;
@@ -6265,9 +6792,9 @@ class StubGenerator: public StubCodeGenerator {
     __ add(dst, dst, doff);
 
     // load the codec base address
-    __ la(codec, ExternalAddress((address) toBase64));
+    __ la(codec, ExternalAddress((address) _encodeBlock_toBase64));
     __ beqz(isURL, ProcessData);
-    __ la(codec, ExternalAddress((address) toBase64URL));
+    __ la(codec, ExternalAddress((address) _encodeBlock_toBase64URL));
     __ BIND(ProcessData);
 
     // vector version
@@ -6376,6 +6903,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return (address) start;
   }
 
@@ -6459,48 +6989,16 @@ class StubGenerator: public StubCodeGenerator {
    */
   address generate_base64_decodeBlock() {
 
-    static const uint8_t fromBase64[256] = {
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,  62u, 255u, 255u, 255u,  63u,
-        52u,  53u,  54u,  55u,  56u,  57u,  58u,  59u,  60u,  61u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u,   0u,   1u,   2u,   3u,   4u,   5u,   6u,   7u,   8u,   9u,  10u,  11u,  12u,  13u,  14u,
-        15u,  16u,  17u,  18u,  19u,  20u,  21u,  22u,  23u,  24u,  25u, 255u, 255u, 255u, 255u, 255u,
-        255u,  26u,  27u,  28u,  29u,  30u,  31u,  32u,  33u,  34u,  35u,  36u,  37u,  38u,  39u,  40u,
-        41u,  42u,  43u,  44u,  45u,  46u,  47u,  48u,  49u,  50u,  51u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-    };
-
-    static const uint8_t fromBase64URL[256] = {
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,  62u, 255u, 255u,
-        52u,  53u,  54u,  55u,  56u,  57u,  58u,  59u,  60u,  61u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u,   0u,   1u,   2u,   3u,   4u,   5u,   6u,   7u,   8u,   9u,  10u,  11u,  12u,  13u,  14u,
-        15u,  16u,  17u,  18u,  19u,  20u,  21u,  22u,  23u,  24u,  25u, 255u, 255u, 255u, 255u,  63u,
-        255u,  26u,  27u,  28u,  29u,  30u,  31u,  32u,  33u,  34u,  35u,  36u,  37u,  38u,  39u,  40u,
-        41u,  42u,  43u,  44u,  45u,  46u,  47u,  48u,  49u,  50u,  51u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-        255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u, 255u,
-    };
-
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_base64_decodeBlock_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
     __ enter();
 
     Register src    = c_rarg0;
@@ -6530,9 +7028,9 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(dstBackup, dst);
 
     // load the codec base address
-    __ la(codec, ExternalAddress((address) fromBase64));
+    __ la(codec, ExternalAddress((address) _decodeBlock_fromBase64));
     __ beqz(isURL, ProcessData);
-    __ la(codec, ExternalAddress((address) fromBase64URL));
+    __ la(codec, ExternalAddress((address) _decodeBlock_fromBase64URL));
     __ BIND(ProcessData);
 
     // vector version
@@ -6654,6 +7152,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave();
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return (address) start;
   }
 
@@ -6742,10 +7243,16 @@ class StubGenerator: public StubCodeGenerator {
    *   c_rarg0   - int adler result
    */
   address generate_updateBytesAdler32() {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_updateBytesAdler32_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     Label L_nmax, L_nmax_loop, L_nmax_loop_entry, L_by16, L_by16_loop,
       L_by16_loop_unroll, L_by1_loop, L_do_mod, L_combine, L_by1;
@@ -6911,6 +7418,9 @@ class StubGenerator: public StubCodeGenerator {
     __ leave(); // Required for proper stackwalking of RuntimeStub frame
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -6920,8 +7430,14 @@ class StubGenerator: public StubCodeGenerator {
   // f10 = result (float)
   // t1  = temporary register
   address generate_float16ToFloat() {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_hf2f_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
     BLOCK_COMMENT("float16ToFloat:");
@@ -6963,6 +7479,10 @@ class StubGenerator: public StubCodeGenerator {
     __ fmv_w_x(dst, t1);
 
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
@@ -6971,8 +7491,14 @@ class StubGenerator: public StubCodeGenerator {
   // f11 = temporary float register
   // t1  = temporary register
   address generate_floatToFloat16() {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_f2hf_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
     address entry = __ pc();
     BLOCK_COMMENT("floatToFloat16:");
@@ -7001,6 +7527,10 @@ class StubGenerator: public StubCodeGenerator {
     __ float_to_float16_NaN(dst, src, t0, t1);
 
     __ ret();
+
+    // record the stub entry and end
+    store_archive_data(stub_id, entry, __ pc());
+
     return entry;
   }
 
@@ -7089,10 +7619,16 @@ static const int64_t right_3_bits = right_n_bits(3);
   // computation.
 
   address generate_poly1305_processBlocks() {
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_poly1305_processBlocks_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
     __ enter();
     Label here;
 
@@ -7208,6 +7744,9 @@ static const int64_t right_3_bits = right_n_bits(3);
     __ leave(); // Required for proper stackwalking
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
@@ -7215,9 +7754,16 @@ static const int64_t right_3_bits = right_n_bits(3);
     assert(UseRVV, "sanity");
     const int lmul = 2;
     const int stride = MaxVectorSize / sizeof(jint) * lmul;
+    StubId stub_id = StubId::stubgen_arrays_hashcode_powers_of_31_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "arrays_hashcode_powers_of_31");
-    address start = __ pc();
+    StubCodeMark mark(this, stub_id);
+    start = __ pc();
     for (int i = stride; i >= 0; i--) {
         jint power_of_31 = 1;
         for (int j = i; j > 0; j--) {
@@ -7225,6 +7771,9 @@ static const int64_t right_3_bits = right_n_bits(3);
         }
         __ emit_int32(power_of_31);
     }
+
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -7245,11 +7794,17 @@ static const int64_t right_3_bits = right_n_bits(3);
   address generate_updateBytesCRC32() {
     assert(UseCRC32Intrinsics, "what are we doing here?");
 
-    __ align(CodeEntryAlignment);
     StubId stub_id = StubId::stubgen_updateBytesCRC32_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
+    __ align(CodeEntryAlignment);
     StubCodeMark mark(this, stub_id);
 
-    address start = __ pc();
+    start = __ pc();
 
     // input parameters
     const Register crc    = c_rarg0;  // crc
@@ -7266,20 +7821,32 @@ static const int64_t right_3_bits = right_n_bits(3);
     __ leave(); // required for proper stackwalking of RuntimeStub frame
     __ ret();
 
+    // record the stub entry and end
+    store_archive_data(stub_id, start, __ pc());
+
     return start;
   }
 
   // exception handler for upcall stubs
   address generate_upcall_stub_exception_handler() {
     StubId stub_id = StubId::stubgen_upcall_stub_exception_handler_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     // Native caller has no idea how to handle exceptions,
     // so we just crash here. Up to callee to catch exceptions.
     __ verify_oop(x10); // return a exception oop in a0
     __ rt_call(CAST_FROM_FN_PTR(address, UpcallLinker::handle_uncaught_exception));
     __ should_not_reach_here();
+
+    // record the stub start and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -7290,8 +7857,14 @@ static const int64_t right_3_bits = right_n_bits(3);
   address generate_upcall_stub_load_target() {
 
     StubId stub_id = StubId::stubgen_upcall_stub_load_target_id;
+    int entry_count = StubInfo::entry_count(stub_id);
+    assert(entry_count == 1, "sanity check");
+    address start = load_archive_data(stub_id);
+    if (start != nullptr) {
+      return start;
+    }
     StubCodeMark mark(this, stub_id);
-    address start = __ pc();
+    start = __ pc();
 
     __ resolve_global_jobject(j_rarg0, t0, t1);
       // Load target method from receiver
@@ -7304,6 +7877,9 @@ static const int64_t right_3_bits = right_n_bits(3);
     __ sd(xmethod, Address(xthread, JavaThread::callee_target_offset())); // just in case callee is deoptimized
 
     __ ret();
+
+    // record the stub start and end
+    store_archive_data(stub_id, start, __ pc());
 
     return start;
   }
@@ -7397,16 +7973,30 @@ static const int64_t right_3_bits = right_n_bits(3);
 
     if (UseMontgomeryMultiplyIntrinsic) {
       StubId stub_id = StubId::stubgen_montgomeryMultiply_id;
-      StubCodeMark mark(this, stub_id);
-      MontgomeryMultiplyGenerator g(_masm, /*squaring*/false);
-      StubRoutines::_montgomeryMultiply = g.generate_multiply();
+      address start = load_archive_data(stub_id);
+      if (start == nullptr) {
+        // we have to generate it
+        StubCodeMark mark(this, stub_id);
+        MontgomeryMultiplyGenerator g(_masm, /*squaring*/false);
+        start = g.generate_multiply();
+        // record the stub start and end
+        store_archive_data(stub_id, start, _masm->pc());
+      }
+      StubRoutines::_montgomeryMultiply = start;
     }
 
     if (UseMontgomerySquareIntrinsic) {
       StubId stub_id = StubId::stubgen_montgomerySquare_id;
-      StubCodeMark mark(this, stub_id);
-      MontgomeryMultiplyGenerator g(_masm, /*squaring*/true);
-      StubRoutines::_montgomerySquare = g.generate_square();
+      address start = load_archive_data(stub_id);
+      if (start == nullptr) {
+        // we have to generate it
+        StubCodeMark mark(this, stub_id);
+        MontgomeryMultiplyGenerator g(_masm, /*squaring*/true);
+        start = g.generate_square();
+        // record the stub start and end
+        store_archive_data(stub_id, start, _masm->pc());
+      }
+      StubRoutines::_montgomerySquare = start;
     }
 
     if (UseAESIntrinsics) {
@@ -7506,8 +8096,27 @@ static const int64_t right_3_bits = right_n_bits(3);
       break;
     };
   }
+#if INCLUDE_CDS
+  static void init_AOTAddressTable(GrowableArray<address>& external_addresses) {
+    // external data defined in this file
+#define ADD(addr) external_addresses.append((address)(addr));
+    ADD(_encodeBlock_toBase64);
+    ADD(_encodeBlock_toBase64URL);
+    ADD(_decodeBlock_fromBase64);
+    ADD(_decodeBlock_fromBase64URL);
+    ADD(_sha256_round_consts);
+    ADD(_sha512_round_consts);
+#undef ADD
+  }
+#endif // INCLUDE_CDS
 }; // end class declaration
 
 void StubGenerator_generate(CodeBuffer* code, BlobId blob_id, AOTStubData* stub_data) {
   StubGenerator g(code, blob_id, stub_data);
 }
+
+#if INCLUDE_CDS
+void StubGenerator_init_AOTAddressTable(GrowableArray<address>& addresses) {
+  StubGenerator::init_AOTAddressTable(addresses);
+}
+#endif // INCLUDE_CDS

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
@@ -507,7 +507,17 @@ ATTRIBUTE_ALIGNED(4096) juint StubRoutines::riscv::_crc_table[] =
 };
 
 #if INCLUDE_CDS
-// nothing to do for riscv
+extern void StubGenerator_init_AOTAddressTable(GrowableArray<address>& external_addresses);
+
 void StubRoutines::init_AOTAddressTable() {
+  ResourceMark rm;
+  GrowableArray<address> external_addresses;
+  // publish static addresses referred to by riscv generator
+  // n.b. we have to use an extern call here because class
+  // StubGenerator, which provides the static method that knows how to
+  // add the relevant addresses, is declared in a source file rather
+  // than in a separately includeable header.
+  StubGenerator_init_AOTAddressTable(external_addresses);
+  AOTCodeCache::publish_external_addresses(external_addresses);
 }
 #endif // INCLUDE_CDS

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -30,6 +30,7 @@
 #include "runtime/vm_version.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/ostream.hpp"
 
 #include <ctype.h>
 
@@ -508,4 +509,63 @@ bool VM_Version::is_intrinsic_supported(vmIntrinsicID id) {
     break;
   }
   return true;
+}
+
+int VM_Version::cpu_features_size() {
+  return sizeof(RVExtFeatures);
+}
+
+void VM_Version::store_cpu_features(void* buf) {
+  memcpy(buf, RVExtFeatures::current(), sizeof(RVExtFeatures));
+}
+
+bool VM_Version::verify_aot_code_cache_features(void* features_buffer) {
+  RVExtFeatures* features_to_test = (RVExtFeatures*)features_buffer;
+  return RVExtFeatures::current()->verify_aot_code_cache_features(features_to_test);
+}
+
+// Print one feature using the same spelling as features_string(): single letter
+// extensions appear as "rvc"/"rvv" and multi-character extensions with a lower
+// case leading character ("Zba" -> "zba"). Must stay in sync with the feature
+// string built in VM_Version::setup_cpu_available_features().
+void VM_Version::print_feature_name(stringStream& ss, RVFeatureValue* feature) {
+  const char* pretty = feature->pretty();
+  if (strlen(pretty) == 1) {
+    ss.print("rv%s", pretty);
+  } else {
+    ss.print("%c%s", (char)tolower(pretty[0]), &pretty[1]);
+  }
+}
+
+void VM_Version::insert_features_names(RVExtFeatures* features, stringStream& ss) {
+  const char* sep = "";
+  int i = 0;
+  while (i < RVExtFeatures::MAX_CPU_FEATURE_INDEX) {
+    if (features->support_feature(i)) {
+      ss.print("%s", sep);
+      print_feature_name(ss, _feature_list[i]);
+      sep = ", ";
+    }
+    i += 1;
+  }
+}
+
+void VM_Version::get_cpu_features_name(void* features_buffer, stringStream& ss) {
+  RVExtFeatures* features = (RVExtFeatures*)features_buffer;
+  insert_features_names(features, ss);
+}
+
+void VM_Version::get_missing_features_name(void* features_set1, void* features_set2, stringStream& ss) {
+  RVExtFeatures* rv_ext_features_set1 = (RVExtFeatures*)features_set1;
+  RVExtFeatures* rv_ext_features_set2 = (RVExtFeatures*)features_set2;
+  const char* sep = "";
+  int i = 0;
+  while (i < RVExtFeatures::MAX_CPU_FEATURE_INDEX) {
+    if (rv_ext_features_set1->support_feature(i) && !rv_ext_features_set2->support_feature(i)) {
+      ss.print("%s", sep);
+      print_feature_name(ss, _feature_list[i]);
+      sep = ", ";
+    }
+    i += 1;
+  }
 }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -36,6 +36,7 @@
 #include "utilities/sizes.hpp"
 
 class RiscvHwprobe;
+class stringStream;
 
 class VM_Version : public Abstract_VM_Version {
   friend RiscvHwprobe;
@@ -396,6 +397,15 @@ private:
       int idx = element_index(f);
       return (_features_bitmap[idx] & feature_bit(f)) != 0;
     }
+
+    bool verify_aot_code_cache_features(RVExtFeatures* features_to_test) const {
+      for (int i = 0; i < element_count(); i++) {
+        if (_features_bitmap[i] != features_to_test->_features_bitmap[i]) {
+          return false;
+        }
+      }
+      return true;
+    }
   };
 
   // enable extensions based on profile, current supported profiles:
@@ -523,6 +533,17 @@ private:
 
   // Check intrinsic support
   static bool is_intrinsic_supported(vmIntrinsicID id);
+
+  // AOT Code Cache support
+  static int  cpu_features_size();
+  static void store_cpu_features(void* buf);
+  static bool verify_aot_code_cache_features(void* features_buffer);
+  static void get_cpu_features_name(void* features_buffer, stringStream& ss);
+  static void get_missing_features_name(void* features_set1, void* features_set2, stringStream& ss);
+
+ private:
+  static void print_feature_name(stringStream& ss, RVFeatureValue* feature);
+  static void insert_features_names(RVExtFeatures* features, stringStream& ss);
 };
 
 #endif // CPU_RISCV_VM_VERSION_RISCV_HPP

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -77,6 +77,11 @@
 
 #define REG_LR       1
 #define REG_FP       8
+// First argument register (x10), used to pass the stop() message
+// to the signal handler.
+#ifndef REG_A0
+#define REG_A0       10
+#endif
 #define REG_BCP      22
 
 NOINLINE address os::current_stack_pointer() {
@@ -240,11 +245,8 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
           stub = SharedRuntime::handle_unsafe_access(thread, next_pc);
         }
       } else if (sig == SIGILL && nativeInstruction_at(pc)->is_stop()) {
-        // Pull a pointer to the error message out of the instruction
-        // stream.
-        const uint64_t *detail_msg_ptr
-          = (uint64_t*)(pc + NativeInstruction::instruction_size);
-        const char *detail_msg = (const char *)*detail_msg_ptr;
+        // A pointer to the message will have been placed in a0
+        const char *detail_msg = (const char *)(uc->uc_mcontext.__gregs[REG_A0]);
         const char *msg = "stop";
         if (TraceTraps) {
           tty->print_cr("trap: %s: (SIGILL)", msg);

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -204,7 +204,7 @@ uint AOTCodeCache::max_aot_code_size() {
 // At this point all AOT class linking seetings are finilized
 // and AOT cache is open so we can map AOT code region.
 void AOTCodeCache::initialize() {
-#if defined(ZERO) || !(defined(AMD64) || defined(AARCH64))
+#if defined(ZERO) || !(defined(AMD64) || defined(AARCH64) || defined(RISCV64))
   log_info(aot, codecache, init)("AOT Code Cache is not supported on this platform.");
   disable_caching();
   return;
@@ -263,7 +263,7 @@ void AOTCodeCache::initialize() {
     FLAG_SET_DEFAULT(ForceUnreachable, true);
   }
   FLAG_SET_DEFAULT(DelayCompilerStubsGeneration, false);
-#endif // defined(AMD64) || defined(AARCH64)
+#endif // defined(AMD64) || defined(AARCH64) || defined(RISCV64)
 }
 
 static AOTCodeCache*  opened_cache = nullptr; // Use this until we verify the cache
@@ -471,7 +471,7 @@ void AOTCodeCache::Config::record(uint cpu_features_offset) {
   _useUnalignedLoadStores = UseUnalignedLoadStores;
 #endif
 
-#if defined(AARCH64)  && !defined(ZERO)
+#if (defined(AARCH64) || defined(RISCV64)) && !defined(ZERO)
   _avoidUnalignedAccesses = AvoidUnalignedAccesses;
 #endif
 
@@ -601,14 +601,14 @@ bool AOTCodeCache::Config::verify(AOTCodeCache* cache) const {
   }
 #endif // defined(X86) && !defined(ZERO)
 
-#if defined(AARCH64) && !defined(ZERO)
+#if (defined(AARCH64) || defined(RISCV64)) && !defined(ZERO)
   // switching on AvoidUnalignedAccesses may affect validity of array
   // copy stubs and nmethods
   if (!_avoidUnalignedAccesses && AvoidUnalignedAccesses) {
     log_config_mismatch(_avoidUnalignedAccesses, AvoidUnalignedAccesses, "AvoidUnalignedAccesses");
     return false;
   }
-#endif // defined(AARCH64) && !defined(ZERO)
+#endif // (defined(AARCH64) || defined(RISCV64)) && !defined(ZERO)
 
   return true;
 }
@@ -1941,6 +1941,8 @@ void AOTCodeAddressTable::init_extrs() {
   ADD_EXTERNAL_ADDRESS(SharedRuntime::allocate_inline_types);
 #if defined(AARCH64) && !defined(ZERO)
   ADD_EXTERNAL_ADDRESS(JavaThread::aarch64_get_thread_helper);
+#endif
+#if (defined(AARCH64) || defined(RISCV64)) && !defined(ZERO)
   ADD_EXTERNAL_ADDRESS(BarrierSetAssembler::patching_epoch_addr());
 #endif
 

--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -352,11 +352,26 @@ public:
 #define AOTCODECACHE_CONFIGS_X86_DO(do_var, do_fun)
 #endif
 
+#if defined(RISCV64) && !defined(ZERO)
+#define AOTCODECACHE_CONFIGS_RISCV_DO(do_var, do_fun) \
+  do_var(intx,  BlockZeroingLowLimit)                   /* zero blocks stub */ \
+  do_var(bool,  UseBlockZeroing)                        /* zero blocks stub and nmethods */ \
+  do_var(bool,  UseConservativeFence)                   /* fence encoding in stubs and nmethods */ \
+  do_var(bool,  UseCtxFencei)                           /* method entry barrier stub */ \
+  do_var(bool,  UseSecondarySupersCache)                /* secondary supers cache in nmethods */ \
+  do_var(bool,  UseZabha)                               /* narrow cmpxchg selection in nmethods */ \
+  do_fun(int,   RVZicbozBlockSize,                      (int)VM_Version::zicboz_block_size.value()) \
+  // END
+#else
+#define AOTCODECACHE_CONFIGS_RISCV_DO(do_var, do_fun)
+#endif
+
 #define AOTCODECACHE_CONFIGS_DO(do_var, do_fun) \
   AOTCODECACHE_CONFIGS_GENERIC_DO(do_var, do_fun) \
   AOTCODECACHE_CONFIGS_COMPILER2_DO(do_var, do_fun) \
   AOTCODECACHE_CONFIGS_AARCH64_DO(do_var, do_fun) \
   AOTCODECACHE_CONFIGS_X86_DO(do_var, do_fun) \
+  AOTCODECACHE_CONFIGS_RISCV_DO(do_var, do_fun) \
   // END
 
 #define AOTCODECACHE_DECLARE_VAR(type, name) type _saved_ ## name;
@@ -377,7 +392,7 @@ protected:
     bool _useUnalignedLoadStores;
 #endif
 
-#if defined(AARCH64) && !defined(ZERO)
+#if (defined(AARCH64) || defined(RISCV64)) && !defined(ZERO)
     bool _avoidUnalignedAccesses;
 #endif
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCPUFeatureIncompatibilityTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCPUFeatureIncompatibilityTest.java
@@ -27,7 +27,7 @@
  * @summary CPU feature compatibility test for AOT Code Cache
  * @requires vm.cds.supports.aot.code.caching
  * @requires vm.compMode != "Xcomp" & vm.compMode != "Xint"
- * @requires os.simpleArch == "x64" | os.simpleArch == "aarch64"
+ * @requires os.simpleArch == "x64" | os.simpleArch == "aarch64" | os.simpleArch == "riscv64"
  * @comment The test verifies AOT checks during VM startup and not code generation.
  *          No need to run it with -Xcomp.
  * @library /test/lib /test/setup_aot
@@ -74,6 +74,11 @@ public class AOTCodeCPUFeatureIncompatibilityTest {
                 testIncompatibleFeature("-XX:-UseCRC32", "crc32", IncompatibilityMode.MISSING);
                 testIncompatibleFeature("-XX:-UseCRC32", "crc32", IncompatibilityMode.ADDITIONAL);
             }
+        } else if (Platform.isRISCV64()) {
+            if (isZbaSupported(cpuFeatures)) {
+                testIncompatibleFeature("-XX:-UseZba", "zba", IncompatibilityMode.MISSING);
+                testIncompatibleFeature("-XX:-UseZba", "zba", IncompatibilityMode.ADDITIONAL);
+            }
         }
     }
 
@@ -87,12 +92,14 @@ public class AOTCodeCPUFeatureIncompatibilityTest {
                     if (mode == IncompatibilityMode.MISSING) {
                         return new String[] {"-Xlog:aot+codecache*=debug"};
                     } else {
-                        return new String[] {vmOption, "-Xlog:aot+codecache*=debug"};
+                        // UnlockDiagnosticVMOptions must precede vmOption because
+                        // some tested CPU feature flags are diagnostic (e.g. UseZba on riscv).
+                        return new String[] {"-XX:+UnlockDiagnosticVMOptions", vmOption, "-Xlog:aot+codecache*=debug"};
                     }
                 } else if (runMode == RunMode.PRODUCTION) {
                     if (mode == IncompatibilityMode.MISSING) {
-                        return new String[] {vmOption,
-                                             "-XX:+UnlockDiagnosticVMOptions",
+                        return new String[] {"-XX:+UnlockDiagnosticVMOptions",
+                                             vmOption,
                                              // Prevent exiting VM on failure
                                              "-XX:-AbortVMOnAOTCodeFailure",
                                              "-Xlog:aot+codecache*=debug"};
@@ -148,5 +155,10 @@ public class AOTCodeCPUFeatureIncompatibilityTest {
     // Only used on aarch64 platofrm
     static boolean isCRC32Supported(List<String> cpuFeatures) {
         return cpuFeatures.contains("crc32");
+    }
+
+    // Only used on riscv64 platform
+    static boolean isZbaSupported(List<String> cpuFeatures) {
+        return cpuFeatures.contains("zba");
     }
 }

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -477,7 +477,7 @@ public class VMProps implements Callable<Map<String, String>> {
     protected String vmCDSSupportsAOTCodeCaching() {
       if ("true".equals(vmCDSSupportsAOTClassLinking()) &&
           !"zero".equals(vmFlavor()) &&
-          (Platform.isX64() || Platform.isAArch64())) {
+          (Platform.isX64() || Platform.isAArch64() || Platform.isRISCV64())) {
         return "true";
       } else {
         return "false";


### PR DESCRIPTION
Hi all,

Please review this PR that ports the AOT Code Cache feature (JDK-8350209 + follow-ups) to RISC-V.

JBS: https://bugs.openjdk.org/browse/JDK-8390102

The implementation follows the existing AArch64 pattern with minimal platform-specific changes.
## Change Summary

**Assembler / Stubs:** Made process-dependent address emissions AOT-safe in `macroAssembler_riscv` and `stubGenerator_riscv` using the standard `relocate` + `RuntimeAddress`/`ExternalAddress` pattern. Added `load/store_archive_data` to all 52 stubs, hoisted StubId declarations, and promoted stub constant tables to file-scope statics, published via `init_AOTAddressTable`. Fixed `decode/encode_klass_not_null` to check `is_on_for_dump()` before the nullptr early return (same as AArch64). Changed `stop()` to pass its message via `add_C_string` + a0 instead of inline `emit_int64`; `reinit_heapbase` now skips the precomputed path when dumping.

**AOT Config:** Enabled RISCV64 gating in `aotCodeCache`. Added `AOTCODECACHE_CONFIGS_RISCV_DO` in the header with the 7 flags not covered by CPU-feature sync. Extended the shared `AvoidUnalignedAccesses` path and `patching_epoch_addr` registration to RISC-V.

**Runtime / Compiler / Barriers:** Adapted `sharedRuntime`, `runtime_riscv`, `riscv.ad`, C1 LIR assembler, `os_linux_riscv`, and G1/Shenandoah barrier assemblers. This covers blob save/restore (deopt, handler, resolve, uncommon-trap/exception), C2 anchor-frame relocate + `loadAOTRCAddress`, C1 dump-time constant specialization with a larger exception handler size, SIGILL handler reading `stop()` message from a0, and dump-time barrier constants.

**CPU Features:** Implemented `store_cpu_features`, `verify_aot_code_cache_features`, and feature-name reporting in `vm_version_riscv`.

**Tests:** Enabled RISC-V in `VMProps.vmCDSSupportsAOTCodeCaching` and `AOTCodeCPUFeatureIncompatibilityTest`. The latter also moves `UnlockDiagnosticVMOptions` before the tested flag on all platforms (UseZba is diagnostic on RISC-V).

## Testing

All tests ran on real RISC-V hardware. Release build for tiered jtreg; fastdebug for extra verification.

- `runtime/cds/appcds/aotCode`: 11/11 test ids (G1, Parallel, Serial, Shenandoah, Z) — Passed
- Tier1: 4 shards (3569 tests) + full runtime/cds — Passed. tier1_gc not run in full; GC barrier sets for G1/Shenandoah + os/arch/native/signal run as targeted passes — Passed
- Two-step AOT flow — Passed
- Tier2: 971/971 — Passed
- Tier3: 355/357 passed; 2 failures are pre-existing environment timeouts, re-verified with extended timeout, unrelated to this change
- Renaissance Suite 0.16.0 (G1 + Shenandoah): 590/590 AOT entries loaded in production runs — Passed. Benchmarks used: fj-kmeans, philosophers, neo4j-analytics, scrabble. Spark-based benchmarks fail to initialize on JDK 28 regardless of AOT (confirmed on baseline).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390102](https://bugs.openjdk.org/browse/JDK-8390102): RISC-V: Support AOT Code Cache (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [d5f44813](https://git.openjdk.org/jdk/pull/32311/files/d5f448134c94a3f4bbc4e8521f49b109089e1ff6)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32311/head:pull/32311` \
`$ git checkout pull/32311`

Update a local copy of the PR: \
`$ git checkout pull/32311` \
`$ git pull https://git.openjdk.org/jdk.git pull/32311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32311`

View PR using the GUI difftool: \
`$ git pr show -t 32311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32311.diff">https://git.openjdk.org/jdk/pull/32311.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32311#issuecomment-5262064492)
</details>
