### PR TITLE
8318477: [jmh] the test gc.MicroLargePages.micro_HOP_DIST_4KB failed with multiple threads

### DIFF
--- a/test/micro/org/openjdk/bench/vm/gc/MicroLargePages.java
+++ b/test/micro/org/openjdk/bench/vm/gc/MicroLargePages.java
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MINUTES)
 @State(Scope.Thread)
-@Fork(jvmArgs = {"-Xmx256m", "-XX:+UseLargePages", "-XX:LargePageSizeInBytes=1g", "-Xlog:pagesize"}, value = 5)
+@Fork(jvmArgs = {"-XX:+UseLargePages", "-XX:LargePageSizeInBytes=1g", "-Xlog:pagesize"}, value = 5)
 
 public class MicroLargePages {
 

--- a/test/micro/org/openjdk/bench/vm/gc/MicroLargePages.java
+++ b/test/micro/org/openjdk/bench/vm/gc/MicroLargePages.java
@@ -26,10 +26,12 @@ package org.openjdk.bench.vm.gc;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.ThreadParams;
 
 @OutputTimeUnit(TimeUnit.MINUTES)
 @State(Scope.Thread)
-@Fork(jvmArgs = {"-XX:+UseLargePages", "-XX:LargePageSizeInBytes=1g", "-Xlog:pagesize"}, value = 5)
+@Threads(1)
+@Fork(jvmArgs = {"-Xmx256m", "-XX:+UseLargePages", "-XX:LargePageSizeInBytes=1g", "-Xlog:pagesize"}, value = 5)
 
 public class MicroLargePages {
 
@@ -43,7 +45,11 @@ public class MicroLargePages {
     public long[][] OUT;
 
     @Setup(Level.Trial)
-    public void BmSetup() {
+    public void BmSetup(ThreadParams params) {
+        if (params.getThreadCount() != 1) {
+            throw new IllegalStateException("MicroLargePages requires exactly one thread");
+        }
+
         INP = new long[NUM][ARRAYSIZE];
         OUT = new long[NUM][ARRAYSIZE];
         for (int i = 0; i < NUM; i++) {


### PR DESCRIPTION
I would like to fix the JMH OOM issue in MicroLargePages.java. Please review this small fix.

When NUM=4, the array elements require approximately the following amount of
memory per thread:

4 * 8 * 2,097,152 * 2 = 128 MiB

Since the benchmark uses `@State(Scope.Thread)`, running it with `-t 2` or more
requires more heap space than the fixed -Xmx256m limit, resulting in a
consistent OOM.

There are several possible solutions:

1. Restrict the benchmark to `-t 1`;
2. Remove `@State(Scope.Thread)`;
3. Remove `-Xmx256m`.

Restricting the benchmark to -t 1 or removing `@State(Scope.Thread)` may change
the original benchmark intent. Therefore, I propose removing the fixed
-Xmx256m heap limit. This allows the JVM to select the heap size based on the
runtime environment, while users can still configure it externally when
needed.

I tested the updated benchmark with -t 100 and NUM=4. It completed successfully
without an OOM.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8318477](https://bugs.openjdk.org/browse/JDK-8318477): [jmh] the test gc.MicroLargePages.micro_HOP_DIST_4KB failed with multiple threads (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32315/head:pull/32315` \
`$ git checkout pull/32315`

Update a local copy of the PR: \
`$ git checkout pull/32315` \
`$ git pull https://git.openjdk.org/jdk.git pull/32315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32315`

View PR using the GUI difftool: \
`$ git pr show -t 32315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32315.diff">https://git.openjdk.org/jdk/pull/32315.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32315#issuecomment-5265805012)
</details>
