### PR TITLE
8389541: failure_handler: section IDs can repeat across appended HTML fragments

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/HtmlPage.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/HtmlPage.java
@@ -29,6 +29,10 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class HtmlPage implements AutoCloseable {
     static final String STYLE_SHEET_FILENAME = "failure-handler-style.css";
@@ -59,11 +63,20 @@ public class HtmlPage implements AutoCloseable {
         if (htmlFileName.isBlank()) {
             throw new IllegalArgumentException("HTML file name cannot be blank");
         }
+        final Set<String> existingIds = new HashSet<>();
+        if (append && Files.isRegularFile(dir.resolve(htmlFileName))) {
+            final Matcher m = Pattern.compile("div id='([^']*)'")
+                    .matcher(Files.readString(dir.resolve(htmlFileName)));
+            while (m.find()) {
+                existingIds.add(m.group(1));
+            }
+        }
         final FileWriter fileWriter = new FileWriter(dir.resolve(htmlFileName).toFile(), append);
         this.writer = new PrintWriter(fileWriter, true);
         createScriptFile(dir);
         createStyleSheetFile(dir);
         rootSection = new HtmlSection(writer);
+        rootSection.preregisterIds(existingIds);
     }
 
 

--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/HtmlSection.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/HtmlSection.java
@@ -77,6 +77,14 @@ public class HtmlSection {
         }
     }
 
+    /**
+     * Records ids that are already present in the output file, so ids issued
+     * by this root never repeat them. Root section only.
+     */
+    void preregisterIds(java.util.Collection<String> ids) {
+        sectionIds.addAll(ids);
+    }
+
     public HtmlSection createChildren(String section) {
         if (child != null) {
             if (child.name.equals(section)) {

--- a/test/failure_handler/test/unit/jdk/test/failurehandler/HtmlSectionTest.java
+++ b/test/failure_handler/test/unit/jdk/test/failurehandler/HtmlSectionTest.java
@@ -121,6 +121,24 @@ public class HtmlSectionTest {
     }
 
     @Test
+    public void appendedFragmentsGetUniqueIds() throws Exception {
+        // two invocations appending to the same file must not
+        // reuse each other's ids
+        Path dir = Files.createTempDirectory("HtmlSectionTest");
+        for (int frag = 1; frag <= 2; frag++) {
+            HtmlPage page = new HtmlPage(dir, "processes.html", true);
+            HtmlSection root = page.getRootSection();
+            HtmlSection s = root.createChildren("jinfo".split("\\."));
+            s.getWriter().println("FRAG-" + frag);
+            root.close();
+            page.close();
+        }
+        String html = Files.readString(dir.resolve("processes.html"));
+        assertUniqueIds(html);
+        Assert.assertNotEquals(sectionIdOf(html, "FRAG-1"), sectionIdOf(html, "FRAG-2"));
+    }
+
+    @Test
     public void adjacentIdenticalCommandsShareSection() throws Exception {
         // adjacent identical commands reuse the open section (existing
         // behavior): one section, both outputs in it


### PR DESCRIPTION
When the failure handler appends a report fragment into an existing html file, each invocation starts a fresh id registry, so section ids from the earlier fragment can repeat and clicks resolve to the first occurrence, the same failure mode recently fixed within a single invocation. This change scans the existing file for div ids when opening in append mode and preregisters them, so a second fragment's repeats get suffixed the same way. The scan uses Files.readString on the existing report, simple over streaming, happy to switch if reviewers prefer




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389541](https://bugs.openjdk.org/browse/JDK-8389541): failure_handler: section IDs can repeat across appended HTML fragments (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32322/head:pull/32322` \
`$ git checkout pull/32322`

Update a local copy of the PR: \
`$ git checkout pull/32322` \
`$ git pull https://git.openjdk.org/jdk.git pull/32322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32322`

View PR using the GUI difftool: \
`$ git pr show -t 32322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32322.diff">https://git.openjdk.org/jdk/pull/32322.diff</a>

</details>
