### PR TITLE
8390183: Some typos in JavaDocs for the java.desktop module

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -648,7 +648,7 @@ public class DirectColorModel extends PackedColorModel {
      *  {@code inData} is not large enough to hold a pixel value
      *  for this {@code ColorModel}
      * @throws UnsupportedOperationException if this
-     *  {@code tranferType} is not supported by this
+     *  {@code transferType} is not supported by this
      *  {@code ColorModel}
      */
     public int getAlpha(Object inData) {

--- a/src/java.desktop/share/classes/java/beans/EventHandler.java
+++ b/src/java.desktop/share/classes/java/beans/EventHandler.java
@@ -229,7 +229,7 @@ import sun.reflect.misc.MethodUtil;
  *</pre>
  * </blockquote>
  * The target property may also be "qualified" with an arbitrary number
- * of property prefixs delimited with the "." character.  For example, the
+ * of property prefixes delimited with the "." character.  For example, the
  * following action listener:
  * <pre>
  *   EventHandler.create(ActionListener.class, target, "a.b", "c.d")

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -1285,7 +1285,7 @@ public class      BeanContextServicesSupport extends BeanContextSupport
     protected transient HashMap<Object, BCSSServiceProvider>  services;
 
     /**
-     * The number of instances of a serializable {@code BeanContextServceProvider}.
+     * The number of instances of a serializable {@code BeanContextServiceProvider}.
      */
     protected transient int                      serializable = 0;
 

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -374,7 +374,7 @@ public class      BeanContextSupport extends BeanContextChildSupport
      * methods that add children to the set.
      * </p>
      * @param targetChild the child to create the Child on behalf of
-     * @param peer        the peer if the tragetChild and the peer are related by an implementation of BeanContextProxy
+     * @param peer        the peer if the targetChild and the peer are related by an implementation of BeanContextProxy
      * @return Subtype-specific subclass of Child without overriding collection methods
      */
 

--- a/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1195,7 +1195,7 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code prepareInsertEmpty} without a corresponding call to
      * {@code endInsertEmpty} has been made.
      * @throws IllegalStateException if a call to
-     * {@code prepareReiplacePixels} has been made without a
+     * {@code prepareReplacePixels} has been made without a
      * matching call to {@code endReplacePixels}.
      * @throws IOException if an I/O error occurs during writing.
      */

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormat.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -443,7 +443,7 @@ public interface IIOMetadataFormat {
      * interpretation of the value of the given attribute within the
      * named element.  If {@code getAttributeValueType} returns
      * {@code VALUE_LIST}, then the legal value is a
-     * whitespace-spearated list of values of the returned datatype.
+     * whitespace-separated list of values of the returned datatype.
      *
      * @param elementName the name of the element being queried.
      * @param attrName the name of the attribute being queried.

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/BaselineTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/BaselineTIFFTagSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -314,21 +314,21 @@ public final class BaselineTIFFTagSet extends TIFFTagSet {
     public static final int TAG_THRESHHOLDING = 263;
 
     /**
-     * A value to be used with the "Thresholding" tag.
+     * A value to be used with the "Threshholding" tag.
      *
      * @see #TAG_THRESHHOLDING
      */
     public static final int THRESHHOLDING_NONE = 1;
 
     /**
-     * A value to be used with the "Thresholding" tag.
+     * A value to be used with the "Threshholding" tag.
      *
      * @see #TAG_THRESHHOLDING
      */
     public static final int THRESHHOLDING_ORDERED_DITHER = 2;
 
     /**
-     * A value to be used with the "Thresholding" tag.
+     * A value to be used with the "Threshholding" tag.
      *
      * @see #TAG_THRESHHOLDING
      */

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/TIFFDirectory.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/TIFFDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -275,7 +275,7 @@ public class TIFFDirectory implements Cloneable {
      * has been defined or {@code null} otherwise.
      *
      * @return The parent {@code TIFFTag} of this
-     * {@code TIFFDiectory} or {@code null}.
+     * {@code TIFFDirectory} or {@code null}.
      */
     public TIFFTag getParentTag() {
         return parentTag;

--- a/src/java.desktop/share/classes/javax/imageio/spi/ImageInputStreamSpi.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ImageInputStreamSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ public abstract class ImageInputStreamSpi extends IIOServiceProvider {
      * Returns {@code true} if the {@code ImageInputStream}
      * implementation associated with this service provider can
      * optionally make use of a cache file for improved performance
-     * and/or memory footrprint.  If {@code false}, the value of
+     * and/or memory footprint.  If {@code false}, the value of
      * the {@code useCache} argument to
      * {@code createInputStreamInstance} will be ignored.
      *

--- a/src/java.desktop/share/classes/javax/imageio/spi/ImageOutputStreamSpi.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ImageOutputStreamSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public abstract class ImageOutputStreamSpi extends IIOServiceProvider {
      * Returns {@code true} if the {@code ImageOutputStream}
      * implementation associated with this service provider can
      * optionally make use of a cache {@code File} for improved
-     * performance and/or memory footrprint.  If {@code false},
+     * performance and/or memory footprint.  If {@code false},
      * the value of the {@code cacheFile} argument to
      * {@code createOutputStreamInstance} will be ignored.
      *

--- a/src/java.desktop/share/classes/javax/sound/SoundClip.java
+++ b/src/java.desktop/share/classes/javax/sound/SoundClip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public final class SoundClip {
      * <p>
      * Threading notes : Most applications will not need to do anything except call {@code loop()}.
      * The following is therefore something most applications need not be concerned about.
-     * Play back is managed in a background thread, which is ususally a daemon thread.
+     * Play back is managed in a background thread, which is usually a daemon thread.
      * Running daemon threads do not prevent the VM from exiting.
      * So at least one thread must be alive to prevent the VM from terminating.
      * A UI application with any window displayed automatically satisfies this requirement.

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -3254,7 +3254,7 @@ public abstract class JComponent extends Container implements Serializable,
      * locations). If you do not wish for this component to respond in any way
      * to drops, you can disable drop support entirely either by removing the
      * drop target ({@code setDropTarget(null)}) or by de-activating it
-     * ({@code getDropTaget().setActive(false)}).
+     * ({@code getDropTarget().setActive(false)}).
      * <p>
      * If the new {@code TransferHandler} is {@code null}, this method removes
      * the drop target.


### PR DESCRIPTION
Few typos in java.desktop module are fixed

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390183](https://bugs.openjdk.org/browse/JDK-8390183): Some typos in JavaDocs for the java.desktop module (**Enhancement** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32330/head:pull/32330` \
`$ git checkout pull/32330`

Update a local copy of the PR: \
`$ git checkout pull/32330` \
`$ git pull https://git.openjdk.org/jdk.git pull/32330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32330`

View PR using the GUI difftool: \
`$ git pr show -t 32330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32330.diff">https://git.openjdk.org/jdk/pull/32330.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32330#issuecomment-5275788072)
</details>
