### PR TITLE
8390292: Pass the timeout factor to the child process in TestInheritFD

### DIFF
--- a/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
+++ b/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
@@ -244,6 +244,7 @@ public class TestInheritFD {
 
         ProcessBuilder pb = createLimitedTestJavaProcessBuilder(
             "-Xlog:gc:\"" + logPath + "\"",
+            "-Dtest.timeout.factor=" + Utils.TIMEOUT_FACTOR,
             "-Dtest.jdk=" + getProperty("test.jdk"),
             VMStartedWithLogging.class.getName(),
             logPath);
@@ -267,6 +268,7 @@ public class TestInheritFD {
         public static void main(String[] args) throws IOException, InterruptedException {
             System.out.println(SECOND_VM_PID_PREFIX + ProcessHandle.current().pid());
             ProcessBuilder pb = createLimitedTestJavaProcessBuilder(
+                "-Dtest.timeout.factor=" + Utils.TIMEOUT_FACTOR,
                 "-Dtest.jdk=" + getProperty("test.jdk"),
                 VMShouldNotInheritFileDescriptors.class.getName(),
                 args[0],


### PR DESCRIPTION
Hi all,

This patch passes the timeout factor to the child process in `TestInheritFD` to avoid the timeout exception.

Best Regards,
-- Guoxiong

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390292](https://bugs.openjdk.org/browse/JDK-8390292): Pass the timeout factor to the child process in TestInheritFD (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32333/head:pull/32333` \
`$ git checkout pull/32333`

Update a local copy of the PR: \
`$ git checkout pull/32333` \
`$ git pull https://git.openjdk.org/jdk.git pull/32333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32333`

View PR using the GUI difftool: \
`$ git pr show -t 32333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32333.diff">https://git.openjdk.org/jdk/pull/32333.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32333#issuecomment-5278695057)
</details>
