### PR TITLE
8389875: java.lang javadoc should summarize object distinguishability

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -640,6 +640,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @jls value-objects-8.1.1.5 {@code value} Classes
      * @see AccessFlag#IDENTITY
+     * @see Object##Indistinguishability object distinguishability
      * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)

--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -29,12 +29,15 @@ import jdk.internal.javac.PreviewFeature;
 /**
  * Thrown when an identity object is required but a value object is supplied.
  * <p>
- * Identity objects are required for synchronization and locking.
- * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">Value-based</a>
- * objects do not have identity and cannot be used for synchronization, locking,
- * or any type of {@link java.lang.ref.Reference}.
+ * Identity objects are required for synchronization, locking, or any type
+ * of {@link java.lang.ref.Reference} that can track object liveness.
+ * Value objects are barred from these operations to avoid erroneous
+ * {@linkplain Object##Indistinguishability distinguishability}
+ * between copies of the same value.
+ * To test if an object is an identity object, use {@link java.util.Objects#hasIdentity}.
  *
  * @since 28
+ * @see Object##Indistinguishability object distinguishability
  */
 @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 public final class IdentityException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -31,8 +31,8 @@ import jdk.internal.javac.PreviewFeature;
  * <p>
  * Identity objects are required for synchronization, locking, or any type
  * of {@link java.lang.ref.Reference} that can track object liveness.
