### PR TITLE
8390249: Add missing @Override annotations in "javax.imageio.stream" package

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,6 +150,7 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
         return pos;
     }
 
+    @Override
     public int read() throws IOException {
         checkClosed();
         bitOffset = 0;
@@ -163,6 +164,7 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
         }
     }
 
+    @Override
     public int read(byte[] b, int off, int len) throws IOException {
         checkClosed();
 
@@ -205,6 +207,7 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
      * @see #isCachedMemory
      * @see #isCachedFile
      */
+    @Override
     public boolean isCached() {
         return true;
     }
@@ -218,6 +221,7 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
      * @see #isCached
      * @see #isCachedMemory
      */
+    @Override
     public boolean isCachedFile() {
         return true;
     }
@@ -232,6 +236,7 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
      * @see #isCached
      * @see #isCachedFile
      */
+    @Override
     public boolean isCachedMemory() {
         return false;
     }
@@ -243,6 +248,7 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
      *
      * @throws IOException if an error occurs.
      */
+    @Override
     public void close() throws IOException {
         super.close();
         disposerRecord.dispose(); // this will close/delete the cache file
@@ -261,6 +267,7 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
             this.cache = cache;
         }
 
+        @Override
         public synchronized void dispose() {
             if (cache != null) {
                 try {

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,6 +108,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
         StreamCloser.addToQueue(closeAction);
     }
 
+    @Override
     public int read() throws IOException {
         checkClosed();
         bitOffset = 0;
@@ -118,6 +119,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
         return val;
     }
 
+    @Override
     public int read(byte[] b, int off, int len) throws IOException {
         checkClosed();
 
@@ -142,6 +144,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
         return nbytes;
     }
 
+    @Override
     public void write(int b) throws IOException {
         flushBits(); // this will call checkClosed() for us
         cache.write(b);
@@ -149,6 +152,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
         maxStreamPos = Math.max(maxStreamPos, streamPos);
     }
 
+    @Override
     public void write(byte[] b, int off, int len) throws IOException {
         flushBits(); // this will call checkClosed() for us
         cache.write(b, off, len);
@@ -156,6 +160,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
         maxStreamPos = Math.max(maxStreamPos, streamPos);
     }
 
+    @Override
     public long length() {
         try {
             checkClosed();
@@ -176,6 +181,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      * than the flushed position.
      * @throws IOException if any other I/O error occurs.
      */
+    @Override
     public void seek(long pos) throws IOException {
         checkClosed();
 
@@ -199,6 +205,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      * @see #isCachedMemory
      * @see #isCachedFile
      */
+    @Override
     public boolean isCached() {
         return true;
     }
@@ -212,6 +219,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      * @see #isCached
      * @see #isCachedMemory
      */
+    @Override
     public boolean isCachedFile() {
         return true;
     }
@@ -226,6 +234,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      * @see #isCached
      * @see #isCachedFile
      */
+    @Override
     public boolean isCachedMemory() {
         return false;
     }
@@ -238,6 +247,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      *
      * @throws IOException if an error occurs.
      */
+    @Override
     public void close() throws IOException {
         maxStreamPos = cache.length();
 
@@ -257,6 +267,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      * @param pos {@inheritDoc ImageOutputStream}
      * @throws IOException {@inheritDoc ImageOutputStream}
      */
+    @Override
     public void flushBefore(long pos) throws IOException {
         long oFlushedPos = flushedPos;
         super.flushBefore(pos); // this will call checkClosed() for us

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileImageInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,6 +97,7 @@ public class FileImageInputStream extends ImageInputStreamImpl {
         Disposer.addRecord(disposerReferent, disposerRecord);
     }
 
+    @Override
     public int read() throws IOException {
         checkClosed();
         bitOffset = 0;
@@ -107,6 +108,7 @@ public class FileImageInputStream extends ImageInputStreamImpl {
         return val;
     }
 
+    @Override
     public int read(byte[] b, int off, int len) throws IOException {
         checkClosed();
         bitOffset = 0;
@@ -124,6 +126,7 @@ public class FileImageInputStream extends ImageInputStreamImpl {
      * @return the file length as a {@code long}, or
      * {@code -1}.
      */
+    @Override
     public long length() {
         try {
             checkClosed();
@@ -133,6 +136,7 @@ public class FileImageInputStream extends ImageInputStreamImpl {
         }
     }
 
+    @Override
     public void seek(long pos) throws IOException {
         checkClosed();
         if (pos < flushedPos) {
@@ -143,6 +147,7 @@ public class FileImageInputStream extends ImageInputStreamImpl {
         streamPos = raf.getFilePointer();
     }
 
+    @Override
     public void close() throws IOException {
         super.close();
         disposerRecord.dispose(); // this closes the RandomAccessFile

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileImageOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,6 +89,7 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
         Disposer.addRecord(disposerReferent, disposerRecord);
     }
 
+    @Override
     public int read() throws IOException {
         checkClosed();
         bitOffset = 0;
@@ -99,6 +100,7 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
         return val;
     }
 
+    @Override
     public int read(byte[] b, int off, int len) throws IOException {
         checkClosed();
         bitOffset = 0;
@@ -109,18 +111,21 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
         return nbytes;
     }
 
+    @Override
     public void write(int b) throws IOException {
         flushBits(); // this will call checkClosed() for us
         raf.write(b);
         ++streamPos;
     }
 
+    @Override
     public void write(byte[] b, int off, int len) throws IOException {
         flushBits(); // this will call checkClosed() for us
         raf.write(b, off, len);
         streamPos += len;
     }
 
+    @Override
     public long length() {
         try {
             checkClosed();
@@ -141,6 +146,7 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
      * than the flushed position.
      * @throws IOException if any other I/O error occurs.
      */
+    @Override
     public void seek(long pos) throws IOException {
         checkClosed();
         if (pos < flushedPos) {
@@ -151,6 +157,7 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
         streamPos = raf.getFilePointer();
     }
 
+    @Override
     public void close() throws IOException {
         super.close();
         disposerRecord.dispose(); // this closes the RandomAccessFile

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,6 +186,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @throws java.io.EOFException if the end of the stream is reached.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     boolean readBoolean() throws IOException;
 
     /**
@@ -204,6 +205,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @throws java.io.EOFException if the end of the stream is reached.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     byte readByte() throws IOException;
 
     /**
@@ -228,6 +230,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @throws java.io.EOFException if the end of the stream is reached.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     int readUnsignedByte() throws IOException;
 
     /**
@@ -246,6 +249,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @see #getByteOrder
      */
+    @Override
     short readShort() throws IOException;
 
     /**
@@ -267,6 +271,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @see #getByteOrder
      */
+    @Override
     int readUnsignedShort() throws IOException;
 
     /**
@@ -284,6 +289,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @see #readUnsignedShort
      */
+    @Override
     char readChar() throws IOException;
 
     /**
@@ -302,6 +308,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @see #getByteOrder
      */
+    @Override
     int readInt() throws IOException;
 
     /**
@@ -340,6 +347,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @see #getByteOrder
      */
+    @Override
     long readLong() throws IOException;
 
     /**
@@ -358,6 +366,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @see #getByteOrder
      */
+    @Override
     float readFloat() throws IOException;
 
     /**
@@ -376,6 +385,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @see #getByteOrder
      */
+    @Override
     double readDouble() throws IOException;
 
     /**
@@ -410,6 +420,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     String readLine() throws IOException;
 
     /**
@@ -494,6 +505,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * a valid modified UTF-8 encoding of a string.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     String readUTF() throws IOException;
 
     /**
@@ -518,6 +530,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * reading all the bytes.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void readFully(byte[] b, int off, int len) throws IOException;
 
     /**
@@ -537,6 +550,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * reading all the bytes.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void readFully(byte[] b) throws IOException;
 
     /**
@@ -822,6 +836,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     int skipBytes(int n) throws IOException;
 
     /**
@@ -995,5 +1010,6 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void close() throws IOException;
 }

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,10 +114,12 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    @Override
     public void setByteOrder(ByteOrder byteOrder) {
         this.byteOrder = byteOrder;
     }
 
+    @Override
     public ByteOrder getByteOrder() {
         return byteOrder;
     }
@@ -139,6 +141,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      *
      * @throws IOException if the stream has been closed.
      */
+    @Override
     public abstract int read() throws IOException;
 
     /**
@@ -154,6 +157,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * {@code null}.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
@@ -185,8 +189,10 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * {@code null}.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     public abstract int read(byte[] b, int off, int len) throws IOException;
 
+    @Override
     public void readBytes(IIOByteBuffer buf, int len) throws IOException {
         if (len < 0) {
             throw new IndexOutOfBoundsException("len < 0!");
@@ -206,6 +212,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public boolean readBoolean() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -217,6 +224,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public byte readByte() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -228,6 +236,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public int readUnsignedByte() throws IOException {
         int ch = this.read();
         if (ch < 0) {
@@ -239,6 +248,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public short readShort() throws IOException {
         if (read(byteBuf, 0, 2) != 2) {
             throw new EOFException();
@@ -251,6 +261,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public int readUnsignedShort() throws IOException {
         return ((int)readShort()) & 0xffff;
     }
@@ -258,6 +269,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public char readChar() throws IOException {
         return (char)readShort();
     }
@@ -265,6 +277,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public int readInt() throws IOException {
         if (read(byteBuf, 0, 4) !=  4) {
             throw new EOFException();
@@ -278,6 +291,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public long readUnsignedInt() throws IOException {
         return ((long)readInt()) & 0xffffffffL;
     }
@@ -285,6 +299,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public long readLong() throws IOException {
         // REMIND: Once 6277756 is fixed, we should do a bulk read of all 8
         // bytes here as we do in readShort() and readInt() for even better
@@ -302,6 +317,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public float readFloat() throws IOException {
         return Float.intBitsToFloat(readInt());
     }
@@ -309,10 +325,12 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public double readDouble() throws IOException {
         return Double.longBitsToDouble(readLong());
     }
 
+    @Override
     public String readLine() throws IOException {
         StringBuilder input = new StringBuilder();
         int c = -1;
@@ -347,6 +365,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * @throws EOFException {@inheritDoc}
      * @throws java.io.UTFDataFormatException {@inheritDoc}
      */
+    @Override
     public String readUTF() throws IOException {
         this.bitOffset = 0;
 
@@ -372,6 +391,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public void readFully(byte[] b, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > b.length || off + len < 0) {
@@ -392,6 +412,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public void readFully(byte[] b) throws IOException {
         readFully(b, 0, b.length);
     }
@@ -399,6 +420,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public void readFully(short[] s, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > s.length || off + len < 0) {
@@ -418,6 +440,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public void readFully(char[] c, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > c.length || off + len < 0) {
@@ -437,6 +460,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public void readFully(int[] i, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > i.length || off + len < 0) {
@@ -456,6 +480,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public void readFully(long[] l, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > l.length || off + len < 0) {
@@ -475,6 +500,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public void readFully(float[] f, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > f.length || off + len < 0) {
@@ -494,6 +520,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public void readFully(double[] d, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > d.length || off + len < 0) {
@@ -600,16 +627,19 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         }
     }
 
+    @Override
     public long getStreamPosition() throws IOException {
         checkClosed();
         return streamPos;
     }
 
+    @Override
     public int getBitOffset() throws IOException {
         checkClosed();
         return bitOffset;
     }
 
+    @Override
     public void setBitOffset(int bitOffset) throws IOException {
         checkClosed();
         if (bitOffset < 0 || bitOffset > 7) {
@@ -621,6 +651,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public int readBit() throws IOException {
         checkClosed();
 
@@ -646,6 +677,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
     /**
      * @throws EOFException {@inheritDoc}
      */
+    @Override
     public long readBits(int numBits) throws IOException {
         checkClosed();
 
@@ -697,6 +729,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      *
      * @return -1L to indicate unknown length.
      */
+    @Override
     public long length() {
         return -1L;
     }
@@ -716,6 +749,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * throws an {@code IOException} when computing either
      * the starting or ending position.
      */
+    @Override
     public int skipBytes(int n) throws IOException {
         long pos = getStreamPosition();
         seek(pos + n);
@@ -737,12 +771,14 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * throws an {@code IOException} when computing either
      * the starting or ending position.
      */
+    @Override
     public long skipBytes(long n) throws IOException {
         long pos = getStreamPosition();
         seek(pos + n);
         return getStreamPosition() - pos;
     }
 
+    @Override
     public void seek(long pos) throws IOException {
         checkClosed();
 
@@ -759,6 +795,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * Pushes the current stream position onto a stack of marked
      * positions.
      */
+    @Override
     public void mark() {
         try {
             markByteStack.push(Long.valueOf(getStreamPosition()));
@@ -776,6 +813,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     public void reset() throws IOException {
         if (markByteStack.empty()) {
             return;
@@ -792,6 +830,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         setBitOffset(offset);
     }
 
+    @Override
     public void flushBefore(long pos) throws IOException {
         checkClosed();
         if (pos < flushedPos) {
@@ -804,10 +843,12 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
         flushedPos = pos;
     }
 
+    @Override
     public void flush() throws IOException {
         flushBefore(getStreamPosition());
     }
 
+    @Override
     public long getFlushedPosition() {
         return flushedPos;
     }
@@ -816,6 +857,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * Default implementation returns false.  Subclasses should
      * override this if they cache data.
      */
+    @Override
     public boolean isCached() {
         return false;
     }
@@ -824,6 +866,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * Default implementation returns false.  Subclasses should
      * override this if they cache data in main memory.
      */
+    @Override
     public boolean isCachedMemory() {
         return false;
     }
@@ -832,10 +875,12 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * Default implementation returns false.  Subclasses should
      * override this if they cache data in a temporary file.
      */
+    @Override
     public boolean isCachedFile() {
         return false;
     }
 
+    @Override
     public void close() throws IOException {
         checkClosed();
 

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void write(int b) throws IOException;
 
     /**
@@ -87,6 +88,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * {@code null}.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void write(byte[] b) throws IOException;
 
     /**
@@ -114,6 +116,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * {@code null}.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void write(byte[] b, int off, int len) throws IOException;
 
     /**
@@ -131,6 +134,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeBoolean(boolean v) throws IOException;
 
     /**
@@ -149,6 +153,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeByte(int v) throws IOException;
 
     /**
@@ -179,6 +184,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeShort(int v) throws IOException;
 
     /**
@@ -191,6 +197,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @see #writeShort(int)
      */
+    @Override
     void writeChar(int v) throws IOException;
 
     /**
@@ -224,6 +231,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeInt(int v) throws IOException;
 
     /**
@@ -265,6 +273,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeLong(long v) throws IOException;
 
     /**
@@ -285,6 +294,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeFloat(float v) throws IOException;
 
     /**
@@ -306,6 +316,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeDouble(double v) throws IOException;
 
     /**
@@ -334,6 +345,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * {@code null}.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeBytes(String s) throws IOException;
 
     /**
@@ -362,6 +374,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * {@code null}.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeChars(String s) throws IOException;
 
     /**
@@ -433,6 +446,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * representation of {@code s} requires more than 65536 bytes.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void writeUTF(String s) throws IOException;
 
     /**
@@ -658,5 +672,6 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * position.
      * @throws IOException if an I/O error occurs.
      */
+    @Override
     void flushBefore(long pos) throws IOException;
 }

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,22 +48,28 @@ public abstract class ImageOutputStreamImpl
     public ImageOutputStreamImpl() {
     }
 
+    @Override
     public abstract void write(int b) throws IOException;
 
+    @Override
     public void write(byte[] b) throws IOException {
         write(b, 0, b.length);
     }
 
+    @Override
     public abstract void write(byte[] b, int off, int len) throws IOException;
 
+    @Override
     public void writeBoolean(boolean v) throws IOException {
         write(v ? 1 : 0);
     }
 
+    @Override
     public void writeByte(int v) throws IOException {
         write(v);
     }
 
+    @Override
     public void writeShort(int v) throws IOException {
         if (byteOrder == ByteOrder.BIG_ENDIAN) {
             ByteArray.setUnsignedShort(byteBuf, 0, v);
@@ -73,10 +79,12 @@ public abstract class ImageOutputStreamImpl
         write(byteBuf, 0, 2);
     }
 
+    @Override
     public void writeChar(int v) throws IOException {
         writeShort(v);
     }
 
+    @Override
     public void writeInt(int v) throws IOException {
         if (byteOrder == ByteOrder.BIG_ENDIAN) {
             ByteArray.setInt(byteBuf, 0, v);
@@ -86,6 +94,7 @@ public abstract class ImageOutputStreamImpl
         write(byteBuf, 0, 4);
     }
 
+    @Override
     public void writeLong(long v) throws IOException {
         if (byteOrder == ByteOrder.BIG_ENDIAN) {
             ByteArray.setLong(byteBuf, 0, v);
@@ -100,14 +109,17 @@ public abstract class ImageOutputStreamImpl
         write(byteBuf, 4, 4);
     }
 
+    @Override
     public void writeFloat(float v) throws IOException {
         writeInt(Float.floatToIntBits(v));
     }
 
+    @Override
     public void writeDouble(double v) throws IOException {
         writeLong(Double.doubleToLongBits(v));
     }
 
+    @Override
     public void writeBytes(String s) throws IOException {
         int len = s.length();
         for (int i = 0 ; i < len ; i++) {
@@ -115,6 +127,7 @@ public abstract class ImageOutputStreamImpl
         }
     }
 
+    @Override
     public void writeChars(String s) throws IOException {
         int len = s.length();
 
@@ -140,6 +153,7 @@ public abstract class ImageOutputStreamImpl
     /**
      * @throws UTFDataFormatException {@inheritDoc}
      */
+    @Override
     public void writeUTF(String s) throws IOException {
         int strlen = s.length();
         int utflen = 0;
@@ -182,6 +196,7 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, utflen + 2);
     }
 
+    @Override
     public void writeShorts(short[] s, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > s.length || off + len < 0) {
@@ -208,6 +223,7 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, len*2);
     }
 
+    @Override
     public void writeChars(char[] c, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > c.length || off + len < 0) {
@@ -234,6 +250,7 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, len*2);
     }
 
+    @Override
     public void writeInts(int[] i, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > i.length || off + len < 0) {
@@ -260,6 +277,7 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, len*4);
     }
 
+    @Override
     public void writeLongs(long[] l, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > l.length || off + len < 0) {
@@ -286,6 +304,7 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, len*8);
     }
 
+    @Override
     public void writeFloats(float[] f, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > f.length || off + len < 0) {
@@ -312,6 +331,7 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, len*4);
     }
 
+    @Override
     public void writeDoubles(double[] d, int off, int len) throws IOException {
         // Fix 4430357 - if off + len < 0, overflow occurred
         if (off < 0 || len < 0 || off + len > d.length || off + len < 0) {
@@ -338,10 +358,12 @@ public abstract class ImageOutputStreamImpl
         write(b, 0, len*8);
     }
 
+    @Override
     public void writeBit(int bit) throws IOException {
         writeBits((1L & bit), 1);
     }
 
+    @Override
     public void writeBits(long bits, int numBits) throws IOException {
         checkClosed();
 

--- a/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,7 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
         this.stream = stream;
     }
 
+    @Override
     public int read() throws IOException {
         checkClosed();
         bitOffset = 0;
@@ -73,6 +74,7 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
         }
     }
 
+    @Override
     public int read(byte[] b, int off, int len) throws IOException {
         checkClosed();
 
@@ -103,6 +105,7 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
         }
     }
 
+    @Override
     public void flushBefore(long pos) throws IOException {
         super.flushBefore(pos); // this will call checkClosed() for us
         cache.disposeBefore(pos);
@@ -118,6 +121,7 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
      * @see #isCachedMemory
      * @see #isCachedFile
      */
+    @Override
     public boolean isCached() {
         return true;
     }
@@ -131,6 +135,7 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
      * @see #isCached
      * @see #isCachedMemory
      */
+    @Override
     public boolean isCachedFile() {
         return false;
     }
@@ -144,6 +149,7 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
      * @see #isCached
      * @see #isCachedFile
      */
+    @Override
     public boolean isCachedMemory() {
         return true;
     }
@@ -152,6 +158,7 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
      * Closes this {@code MemoryCacheImageInputStream}, freeing
      * the cache.  The source {@code InputStream} is not closed.
      */
+    @Override
     public void close() throws IOException {
         super.close();
         stream = null;

--- a/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
         this.stream = stream;
     }
 
+    @Override
     public int read() throws IOException {
         checkClosed();
 
@@ -73,6 +74,7 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
         return val;
     }
 
+    @Override
     public int read(byte[] b, int off, int len) throws IOException {
         checkClosed();
 
@@ -107,18 +109,21 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
         return len;
     }
 
+    @Override
     public void write(int b) throws IOException {
         flushBits(); // this will call checkClosed() for us
         cache.write(b, streamPos);
         ++streamPos;
     }
 
+    @Override
     public void write(byte[] b, int off, int len) throws IOException {
         flushBits(); // this will call checkClosed() for us
         cache.write(b, off, len, streamPos);
         streamPos += len;
     }
 
+    @Override
     public long length() {
         try {
             checkClosed();
@@ -138,6 +143,7 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
      * @see #isCachedMemory
      * @see #isCachedFile
      */
+    @Override
     public boolean isCached() {
         return true;
     }
@@ -151,6 +157,7 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
      * @see #isCached
      * @see #isCachedMemory
      */
+    @Override
     public boolean isCachedFile() {
         return false;
     }
@@ -164,6 +171,7 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
      * @see #isCached
      * @see #isCachedFile
      */
+    @Override
     public boolean isCachedMemory() {
         return true;
     }
@@ -174,6 +182,7 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
      * is released.  The destination {@code OutputStream}
      * is not closed.
      */
+    @Override
     public void close() throws IOException {
         long length = cache.getLength();
         seek(length);
@@ -189,6 +198,7 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
      * @param pos {@inheritDoc ImageOutputStream}
      * @throws IOException {@inheritDoc ImageOutputStream}
      */
+    @Override
     public void flushBefore(long pos) throws IOException {
         long oFlushedPos = flushedPos;
         super.flushBefore(pos); // this will call checkClosed() for us


### PR DESCRIPTION
This patch adds missing `@Override` annotations to methods in the `javax.imageio.stream` package that override methods from a superclass or interface.
Only source annotations are added; there are no behavioral changes.

The previous patch for `com.sun.beans` can be found here: https://github.com/openjdk/jdk/pull/27887.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390249](https://bugs.openjdk.org/browse/JDK-8390249): Add missing @<!---->Override annotations in "javax.imageio.stream" package (**Enhancement** - P5)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32323/head:pull/32323` \
`$ git checkout pull/32323`

Update a local copy of the PR: \
`$ git checkout pull/32323` \
`$ git pull https://git.openjdk.org/jdk.git pull/32323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32323`

View PR using the GUI difftool: \
`$ git pr show -t 32323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32323.diff">https://git.openjdk.org/jdk/pull/32323.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32323#issuecomment-5275767536)
</details>
