### PR TITLE
8386893: add "#include <new>" to get defintion of "std::nothrow_t"

### DIFF
--- a/src/jdk.jpackage/share/native/common/tstrings.h
+++ b/src/jdk.jpackage/share/native/common/tstrings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@
 #include <string>
 #include <sstream>
 #include <iostream>
+#include <new>
 #include <vector>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Add the missing `#include <new>` to jpackage native code.

Only "tstrings.h" required the fix. All other sources get `#include <new>` transitively through it.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8386893: add "#include <new>" to get defintion of "std::nothrow_t"`

### Issue
 * [JDK-8386893](https://bugs.openjdk.org/browse/JDK-8386893): add "#include &lt;new&gt;" to get defintion of "std::nothrow_t" (**Enhancement** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32321/head:pull/32321` \
`$ git checkout pull/32321`

Update a local copy of the PR: \
`$ git checkout pull/32321` \
`$ git pull https://git.openjdk.org/jdk.git pull/32321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32321`

View PR using the GUI difftool: \
`$ git pr show -t 32321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32321.diff">https://git.openjdk.org/jdk/pull/32321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32321#issuecomment-5269706367)
</details>
