### PR TITLE
8390299: Unify *oop type hierarchy with *oopDesc type hierarchy

### DIFF
--- a/src/hotspot/share/oops/oopsHierarchy.hpp
+++ b/src/hotspot/share/oops/oopsHierarchy.hpp
@@ -82,6 +82,10 @@ using CheckOopFunctionPointer = void(*)(oopDesc*);
 extern CheckOopFunctionPointer check_oop_function;
 
 class oop {
+public:
+  using DescType = oopDesc;
+
+private:
   oopDesc* _o;
 
   void register_oop();
@@ -125,41 +129,54 @@ struct PrimitiveConversions::Translate<oop> : public std::true_type {
   static Value recover(Decayed x) { return oop(x); }
 };
 
-#define DEF_OOP(type)                                                          \
-   class type##OopDesc;                                                        \
-   class type##Oop : public oop {                                              \
-     public:                                                                   \
-       type##Oop() : oop() {}                                                  \
-       type##Oop(const type##Oop& o) : oop(o) {}                               \
-       type##Oop(const oop& o) : oop(o) {}                                     \
-       type##Oop(type##OopDesc* o) : oop((oopDesc*)o) {}                       \
-       operator type##OopDesc* () const { return (type##OopDesc*)obj(); }      \
-       type##OopDesc* operator->() const {                                     \
-            return (type##OopDesc*)obj();                                      \
-       }                                                                       \
-       type##Oop& operator=(const type##Oop& o) {                              \
-            oop::operator=(o);                                                 \
-            return *this;                                                      \
-       }                                                                       \
-   };                                                                          \
+#define DEF_OOP_IMPL(OopType, OopDescType, BaseOopType)                        \
+  class OopDescType;                                                           \
+  class OopType : public BaseOopType {                                         \
+  public:                                                                      \
+    using DescType = OopDescType;                                              \
+    OopType() : BaseOopType() {}                                               \
+    OopType(std::nullptr_t) : BaseOopType() {}                                 \
+    OopType(const OopType& o) : BaseOopType(o) {}                              \
+    explicit OopType(const oop& o) : BaseOopType(o) {}                         \
+    OopType(DescType* o) : BaseOopType((BaseOopType::DescType*)o) {}           \
+    operator DescType*() const { return (DescType*)obj(); }                    \
+    DescType* operator->() const { return (DescType*)obj(); }                  \
+    OopType& operator=(std::nullptr_t) {                                       \
+      BaseOopType::operator=(nullptr);                                         \
+      return *this;                                                            \
+    }                                                                          \
+    OopType& operator=(const OopType& o) {                                     \
+      BaseOopType::operator=(o);                                               \
+      return *this;                                                            \
+    }                                                                          \
+    OopType& operator=(const oop& o) = delete;                                 \
+  };                                                                           \
                                                                                \
-   template<>                                                                  \
-   struct PrimitiveConversions::Translate<type##Oop> : public std::true_type { \
-     typedef type##Oop Value;                                                  \
-     typedef type##OopDesc* Decayed;                                           \
+  template <>                                                                  \
+  struct PrimitiveConversions::Translate<OopType> : public std::true_type {    \
+    typedef OopType Value;                                                     \
+    typedef OopType::DescType* Decayed;                                        \
                                                                                \
-     static Decayed decay(Value x) { return (type##OopDesc*)x.obj(); }         \
-     static Value recover(Decayed x) { return type##Oop(x); }                  \
-   };
+    static Decayed decay(Value x) { return (OopType::DescType*)x.obj(); }      \
+    static Value recover(Decayed x) { return OopType(x); }                     \
+  };
+
+#define DEF_OOP_BASE(type, base)                                               \
+  DEF_OOP_IMPL(type##Oop, type##OopDesc, base##Oop)
+#define DEF_OOP(type) DEF_OOP_IMPL(type##Oop, type##OopDesc, oop)
 
 DEF_OOP(instance);
-DEF_OOP(inline);
-DEF_OOP(stackChunk);
+DEF_OOP_BASE(inline, instance);
+DEF_OOP_BASE(stackChunk, instance);
 DEF_OOP(array);
-DEF_OOP(objArray);
-DEF_OOP(typeArray);
-DEF_OOP(flatArray);
-DEF_OOP(refArray);
+DEF_OOP_BASE(objArray, array);
+DEF_OOP_BASE(typeArray, array);
+DEF_OOP_BASE(flatArray, objArray);
+DEF_OOP_BASE(refArray, objArray);
+
+#undef DEF_OOP_IMPL
+#undef DEF_OOP_BASE
+#undef DEF_OOP
 
 #endif // CHECK_UNHANDLED_OOPS
 


### PR DESCRIPTION
Today there is a discrepancy between the `oopDesc` type hierarchy, which reflects our `Klass` hierarchy, and the `CHECK_UNHANDLED_OOPS`'s `oop` class hierarchy, where every different type has `oop` as its direct base class.

Each derived `<Type>Oop` class also is implicitly constructible from an `oop` which when `CHECK_UNHANDLED_OOPS` is disabled is invalid as there is no implicit conversion available from `oopDesc*` to a `.<Type>OopDesc*`.

I suggest we remedy this so we have similar semantics between `<Type>Oop` and `<Type>OopDesc*`. This will allow us to create variant function overrides, get compilation errors on implicit upcasts when building with `CHECK_UNHANDLED_OOPS`, and avoid casting when down-casting with `CHECK_UNHANDLED_OOPS`.

After this is integrated I will try to go through and create enhancements for places where we obviously could benefit from type variance in our virtual methods, and places where we have unnecessary down-casts.

* Testing 
  * Tier1-3 Oracle supported platforms
  * GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390299](https://bugs.openjdk.org/browse/JDK-8390299): Unify *oop type hierarchy with *oopDesc type hierarchy (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32339/head:pull/32339` \
`$ git checkout pull/32339`

Update a local copy of the PR: \
`$ git checkout pull/32339` \
`$ git pull https://git.openjdk.org/jdk.git pull/32339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32339`

View PR using the GUI difftool: \
`$ git pr show -t 32339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32339.diff">https://git.openjdk.org/jdk/pull/32339.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32339#issuecomment-5280147069)
</details>
