### PR TITLE
8360517: C2: Incomplete ArrayList foreach optimization (java.base library update)

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -1043,7 +1043,9 @@ public class ArrayList<E> extends AbstractList<E>
      */
     private class Itr implements Iterator<E> {
         int cursor;       // index of next element to return
-        int lastRet = -1; // index of last element returned; -1 if no such
+        static final int LAST_RET_UNSET = -1;
+        static final int LAST_RET_CURSOR = -2; // special case: lastRet = cursor - 1
+        int lastRet = LAST_RET_UNSET; // index of last element returned, or a sentinel
         int expectedModCount = modCount;
 
         // prevent creating a synthetic constructor
@@ -1063,18 +1065,21 @@ public class ArrayList<E> extends AbstractList<E>
             if (i >= elementData.length)
                 throw new ConcurrentModificationException();
             cursor = i + 1;
-            return (E) elementData[lastRet = i];
+            // in place of "lastRet = i", which would make C2 keep two loop values live instead of one
+            lastRet = LAST_RET_CURSOR;
+            return (E) elementData[i];
         }
 
         public void remove() {
-            if (lastRet < 0)
+            if (lastRet == LAST_RET_UNSET)
                 throw new IllegalStateException();
             checkForComodification();
 
             try {
-                ArrayList.this.remove(lastRet);
-                cursor = lastRet;
-                lastRet = -1;
+                int removeIdx = lastRet == LAST_RET_CURSOR ? cursor - 1 : lastRet;
+                ArrayList.this.remove(removeIdx);
+                cursor = removeIdx;
+                lastRet = LAST_RET_UNSET;
                 expectedModCount = modCount;
             } catch (IndexOutOfBoundsException ex) {
                 throw new ConcurrentModificationException();
@@ -1140,12 +1145,12 @@ public class ArrayList<E> extends AbstractList<E>
         }
 
         public void set(E e) {
-            if (lastRet < 0)
+            if (lastRet == LAST_RET_UNSET)
                 throw new IllegalStateException();
             checkForComodification();
 
             try {
-                ArrayList.this.set(lastRet, e);
+                ArrayList.this.set(lastRet == LAST_RET_CURSOR ? cursor - 1 : lastRet, e);
             } catch (IndexOutOfBoundsException ex) {
                 throw new ConcurrentModificationException();
             }
@@ -1158,7 +1163,7 @@ public class ArrayList<E> extends AbstractList<E>
                 int i = cursor;
                 ArrayList.this.add(i, e);
                 cursor = i + 1;
-                lastRet = -1;
+                lastRet = LAST_RET_UNSET;
                 expectedModCount = modCount;
             } catch (IndexOutOfBoundsException ex) {
                 throw new ConcurrentModificationException();

--- a/test/micro/org/openjdk/bench/java/util/ArrayListIterate.java
+++ b/test/micro/org/openjdk/bench/java/util/ArrayListIterate.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.util;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 300, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 300, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-XX:+UseSerialGC", "-XX:+UnlockDiagnosticVMOptions", "-XX:LoopMaxUnroll=1", "-Xmx1g"})
+@State(Scope.Benchmark)
+public class ArrayListIterate {
+
+    private static final int SIZE = 1048576;
+
+    private ArrayList<Object> list;
+
+    @Setup
+    public void setup() {
+        list = new ArrayList<>(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            list.add(new Object());
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void list_foreach(Blackhole bh) {
+        for (Object o : list) {
+            bh.consume(o);
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(SIZE)
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void list_indexed(Blackhole bh) {
+        for (int i = 0; i < list.size(); i++) {
+            bh.consume(list.get(i));
+        }
+    }
+}


### PR DESCRIPTION
Let's consider an approach to speed up ArrayList for-each iteration. It is known that ArrayList for-each iteration is more expensive than for-index iteration. It is known that the for-each hot loop contains more instructions, specifically it does redundant copying.

The reason is that for-each iterates two variables. Two variables come out of the block: cursor (the index of the next element that next() will return) and lastRet (the index of the last returned element). In essence, cursor and lastRet are one and the same linear recurrence, just shifted by one: lastRet = cursor - 1. But the compiler doesn't see this: next() writes the pre-increment value into lastRet, while cursor gets the post-increment value. At the boundary where the main loop transitions into the post loop, both versions must be live at the same time. The register allocator has to allocate separate registers for them, register coalescing fails here - and as a result an extra copying mov is inserted.

If the code is reworked so that lastRet holds a special marker instead of the index, the graph simplifies as follows:
```
  BEFORE:
      634 CountedLoop === 634 633 555  [[634 499 595]]      // main_loop
      595 Phi === 634 981 626  [[488 635 626 638 841]]      // cursor
      626 AddI === _ 595 41    [[595 627 833 981 993]]      // cursor + 1

      833 Phi === 831 41 626  [[787 749 949 796]]           // post_loop.cursor  <- main_loop.cursor
      841 Phi === 831 39 595  [[717]]                       // post_loop.lastRet <- main_loop.lastRet
      716 CountedLoop === 716 777 727  [[716 717 719 720]]  // post_loop
      717 Phi === 716 841 719  [[421 741]]                  // lastRet
      706 AddI === _ 719 41  [[ 705 719 ]]                  // cursor + 1

  AFTER (lastRet is a constant now, not a value - doesn't need a Phi to enter post_loop):
      635 CountedLoop === 635 634 556  [[635 500 596]]      // main_loop
      596 Phi === 635 984 627  [[489 627 639]]              // cursor
      627 AddI === _ 596 41    [[596 628 834 984 996]]      // cursor + 1

      834 Phi === 832 41 627  [[788 750 952 797]]           // post_loop.cursor <- main_loop.cursor
      717 CountedLoop === 717 778 728  [[717 721 720]]      // post_loop
      707 AddI  === _ 720 41  [[ 706 720 ]]                 // cursor + 1
```

As a result, the redundant register copying disappears from the assembly, and the pipeline is straightened out:
```
BEFORE (AARCH):
  0x00000001196e9f30:  mov     w14, w16            ;*getfield cursor {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
  0x00000001196e9f34:  add     x12, x10, w14, sxtw #2
  0x00000001196e9f38:  ldr     w12, [x12, #0xc]
  0x00000001196e9f3c:  add     w16, w14, #0x1      ;*iadd {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
  0x00000001196e9f40:  lsl     x12, x12, #3        ;*invokestatic consumeCompiler {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
  0x00000001196e9f44:  cmp     w16, w11
  0x00000001196e9f48:  b.lt    #-0x18              ;*ifeq {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}

AFTER:
  0x000000011b999220:  add     x14, x12, w17, sxtw #2
  0x000000011b999224:  ldr     w15, [x14, #0xc]
  0x000000011b999228:  add     w17, w17, #0x1      ;*iadd {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
  0x000000011b99922c:  lsl     x14, x15, #3        ;*invokestatic consumeCompiler {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
  0x000000011b999230:  cmp     w17, w13
  0x000000011b999234:  b.lt    #-0x14              ;*ifeq {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}

BEFORE: ArrayListIterate.list_foreach      avgt    5  0.527 ± 0.004  ns/op
AFTER:  ArrayListIterate.list_foreach      avgt    5  0.302 ± 0.001  ns/op

```

```
BEFORE (X86):  
  21.34%  ↗  0x0000745acc019850:   mov    r11d,r9d                     ;*getfield cursor {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
   6.07%  │  0x0000745acc019853:   mov    esi,DWORD PTR [rdi+r11*4+0xc]
  35.94%  │  0x0000745acc019858:   mov    r9,rsi                       ;*invokestatic consumeCompiler {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
   6.53%  │  0x0000745acc01985b:   mov    r9d,r11d
  17.03%  │  0x0000745acc01985e:   inc    r9d                          ;*iadd {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
   3.72%  │  0x0000745acc019861:   cmp    r9d,ebx
          ╰  0x0000745acc019864:   jl     0x0000745acc019850           ;*ifeq {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}

AFTER:
  86.87%  ↗  0x000074d36001ae50:   mov    edi,DWORD PTR [rax+rcx*4+0xc];*invokestatic consumeCompiler {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
   1.19%  │  0x000074d36001ae54:   inc    ecx                          ;*iadd {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
   0.08%  │  0x000074d36001ae56:   cmp    ecx,esi
          ╰  0x000074d36001ae58:   jl     0x000074d36001ae50           ;*ifeq {reexecute=0 rethrow=0 return_oop=0 return_scalarized=0}
		  
BEFORE: ArrayListIterate.list_foreach  avgt    5  0.669 ± 0.049  ns/op
AFTER:  ArrayListIterate.list_foreach  avgt    5  0.326 ± 0.014  ns/op
```

As can be seen, this change brings a noticeable performance improvement for trivial iteration. At this point I don't see how this could be done automatically in the C2 compiler.

If we want to rework the java.base library for C2 performance, similar cases exist in other java.base classes:
- java.util.Vector
- java.util.AbstractList
- java.util.ArrayList.SubList
- java.util.ArrayDeque
- java.util.PriorityQueue
- java.util.concurrent.DelayQueue
- java.util.concurrent.ScheduledThreadPoolExecutor
- java.util.concurrent.PriorityBlockingQueue


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8360517](https://bugs.openjdk.org/browse/JDK-8360517)

### Issue
 * [JDK-8360517](https://bugs.openjdk.org/browse/JDK-8360517): C2: Incomplete ArrayList foreach optimization (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32344/head:pull/32344` \
`$ git checkout pull/32344`

Update a local copy of the PR: \
`$ git checkout pull/32344` \
`$ git pull https://git.openjdk.org/jdk.git pull/32344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32344`

View PR using the GUI difftool: \
`$ git pr show -t 32344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32344.diff">https://git.openjdk.org/jdk/pull/32344.diff</a>

</details>
