### PR TITLE
8389868: Empty LocalVariableTable attribute is generated for an unused variable in clinit

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1144,10 +1144,11 @@ public class ClassWriter extends ClassFile {
         }
 
         // counter for number of generic local variables
-        if (code.varDebugInfo && code.varBufferSize > 0) {
+        int lvtSize = code.getLVTSize();
+        if (code.varDebugInfo && lvtSize > 0) {
             int nGenericVars = 0;
             int alenIdx = writeAttr(names.LocalVariableTable);
-            databuf.appendChar(code.getLVTSize());
+            databuf.appendChar(lvtSize);
             for (int i=0; i<code.varBufferSize; i++) {
                 Code.LocalVar var = code.varBuffer[i];
 

--- a/test/langtools/tools/javac/classfiles/attributes/LocalVariableTable/EmptyLocalVariableTableTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LocalVariableTable/EmptyLocalVariableTableTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389868
+ * @summary Test that empty LocalVariableTable attribute is not generated.
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit ${test.main.class}
+ */
+
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.attribute.CodeAttribute;
+import java.lang.classfile.attribute.LocalVariableTableAttribute;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import toolbox.JavacTask;
+import toolbox.ToolBox;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class EmptyLocalVariableTableTest {
+
+    Path base;
+    ToolBox tb = new ToolBox();
+
+    @Test
+    void testNoEmptyLVT() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString(), "-g")
+                .sources("""
+                         public class UnusedVariable {
+                             static void test() {
+                                 {
+                                     Class<?> unused = null;
+                                 }
+                             }
+                             static {
+                                 Class<?> unused = null;
+                             }
+                         }
+                         """)
+                .run()
+                .writeAll();
+        ClassFile.of().parse(classes.resolve("UnusedVariable.class")).methods().stream()
+                .forEach(mm -> {
+                    CodeAttribute codeAttribute = mm.findAttribute(Attributes.code()).orElse(null);
+                    Assertions.assertNotNull(codeAttribute);
+                    codeAttribute.attributes().stream()
+                            .filter(attr -> attr instanceof LocalVariableTableAttribute)
+                            .map(attr -> (LocalVariableTableAttribute) attr)
+                            .forEach(attr -> {
+                                Assertions.assertFalse(attr.localVariables().isEmpty(), "Empty LocalVariableTableAttribute found");
+                            });
+                });
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}

--- a/test/langtools/tools/javac/classfiles/attributes/LocalVariableTable/EmptyLocalVariableTableTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LocalVariableTable/EmptyLocalVariableTableTest.java
@@ -36,7 +36,6 @@
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.attribute.CodeAttribute;
-import java.lang.classfile.attribute.LocalVariableTableAttribute;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -77,9 +76,7 @@ public class EmptyLocalVariableTableTest {
                 .forEach(mm -> {
                     CodeAttribute codeAttribute = mm.findAttribute(Attributes.code()).orElse(null);
                     Assertions.assertNotNull(codeAttribute);
-                    codeAttribute.attributes().stream()
-                            .filter(attr -> attr instanceof LocalVariableTableAttribute)
-                            .map(attr -> (LocalVariableTableAttribute) attr)
+                    codeAttribute.findAttributes(Attributes.localVariableTable()).stream()
                             .forEach(attr -> {
                                 Assertions.assertFalse(attr.localVariables().isEmpty(), "Empty LocalVariableTableAttribute found");
                             });


### PR DESCRIPTION
Consider the following code snippet:
```
public class UnusedVariable {
    static void test() {
        {
            Class<?> unused = null;
        }
    }
    static {
        Class<?> unused = null;
    }
}
```
When compiling this code with -g, javac currently emits empty `LocalVariableTable` attributes for the `test` and `<clinit>` methods.

This happens because `Code.varBuffer` contains variables whose live ranges have been removed because their calculated lengths are zero. `ClassWriter` uses `varBufferSize` to decide whether to emit the attribute, even though `Code.getLVTSize()` (the actual number of entries written) returns zero.

This change computes the effective `LocalVariableTable` size before writing the attribute and emits the attribute only when that size is greater than zero.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389868](https://bugs.openjdk.org/browse/JDK-8389868): Empty LocalVariableTable attribute is generated for an unused variable in clinit (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) Review applies to [eaa0e242](https://git.openjdk.org/jdk/pull/32342/files/eaa0e2427be60b4b244a74a7324a4593340e33f4)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32342/head:pull/32342` \
`$ git checkout pull/32342`

Update a local copy of the PR: \
`$ git checkout pull/32342` \
`$ git pull https://git.openjdk.org/jdk.git pull/32342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32342`

View PR using the GUI difftool: \
`$ git pr show -t 32342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32342.diff">https://git.openjdk.org/jdk/pull/32342.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32342#issuecomment-5281044689)
</details>
