### PR TITLE
8390288: The javax/swing/JTable/7124218/SelectEditTableCell.java fails on OL9.5

### DIFF
--- a/test/jdk/javax/swing/JTable/7124218/SelectEditTableCell.java
+++ b/test/jdk/javax/swing/JTable/7124218/SelectEditTableCell.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @key headful
- * @bug 7124218 8390288
+ * @bug 7124218
  * @summary verifies different behaviour of SPACE and ENTER in JTable
  * @run main SelectEditTableCell
  */

--- a/test/jdk/javax/swing/JTable/7124218/SelectEditTableCell.java
+++ b/test/jdk/javax/swing/JTable/7124218/SelectEditTableCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,13 +24,12 @@
 /*
  * @test
  * @key headful
- * @bug 7124218
+ * @bug 7124218 8390288
  * @summary verifies different behaviour of SPACE and ENTER in JTable
- * @library ../../regtesthelpers
- * @build Util
  * @run main SelectEditTableCell
  */
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -99,13 +98,16 @@ public class SelectEditTableCell {
     }
 
     private static void runTestCase() throws Exception {
-        Point centerPoint;
-        centerPoint = Util.getCenterPoint(table);
-        LookAndFeel lookAndFeel = UIManager.getLookAndFeel();
+        Rectangle cellRect = table.getCellRect(0, 0, true);
+        Point centerPoint = new Point(cellRect.x + cellRect.width / 2,cellRect.y + cellRect.height / 2);
+        SwingUtilities.convertPointToScreen(centerPoint, table);
+
         robot.mouseMove(centerPoint.x, centerPoint.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
+        robot.delay(500);
+
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
@@ -120,7 +122,7 @@ public class SelectEditTableCell {
         });
 
         int fetchKeyCode;
-        keyTap(fetchKeyCode = isMac(lookAndFeel)
+        keyTap(fetchKeyCode = isMac(UIManager.getLookAndFeel())
                 ? KeyEvent.VK_ENTER : KeyEvent.VK_SPACE);
         final int keyCode = fetchKeyCode;
         robot.waitForIdle();


### PR DESCRIPTION
The test fails because it clicks at the wrong location when focusing a table cell. It attempts to click the center of the table instead of the center of the cell.

The center of the table works on Ubuntu 24.04:
<img width="515" height="63" alt="image" src="https://github.com/user-attachments/assets/ce7e0621-3658-479e-87f2-c66aef416138" />


However, it doesn't work on Oracle Linux 9:
<img width="524" height="70" alt="image" src="https://github.com/user-attachments/assets/84aef905-95a4-4767-bbf8-d125caca16d5" />

On OL9, the frame title is shorter, which shifts the cell so that it is no longer rendered at the center of the table.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390288](https://bugs.openjdk.org/browse/JDK-8390288): The javax/swing/JTable/7124218/SelectEditTableCell.java fails on OL9.5 (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32332/head:pull/32332` \
`$ git checkout pull/32332`

Update a local copy of the PR: \
`$ git checkout pull/32332` \
`$ git pull https://git.openjdk.org/jdk.git pull/32332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32332`

View PR using the GUI difftool: \
`$ git pr show -t 32332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32332.diff">https://git.openjdk.org/jdk/pull/32332.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32332#issuecomment-5278561363)
</details>
