### PR TITLE
8313315: runtime/ErrorHandling/MachCodeFramesInErrorFile.java fails on linux ppc64le

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,7 +102,6 @@ runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
-runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/NMT/VirtualAllocCommitMerge.java 8309698 linux-s390x
 runtime/Thread/TestAlwaysPreTouchStacks.java 8383372 macosx-aarch64
 


### PR DESCRIPTION

[JDK-8313315](https://bugs.openjdk.org/browse/JDK-8313315)


Removes `runtime/ErrorHandling/MachCodeFramesInErrorFile.java` from the
ProblemList for `linux-ppc64le`. The test no longer reproduces the reported
failure on current mainline.

### Background

The test crashes a JVM and checks that the resulting hs_err file contains a
`[MachCode]` section for each compiled Java frame the error handler listed:

```java
int minExpectedMachCodeSections = Math.max(1, compiledJavaFrames);
```

The reported failure (`1 < 2`) meant the hs_err named two compiled Java frames
but dumped machine code for only one of them.

### Testing

Ran on POWER10 (IBM 9105-22A, 320 CPUs, RHEL, gcc 11.5.0), 50 iterations per
configuration via `JTREG="REPEAT_COUNT=50"`:

- `linux-ppc64le-server-fastdebug` - 50/50 passed


Each run was verified to have exercised the check rather than exited early
: `[Disassembly]` count 0, `[MachCode]` count >= 2.



### Note on hsdis

Worth recording for anyone looking at this again: the test cannot fail on a
build with hsdis available. It returns success as soon as it finds a
`[Disassembly]` block, before reaching the MachCode check:

```java
if (matcherDisasm.find()) {
    // Real disassembly is present, no MachCode is expected.
    return;
}
```

This may explain the discrepancy in the JBS issue between the failures seen
in SapMachine CI and the inability to reproduce locally. 


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8313315](https://bugs.openjdk.org/browse/JDK-8313315): runtime/ErrorHandling/MachCodeFramesInErrorFile.java fails on linux ppc64le (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [David Briemann](https://openjdk.org/census#dbriemann) (@dbriemann - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32318/head:pull/32318` \
`$ git checkout pull/32318`

Update a local copy of the PR: \
`$ git checkout pull/32318` \
`$ git pull https://git.openjdk.org/jdk.git pull/32318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32318`

View PR using the GUI difftool: \
`$ git pr show -t 32318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32318.diff">https://git.openjdk.org/jdk/pull/32318.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32318#issuecomment-5316316156)
</details>
