### PR TITLE
8387332: Template Framework: Add utility methods to build scopes

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/template_framework/Template.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/Template.java
@@ -1088,7 +1088,7 @@ public sealed interface Template permits Template.ZeroArgs,
      * @return      A list of ScopeTokens.
      */
     static List<ScopeToken> repeat(int count, ScopeToken scope) {
-        return Collections.nCopies(count, scope);
+        return repeat(count, _ -> scope);
     }
 
     /**
@@ -1116,6 +1116,9 @@ public sealed interface Template permits Template.ZeroArgs,
      * @return      A list of ScopeTokens.
      */
     static List<ScopeToken> repeat(int count, IntFunction<ScopeToken> scope) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must not be negative: " + count);
+        }
         return IntStream.range(0, count)
                         .mapToObj(scope)
                         .toList();
@@ -1151,7 +1154,7 @@ public sealed interface Template permits Template.ZeroArgs,
      * <p>
      * {@snippet lang=java:
      * // Output:
-     * // Element 1, Element 2, Element 3
+     * // Element 0, Element 1, Element 2
      * Template.make(() -> scope(
      *     repeatAndJoin(3, ", ", (index) -> scope("Element " + index))
      * ));
@@ -1163,6 +1166,10 @@ public sealed interface Template permits Template.ZeroArgs,
      * @return          A list of ScopeTokens.
      */
     static List<ScopeToken> repeatAndJoin(int count, String delimiter, IntFunction<ScopeToken> scope) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count must not be negative: " + count);
+        }
+
         List<ScopeToken> scopeTokens = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             if (i > 0) {
@@ -1220,9 +1227,15 @@ public sealed interface Template permits Template.ZeroArgs,
      * @return      A list of ScopeTokens.
      */
     static <T> List<ScopeToken> map(List<T> list, BiFunction<T, Integer, ScopeToken> scope) {
-        return IntStream.range(0, list.size())
-                        .mapToObj(i -> scope.apply(list.get(i), i))
-                        .toList();
+        List<ScopeToken> scopeTokens = new ArrayList<>(list.size());
+        int i = 0;
+        for (T element : list) {
+            scopeTokens.add(scope.apply(element, i));
+            i++;
+        }
+
+        // Return an unmodifiable list.
+        return List.copyOf(scopeTokens);
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/template_framework/Template.java
+++ b/test/hotspot/jtreg/compiler/lib/template_framework/Template.java
@@ -23,11 +23,15 @@
 
 package compiler.lib.template_framework;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import compiler.lib.compile_framework.CompileFramework;
 import compiler.lib.ir_framework.TestFramework;
@@ -1062,5 +1066,217 @@ public sealed interface Template permits Template.ZeroArgs,
      */
     static StructuralName.FilteredSet structuralNames() {
         return new StructuralName.FilteredSet();
+    }
+
+
+    /**
+     * Create {@code count} times a {@link ScopeToken}. This can be used inside another {@link #scope}.
+     *
+     * <p>
+     * {@snippet lang=java:
+     * // Output:
+     * // scope
+     * // scope
+     * // scope
+     * Template.make(() -> scope(
+     *     repeat(3, scope("scope\n"))
+     * ));
+     * }
+     *
+     * @param count How many times do we repeat the provided scope?
+     * @param scope The scope() method.
+     * @return      A list of ScopeTokens.
+     */
+    static List<ScopeToken> repeat(int count, ScopeToken scope) {
+        return Collections.nCopies(count, scope);
+    }
+
+    /**
+     * Same as {@link #repeat(int, ScopeToken)} but instead of a {@link ScopeToken}, this method takes a
+     * {@code scopeFactory} {@link IntFunction} that takes an integer index, denoting the current iteration index
+     * ranging from iteration 0 to count - 1, and passes it into a {@link #scope}. This can be used inside another
+     * {@link #scope}:
+     *
+     * <p>
+     * {@snippet lang=java:
+     * // Output:
+     * // 1: scope for index 0
+     * // 1: scope for index 1
+     * // 2: scope for index 0
+     * // 2: scope for index 1
+     * // 2: scope for index 2
+     * Template.make(() -> scope(
+     *     repeat(2, index -> scope("1: scope for index " + index +"\n")),
+     *     repeat(3, index -> scope("2: scope for index " + index +"\n"))
+     * ));
+     * }
+     *
+     * @param count How many times do we repeat the provided scope?
+     * @param scope The scope() function taking an iteration index.
+     * @return      A list of ScopeTokens.
+     */
+    static List<ScopeToken> repeat(int count, IntFunction<ScopeToken> scope) {
+        return IntStream.range(0, count)
+                        .mapToObj(scope)
+                        .toList();
+    }
+
+    /**
+     * Same as {@link #repeat(int, ScopeToken)} but join all resulting {@link ScopeToken}s together by using an
+     * additional {@code delimiter} which is put into a separate {@link ScopeToken}s in between.
+     *
+     * <p>
+     * {@snippet lang=java:
+     * // Output:
+     * // Element 1, Element 2, Element 3
+     * Template.make(() -> scope(
+     *     repeatAndJoin(3, ", ", (index) -> scope("Element " + index))
+     * ));
+     * }
+     *
+     * @param count     How many times do we repeat the provided scope?
+     * @param delimiter The delimiter to join the individual repeated scopes together.
+     * @param scope     The scope() function.
+     * @return          A list of ScopeTokens.
+     */
+    static List<ScopeToken> repeatAndJoin(int count, String delimiter, ScopeToken scope) {
+        return repeatAndJoin(count, delimiter, (_) -> scope);
+    }
+
+    /**
+     * Same as the indexed {@link #repeat(int, IntFunction)} but join all resulting {@link ScopeToken}s together by using
+     * an additional {@code delimiter} which is put into a separate {@link ScopeToken}s in between. This is the indexed
+     * version of {@link #repeatAndJoin(int, String, ScopeToken)}.
+     *
+     * <p>
+     * {@snippet lang=java:
+     * // Output:
+     * // Element 1, Element 2, Element 3
+     * Template.make(() -> scope(
+     *     repeatAndJoin(3, ", ", (index) -> scope("Element " + index))
+     * ));
+     * }
+     *
+     * @param count     How many times do we repeat the provided scope?
+     * @param delimiter The delimiter to join the individual repeated scopes together.
+     * @param scope     The scope() function taking an iteration index.
+     * @return          A list of ScopeTokens.
+     */
+    static List<ScopeToken> repeatAndJoin(int count, String delimiter, IntFunction<ScopeToken> scope) {
+        List<ScopeToken> scopeTokens = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                // Add delimiter before the actual scope, skipping the very first element.
+                scopeTokens.add(scope(delimiter));
+            }
+            // Create the actual scope.
+            scopeTokens.add(scope.apply(i));
+        }
+        // Return an unmodifiable list.
+        return List.copyOf(scopeTokens);
+    }
+
+    /**
+     * Map each element in {@code list} to the {@code scopeFactory} which is a {@link Function} taking an individual
+     * element of the {@code list} which is passed into a {@link #scope}.
+     *
+     * <p>
+     * {@snippet lang=java:
+     * // Output:
+     * // Element 1
+     * // Element 2
+     * // Element 3
+     * Template.make(() -> scope(
+     *     map(List.of(1, 2, 3), element -> scope("Element " + element +"\n"))
+     * ));
+     * }
+     *
+     * @param list  List of elements to be mapped to the provided scope() function.
+     * @param scope The scope() function taking a list element.
+     * @return      A list of ScopeTokens.
+     */
+    static <T> List<ScopeToken> map(List<T> list, Function<T, ScopeToken> scope) {
+        return map(list, (element, _) -> scope.apply(element));
+    }
+
+    /**
+     * Same as {@link #map(List, Function)} but the {@code scopeFactory} is a {@link BiFunction} that takes an additional
+     * integer index, denoting the current list index ranging from iteration 0 to count - 1. Each element and its list
+     * index element are passed into a {@link #scope}.
+     *
+     * <p>
+     * {@snippet lang=java :
+     * // Output:
+     * // Element 1 at index 0
+     * // Element 2 at index 1
+     * // Element 3 at index 2
+     * Template.make(() -> scope(
+     *     map(List.of(1, 2, 3), (element, index) -> scope("Element " + element + " at index " + index + "\n"))
+     * ));
+     * }
+     *
+     * @param list  List of elements to be mapped to the provided scope() function.
+     * @param scope The scope() function taking a list element and list index.
+     * @return      A list of ScopeTokens.
+     */
+    static <T> List<ScopeToken> map(List<T> list, BiFunction<T, Integer, ScopeToken> scope) {
+        return IntStream.range(0, list.size())
+                        .mapToObj(i -> scope.apply(list.get(i), i))
+                        .toList();
+    }
+
+    /**
+     * Same as {@link #map(List, Function)} but join all resulting {@link ScopeToken}s together by using an additional
+     * {@code delimiter} which is put into a separate {@link ScopeToken}s in between.
+     *
+     * <p>
+     * {@snippet lang=java:
+     * // Output:
+     * // Element 1, Element 2, Element 3
+     * Template.make(() -> scope(
+     *     mapAndJoin(List.of(1, 2, 3), ", ", (element) -> scope("Element " + element))
+     * ));
+     *}
+     * @param list      List of elements to be mapped to the provided scope() function and then be joined with delimiter.
+     * @param delimiter The delimiter to join the individual scopes for all list elements together.
+     * @param scope     The scope() function taking a list element.
+     * @return          A list of ScopeTokens.
+     */
+    static <T> List<ScopeToken> mapAndJoin(List<T> list, String delimiter, Function<T, ScopeToken> scope) {
+        return mapAndJoin(list, delimiter, (element, _) -> scope.apply(element));
+    }
+
+    /**
+     * Same as the indexed {@link #map(List, BiFunction)} but join all resulting {@link ScopeToken}s together by using
+     * an additional {@code delimiter} which is put into a separate {@link ScopeToken}s in between. This is the indexed
+     * version of {@link #mapAndJoin(List, String, Function)}.
+     *
+     * <p>
+     * {@snippet lang=java:
+     * // Output:
+     * // Element 1 at index 0, Element 2 at index 1, Element 3 at index 2
+     * Template.make(() -> scope(
+     *     mapAndJoin(List.of(1, 2, 3), ", ", (element, index) -> scope("Element " + element + " at index " + index))
+     * ));
+     *}
+     * @param list      List of elements to be mapped to the provided scope() function and then be joined with delimiter.
+     * @param delimiter The delimiter to join the individual scopes for all list elements together.
+     * @param scope     The scope() function taking a list element and list index.
+     * @return          A list of ScopeTokens.
+     */
+    static <T> List<ScopeToken> mapAndJoin(List<T> list, String delimiter, BiFunction<T, Integer, ScopeToken> scope) {
+        List<ScopeToken> scopeTokens = new ArrayList<>();
+        int i = 0;
+        for (T item : list) {
+            if (i > 0) {
+                // Add delimiter before the actual scope, skipping the very first element.
+                scopeTokens.add(scope(delimiter));
+            }
+            // Create the actual scope.
+            scopeTokens.add(scope.apply(item, i));
+            i++;
+        }
+        // Return an unmodifiable list.
+        return List.copyOf(scopeTokens);
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArraysCopyOf.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArraysCopyOf.java
@@ -112,13 +112,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
-import java.util.function.IntFunction;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static compiler.lib.template_framework.Template.*;
-import static compiler.lib.template_framework.Template.scope;
 
 public class TestArraysCopyOf {
     private static final RestrictableGenerator<Integer> RANDOM_LENGTH = Generators.G.ints().restricted(0, 32);
@@ -226,9 +221,9 @@ public class TestArraysCopyOf {
 
                                 public #klass(\
                         """,
-                concat(primitiveTypes, (type, _) -> scope(type.name() + " _" + type.name())),
+                    mapAndJoin(primitiveTypes, ", ", (type, _) -> scope(type.name() + " _" + type.name())),
                         ") {\n",
-                loop(primitiveTypes, (type, _) -> scope(
+                    map(primitiveTypes, (type, _) -> scope(
                         let("type", type.name()),
                         "            this._#type = _#type;\n")),
                         // Initializer
@@ -238,7 +233,7 @@ public class TestArraysCopyOf {
                                 static #klass init() {
                                     return new #klass(\
                         """,
-                concat(primitiveTypes, (type, _) -> scope(type.con())),
+                    mapAndJoin(primitiveTypes, ", ", (type, _) -> scope(type.con())),
                         ");\n",
                         """
                                 }
@@ -249,7 +244,7 @@ public class TestArraysCopyOf {
                             static Object[] oArr = new Object[1];
                         """,
                 // Passing A.class, int.class etc. Should always throw.
-                loop(instanceAndPrimitiveClasses.size(), i -> scope(
+                repeat(instanceAndPrimitiveClasses.size(), i -> scope(
                         let("i", uniqueIndex.getAndIncrement()),
                         let("klass", instanceAndPrimitiveClasses.get(i)),
                         let("test", "testNonArrayClass_" + instanceAndPrimitiveClasses.get(i)),
@@ -267,7 +262,7 @@ public class TestArraysCopyOf {
                             }
                         """)),
                 // Passing in primitive type arrays which like int[].class which should throw.
-                loop(primitiveTypeClasses.size(), i -> scope(
+                repeat(primitiveTypeClasses.size(), i -> scope(
                         let("i", uniqueIndex.getAndIncrement()),
                         let("klass", primitiveTypeClasses.get(i) + "[]"),
                         let("test", "testPrimitiveArrayClass_" + primitiveTypeClasses.get(i)),
@@ -285,7 +280,7 @@ public class TestArraysCopyOf {
                             }
                         """)),
                 // Normal tests with non-primitive type arrays.
-                loop(concreteInstanceClasses.size(), i -> scope(
+                repeat(concreteInstanceClasses.size(), i -> scope(
                         let("i", uniqueIndex.getAndIncrement()),
                         let("klass_name", concreteInstanceClasses.get(i).name()),
                         let("klass", concreteInstanceClasses.get(i).name() + "[]"),
@@ -312,7 +307,7 @@ public class TestArraysCopyOf {
                             }
                         """)),
                 // Normal tests with value class arrays.
-                loop(newValueClassArrayScopes, (init, i) -> scope(
+                map(newValueClassArrayScopes, (init, i) -> scope(
                         let("i", uniqueIndex.getAndIncrement()),
                         let("klass_name", valueClasses.get(i).name()),
                         let("klass", valueClasses.get(i).name() + "[]"),
@@ -359,29 +354,5 @@ public class TestArraysCopyOf {
                         return Arrays.copyOf(arr, length, c);
                     }
                 """;
-    }
-
-    static List<ScopeToken> loop(int limit, IntFunction<ScopeToken> function) {
-        return IntStream.range(0, limit)
-                .mapToObj(function)
-                .toList();
-    }
-
-    static <T> List<ScopeToken> loop(List<T> items, BiFunction<T, Integer, ScopeToken> function) {
-        return IntStream.range(0, items.size())
-                .mapToObj(i -> function.apply(items.get(i), i))
-                .toList();
-    }
-
-    static <T> List<ScopeToken> concat(List<T> items, BiFunction<T, Integer, ScopeToken> function) {
-        return IntStream.range(0, items.size())
-                .boxed()
-                .flatMap(i -> {
-                    ScopeToken token = function.apply(items.get(i), i);
-                    return i == items.size() - 1 ?
-                            Stream.of(token) :
-                            Stream.of(token, scope(", "));
-                })
-                .toList();
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArraysCopyOf.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArraysCopyOf.java
@@ -221,9 +221,9 @@ public class TestArraysCopyOf {
 
                                 public #klass(\
                         """,
-                    mapAndJoin(primitiveTypes, ", ", (type, _) -> scope(type.name() + " _" + type.name())),
+                    mapAndJoin(primitiveTypes, ", ", type -> scope(type.name() + " _" + type.name())),
                         ") {\n",
-                    map(primitiveTypes, (type, _) -> scope(
+                    map(primitiveTypes, type -> scope(
                         let("type", type.name()),
                         "            this._#type = _#type;\n")),
                         // Initializer
@@ -233,7 +233,7 @@ public class TestArraysCopyOf {
                                 static #klass init() {
                                     return new #klass(\
                         """,
-                    mapAndJoin(primitiveTypes, ", ", (type, _) -> scope(type.con())),
+                    mapAndJoin(primitiveTypes, ", ", type -> scope(type.con())),
                         ");\n",
                         """
                                 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestScalarizedCallingConventionLimits.java
@@ -51,8 +51,7 @@ import compiler.lib.compile_framework.CompileFramework;
 import compiler.lib.template_framework.ScopeToken;
 import compiler.lib.template_framework.Template;
 
-import static compiler.lib.template_framework.Template.let;
-import static compiler.lib.template_framework.Template.scope;
+import static compiler.lib.template_framework.Template.*;
 
 public class TestScalarizedCallingConventionLimits {
     private static final String GENERATED_CLASS_NAME = "GeneratedScalarizedCallingConventionLimits";
@@ -89,7 +88,7 @@ public class TestScalarizedCallingConventionLimits {
                 """,
             // Generate interfaces with value and identity-class implementations and a method
             // with a varying number of arguments to stress test the calling convention.
-            loop(MAX_ARGUMENT_COUNT, argumentCount -> scope(
+            repeat(MAX_ARGUMENT_COUNT, argumentCount -> scope(
                 let("argumentCount", argumentCount),
                 let("classname", "ValueImpl" + argumentCount),
                 let("parameters", commaSeparated(argumentCount, i -> "Integer a" + i)),
@@ -138,19 +137,19 @@ public class TestScalarizedCallingConventionLimits {
                 """)),
             // Generate methods with a value class receiver with a varying number of oop fields to stress
             // test code buffers during nmethod entry point generation (oops need GC barriers etc.)
-            loop(MAX_OOP_RECEIVER_FIELD_COUNT, fieldCount -> scope(
+            repeat(MAX_OOP_RECEIVER_FIELD_COUNT, fieldCount -> scope(
                 let("fieldCount", fieldCount),
                 let("arguments", commaSeparated(fieldCount, i -> "f" + i)),
                 """
                     static value class OopReceiver#fieldCount {
                 """,
-            loop(fieldCount, i -> scope(
+            repeat(fieldCount, i -> scope(
                "        Object f" + i + ";\n")),
                 """
 
                         OopReceiver#fieldCount(Object[] values) {
                 """,
-            loop(fieldCount, i -> scope(
+            repeat(fieldCount, i -> scope(
                "            this.f" + i + " = values[" + i + "];\n")),
                 """
                         }
@@ -176,9 +175,9 @@ public class TestScalarizedCallingConventionLimits {
                 """
                     public static void run() {
                 """,
-            loop(MAX_ARGUMENT_COUNT, i -> scope(
+            repeat(MAX_ARGUMENT_COUNT, i -> scope(
                "        test" + i + "();\n")),
-            loop(MAX_OOP_RECEIVER_FIELD_COUNT, i -> scope(
+            repeat(MAX_OOP_RECEIVER_FIELD_COUNT, i -> scope(
                "        testOopReceiver" + i + "();\n")),
                 """
                     }
@@ -189,12 +188,6 @@ public class TestScalarizedCallingConventionLimits {
 
     private static String commaSeparated(int count, IntFunction<String> element) {
         return IntStream.range(0, count).mapToObj(element).collect(Collectors.joining(", "));
-    }
-
-    private static List<ScopeToken> loop(int limit, IntFunction<ScopeToken> function) {
-        return IntStream.range(0, limit)
-                        .mapToObj(function)
-                        .toList();
     }
 }
 

--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestTutorial.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestTutorial.java
@@ -569,14 +569,14 @@ public class TestTutorial {
 
                     void testRepeatAndJoin() {
                 """,
-                "        fiveInts(", repeatAndJoin(5, ", ", scope("0")), ");\n",
+               "        fiveInts(", repeatAndJoin(5, ", ", scope("0")), ");\n",
 
                 // If we want to have some ascending numbers, we can use the indexed repeatAndJoin() version:
-                "        fiveInts(", repeatAndJoin(5, ", ", index -> scope("" + index)), ");\n",
+               "        fiveInts(", repeatAndJoin(5, ", ", index -> scope("" + index)), ");\n",
 
                 // Let's assume you want to AND several conditions together. You can use the utility method mapAndJoin()
                 // that maps and then joins the resulting scopes together:
-                "        if (", mapAndJoin(List.of("flagA", "flagB", "flagC"), " && ", flag -> scope(flag)), ") {\n",
+               "        if (", mapAndJoin(List.of("flagA", "flagB", "flagC"), " && ", flag -> scope(flag)), ") {\n",
                 """
                         }
                     }
@@ -585,7 +585,7 @@ public class TestTutorial {
 
                 // You can also use the indexed version of mapAndJoin() which is useful, for example, to define a method
                 // with different parameter names:
-                "    void testJoin(",
+               "    void testJoin(",
             mapAndJoin(List.of("int", "float", "long"), ", ", (type, index) -> scope(
                 let("type", type),
                 let("index", index),

--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestTutorial.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestTutorial.java
@@ -43,19 +43,11 @@ import compiler.lib.template_framework.Hook;
 import compiler.lib.template_framework.TemplateBinding;
 import compiler.lib.template_framework.DataName;
 import compiler.lib.template_framework.StructuralName;
-import static compiler.lib.template_framework.Template.scope;
-import static compiler.lib.template_framework.Template.transparentScope;
-import static compiler.lib.template_framework.Template.hashtagScope;
-import static compiler.lib.template_framework.Template.let;
-import static compiler.lib.template_framework.Template.$;
-import static compiler.lib.template_framework.Template.fuel;
-import static compiler.lib.template_framework.Template.addDataName;
-import static compiler.lib.template_framework.Template.dataNames;
-import static compiler.lib.template_framework.Template.addStructuralName;
-import static compiler.lib.template_framework.Template.structuralNames;
+
 import static compiler.lib.template_framework.DataName.Mutability.MUTABLE;
 import static compiler.lib.template_framework.DataName.Mutability.IMMUTABLE;
 import static compiler.lib.template_framework.DataName.Mutability.MUTABLE_OR_IMMUTABLE;
+import static compiler.lib.template_framework.Template.*;
 
 import compiler.lib.template_framework.library.Hooks;
 
@@ -71,6 +63,7 @@ public class TestTutorial {
         comp.addJavaSourceCode("p.xyz.InnerTest3",  generateWithHashtagAndDollarReplacements());
         comp.addJavaSourceCode("p.xyz.InnerTest3b", generateWithHashtagAndDollarReplacements2());
         comp.addJavaSourceCode("p.xyz.InnerTest3c", generateWithHashtagAndDollarReplacements3());
+        comp.addJavaSourceCode("p.xyz.InnerTest12", generateScopeBuildingUtilityMethods());
         comp.addJavaSourceCode("p.xyz.InnerTest4",  generateWithCustomHooks());
         comp.addJavaSourceCode("p.xyz.InnerTest5",  generateWithLibraryHooks());
         comp.addJavaSourceCode("p.xyz.InnerTest6",  generateWithRecursionAndBindingsAndFuel());
@@ -95,6 +88,7 @@ public class TestTutorial {
         comp.invoke("p.xyz.InnerTest3",  "main", new Object[] {});
         comp.invoke("p.xyz.InnerTest3b", "main", new Object[] {});
         comp.invoke("p.xyz.InnerTest3c", "main", new Object[] {});
+        comp.invoke("p.xyz.InnerTest12", "main", new Object[] {});
         comp.invoke("p.xyz.InnerTest4",  "main", new Object[] {});
         comp.invoke("p.xyz.InnerTest5",  "main", new Object[] {});
         comp.invoke("p.xyz.InnerTest6",  "main", new Object[] {});
@@ -481,6 +475,127 @@ public class TestTutorial {
         // Render templateClass to String.
         return templateClass.render();
     }
+
+
+    // The following examples show how to use the additional utility methods to build scopes in a top down readable way.
+    // Note that the code was specially indented with spaces such that the generated code is nicely formatted while the
+    // generating source code remains easy to read.
+    static String generateScopeBuildingUtilityMethods() {
+        return Template.make(() -> scope(
+                """
+                package p.xyz;
+
+                public class InnerTest12 {
+                    int iFld;
+                    static int iFld0;
+                    static int iFld1;
+                    static int iFld2;
+                    boolean flagA;
+                    boolean flagB;
+                    boolean flagC;
+
+                    public static void main() {
+                        var t = new InnerTest12();
+                        t.testRepeat1();
+                        t.testRepeat2();
+                        t.testRepeatAndJoin();
+                        t.testJoin(1, 2, 3);
+                    }
+
+                    void testRepeat1() {
+                """,
+
+                // Assume you want to repeat incrementing iFld. You could either duplicate the lines:
+                "        iFld += 3;\n",
+                "        iFld += 3;\n",
+                "        iFld += 3;\n",
+                // Or you can use the repeat() utility method to achieve the same task:
+            repeat(3, scope(
+               "        iFld += 5;\n")),
+                """
+                    }
+
+                """,
+
+                // Sometimes repeats should be slightly different, for example, to generate code. Let's assume you want
+                // to create a couple of equally looking classes. You can use the indexed repeat() utility method.
+                // Let's create vie classes:
+            repeat(5, i -> scope(
+               "    class MyClass", i,  "{}\n")),
+                """
+
+                    void testRepeat2() {
+                """,
+                // And then create an instance for each of them:
+            repeat(5, i -> scope(
+               "        new MyClass", i, "();\n")),
+                // Or you directly define 'i' with let to use #-replacements (you can, of course, also define more
+                // variables with let()):
+            repeat(5, i -> scope(
+                let("i", i),
+               "        new MyClass#i();\n")),
+                """
+                    }
+
+                """,
+
+                // Let's assume that you want to put some varying strings into the same scope multiple times. We can use
+                // the map() utility method to map a string to a scope. For exapmle, you could define your class names
+                // upfront and use them directly:
+            map(List.of("One", "Two", "Three"), klass -> scope(
+                let("klass", klass),
+               "    class #klass{}\n")),
+                "\n",
+                // If you still need an incrementing index, for example, to also generate different field accesses,
+                // you can use the indexed map() version:
+            map(List.of("Four", "Five", "Six"), (klass, fieldIndex) -> scope(
+                let("klass", klass),
+                let("fieldIndex", fieldIndex),
+                """
+                    class #klass{
+                        void test() {
+                            InnerTest12.iFld#fieldIndex = 34; // Assign to a specific static field
+                        }
+                    }
+
+                """)),
+
+                // Suppose you have a method with 5 int args:
+                "    void fiveInts(int a, int b, int c, int d, int e) {}\n",
+                // and want to call it with all zeros. You could be tempted to use repeat() with "0 ,", but what about
+                // the last comma? You need to omit it, otherwise it will fail to compile. What we need here is a join
+                // and not a bare concat of repeated scopes. We can use the repeatAndJoin() utility method for that:
+                """
+
+                    void testRepeatAndJoin() {
+                """,
+                "        fiveInts(", repeatAndJoin(5, ", ", scope("0")), ");\n",
+
+                // If we want to have some ascending numbers, we can use the indexed repeatAndJoin() version:
+                "        fiveInts(", repeatAndJoin(5, ", ", index -> scope("" + index)), ");\n",
+
+                // Let's assume you want to AND several conditions together. You can use the utility method mapAndJoin()
+                // that maps and then joins the resulting scopes together:
+                "        if (", mapAndJoin(List.of("flagA", "flagB", "flagC"), " && ", flag -> scope(flag)), ") {\n",
+                """
+                        }
+                    }
+
+                """,
+
+                // You can also use the indexed version of mapAndJoin() which is useful, for example, to define a method
+                // with different parameter names:
+                "    void testJoin(",
+            mapAndJoin(List.of("int", "float", "long"), ", ", (type, index) -> scope(
+                let("type", type),
+                let("index", index),
+                "#type x#index")), ") {}\n",
+                """
+                }
+                """
+        )).render();
+    }
+
 
     // In this example, we look at the use of Hooks. They allow us to reach back, to outer
     // scopes. For example, we can reach out from inside a method body to a hook anchored at

--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/tests/TestTemplate.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/tests/TestTemplate.java
@@ -34,9 +34,7 @@
 
 package template_framework.tests;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.HashSet;
 
 import compiler.lib.template_framework.Template;
 import compiler.lib.template_framework.DataName;
@@ -44,22 +42,11 @@ import compiler.lib.template_framework.StructuralName;
 import compiler.lib.template_framework.Hook;
 import compiler.lib.template_framework.TemplateBinding;
 import compiler.lib.template_framework.RendererException;
-import static compiler.lib.template_framework.Template.scope;
-import static compiler.lib.template_framework.Template.transparentScope;
-import static compiler.lib.template_framework.Template.nameScope;
-import static compiler.lib.template_framework.Template.hashtagScope;
-import static compiler.lib.template_framework.Template.setFuelCostScope;
-import static compiler.lib.template_framework.Template.$;
-import static compiler.lib.template_framework.Template.let;
-import static compiler.lib.template_framework.Template.fuel;
-import static compiler.lib.template_framework.Template.setFuelCost;
-import static compiler.lib.template_framework.Template.addDataName;
-import static compiler.lib.template_framework.Template.dataNames;
-import static compiler.lib.template_framework.Template.addStructuralName;
-import static compiler.lib.template_framework.Template.structuralNames;
+
 import static compiler.lib.template_framework.DataName.Mutability.MUTABLE;
 import static compiler.lib.template_framework.DataName.Mutability.IMMUTABLE;
 import static compiler.lib.template_framework.DataName.Mutability.MUTABLE_OR_IMMUTABLE;
+import static compiler.lib.template_framework.Template.*;
 
 /**
  * The tests in this file are mostly there to ensure that the Template Rendering
@@ -171,6 +158,14 @@ public class TestTemplate {
         testHookAndScopes1();
         testHookAndScopes2();
         testHookAndScopes3();
+        testRepeat();
+        testRepeatIndexed();
+        testRepeatAndJoin();
+        testRepeatAndJoinIndexed();
+        testMap();
+        testMapIndexed();
+        testMapAndJoin();
+        testMapAndJoinIndexed();
 
         // The following tests should all fail, with an expected exception and message.
         expectRendererException(() -> testFailingNestedRendering(), "Nested render not allowed.");
@@ -3372,6 +3367,128 @@ public class TestTemplate {
             """;
         checkEQ(code, expected);
     }
+
+    static void testRepeat() {
+        var templateString = Template.make(() -> scope(
+            repeat(3, scope("repeat\n"))
+        )).render();
+
+        String expected =
+                """
+                repeat
+                repeat
+                repeat
+                """;
+        checkEQ(templateString, expected);
+    }
+
+    static void testRepeatIndexed() {
+        var templateString = Template.make(() -> scope(
+                repeat(2, index -> scope("1: scope for index " + index +"\n")),
+                repeat(3, index -> scope("2: scope for index " + index +"\n"))
+        )).render();
+
+        String expected =
+                """
+                1: scope for index 0
+                1: scope for index 1
+                2: scope for index 0
+                2: scope for index 1
+                2: scope for index 2
+                """;
+        checkEQ(templateString, expected);
+    }
+
+    static void testRepeatAndJoin() {
+        var templateString = Template.make(() -> scope(
+                repeatAndJoin(2, ",\n", scope("1: scope")),
+                "\n\n",
+                repeatAndJoin(3, ",\n", scope("2: scope")),
+                "\n"
+                )).render();
+
+        String expected =
+                """
+                1: scope,
+                1: scope
+
+                2: scope,
+                2: scope,
+                2: scope
+                """;
+        checkEQ(templateString, expected);
+    }
+
+    static void testRepeatAndJoinIndexed() {
+        var templateString = Template.make(() -> scope(
+                repeatAndJoin(2, ",\n", index -> scope("1: scope for index " + index)),
+                "\n\n",
+                repeatAndJoin(3, ",\n", index -> scope("2: scope for index " + index)),
+                "\n"
+        )).render();
+
+        String expected =
+                """
+                1: scope for index 0,
+                1: scope for index 1
+
+                2: scope for index 0,
+                2: scope for index 1,
+                2: scope for index 2
+                """;
+        checkEQ(templateString, expected);
+    }
+
+    static void testMap() {
+        var templateString = Template.make(() -> scope(
+                map(List.of(1, 2, 3), element -> scope("Element " + element +"\n"))
+        )).render();
+
+        String expected =
+                """
+                Element 1
+                Element 2
+                Element 3
+                """;
+        checkEQ(templateString, expected);
+    }
+
+    static void testMapIndexed() {
+        var templateString = Template.make(() -> scope(
+                map(List.of(1, 2, 3), (element, index) -> scope("Element " + element + " at index " + index + "\n"))
+        )).render();
+
+        String expected =
+                """
+                Element 1 at index 0
+                Element 2 at index 1
+                Element 3 at index 2
+                """;
+        checkEQ(templateString, expected);
+    }
+
+    static void testMapAndJoin() {
+        var templateString = Template.make(() -> scope(
+                mapAndJoin(List.of(1, 2, 3), ", ", (element) -> scope("Element " + element))
+        )).render();
+
+        String expected = "Element 1, Element 2, Element 3";
+        checkEQ(templateString, expected);
+    }
+
+    static void testMapAndJoinIndexed() {
+        var templateString = Template.make(() -> scope(
+                mapAndJoin(List.of(1, 2, 3), ", ",
+                            (element, index) -> scope("Element " + element + " at index " + index))
+        )).render();
+
+        String expected = "Element 1 at index 0, Element 2 at index 1, Element 3 at index 2";
+        checkEQ(templateString, expected);
+    }
+
+    /*
+     * Failing tests start here
+     */
 
     public static void testFailingNestedRendering() {
         var template1 = Template.make(() -> scope(


### PR DESCRIPTION
This patch proposes a couple of utility methods to build scopes that I found useful to write more top to bottom readable templates with inline scopes. By doing so, I also replaced some usages in already existing tests with the new methods.

The following methods were added, each with an indexed and non-indexed version as overloads:
- `repeat()`: Repeat a scope
- `repeatAndJoin()`: Same as `repeat()` but we join the repeated scopes together with a delimiter
- `map()`: Map each element of a list to a separate scope
- `mapAndJoin()`: Same as `map()` but we join the mapped scopes together with a delimiter

The new methods are added to `Template.java` for easier use together with some Javadocs.

I also added some tests and added usability examples to `TestTutorial.java`.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387332](https://bugs.openjdk.org/browse/JDK-8387332): Template Framework: Add utility methods to build scopes (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32331/head:pull/32331` \
`$ git checkout pull/32331`

Update a local copy of the PR: \
`$ git checkout pull/32331` \
`$ git pull https://git.openjdk.org/jdk.git pull/32331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32331`

View PR using the GUI difftool: \
`$ git pr show -t 32331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32331.diff">https://git.openjdk.org/jdk/pull/32331.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32331#issuecomment-5278209563)
</details>
