### PR TITLE
8389648: [TEST_BUG] java/awt/TextField/CaretPositionTest/CaretPositionTest.java fails in OL-9

### DIFF
--- a/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
+++ b/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
@@ -79,13 +79,15 @@ public class CaretPositionTest extends Frame {
 
     public void test() throws AWTException, InterruptedException,
             InvocationTargetException {
-        EventQueue.invokeAndWait(() -> {
-                    onScreen = text_field.getLocationOnScreen();
-                    size = text_field.getSize();
-                });
         Robot robot = new Robot();
         robot.setAutoDelay(50);
         robot.delay(1000);
+
+        EventQueue.invokeAndWait(() -> {
+            onScreen = text_field.getLocationOnScreen();
+            size = text_field.getSize();
+        });
+
         int y = onScreen.y + (size.height / 2);
         robot.mouseMove(onScreen.x + (size.width / 2), y);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0239ef45](https://github.com/openjdk/jdk/commit/0239ef459706655258934ae67120e02a04f12603) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexander Zvegintsev on 10 Aug 2026 and was reviewed by Phil Race and Jayathirth D V.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389648](https://bugs.openjdk.org/browse/JDK-8389648): [TEST_BUG] java/awt/TextField/CaretPositionTest/CaretPositionTest.java fails in OL-9 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32335/head:pull/32335` \
`$ git checkout pull/32335`

Update a local copy of the PR: \
`$ git checkout pull/32335` \
`$ git pull https://git.openjdk.org/jdk.git pull/32335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32335`

View PR using the GUI difftool: \
`$ git pr show -t 32335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32335.diff">https://git.openjdk.org/jdk/pull/32335.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32335#issuecomment-5278762949)
</details>
