### PR TITLE
8389987: null is accepted as synchronized lock

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1965,7 +1965,7 @@ public class Attr extends JCTree.Visitor {
     }
 
     public void visitSynchronized(JCSynchronized tree) {
-        boolean identityType = chk.checkIdentityType(tree.pos(), attribExpr(tree.lock, env));
+        boolean identityType = chk.checkIdentityRefType(tree.pos(), attribExpr(tree.lock, env));
         if (identityType && tree.lock.type != null && tree.lock.type.isValueBased()) {
             log.warning(tree.pos(), LintWarnings.AttemptToSynchronizeOnInstanceOfValueBasedClass);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -733,14 +733,15 @@ public class Check {
                                 t);
     }
 
-    /** Check that type is an identity type, i.e. not a value type.
+    /** Check that type is an identity reference type, i.e. a reference type and
+     *  not a value type.
      *  When not discernible statically, give it the benefit of doubt
      *  and defer to runtime.
      *
      *  @param pos           Position to be used for error reporting.
      *  @param t             The type to be checked.
      */
-    boolean checkIdentityType(DiagnosticPosition pos, Type t) {
+    boolean checkIdentityRefType(DiagnosticPosition pos, Type t) {
         if (t.hasTag(TYPEVAR)) {
             t = types.skipTypeVars(t, false);
         }
@@ -748,12 +749,15 @@ public class Check {
             IntersectionClassType ict = (IntersectionClassType)t;
             boolean result = true;
             for (Type component : ict.getExplicitComponents()) {
-                result &= checkIdentityType(pos, component);
+                result &= checkIdentityRefType(pos, component);
             }
             return result;
         }
-        if (t.isPrimitive() || (t.isValueClass() && !t.tsym.isAbstract())) {
-            typeTagError(pos, diags.fragment(Fragments.TypeReqIdentity), t);
+        if (!t.isReference() || (t.isValueClass() && !t.tsym.isAbstract())) {
+            Fragment required =
+                    allowValueClasses ? Fragments.TypeReqIdentity
+                                      : Fragments.TypeReqRef;
+            typeTagError(pos, diags.fragment(required), t);
             return false;
         }
         return true;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2938,7 +2938,7 @@ compiler.misc.type.req.exact=\
     class or interface without bounds
 
 compiler.misc.type.req.identity=\
-    a type with identity
+    identity class
 
 # 0: type
 compiler.misc.type.parameter=\

--- a/test/langtools/tools/javac/attr/Synchronized.java
+++ b/test/langtools/tools/javac/attr/Synchronized.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8389987
+ * @summary Verify correct handling of synchronized
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit Synchronized
+*/
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class Synchronized {
+
+    private Path base;
+    private ToolBox tb = new ToolBox();
+
+    @Test
+    public void testSynchronizedNull() throws Exception {
+        Path src = base.resolve("src");
+        Path classes = base.resolve("classes");
+        tb.writeJavaFiles(src,
+                          """
+                          public class Test {
+                              void t() {
+                                  synchronized (null) {}
+                              }
+                          }
+                          """);
+
+        Files.createDirectories(classes);
+
+        List<String> log;
+        List<String> expected;
+
+        log = new JavacTask(tb)
+            .options("-XDrawDiagnostics")
+            .outdir(classes)
+            .files(tb.findJavaFiles(src))
+            .run(Task.Expect.FAIL)
+            .writeAll()
+            .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+            "Test.java:3:9: compiler.err.type.found.req: compiler.misc.type.null, (compiler.misc.type.req.ref)",
+            "1 error"
+        );
+
+        assertEquals(expected, log);
+
+        log = new JavacTask(tb)
+            .options("-XDrawDiagnostics",
+                     "--enable-preview", "--release", System.getProperty("java.specification.version"))
+            .outdir(classes)
+            .files(tb.findJavaFiles(src))
+            .run(Task.Expect.FAIL)
+            .writeAll()
+            .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+            "Test.java:3:9: compiler.err.type.found.req: compiler.misc.type.null, (compiler.misc.type.req.identity)",
+            "1 error"
+        );
+
+        assertEquals(expected, log);
+    }
+
+    @Test
+    public void testSynchronizedValueClassValueClassesDisabled() throws Exception {
+        Path src = base.resolve("src");
+        Path classes = base.resolve("classes");
+        tb.writeJavaFiles(src,
+                          """
+                          public value class Test {
+                              void t() {
+                                  synchronized (new Test()) {}
+                              }
+                          }
+                          """);
+
+        Files.createDirectories(classes);
+
+        List<String> log;
+        List<String> expected;
+
+        log = new JavacTask(tb)
+            .options("-XDrawDiagnostics",
+                     "-XDshould-stop.at=WARN")
+            .outdir(classes)
+            .files(tb.findJavaFiles(src))
+            .run(Task.Expect.FAIL)
+            .writeAll()
+            .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+            "Test.java:1:8: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.value.classes)",
+            "Test.java:3:9: compiler.err.type.found.req: Test, (compiler.misc.type.req.ref)",
+            "2 errors"
+        );
+
+        assertEquals(expected, log);
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}


### PR DESCRIPTION
Consider this code:
```
$ cat /tmp/Synchronized.java 
public class Synchronized {
    private void test() {
        synchronized (null) {}
    }
}
```

The current JDK mainline incorrectly accept this code. The code is illegal because `synchronized` requires a reference type and `null` is not a reference type. The current state is a consequence of adjusting the code to verify synchronization uses identity classes.

The proposal herein is to replace the `isPrimitive()` check with a more strict `!isReference()` in `Check.checkIdentityType`. I believe this method is only used by `Attr.visitSynchronized`, and this patch is also adjusting the name to make it more obvious it check for a reference type.

The error are proposed to replicate the JDK 27 error when value classes are disabled:
```
$ javac /tmp/Synchronized.java 
/tmp/Synchronized.java:3: error: unexpected type
        synchronized (null) {}
        ^
  required: reference
  found:    <null>
1 error
```

and use the new, slightly adjusted, error when value classes are enabled:
```
$ ~/src/jdk/jd/build/linux-x86_64-server-release/jdk/bin/javac --enable-preview --release 28c /tmp/Synchronized.java 
/tmp/Synchronized.java:3: error: unexpected type
        synchronized (null) {}
        ^
  required: identity class
  found:    <null>
1 error
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8389987: null is accepted as synchronized lock`

### Issue
 * [JDK-8389987](https://bugs.openjdk.org/browse/JDK-8389987): null is accepted as synchronized lock (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32320/head:pull/32320` \
`$ git checkout pull/32320`

Update a local copy of the PR: \
`$ git checkout pull/32320` \
`$ git pull https://git.openjdk.org/jdk.git pull/32320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32320`

View PR using the GUI difftool: \
`$ git pr show -t 32320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32320.diff">https://git.openjdk.org/jdk/pull/32320.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32320#issuecomment-5268617964)
</details>
