### PR TITLE
8390186: [Valhalla] LoadNode::Value should check for ary->is_not_flat()

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2395,7 +2395,7 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
     // expression (LShiftL quux 3) independently optimized to the constant 8.
     if ((t->isa_int() == nullptr) && (t->isa_long() == nullptr)
         && (_type->isa_vect() == nullptr)
-        && !ary->is_flat()
+        && ary->is_not_flat()
         && Opcode() != Op_LoadKlass && Opcode() != Op_LoadNKlass) {
       // t might actually be lower than _type, if _type is a unique
       // concrete subclass of abstract class t.


### PR DESCRIPTION
Hi,

Currently, for a load from an array element, we check whether the array is flat with !ary->is_flat(). This is problematic due to [JDK-8390141](https://bugs.openjdk.org/browse/JDK-8390141), we should check for ary->is_not_flat() instead. This issue is found with the additional verification added by [JDK-8370914](https://bugs.openjdk.org/browse/JDK-8370914).

Testing:

- [x] tier1-4,hs-comp-stress,valhalla-comp-stress

Please take a look and leave your review, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390186](https://bugs.openjdk.org/browse/JDK-8390186): [Valhalla] LoadNode::Value should check for ary-&gt;is_not_flat() (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32312/head:pull/32312` \
`$ git checkout pull/32312`

Update a local copy of the PR: \
`$ git checkout pull/32312` \
`$ git pull https://git.openjdk.org/jdk.git pull/32312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32312`

View PR using the GUI difftool: \
`$ git pr show -t 32312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32312.diff">https://git.openjdk.org/jdk/pull/32312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32312#issuecomment-5262369991)
</details>