- * Value objects are barred from these operations to avoid erroneous
- * {@linkplain Object##Indistinguishability distinguishability}
+ * Value objects are barred from these operations to avoid erroneous attempts at 
+ * {@linkplain Object##Indistinguishability distinguishing}
  * between copies of the same value.
  * To test if an object is an identity object, use {@link java.util.Objects#hasIdentity}.
  *

--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -31,7 +31,7 @@ import jdk.internal.javac.PreviewFeature;
  * <p>
  * Identity objects are required for synchronization, locking, or any type
  * of {@link java.lang.ref.Reference} that can track object liveness.
- * Value objects are barred from these operations to avoid erroneous attempts at 
+ * Value objects are barred from these operations to avoid erroneous attempts at
  * {@linkplain Object##Indistinguishability distinguishing}
  * between copies of the same value.
  * To test if an object is an identity object, use {@link java.util.Objects#hasIdentity}.

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -59,14 +59,39 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          even if access to the field has been granted.
  *
  *          <h2 id="Indistinguishability">Object Distinguishability</h2>
- *          Two value references appear to be exactly the same value
- *          whenever their corresponding field values are (recursively)
- *          exactly the same.  In that case the two references are
- *          said to be <em>indistinguishable</em>.  One reference can
- *          be substituted for the other with no change to program
+ *          As defined by the Java Language Specification 4.3.1
+ *          {@jls value-objects-4.3.1 Objects},
+ *          any Java object, whether a value object or identity
+ *          object, is reachable only via one or more references;
+ *          conversely every non-null reference refers to a Java
+ *          object.  Java variables contain references, and Java
+ *          expressions produce references.
+ *          <p>
+ *          Even if the JVM chooses to format a reference internally
+ *          as a flattened set of field values (which can happen
+ *          with value objects), those flattened field values are
+ *          made to behave exactly the same as a "classic" indirect
+ *          representation, a pointer to an object header with fields.
+ *          Such an indirect object is called a <em>buffered</em>
+ *          value (not a boxed one, since boxes might have observable
+ *          identity).  The JVM is free to buffer a flattened value's
+ *          fields into the heap, or else copy the flattened field
+ *          values out of a buffer, and all such representations are
+ *          fully indistinguishable from each other, as long as they
+ *          agree on the field values.  Such tricks of representation
+ *          shifting only work if the JVM makes it impossible to
+ *          observe when and where the tricks are being played.
+ *          <p>
+ *          Therefore, two references must appear to refer to exactly
+ *          the same value object whenever the corresponding object
+ *          field values are (recursively) exactly the same.  In this
+ *          case, the references are said to be <em>indistinguishable</em>.
+ *          Under such rules, one indistinguishable reference can be
+ *          substituted for the other with no change to program
  *          behavior.  For all purposes in the JVM, the referenced
  *          objects don't just appear to be the same value: they are
- *          the same.
+ *          the same, even as the JVM shifts them, below the virtual
+ *          metal, through many physical representations.
  *          <p>
  *          Value indistinguishability can be counter-intuitive when
  *          the two values were created independently.  After all,
@@ -85,10 +110,10 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          difference between their field values (for immutable
  *          fields).  But for two value objects, the JVM provides no
  *          other way to make distinctions.  If they are fieldwise
- *          equivalent, the VM makes them look exactly the same.
+ *          equivalent, the JVM makes them look exactly the same.
  *          This is true whether they were created independently or
- *          not, and whether they are stored in one heap location or
- *          in many places on heap and stack.
+ *          not, and regardless of any invisible physical
+ *          representation tricks the JVM might be playing.
  *          <p>
  *          In short, unlike a regular identity object, a value has no
  *          object identity, leaving only its field states to carry
@@ -196,13 +221,13 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          the same kind of tree-walking work twice, once for {@code
  *          ==} as a failed optimization, and once for {@code equals}
  *          to get the real answer.  Just call {@code equals} or
- *          {@link java.util.Objects::equals}.
+ *          {@link java.util.Objects#equals Objects.equals}.
  *          As a special case, if a value class documents a commitment
  *          never to override {@code Object.equals}, and in that case
  *          only, {@code ==} will be a shorthand for {@code equals}.
  *          There is no special accommodation to make {@code ==}
  *          easier to use, and
- *          <a href="https://openjdk.org/jeps/401#Non-Goals"> JEP 401
+ *          <a href="https://openjdk.org/jeps/401#Non-Goals">JEP 401
  *          explicitly disavows</a> fixing {@code ==} to make it align
  *          more closely with value objects or {@code equals}.
  *          <p>
@@ -223,8 +248,8 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          to value objects would allow code to distinguish, over
  *          time-varying conditions, values which would otherwise be
  *          indistinguishable.  The JVM does not allow value objects
- *          to vary over time, as it could cause a particular value
- *          reference to change over time, even though it has not been
+ *          to vary over time, as it could cause a particular reference
+ *          to a value to change over time, even though it has not been
  *          updated by assignment.
  *          <p>
  *          As a rule, both identity and value objects are created by
@@ -238,10 +263,9 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          immediately be indistinguishable from any previously
  *          created value object with those same field values.  Thus,
  *          object creation is subtly different between values and
- *          identity objects.  For more details, see
- *          {@jls value-objects-4.3.1 Objects} and
- *          {@jls value-objects-15.9.4 Run-Time Evaluation of Class
- *          Instance Creation Expressions}.
+ *          identity objects.  For more details, see the Java Language
+ *          Specification 15.9.4 {@jls value-objects-15.9.4 Run-Time
+ *          Evaluation of Class Instance Creation Expressions}.
  *          <p>
  *          This difference applies evenly across all kinds of object
  *          creation events: {@code new} expressions, creation by

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -68,19 +68,11 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          expressions produce references.
  *          <p>
  *          Even if the JVM chooses to format a reference internally
- *          as a flattened set of field values (which can happen
- *          with value objects), those flattened field values are
+ *          as a flattened or scalarized group of field values
+ *          (which can happen with value objects &mdash; see below),
+ *          those loose sets of field values are
  *          made to behave exactly the same as a "classic" indirect
  *          representation, a pointer to an object header with fields.
- *          Such an indirect object is called a <em>buffered</em>
- *          value (not a boxed one, since boxes might have observable
- *          identity).  The JVM is free to buffer a flattened value's
- *          fields into the heap, or else copy the flattened field
- *          values out of a buffer, and all such representations are
- *          fully indistinguishable from each other, as long as they
- *          agree on the field values.  Such tricks of representation
- *          shifting only work if the JVM makes it impossible to
- *          observe when and where the tricks are being played.
  *          <p>
  *          Therefore, two references must appear to refer to exactly
  *          the same value object whenever the corresponding object
@@ -104,7 +96,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          and regardless of where, how, and how many times it is
  *          stored.  For a longer discussion of these points, see
  *          <a href="https://openjdk.org/jeps/401#Programming-without-identity">
- *          JEP 401, "Programming without identity" section</a>.
+ *          JEP 401, "Programming without identity"</a>.
  *          <p>
  *          Any two objects might be told apart by observing a
  *          difference between their field values (for immutable
@@ -157,8 +149,10 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          word comparison for most operands, it is more complicated
  *          when applied to value objects.  It may need to compare
  *          several field values, or even walk recursively into nested
- *          values.  Such walks are usually short.  And since values
- *          are inherently acyclic, the recursion always bottoms out.
+ *          values.  Such walks are usually short.  And since
+ *          <a href="https://openjdk.org/jeps/401#Safe-construction-of-value-objects">
+ *          values are inherently acyclic</a>,
+ *          the recursion always bottoms out.
  *          In its general structure, a value object is the root of a
  *          tree of value objects, whose leaves can be any mix of primitives
  *          and identity objects.
@@ -173,7 +167,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          tree walking, because a large tree may need to be
  *          walked, to prove there are no differences.  See also
  *          <a href="https://openjdk.org/jeps/401#Comparing-value-objects">
- *          JEP 401, "Comparing value objects" section</a>.
+ *          JEP 401, "Comparing value objects"</a>.
  *          <p>
  *          The authoritative definition of the equality operator,
  *          including its connection to indistinguishability,
@@ -183,7 +177,9 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          been extended to detect indistinguishability; see JVMS
  *          section 6.5, <i>if_acmp&lt;cond&gt;</i>, in the JEP 401 preview
  *          specifications.
- *          <p>
+ *
+ *          <h2 id="ValueEqualsHash">Equality and hashing for value classes</h2>
+ *
  *          The {@code ==} operator supplies the behavior of the
  *          default {@link Object#equals} method.  As a consequence,
  *          that built-in method can sometimes be used, without any
@@ -206,6 +202,10 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          case, the class author should let the JVM do what it
  *          already knows how to do, and refrain from overriding the
  *          {@code equals} and {@code hashCode} methods.
+ *          For more about interactions between {@code Object} methods
+ *          and value classes, see
+ *          <a href="https://openjdk.org/jeps/401#Inherited-methods-of-java-lang-Object">
+ *          JEP 401, "Inherited methods of {@code java.lang.Object}"</a>.
  *          <p>
  *          These considerations (of whether to override {@code
  *          equals} or not) affect clients as well as authors of value
@@ -231,7 +231,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          explicitly disavows</a> fixing {@code ==} to make it align
  *          more closely with value objects or {@code equals}.
  *          <p>
- *          Equality methods and hash methods come in pairs, so the
+ *          Since equality methods and hash methods come in pairs, the
  *          similarity (for values) between the two forms of equality
  *          ({@code ==} and {@code equals}) corresponds to an
  *          analogous similarity between the two kinds of {@code
@@ -239,33 +239,56 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          of value trees, {@link java.lang.System#identityHashCode}
  *          must walk a value's tree as well, computing a hash based
  *          on its structure and the field values at its leaves.
+ *
+ *          <h2 id="ValuesIdentities">Values versus identities</h2>
+ *          A value object is fully determined at creation, and there
+ *          is no way to witness any change in the value, at any time.
+ *          This may be surprising when one considers that the JVM
+ *          interpreter allocates a heap block (via the {@code new}
+ *          instruction), calls a constructor ({@code invokespecial}),
+ *          and stores value fields into the heap ({@code putfield}).
+ *          It would seem the self-reference {@code this} within a value
+ *          class constructor can violate all the rules of mutability and
+ *          indistinguishability, except that {@code this} is in a
+ *          <em>larval</em> condition.  Its reference cannot escape to
+ *          be tested for equality against any other object, nor can
+ *          any field mutations (via {@code putfield}) be observed.
+ *          Until the object exits its larval condition, it can initialize
+ *          itself but none of the state changes are visible;
+ *          afterwards it is fully immutable.  No escape analysis is
+ *          required to prove these facts.  For more on value
+ *          construction, see
+ *          <a href="https://openjdk.org/jeps/401#Safe-construction-of-value-objects">
+ *          JEP 401, "Safe construction of value objects"</a>.
+ *          For the basic details, see the Java Language
+ *          Specification 15.9.4 {@jls value-objects-15.9.4 Run-Time
+ *          Evaluation of Class Instance Creation Expressions}.
  *          <p>
- *          Note that the identity-sensitive operations (field
- *          mutation, synchronization, weak references) provide ways
- *          to make time-varying distinctions between two identity
- *          objects, whether or not they have the same corresponding
- *          field values.  Hypothetically extending those operations
- *          to value objects would allow code to distinguish, over
- *          time-varying conditions, values which would otherwise be
- *          indistinguishable.  The JVM does not allow value objects
- *          to vary over time, as it could cause a particular reference
- *          to a value to change over time, even though it has not been
- *          updated by assignment.
+ *          The identity-sensitive object operations &mdash; field
+ *          mutation, synchronization, weak references &mdash; provide
+ *          many ways to make time-varying distinctions between two
+ *          identity objects, whether or not they have the same
+ *          corresponding field values.  Hypothetically extending
+ *          those operations to value objects would allow code to
+ *          distinguish, over time-varying conditions, values which
+ *          would otherwise be indistinguishable.  If the JVM were to
+ *          allow value object states to vary over time, a particular
+ *          variable, a reference to a value, could appear to change
+ *          over time, without being updated by assignment.
  *          <p>
  *          As a rule, both identity and value objects are created by
  *          invoking constructors. (Arrays and deserialization can
- *          break the rule.)  When a new object first becomes visible
+ *          break this rule.)  When a new object first becomes visible
  *          as an assignable reference, it carries whatever field
  *          values it was initially given.
  *          If it is an identity object it also has a freshly assigned
- *          identity.  If it is a value object, its fields will never
+ *          identity, which supports identity-sensitive operations.
+ *          If it is a value object, its fields will never
  *          change, and because it has no identity, it will
  *          immediately be indistinguishable from any previously
- *          created value object with those same field values.  Thus,
- *          object creation is subtly different between values and
- *          identity objects.  For more details, see the Java Language
- *          Specification 15.9.4 {@jls value-objects-15.9.4 Run-Time
- *          Evaluation of Class Instance Creation Expressions}.
+ *          created value object with those same field values.
+ *          Identity and fieldwise indistinguishability are mutually
+ *          exclusive.
  *          <p>
  *          This difference applies evenly across all kinds of object
  *          creation events: {@code new} expressions, creation by
@@ -279,7 +302,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          It is true that object creation events necessarily
  *          allocate memory, somewhere, to hold the new object's
  *          fields.  And one might suppose that the JVM secretly knows
- *          the one heap block where the new value is stored.  One
+ *          the unique heap block where the new value is stored.  One
  *          might even guess that an object's memory address
  *          determines its identity.  But that would be a fallacy of
  *          oversimplification.  When the GC is working, any single
@@ -295,13 +318,21 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          boundless, because the whole value object lives in its
  *          collection of individual field values, and nowhere else.
  *          During or after construction, the JVM might choose to
- *          store the value in one heap block, on the stack, split up
- *          fieldwise in registers, or inlined into a containing
- *          object or array.  It might use all these techniques
+ *          store the value many ways: buffered in a heap block
+ *          (or "boxed", though that term wrongly suggests autoboxing),
+ *          scalarized fieldwise in registers, spilled to the stack,
+ *          or flattened (allocated inline) within some containing object or array.
+ *          (For a full discussion about value object encodings, see
+ *          <a href="https://openjdk.org/jeps/401#Run-time-optimizations-for-value-objects">
+ *          JEP 401, "Run-time optimizations for value objects"</a>.)
+ *          Such techniques will often be applied
  *          simultaneously, because the JVM can split one value into
  *          many copies.  It might also merge two copies of a value
  *          object into one stored value, if it can prove they are
  *          indistinguishable.
+ *          All of these optimizations require that value objects have
+ *          no identity, and instead become indistinguishable whenever
+ *          their field values are identical.
  *          <p>
  *          Value objects are built into the core of the language
  *          and JVM.  An historical approximation to the concept is
@@ -310,6 +341,10 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          for which the use of both {@code ==} and identity-sensitive
  *          operations is strongly discouraged.  Some classes previously
  *          marked as value based are migrated to proper value classes.
+ *          Other application and library classes may also be candidates
+ *          for such migration.  See
+ *          <a href="https://openjdk.org/jeps/401#Migrating-to-value-classes">
+ *          JEP 401, "Migrating to value classes"</a>, for more details.
  *      </div>
  * </div>
  *

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -53,6 +53,187 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          A {@linkplain java.lang.ref.Reference Reference object} can only refer to an
  *          object with identity. Creating a reference object with a value object as
  *          the referent throws {@code IdentityException}.
+ *          <p>
+ *          It is impossible to mutate any value object field, either directly
+ *          or {@linkplain java.lang.reflect.Field#set reflectively},
+ *          even if access to the field has been granted.
+ *
+ *          <h2 id="Indistinguishability">Object Distinguishability</h2>
+ *          Two value references appear to be exactly the same value
+ *          whenever their corresponding field values are likewise
+ *          exactly the same.  In that case the two references are
+ *          said to be <em>indistinguishable</em>.  One reference can
+ *          be substituted for the other with no change to program
+ *          behavior.  For all purposes in the JVM, the referenced
+ *          objects don't just appear to be the same value: they are
+ *          the same.
+ *          <p>
+ *          Value indistinguishability can be counter-intuitive when
+ *          the two values were created independently.  After all,
+ *          with identity objects, distinct creation events always
+ *          create distinct objects.  But two values created in
+ *          completely different places can turn out to be the same.
+ *          In this respect, value objects work like primitives.
+ *          The single number 4 is the same value everywhere,
+ *          regardless of how many places and times it was recomputed,
+ *          and regardless of where, how, and how many times it is
+ *          stored.  For a longer discussion of these points, see
+ *          <a href="https://openjdk.org/jeps/401#Programming-without-identity">
+ *          JEP 401, "Programming without identity" section</a>.
+ *          <p>
+ *          Any two objects might be told apart by observing a
+ *          difference between their field values (for immutable
+ *          fields).  But for two value objects, the JVM provides no
+ *          other way to make distinctions.  If they are fieldwise
+ *          equivalent, the VM makes them look exactly the same.
+ *          This is true whether they were created independently or
+ *          not, and whether they are stored in one heap location or
+ *          in many places on heap and stack.
+ *          <p>
+ *          In short, unlike a regular identity object, a value has no
+ *          object identity, leaving only its field states to carry
+ *          the full semantic weight.
+ *          <p>
+ *          In detail, two object references are said to be
+ *          <em>indistinguishable</em> if and only if
+ *          <ul>
+ *          <li>(a) both are the null reference, or</li>
+ *          <li>(b) both are the same identity object, or</li>
+ *          <li>(c) both refer to value objects of the same class, and</li>
+ *          <li><ul><li>their reference fields are pairwise indistinguishable,
+ *                      appealing recursively to this same definition, and</li>
+ *                  <li>their primitive fields are also pairwise
+ *                      indistinguishable, in the sense of bit-wise
+ *                      equivalence.</li>
+ *              </ul></li>
+ *          </ul>
+ *          The equality operator {@code ==} detects exactly this
+ *          condition of indistinguishability when applied directly to
+ *          any type, with the exception of {@code float} and {@code
+ *          double}.
+ *          <p>
+ *          There are special rules for {@code ==} when applied to
+ *          {@code float} and {@code double} operands, requiring
+ *          {@code -0.0 == 0.0} and {@code Double.NaN != Double.NaN},
+ *          even though the first pair of values are in fact
+ *          distinguishable, while the second pair are not.  Thus,
+ *          {@code ==} fails to detect indistinguishability of
+ *          floating-point values. The {@link Double#compare} method
+ *          also fails to detect indistinguishability, comparing all
+ *          {@code NaN} values as equal even if their raw bits differ.
+ *          See also {@linkplain Double##equivalenceRelation this
+ *          discussion of equivalence of floating-point values}.
+ *          Indistinguishability of floating-point values must be
+ *          tested by examining the bit-wise representation, as a
+ *          {@linkplain Float#floatToRawIntBits raw <code>int</code>} or
+ *          {@linkplain Double#doubleToRawLongBits raw <code>long</code>}.
+ *          <p>
+ *          While the {@code ==} operator performs a basic machine
+ *          word comparison for most operands, it is more complicated
+ *          when applied to value objects.  It may need to compare
+ *          several field values, or even walk recursively into nested
+ *          values.  Such walks are usually short.  And since values
+ *          are inherently acyclic, the recursion always bottoms out.
+ *          In its general structure, a value object is the root of a
+ *          tree of value objects, whose leaves are either primitives
+ *          or identity objects.
+ *          <p>
+ *          The {@code ==} operator on a deeply nested value has similar
+ *          costs to a call to {@link Object#equals} on a deeply nested
+ *          tree of {@link java.util.ArrayList ArrayList}s.
+ *          Both can require significant machine resources for
+ *          tree walking, because a large tree may need to be
+ *          walked, to prove there are no differences.
+ *          <p>
+ *          The authoritative definition of the equality operator,
+ *          including its connection to indistinguishability,
+ *          is found in the Java Language Specification
+ *          {@jls value-objects-15.21.3 Object Equality Operators}.
+ *          The JVM instruction which implements {@code ==} has also
+ *          been extended to detect indistinguishability; see JVMS
+ *          section 6.5, <i>if_acmp&lt;cond&gt;</i>, in the JEP 401 preview
+ *          specifications.
+ *          <p>
+ *          Equality methods and hash methods come in pairs, so the
+ *          similarity (for values) between the two forms of equality
+ *          ({@code ==} and {@code equals}) corresponds to an
+ *          analogous similarity between the two kinds of {@code
+ *          hashCode} methods.  Just as {@code ==} must walk over a pair
+ *          of value trees, {@link java.lang.System#identityHashCode}
+ *          must walk a value's tree as well, computing a hash based
+ *          on its structure and the field values at its leaves.
+ *          <p>
+ *          Note that the identity-sensitive operations (field
+ *          mutation, synchronization, weak references) provide ways
+ *          to make time-varying distinctions between two identity
+ *          objects, whether or not they have the same corresponding
+ *          field values.  Hypothetically extending those operations
+ *          to value objects would allow code to distinguish, over
+ *          time-varying conditions, values which would otherwise be
+ *          indistinguishable.  The JVM does not allow value objects
+ *          to vary over time, as it could cause a particular value
+ *          reference to change over time, even though it has not been
+ *          updated by assignment.
+ *          <p>
+ *          As a rule, both identity and value objects are created by
+ *          invoking constructors. (Arrays and deserialization can
+ *          break the rule.)  When a new object first becomes visible
+ *          as an assignable reference, it carries whatever field
+ *          values it was initially given.
+ *          If it is an identity object it also has a freshly assigned
+ *          identity.  If it is a value object, its fields will never
+ *          change, and because it has no identity, it will
+ *          immediately be indistinguishable from any previously
+ *          created value object with those same field values.  Thus,
+ *          object creation is subtly different between values and
+ *          identity objects.  For more details, see
+ *          {@jls value-objects-4.3.1 Objects} and
+ *          {@jls value-objects-15.9.4 Run-Time Evaluation of Class
+ *          Instance Creation Expressions}.
+ *          <p>
+ *          This difference applies evenly across all kinds of object
+ *          creation events: {@code new} expressions, creation by
+ *          reflection ({@code newInstance}) or method handle or JNI,
+ *          lambda capture or autoboxing, deserialization, and more.
+ *          When creating an identity object, you will always get
+ *          a fresh identity distinct from all others, but if it is a
+ *          value, it might be indistinguishable from some
+ *          already-existing value.
+ *          <p>
+ *          It is true that object creation events necessarily
+ *          allocate memory, somewhere, to hold the new object's
+ *          fields.  And one might suppose that the JVM secretly knows
+ *          the one heap block where the new value is stored.  One
+ *          might even guess that an object's memory address
+ *          determines its identity.  But that would be a fallacy of
+ *          oversimplification.  When the GC is working, any single
+ *          object might be stored temporarily in two blocks, linked
+ *          by some forwarding mechanism.  When the JVM creates any
+ *          kind of object it may delay or omit creation of the heap
+ *          block, and use some kind of bookkeeping (not a memory
+ *          address) to track the object's identity.  For identity
+ *          objects, this delay requires prior escape analysis; for
+ *          value objects it comes for free.
+ *          <p>
+ *          For values, the implementation possibilities are
+ *          boundless, because the whole value object lives in its
+ *          collection of individual field values, and nowhere else.
+ *          During or after construction, the JVM might choose to
+ *          store the value in one heap block, on the stack, split up
+ *          fieldwise in registers, or inlined into a containing
+ *          object or array.  It might use all these techniques
+ *          simultaneously, because the JVM can split one value into
+ *          many copies.  It might also merge two copies of a value
+ *          object into one stored value, if it can prove they are
+ *          indistinguishable.
+ *          <p>
+ *          Value objects are built into the core of the language
+ *          and JVM.  An historical approximation to the concept is
+ *          <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">
+ *          value-based objects</a>, which are regular identity objects
+ *          for which the use of both {@code ==} and identity-sensitive
+ *          operations is strongly discouraged.  Some classes previously
+ *          marked as value based are migrated to proper value classes.
  *      </div>
  * </div>
  *
@@ -167,15 +348,15 @@ public class Object {
      *
      * @implSpec
      * The {@code equals} method for class {@code Object} implements
-     * the most discriminating possible equivalence relation on objects;
-     * that is, for any non-null reference values {@code x} and
+     * the most discriminating possible equivalence relation on objects,
+     * which is {@linkplain ##Indistinguishability indistinguishability}.
+     * That is, for any non-null reference values {@code x} and
      * {@code y}, this method returns {@code true} if and only
-     * if {@code x} and {@code y} refer to the same identity object or
-     * <a id=equalsIndistinguishable>indistinguishable value objects ({@code x == y} has the value
-     * {@code true})</a>.
+     * if {@code x == y} has the value {@code true}.
      * <p>
      * In other words, under the object equality equivalence
-     * relation, each equivalence class only has a single element.
+     * relation, each equivalence class only has a single
+     * distinguishable element.
      *
      * @apiNote
      * It is generally necessary to override the {@link #hashCode() hashCode}
@@ -208,7 +389,8 @@ public class Object {
      * <pre>
      * x.clone().getClass() == x.getClass()</pre></blockquote>
      * will also be {@code true}, but these are not absolute requirements.
-     * The clone of a value object, in particular, may be indistinguishable from
+     * The clone of a value object, in particular, may be
+     * {@linkplain ##Indistinguishability indistinguishable} from
      * the original.
      * <p>
      * While it is typically the case that:
@@ -258,7 +440,8 @@ public class Object {
      * contents of the fields are not themselves cloned. Thus, this method
      * performs a "shallow copy" of this object, not a "deep copy" operation.
      * <p>
-     * For a value object, this method returns an object that is indistinguishable
+     * For a value object, this method returns an object that is
+     * {@linkplain ##Indistinguishability indistinguishable}
      * from this object.
      * <p>
      * The class {@code Object} does not itself implement the interface

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -60,7 +60,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *
  *          <h2 id="Indistinguishability">Object Distinguishability</h2>
  *          Two value references appear to be exactly the same value
- *          whenever their corresponding field values are likewise
+ *          whenever their corresponding field values are (recursively)
  *          exactly the same.  In that case the two references are
  *          said to be <em>indistinguishable</em>.  One reference can
  *          be substituted for the other with no change to program
@@ -135,15 +135,20 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          values.  Such walks are usually short.  And since values
  *          are inherently acyclic, the recursion always bottoms out.
  *          In its general structure, a value object is the root of a
- *          tree of value objects, whose leaves are either primitives
- *          or identity objects.
+ *          tree of value objects, whose leaves can be any mix of primitives
+ *          and identity objects.
+ *          The tree can also contain {@code null}s; those can be
+ *          thought of as either a kind of internal tree structure, or
+ *          as a third kind of leaf.
  *          <p>
  *          The {@code ==} operator on a deeply nested value has similar
  *          costs to a call to {@link Object#equals} on a deeply nested
  *          tree of {@link java.util.ArrayList ArrayList}s.
  *          Both can require significant machine resources for
  *          tree walking, because a large tree may need to be
- *          walked, to prove there are no differences.
+ *          walked, to prove there are no differences.  See also
+ *          <a href="https://openjdk.org/jeps/401#Comparing-value-objects">
+ *          JEP 401, "Comparing value objects" section</a>.
  *          <p>
  *          The authoritative definition of the equality operator,
  *          including its connection to indistinguishability,
@@ -153,6 +158,53 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *          been extended to detect indistinguishability; see JVMS
  *          section 6.5, <i>if_acmp&lt;cond&gt;</i>, in the JEP 401 preview
  *          specifications.
+ *          <p>
+ *          The {@code ==} operator supplies the behavior of the
+ *          default {@link Object#equals} method.  As a consequence,
+ *          that built-in method can sometimes be used, without any
+ *          override, for comparing the structure of two values.  This
+ *          affects the design of value classes.  An author of a new
+ *          value class must determine, within the class's own
+ *          semantic rules, whether two <em>distinguishable</em>
+ *          instances of that class ({@code x!=y}) should ever be
+ *          regarded as <em>interchangeable</em> (semantically
+ *          equivalent, {@code x.equals(y)}).  For example, does the
+ *          class contain an array (or string or list) whose identity
+ *          is insignificant?  If so, the class must override the
+ *          {@code equals} and {@code hashCode} methods, providing
+ *          logic which discounts non-semantic representational
+ *          differences (such as the identity of an array, string, or
+ *          list).  But for some simple classes, if values are at all
+ *          distinguishable (if they have any differing leaf items),
+ *          then {@code equals} should return {@code false}; it should
+ *          never hide any representational differences.  In that
+ *          case, the class author should let the JVM do what it
+ *          already knows how to do, and refrain from overriding the
+ *          {@code equals} and {@code hashCode} methods.
+ *          <p>
+ *          These considerations (of whether to override {@code
+ *          equals} or not) affect clients as well as authors of value
+ *          classes.  There is a long-standing practice to precede an
+ *          {@code equals} call comparing two identity objects with
+ *          {@code ==}, as a cheap way to sometimes avoid calling the
+ *          more expensive {@code equals} method.  (It looks like
+ *          {@code x==y || x.equals(y)}.)  But users of value classes
+ *          should know that using {@code ==} first is <em>not</em>
+ *          likely to be much cheaper than calling {@code equals}.
+ *          The idiom created for identity objects is not incorrect
+ *          for value objects, but you are likely to ask the JVM to do
+ *          the same kind of tree-walking work twice, once for {@code
+ *          ==} as a failed optimization, and once for {@code equals}
+ *          to get the real answer.  Just call {@code equals} or
+ *          {@link java.util.Objects::equals}.
+ *          As a special case, if a value class documents a commitment
+ *          never to override {@code Object.equals}, and in that case
+ *          only, {@code ==} will be a shorthand for {@code equals}.
+ *          There is no special accommodation to make {@code ==}
+ *          easier to use, and
+ *          <a href="https://openjdk.org/jeps/401#Non-Goals"> JEP 401
+ *          explicitly disavows</a> fixing {@code ==} to make it align
+ *          more closely with value objects or {@code equals}.
  *          <p>
  *          Equality methods and hash methods come in pairs, so the
  *          similarity (for values) between the two forms of equality

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -482,21 +482,34 @@ public final class System {
 
     /**
      * Returns the same hash code for the given object as
-     * would be returned by the default method hashCode(),
+     * would be returned by the default method {@linkplain Object#hashCode hashCode()},
      * whether or not the given object's class overrides
-     * hashCode().
+     * {@code hashCode()}.
      * The hash code for the null reference is zero.
      *
      * <div class="preview-block">
      *      <div class="preview-comment">
-     *          The "identity hash code" of a {@linkplain Class#isValue() value object}
-     *          is computed by combining the identity hash codes of the value object's fields recursively.
+     *          The hash code produced by this method is always
+     *          compatible with the {@code ==} operator.  That is,
+     *          if two object references are
+     *          {@linkplain Object##Indistinguishability indistinguishable},
+     *          their hashes will be identical as well.
+     *          <p>
+     *          For a {@linkplain Class#isValue() value object}, which
+     *          lacks object identity, the hash code may be computed
+     *          by a recursive walk of the value tree, combining (in
+     *          an unspecified manner) identity hash codes of
+     *          reference fields and bits from the primitive fields.
+     *          <p>
+     *          Despite its name, {@code identityHashCode} can accept both
+     *          value objects and identity objects, because it is behaviorally
+     *          compatible with the default {@code hashCode()} method.
      *      </div>
      * </div>
      * @apiNote
      * <div class="preview-block">
      *      <div class="preview-comment">
-     *          Note that, like ==, this hash code exposes information about a value object's
+     *          Note that, like {@code ==}, this hash code may expose information about a value object's
      *          private fields that might otherwise be hidden by an identity object.
      *          Developers should be cautious about storing sensitive secrets in value object fields.
      *      </div>

--- a/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
+++ b/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
@@ -69,7 +69,8 @@ In a future release, they may become value classes (JLS
     because the programmer cannot guarantee exclusive ownership of the
     associated monitor.</p>
 
-<p>When preview features are enabled, some value-based classes become value classes.
+<p>When preview features are enabled, some value-based classes become
+    {@linkplain Object##Indistinguishability value classes}.
     Instances of these classes become value objects, which have different identity-related
     behaviors compared to identity objects:</p>
 <ul>

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -42,10 +42,15 @@ final class ValueObjectMethods {
     }
 
     /**
-     * Return whether two value objects of the same class are indistinguishable,
-     * as used by {@code ==} operator.
+     * Return whether two value objects of the same class are
+     * {@linkplain Object##Indistinguishability indistinguishable},
+     * as determined by {@code ==} operator.
      * The fields to compare are determined by Unsafe.getFieldMap.
      * This method is called by the JVM.
+     *
+     * The name {@code isSubstitutable} is historic, referring to the
+     * fact that indistinguishable references can be safely
+     * substituted for each other.
      *
      * @param a a value class instance, non-null
      * @param b a value class instance of the same class as {@code a}, non-null

--- a/src/java.base/share/classes/java/util/IdentityHashMap.java
+++ b/src/java.base/share/classes/java/util/IdentityHashMap.java
@@ -52,8 +52,8 @@ import jdk.internal.access.SharedSecrets;
  *      <div class="preview-comment">
  *          When preview features are enabled, keys and values may be
  *          {@linkplain java.util.Objects#hasIdentity value objects}.
- *          Two value object keys are {@code ==} if they are instances
- *          of the same class and the values of their instance fields are the same.
+ *          Two value object keys are {@code ==} if and only if they are
+ *          {@linkplain Object##Indistinguishability indistinguishable}.
  *      </div>
  * </div>
  *

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -212,6 +212,7 @@ public final class Objects {
      *     }
      * }
      * @param obj an object or {@code null}
+     * @see Object##Indistinguishability object distinguishability
      * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
@@ -233,6 +234,7 @@ public final class Objects {
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}
      * @throws IdentityException if {@code obj} is not an identity object
+     * @see Object##Indistinguishability object distinguishability
      * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective = true)
@@ -260,6 +262,7 @@ public final class Objects {
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}
      * @throws IdentityException if {@code obj} is not an identity object
+     * @see Object##Indistinguishability object distinguishability
      * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective = true)
@@ -287,6 +290,7 @@ public final class Objects {
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}
      * @throws IdentityException if {@code obj} is not an identity object
+     * @see Object##Indistinguishability object distinguishability
      * @since 28
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective = true)

--- a/src/java.base/share/classes/java/util/WeakHashMap.java
+++ b/src/java.base/share/classes/java/util/WeakHashMap.java
@@ -45,7 +45,8 @@ import java.util.function.Consumer;
  *
  * <div class="preview-block">
  *      <div class="preview-comment">
- *          {@linkplain java.util.Objects#hasIdentity Value objects} can not be used as
+ *          Only {@linkplain java.util.Objects#hasIdentity identity objects}
+ *          and {@code null} may be used as
  *          keys in a {@code WeakHashMap}. The {@link #put(Object, Object) put(K, V)}
  *          method, and all methods that associate a value with a key, throw {@link
  *          IdentityException} if the key is a value object.
@@ -567,7 +568,7 @@ public class WeakHashMap<@jdk.internal.RequiresIdentity K,V>
      *
      * @apiNote If the specified map contains keys that are
      * {@linkplain java.util.Objects#hasIdentity value objects},
-     * an {@linkplain IdentityException} is thrown when the first value object
+     * an {@link IdentityException} is thrown when the first value object
      * key is encountered. Zero or more mappings may have already been copied to
      * this map.
      *


### PR DESCRIPTION
The core specs were updated ([JDK-8388175](https://bugs.openjdk.org/browse/JDK-8388175) for JLS and [JDK-8388177](https://bugs.openjdk.org/browse/JDK-8388177) for
javadoc) to introduce the concept of object indistinguishability.
(This replaced an earlier concept of "statewise equivalence".) JLS
15.21.3 ("Object Equality Operators") now defines when two object
references are indistinguishable, allowing for distinctly created
value objects to be indistinguishable, virtually the same object.
In parallel, the updated JVMS describes the VM-level view of the
same concept.

These specs describe Valhalla's crucial modification to the Java
object model, the ability of two distinctly created value objects
to be processed as fully indistinguishable by the VM.

The terse, technical language of the JLS (and that of the JVMS, with the
explanations of the JEP) must be summarized usefully for the users
of javadoc.

This draft shows one good way to use the javadoc to teach the new user model for value objects.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389875](https://bugs.openjdk.org/browse/JDK-8389875): java.lang javadoc should summarize object distinguishability (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32336/head:pull/32336` \
`$ git checkout pull/32336`

Update a local copy of the PR: \
`$ git checkout pull/32336` \
`$ git pull https://git.openjdk.org/jdk.git pull/32336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32336`

View PR using the GUI difftool: \
`$ git pr show -t 32336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32336.diff">https://git.openjdk.org/jdk/pull/32336.diff</a>

</details>
