### PR TITLE
8389859: Missing TYPE_USE annotations on type variable uses

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -485,7 +485,7 @@ public class TypeAnnotations {
             if (type.hasTag(TypeTag.ARRAY)) {
                 ret = rewriteArrayType(typetree, (ArrayType)type, annotations, onlyTypeAnnotations, pos);
             } else if (type.hasTag(TypeTag.TYPEVAR)) {
-                ret = type.annotatedType(onlyTypeAnnotations);
+                ret = type.annotatedType(annotations);
             } else if (type.getKind() == TypeKind.UNION) {
                 // There is a TypeKind, but no TypeTag.
                 UnionClassType ut = (UnionClassType) type;

--- a/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
+++ b/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8013852 8031744 8225377 8323684
+ * @bug 8013852 8031744 8225377 8323684 8389859
  * @summary Annotations on types
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -103,7 +103,9 @@ public class BasicAnnoTests extends JavacTestingAbstractProcessor {
                       new NameToAnnotationEntry("BasicAnnoTests.TB",   BasicAnnoTests.TB.class),
                       new NameToAnnotationEntry("BasicAnnoTests.TC",   BasicAnnoTests.TC.class),
                       new NameToAnnotationEntry("BasicAnnoTests.TCs",  BasicAnnoTests.TCs.class),
-                      new NameToAnnotationEntry("BasicAnnoTests.TD",  BasicAnnoTests.TD.class));
+                      new NameToAnnotationEntry("BasicAnnoTests.TD",   BasicAnnoTests.TD.class),
+                      new NameToAnnotationEntry("BasicAnnoTests.DTF",  BasicAnnoTests.DTF.class),
+                      new NameToAnnotationEntry("BasicAnnoTests.DTP",  BasicAnnoTests.DTP.class));
 
     static class NameToAnnotationEntry extends  AbstractMap.SimpleEntry<String, Class<? extends Annotation>> {
         public NameToAnnotationEntry(String key, Class<? extends Annotation> entry) {
@@ -531,6 +533,16 @@ public class BasicAnnoTests extends JavacTestingAbstractProcessor {
         int value();
     }
 
+    @Target({ElementType.TYPE_USE, ElementType.FIELD})
+    public @interface DTF {
+        int value();
+    }
+
+    @Target({ElementType.TYPE_USE, ElementType.PARAMETER})
+    public @interface DTP {
+        int value();
+    }
+
     // Test cases
 
     // TODO: add more cases for arrays
@@ -696,6 +708,29 @@ public class BasicAnnoTests extends JavacTestingAbstractProcessor {
     @Test(posn=6, annoType = TA.class, expect = "60")
     @Test(posn=6, annoType = TB.class, expect = "61")
     <T> void m60(@TA(60) @TB(61) String t) { }
+
+    // Test dual target annotations on uses of type variables
+    @Test(posn=6, annoType = DTP.class, expect = "61")
+    <T> void m61(@DTP(61) T t) { }
+
+    @Test(posn=7, annoType = DTP.class, expect = "62")
+    <T> void m62(@DTP(62) T[] t) { }
+
+    class Inner63<T> {
+        @Test(posn=0, annoType = DTF.class, expect = "63")
+        @DTF(63) T f;
+    }
+    // Test dual target annotations on uses of Class types
+    @Test(posn=6, annoType = DTP.class, expect = "64")
+    <T> void m64(@DTP(64) String t) { }
+
+    @Test(posn=7, annoType = DTP.class, expect = "65")
+    <T> void m65(@DTP(65) String[] t) { }
+
+    class Inner66<T> {
+        @Test(posn=0, annoType = DTF.class, expect = "66")
+        @DTF(66) String f;
+    }
 
     class Inner70<T> {
         @Test(posn=0, annoType = TA.class, expect = "70")


### PR DESCRIPTION
The source model currently does not expose dual-target annotations on uses of type variables.

For example, consider the following code snippet:
```
import java.lang.annotation.ElementType;
import java.lang.annotation.Target;

@Target({ElementType.PARAMETER, ElementType.TYPE_USE})
@interface A {}

class S<T> {
  void f(@A T a, @A String b) {}
}
```
Given an annotation that targets both `PARAMETER` and `TYPE_USE`, the annotation on `@A T` is available from the parameter element but missing from the parameter's `TypeMirror`. The equivalent annotation on `@A String` is correctly exposed by both the parameter element and the paremeter's `TypeMirror`. Reading the generated class file also produces the correct result, causing source-backed and class-file-backed models to behave differently.

The problem is that when annotating a type variable, `TypeAnnotations.typeWithAnnotations` uses `onlyTypeAnnotations`. That list deliberately excludes annotations applicable to both a declaration and a type. Other type kinds use the complete `annotations` list.

This change makes the type variable path use the complete list as well.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389859](https://bugs.openjdk.org/browse/JDK-8389859): Missing TYPE_USE annotations on type variable uses (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32337/head:pull/32337` \
`$ git checkout pull/32337`

Update a local copy of the PR: \
`$ git checkout pull/32337` \
`$ git pull https://git.openjdk.org/jdk.git pull/32337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32337`

View PR using the GUI difftool: \
`$ git pr show -t 32337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32337.diff">https://git.openjdk.org/jdk/pull/32337.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32337#issuecomment-5279157249)
</details>
