### PR TITLE
8390266: Avoid static for the template function in headers

### DIFF
--- a/src/hotspot/share/jfr/recorder/storage/jfrStorageUtils.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorageUtils.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ inline bool MutexedWriteOp<Operation>::process(typename Operation::Type* t) {
 }
 
 template <typename Type>
-static void retired_sensitive_acquire(Type* t, Thread* thread) {
+inline void retired_sensitive_acquire(Type* t, Thread* thread) {
   assert(t != nullptr, "invariant");
   assert(thread != nullptr, "invariant");
   assert(thread == Thread::current(), "invariant");

--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,11 +48,6 @@ static oop new_java_util_arraylist(TRAPS) {
 }
 
 static const int initial_array_size = 64;
-
-template <typename T>
-static GrowableArray<T>* c_heap_allocate_array(int size = initial_array_size) {
-  return new (mtTracing) GrowableArray<T>(size, mtTracing);
-}
 
 static bool initialize(TRAPS) {
   static bool initialized = false;

--- a/src/hotspot/share/oops/accessBackend.hpp
+++ b/src/hotspot/share/oops/accessBackend.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1133,7 +1133,7 @@ namespace AccessInternal {
   // that the passed in types make sense.
 
   template <DecoratorSet decorators, typename T>
-  static void verify_types(){
+  inline void verify_types(){
     // If this fails to compile, then you have sent in something that is
     // not recognized as a valid primitive type to a primitive Access function.
     STATIC_ASSERT((HasDecorator<decorators, INTERNAL_VALUE_IS_OOP>::value || // oops have already been validated

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -82,7 +82,7 @@ class Metadata : public MetaspaceObj {
 };
 
 template <typename M>
-static void print_on_maybe_null(outputStream* st, const char* str, const M* m) {
+inline void print_on_maybe_null(outputStream* st, const char* str, const M* m) {
   if (nullptr != m) {
     st->print_raw(str);
     m->print_value_on(st);

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1207,7 +1207,7 @@ inline int build_int_from_shorts( u2 low, u2 high ) {
 }
 
 // swap a & b
-template<class T> static void swap(T& a, T& b) {
+template<class T> inline void swap(T& a, T& b) {
   T tmp = a;
   a = b;
   b = tmp;

--- a/src/hotspot/share/utilities/parseInteger.hpp
+++ b/src/hotspot/share/utilities/parseInteger.hpp
@@ -115,7 +115,7 @@ inline bool multiply_by_1k(T& n) {
 // Example: "1024M:oom" will yield true, result=1G, endptr pointing to ":oom"
 
 template<typename T>
-static bool parse_integer(const char *s, char **endptr, T* result) {
+inline bool parse_integer(const char *s, char **endptr, T* result) {
 
   if (!isdigit(s[0]) && s[0] != '-') {
     // strtoll/strtoull may allow leading spaces. Forbid it.
@@ -163,7 +163,7 @@ static bool parse_integer(const char *s, char **endptr, T* result) {
 // characters. No remainder are allowed here.
 // Example: "100m" - okay, "100m:oom" -> not okay
 template<typename T>
-static bool parse_integer(const char *s, T* result) {
+inline bool parse_integer(const char *s, T* result) {
   char* remainder;
   bool rc = parse_integer(s, &remainder, result);
   rc = rc && (*remainder == '\0');


### PR DESCRIPTION
This patch cleans up static template functions in headers.

If a template function is static, C++ compilers use internal linkage.
1. the good case: nobody in TranslationUnit(TU) uses it. We get a warning.
2. the bad case: multiple TUs do use it. We have multiple identical copies.
3. the worst case: if it is referenced by another inline function in a header, we have latent ODR violation! I explain it in [the JBS issue](https://bugs.openjdk.org/browse/JDK-8390266).

Upstream clang has enabled [-Wunused-template](https://github.com/llvm/llvm-project/issues/202945) under -Wall and cleaned up their own codebase. When I build hotspot, clang emits over 1300+ warnings from a few global headers like globalDefinitions.hpp.
 
This cleanup can eliminate all warnings of -Wunused-template. I replace static by inline. This guarantees only one copy of instantiation exists in COMDAT section if it's necessary. only exception: I delete c_heap_allocate_array because there's no reference. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390266](https://bugs.openjdk.org/browse/JDK-8390266): Avoid static for the template function in headers (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Man Cao](https://openjdk.org/census#manc) (@caoman - Committer)
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32329/head:pull/32329` \
`$ git checkout pull/32329`

Update a local copy of the PR: \
`$ git checkout pull/32329` \
`$ git pull https://git.openjdk.org/jdk.git pull/32329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32329`

View PR using the GUI difftool: \
`$ git pr show -t 32329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32329.diff">https://git.openjdk.org/jdk/pull/32329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32329#issuecomment-5275653108)
</details>
