### PR TITLE
8390316: RISC-V: Materialize pointers with fewer instructions on sv39

### DIFF
--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
@@ -48,8 +48,15 @@ static int entry_barrier_offset(nmethod* nm) {
   switch (bs_asm->nmethod_patching_type()) {
     case NMethodPatchingType::stw_instruction_and_data_patch:
       return -4 * (5 + slow_path_size(nm));
-    case NMethodPatchingType::conc_instruction_and_data_patch:
-      return -4 * ((UseZtso ? 14 : 16) + slow_path_size(nm));
+    case NMethodPatchingType::conc_instruction_and_data_patch: {
+      // The fixed part excludes the movptr used by
+      // BarrierSetAssembler::nmethod_entry_barrier() to materialize
+      // the address of the patching epoch.
+      const int fixed_instruction_count =
+          (UseZtso ? 8 : 10) + slow_path_size(nm);
+      return -(fixed_instruction_count * NativeInstruction::instruction_size +
+               MacroAssembler::movptr_instruction_size(/* use_temp */ false));
+    }
   }
   ShouldNotReachHere();
   return 0;

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3191,13 +3191,16 @@ void MacroAssembler::movptr_for_mode(Register Rd, uint64_t addr, int32_t &offset
   }
 }
 
-int MacroAssembler::movptr_instruction_size() {
+int MacroAssembler::movptr_instruction_size(bool use_temp) {
   switch (VM_Version::satp_mode.value()) {
     case VM_Version::VM_SV39:
       return movptr_sv39_instruction_size;
     case VM_Version::VM_SV48:
-      return movptr2_sv48_instruction_size;
-    default: ShouldNotReachHere(); return 0;
+      return use_temp ? movptr2_sv48_instruction_size
+                      : movptr1_sv48_instruction_size;
+    default:
+      ShouldNotReachHere();
+      return 0;
   }
 }
 
@@ -5823,15 +5826,8 @@ int MacroAssembler::max_reloc_call_address_stub_size() {
 }
 
 int MacroAssembler::static_call_stub_size() {
-  switch (VM_Version::satp_mode.value()) {
-    case VM_Version::VM_SV39:
-      return 2 * movptr_sv39_instruction_size;
-    case VM_Version::VM_SV48:
-      return movptr1_sv48_instruction_size + movptr2_sv48_instruction_size;
-    default:
-      ShouldNotReachHere();
-      return 0;
-  }
+  return movptr_instruction_size(/* use_temp */ false) +
+         movptr_instruction_size(/* use_temp */ true);
 }
 
 Address MacroAssembler::add_memory_helper(const Address dst, Register tmp) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -919,7 +919,7 @@ void MacroAssembler::emit_static_call_stub() {
 
   // Jump to the entry point of the c2i stub.
   int32_t offset = 0;
-  movptr(t1, 0, offset, t0); // lui + lui + slli + add (sv39: lui + addi + slli)
+  movptr(t1, (address)0, offset, t0); // lui + lui + slli + add (sv39: lui + addi + slli)
   jr(t1, offset);
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -138,6 +138,16 @@ bool MacroAssembler::is_movptr2_at(address instr) {
          check_movptr2_data_dependency(instr);
 }
 
+bool MacroAssembler::is_movptr_sv39_at(address instr) {
+  return is_lui_at(instr) && // lui
+         is_addi_at(instr + MacroAssembler::instruction_size) && // addi
+         is_slli_shift_at(instr + MacroAssembler::instruction_size * 2, 9) && // slli Rd, Rs, 9
+         (is_addi_at(instr + MacroAssembler::instruction_size * 3) ||
+          is_jalr_at(instr + MacroAssembler::instruction_size * 3) ||
+          is_load_at(instr + MacroAssembler::instruction_size * 3)) && // Addi/Jalr/Load
+         check_movptr_sv39_data_dependency(instr);
+}
+
 bool MacroAssembler::is_li16u_at(address instr) {
   return is_lui_at(instr) && // lui
          is_srli_at(instr + MacroAssembler::instruction_size) && // srli
@@ -909,7 +919,7 @@ void MacroAssembler::emit_static_call_stub() {
 
   // Jump to the entry point of the c2i stub.
   int32_t offset = 0;
-  movptr2(t1, 0, offset, t0); // lui + lui + slli + add
+  movptr(t1, 0, offset, t0); // lui + lui + slli + add (sv39: lui + addi + slli)
   jr(t1, offset);
 }
 
@@ -2907,6 +2917,24 @@ static int patch_addr_in_movptr2(address instruction_address, address target) {
   return MacroAssembler::movptr2_instruction_size;
 }
 
+static int patch_addr_in_movptr_sv39(address instruction_address, address target) {
+  uintptr_t addr = (uintptr_t)target;
+
+  assert(addr < (1ull << 39), "39-bit overflow in address constant");
+  uint64_t upper30 = addr >> 9;
+  int64_t lower12 = ((int64_t)(upper30 << 52)) >> 52;
+  int64_t hi20 = upper30 - lower12;
+
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 0), 31, 12, (hi20 >> 12) & 0xfffff); // Lui.            target[38:21]
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 1), 31, 20, lower12 & 0xfff);        // Addi.           target[20: 9]
+                                                                                                                  // Slli.
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 3), 31, 20, addr & 0x1ff);           // Addi/Jalr/Load. target[ 8: 0]
+
+  assert(MacroAssembler::target_addr_for_insn(instruction_address) == target, "Must be");
+
+  return MacroAssembler::movptr_sv39_instruction_size;
+}
+
 static int patch_imm_in_li16u(address branch, uint16_t target) {
   Assembler::patch(branch, 31, 12, target); // patch lui only
   return MacroAssembler::instruction_size;
@@ -2977,6 +3005,15 @@ static address get_target_of_movptr2(address insn_addr) {
   return ret;
 }
 
+static address get_target_of_movptr_sv39(address insn_addr) {
+  assert_cond(insn_addr != nullptr);
+  intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 12; // Lui.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 1), 31, 20)); // Addi.
+  target_address <<= 9;                                                                                                            // Slli.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 3), 31, 20)); // Addi/Jalr/Load.
+  return (address)target_address;
+}
+
 address MacroAssembler::get_target_of_li32(address insn_addr) {
   assert_cond(insn_addr != nullptr);
   intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 12; // Lui.
@@ -2999,6 +3036,8 @@ int MacroAssembler::pd_patch_instruction_size(address instruction_address, addre
     return patch_addr_in_movptr1(instruction_address, target);
   } else if (MacroAssembler::is_movptr2_at(instruction_address)) {              // movptr2
     return patch_addr_in_movptr2(instruction_address, target);
+  } else if (MacroAssembler::is_movptr_sv39_at(instruction_address)) {          // movptr_sv39
+    return patch_addr_in_movptr_sv39(instruction_address, target);
   } else if (MacroAssembler::is_li32_at(instruction_address)) {                 // li32
     int64_t imm = (intptr_t)target;
     return patch_imm_in_li32(instruction_address, (int32_t)imm);
@@ -3029,6 +3068,8 @@ address MacroAssembler::target_addr_for_insn(address insn_addr) {
     return get_target_of_movptr1(insn_addr);
   } else if (MacroAssembler::is_movptr2_at(insn_addr)) {          // movptr2
     return get_target_of_movptr2(insn_addr);
+  } else if (MacroAssembler::is_movptr_sv39_at(insn_addr)) {      // movptr_sv39
+    return get_target_of_movptr_sv39(insn_addr);
   } else if (MacroAssembler::is_li32_at(insn_addr)) {             // li32
     return get_target_of_li32(insn_addr);
   } else {
@@ -3038,9 +3079,9 @@ address MacroAssembler::target_addr_for_insn(address insn_addr) {
 }
 
 int MacroAssembler::patch_oop(address insn_addr, address o) {
-  // OOPs are either narrow (32 bits) or wide (48 bits).  We encode
-  // narrow OOPs by setting the upper 16 bits in the first
-  // instruction.
+  // OOPs are either narrow (32 bits) or wide (48 bits on sv48, 39 bits
+  // on sv39).  We encode narrow OOPs by setting the upper 16 bits in the
+  // first instruction.
   if (MacroAssembler::is_li32_at(insn_addr)) {
     // Move narrow OOP
     uint32_t n = CompressedOops::narrow_oop_value(cast_to_oop(o));
@@ -3051,6 +3092,9 @@ int MacroAssembler::patch_oop(address insn_addr, address o) {
   } else if (MacroAssembler::is_movptr2_at(insn_addr)) {
     // Move wide OOP
     return patch_addr_in_movptr2(insn_addr, o);
+  } else if (MacroAssembler::is_movptr_sv39_at(insn_addr)) {
+    // Move wide OOP
+    return patch_addr_in_movptr_sv39(insn_addr, o);
   }
   ShouldNotReachHere();
   return -1;
@@ -3088,7 +3132,14 @@ void MacroAssembler::movptr(Register Rd, address addr, int32_t &offset, Register
     block_comment(buffer);
   }
 #endif
-  assert(uimm64 < (1ull << 48), "48-bit overflow in address constant");
+
+  assert(uimm64 < (1ull << VM_Version::max_va_bits()),
+         "%d-bit overflow in address constant", VM_Version::max_va_bits());
+
+  if (use_movptr_sv39()) {
+    movptr_sv39(Rd, uimm64, offset);
+    return;
+  }
 
   if (temp == noreg) {
     movptr1(Rd, uimm64, offset);
@@ -3153,6 +3204,29 @@ void MacroAssembler::movptr2(Register Rd, uint64_t addr, int32_t &offset, Regist
   add(Rd, Rd, tmp);
 
   offset = lower12;
+}
+
+bool MacroAssembler::use_movptr_sv39() {
+  return VM_Version::max_va_bits() == 39;
+}
+
+void MacroAssembler::movptr_sv39(Register Rd, uint64_t addr, int32_t &offset) {
+  // addr: [upper30[hi20, low12], lower9]
+  //
+  // Load upper 30 bits, i.e. addr >> 9. Since addr < 2^39, upper30 < 2^30,
+  // so even when the sign-extended low12 borrows from hi20 (see movptr1
+  // above for the trick), hi20 never reaches the sign bit of the lui
+  // immediate. This covers the whole [0, 2^39) range exactly.
+  uint64_t upper30 = addr >> 9;
+  int64_t lower12 = ((int64_t)(upper30 << 52)) >> 52;
+  int64_t hi20 = upper30 - lower12;
+  lui(Rd, hi20);
+  addi(Rd, Rd, lower12);
+
+  slli(Rd, Rd, 9);
+
+  // This offset will be used by following jalr/ld.
+  offset = addr & 0x1ff;
 }
 
 // floating point imm move
@@ -3594,7 +3668,8 @@ void MacroAssembler::movoop(Register dst, jobject obj) {
 
 // Move a metadata address into a register.
 void MacroAssembler::mov_metadata(Register dst, Metadata* obj) {
-  assert((uintptr_t)obj < (1ull << 48), "48-bit overflow in metadata");
+  assert((uintptr_t)obj < (1ull << VM_Version::max_va_bits()),
+         "%d-bit overflow in metadata", VM_Version::max_va_bits());
   int oop_index;
   if (obj == nullptr) {
     oop_index = oop_recorder()->allocate_metadata_index(obj);
@@ -5699,6 +5774,10 @@ int MacroAssembler::max_reloc_call_address_stub_size() {
 }
 
 int MacroAssembler::static_call_stub_size() {
+  if (use_movptr_sv39()) {
+    // (lui, addi, slli, addi) + (lui, addi, slli) + jalr
+    return 8 * MacroAssembler::instruction_size;
+  }
   // (lui, addi, slli, addi, slli, addi) + (lui + lui + slli + add) + jalr
   return 11 * MacroAssembler::instruction_size;
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -115,29 +115,6 @@ bool MacroAssembler::is_load_pc_relative_at(address instr) {
          check_load_pc_relative_data_dependency(instr);
 }
 
-bool MacroAssembler::is_movptr1_at(address instr) {
-  return is_lui_at(instr) && // Lui
-         is_addi_at(instr + MacroAssembler::instruction_size) && // Addi
-         is_slli_shift_at(instr + MacroAssembler::instruction_size * 2, 11) && // Slli Rd, Rs, 11
-         is_addi_at(instr + MacroAssembler::instruction_size * 3) && // Addi
-         is_slli_shift_at(instr + MacroAssembler::instruction_size * 4, 6) && // Slli Rd, Rs, 6
-         (is_addi_at(instr + MacroAssembler::instruction_size * 5) ||
-          is_jalr_at(instr + MacroAssembler::instruction_size * 5) ||
-          is_load_at(instr + MacroAssembler::instruction_size * 5)) && // Addi/Jalr/Load
-         check_movptr1_data_dependency(instr);
-}
-
-bool MacroAssembler::is_movptr2_at(address instr) {
-  return is_lui_at(instr) && // lui
-         is_lui_at(instr + MacroAssembler::instruction_size) && // lui
-         is_slli_shift_at(instr + MacroAssembler::instruction_size * 2, 18) && // slli Rd, Rs, 18
-         is_add_at(instr + MacroAssembler::instruction_size * 3) &&
-         (is_addi_at(instr + MacroAssembler::instruction_size * 4) ||
-          is_jalr_at(instr + MacroAssembler::instruction_size * 4) ||
-          is_load_at(instr + MacroAssembler::instruction_size * 4)) && // Addi/Jalr/Load
-         check_movptr2_data_dependency(instr);
-}
-
 bool MacroAssembler::is_movptr_sv39_at(address instr) {
   return is_lui_at(instr) && // lui
          is_addi_at(instr + MacroAssembler::instruction_size) && // addi
@@ -146,6 +123,29 @@ bool MacroAssembler::is_movptr_sv39_at(address instr) {
           is_jalr_at(instr + MacroAssembler::instruction_size * 3) ||
           is_load_at(instr + MacroAssembler::instruction_size * 3)) && // Addi/Jalr/Load
          check_movptr_sv39_data_dependency(instr);
+}
+
+bool MacroAssembler::is_movptr1_sv48_at(address instr) {
+  return is_lui_at(instr) && // Lui
+         is_addi_at(instr + MacroAssembler::instruction_size) && // Addi
+         is_slli_shift_at(instr + MacroAssembler::instruction_size * 2, 11) && // Slli Rd, Rs, 11
+         is_addi_at(instr + MacroAssembler::instruction_size * 3) && // Addi
+         is_slli_shift_at(instr + MacroAssembler::instruction_size * 4, 6) && // Slli Rd, Rs, 6
+         (is_addi_at(instr + MacroAssembler::instruction_size * 5) ||
+          is_jalr_at(instr + MacroAssembler::instruction_size * 5) ||
+          is_load_at(instr + MacroAssembler::instruction_size * 5)) && // Addi/Jalr/Load
+         check_movptr1_sv48_data_dependency(instr);
+}
+
+bool MacroAssembler::is_movptr2_sv48_at(address instr) {
+  return is_lui_at(instr) && // lui
+         is_lui_at(instr + MacroAssembler::instruction_size) && // lui
+         is_slli_shift_at(instr + MacroAssembler::instruction_size * 2, 18) && // slli Rd, Rs, 18
+         is_add_at(instr + MacroAssembler::instruction_size * 3) &&
+         (is_addi_at(instr + MacroAssembler::instruction_size * 4) ||
+          is_jalr_at(instr + MacroAssembler::instruction_size * 4) ||
+          is_load_at(instr + MacroAssembler::instruction_size * 4)) && // Addi/Jalr/Load
+         check_movptr2_sv48_data_dependency(instr);
 }
 
 bool MacroAssembler::is_li16u_at(address instr) {
@@ -2887,36 +2887,6 @@ static int patch_offset_in_pc_relative(address branch, int64_t offset) {
   return PC_RELATIVE_INSTRUCTION_NUM * MacroAssembler::instruction_size;
 }
 
-static int patch_addr_in_movptr1(address branch, address target) {
-  int32_t lower = ((intptr_t)target << 35) >> 35;
-  int64_t upper = ((intptr_t)target - lower) >> 29;
-  Assembler::patch(branch + 0,  31, 12, upper & 0xfffff);                       // Lui.             target[48:29] + target[28] ==> branch[31:12]
-  Assembler::patch(branch + 4,  31, 20, (lower >> 17) & 0xfff);                 // Addi.            target[28:17] ==> branch[31:20]
-  Assembler::patch(branch + 12, 31, 20, (lower >> 6) & 0x7ff);                  // Addi.            target[16: 6] ==> branch[31:20]
-  Assembler::patch(branch + 20, 31, 20, lower & 0x3f);                          // Addi/Jalr/Load.  target[ 5: 0] ==> branch[31:20]
-  return MacroAssembler::movptr1_instruction_size;
-}
-
-static int patch_addr_in_movptr2(address instruction_address, address target) {
-  uintptr_t addr = (uintptr_t)target;
-
-  assert(addr < (1ull << 48), "48-bit overflow in address constant");
-  unsigned int upper18 = (addr >> 30ull);
-  int lower30 = (addr & 0x3fffffffu);
-  int low12 = (lower30 << 20) >> 20;
-  int mid18 = ((lower30 - low12) >> 12);
-
-  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 0), 31, 12, (upper18 & 0xfffff)); // Lui
-  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 1), 31, 12, (mid18   & 0xfffff)); // Lui
-                                                                                                                  // Slli
-                                                                                                                  // Add
-  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 4), 31, 20, low12 & 0xfff);      // Addi/Jalr/Load
-
-  assert(MacroAssembler::target_addr_for_insn(instruction_address) == target, "Must be");
-
-  return MacroAssembler::movptr2_instruction_size;
-}
-
 static int patch_addr_in_movptr_sv39(address instruction_address, address target) {
   uintptr_t addr = (uintptr_t)target;
 
@@ -2933,6 +2903,59 @@ static int patch_addr_in_movptr_sv39(address instruction_address, address target
   assert(MacroAssembler::target_addr_for_insn(instruction_address) == target, "Must be");
 
   return MacroAssembler::movptr_sv39_instruction_size;
+}
+
+static int patch_addr_in_movptr1_sv48(address branch, address target) {
+  int32_t lower = ((intptr_t)target << 35) >> 35;
+  int64_t upper = ((intptr_t)target - lower) >> 29;
+  Assembler::patch(branch + 0,  31, 12, upper & 0xfffff);                       // Lui.             target[48:29] + target[28] ==> branch[31:12]
+  Assembler::patch(branch + 4,  31, 20, (lower >> 17) & 0xfff);                 // Addi.            target[28:17] ==> branch[31:20]
+  Assembler::patch(branch + 12, 31, 20, (lower >> 6) & 0x7ff);                  // Addi.            target[16: 6] ==> branch[31:20]
+  Assembler::patch(branch + 20, 31, 20, lower & 0x3f);                          // Addi/Jalr/Load.  target[ 5: 0] ==> branch[31:20]
+  return MacroAssembler::movptr1_sv48_instruction_size;
+}
+
+static int patch_addr_in_movptr2_sv48(address instruction_address, address target) {
+  uintptr_t addr = (uintptr_t)target;
+
+  assert(addr < (1ull << 48), "48-bit overflow in address constant");
+  unsigned int upper18 = (addr >> 30ull);
+  int lower30 = (addr & 0x3fffffffu);
+  int low12 = (lower30 << 20) >> 20;
+  int mid18 = ((lower30 - low12) >> 12);
+
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 0), 31, 12, (upper18 & 0xfffff)); // Lui
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 1), 31, 12, (mid18   & 0xfffff)); // Lui
+                                                                                                                  // Slli
+                                                                                                                  // Add
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 4), 31, 20, low12 & 0xfff);      // Addi/Jalr/Load
+
+  assert(MacroAssembler::target_addr_for_insn(instruction_address) == target, "Must be");
+
+  return MacroAssembler::movptr2_sv48_instruction_size;
+}
+
+static bool patch_addr_in_movptr_for_mode(address instruction_address, address target, int& patched_size) {
+  switch (VM_Version::satp_mode.value()) {
+    case VM_Version::VM_SV39:
+      if (MacroAssembler::is_movptr_sv39_at(instruction_address)) {
+        patched_size = patch_addr_in_movptr_sv39(instruction_address, target);
+        return true;
+      }
+      break;
+    case VM_Version::VM_SV48:
+      if (MacroAssembler::is_movptr1_sv48_at(instruction_address)) {
+        patched_size = patch_addr_in_movptr1_sv48(instruction_address, target);
+        return true;
+      } else if (MacroAssembler::is_movptr2_sv48_at(instruction_address)) {
+        patched_size = patch_addr_in_movptr2_sv48(instruction_address, target);
+        return true;
+      }
+      break;
+    default:
+      ShouldNotReachHere();
+  }
+  return false;
 }
 
 static int patch_imm_in_li16u(address branch, uint16_t target) {
@@ -2985,7 +3008,16 @@ static long get_offset_of_pc_relative(address insn_addr) {
   return offset;
 }
 
-static address get_target_of_movptr1(address insn_addr) {
+static address get_target_of_movptr_sv39(address insn_addr) {
+  assert_cond(insn_addr != nullptr);
+  intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 12; // Lui.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 1), 31, 20)); // Addi.
+  target_address <<= 9;                                                                                                            // Slli.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 3), 31, 20)); // Addi/Jalr/Load.
+  return (address)target_address;
+}
+
+static address get_target_of_movptr1_sv48(address insn_addr) {
   assert_cond(insn_addr != nullptr);
   intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 29; // Lui.
   target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 4), 31, 20)) << 17;                 // Addi.
@@ -2994,7 +3026,7 @@ static address get_target_of_movptr1(address insn_addr) {
   return (address) target_address;
 }
 
-static address get_target_of_movptr2(address insn_addr) {
+static address get_target_of_movptr2_sv48(address insn_addr) {
   assert_cond(insn_addr != nullptr);
   int32_t upper18 = ((Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 0), 31, 12)) & 0xfffff); // Lui
   int32_t mid18   = ((Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 1), 31, 12)) & 0xfffff); // Lui
@@ -3005,13 +3037,27 @@ static address get_target_of_movptr2(address insn_addr) {
   return ret;
 }
 
-static address get_target_of_movptr_sv39(address insn_addr) {
-  assert_cond(insn_addr != nullptr);
-  intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 12; // Lui.
-  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 1), 31, 20)); // Addi.
-  target_address <<= 9;                                                                                                            // Slli.
-  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 3), 31, 20)); // Addi/Jalr/Load.
-  return (address)target_address;
+static bool get_target_of_movptr_for_mode(address insn_addr, address& target) {
+  switch (VM_Version::satp_mode.value()) {
+    case VM_Version::VM_SV39:
+      if (MacroAssembler::is_movptr_sv39_at(insn_addr)) {
+        target = get_target_of_movptr_sv39(insn_addr);
+        return true;
+      }
+      break;
+    case VM_Version::VM_SV48:
+      if (MacroAssembler::is_movptr1_sv48_at(insn_addr)) {
+        target = get_target_of_movptr1_sv48(insn_addr);
+        return true;
+      } else if (MacroAssembler::is_movptr2_sv48_at(insn_addr)) {
+        target = get_target_of_movptr2_sv48(insn_addr);
+        return true;
+      }
+      break;
+    default:
+      ShouldNotReachHere();
+  }
+  return false;
 }
 
 address MacroAssembler::get_target_of_li32(address insn_addr) {
@@ -3026,18 +3072,15 @@ address MacroAssembler::get_target_of_li32(address insn_addr) {
 int MacroAssembler::pd_patch_instruction_size(address instruction_address, address target) {
   assert_cond(instruction_address != nullptr);
   int64_t offset = target - instruction_address;
+  int movptr_size = 0;
   if (MacroAssembler::is_jal_at(instruction_address)) {                         // jal
     return patch_offset_in_jal(instruction_address, offset);
   } else if (MacroAssembler::is_branch_at(instruction_address)) {               // beq/bge/bgeu/blt/bltu/bne
     return patch_offset_in_conditional_branch(instruction_address, offset);
   } else if (MacroAssembler::is_pc_relative_at(instruction_address)) {          // auipc, addi/jalr/load
     return patch_offset_in_pc_relative(instruction_address, offset);
-  } else if (MacroAssembler::is_movptr1_at(instruction_address)) {              // movptr1
-    return patch_addr_in_movptr1(instruction_address, target);
-  } else if (MacroAssembler::is_movptr2_at(instruction_address)) {              // movptr2
-    return patch_addr_in_movptr2(instruction_address, target);
-  } else if (MacroAssembler::is_movptr_sv39_at(instruction_address)) {          // movptr_sv39
-    return patch_addr_in_movptr_sv39(instruction_address, target);
+  } else if (patch_addr_in_movptr_for_mode(instruction_address, target, movptr_size)) {
+    return movptr_size;
   } else if (MacroAssembler::is_li32_at(instruction_address)) {                 // li32
     int64_t imm = (intptr_t)target;
     return patch_imm_in_li32(instruction_address, (int32_t)imm);
@@ -3057,6 +3100,7 @@ int MacroAssembler::pd_patch_instruction_size(address instruction_address, addre
 
 address MacroAssembler::target_addr_for_insn(address insn_addr) {
   long offset = 0;
+  address target = nullptr;
   assert_cond(insn_addr != nullptr);
   if (MacroAssembler::is_jal_at(insn_addr)) {                     // jal
     offset = get_offset_of_jal(insn_addr);
@@ -3064,12 +3108,8 @@ address MacroAssembler::target_addr_for_insn(address insn_addr) {
     offset = get_offset_of_conditional_branch(insn_addr);
   } else if (MacroAssembler::is_pc_relative_at(insn_addr)) {      // auipc, addi/jalr/load
     offset = get_offset_of_pc_relative(insn_addr);
-  } else if (MacroAssembler::is_movptr1_at(insn_addr)) {          // movptr1
-    return get_target_of_movptr1(insn_addr);
-  } else if (MacroAssembler::is_movptr2_at(insn_addr)) {          // movptr2
-    return get_target_of_movptr2(insn_addr);
-  } else if (MacroAssembler::is_movptr_sv39_at(insn_addr)) {      // movptr_sv39
-    return get_target_of_movptr_sv39(insn_addr);
+  } else if (get_target_of_movptr_for_mode(insn_addr, target)) {
+    return target;
   } else if (MacroAssembler::is_li32_at(insn_addr)) {             // li32
     return get_target_of_li32(insn_addr);
   } else {
@@ -3082,19 +3122,14 @@ int MacroAssembler::patch_oop(address insn_addr, address o) {
   // OOPs are either narrow (32 bits) or wide (48 bits on sv48, 39 bits
   // on sv39).  We encode narrow OOPs by setting the upper 16 bits in the
   // first instruction.
+  int movptr_size = 0;
   if (MacroAssembler::is_li32_at(insn_addr)) {
     // Move narrow OOP
     uint32_t n = CompressedOops::narrow_oop_value(cast_to_oop(o));
     return patch_imm_in_li32(insn_addr, (int32_t)n);
-  } else if (MacroAssembler::is_movptr1_at(insn_addr)) {
+  } else if (patch_addr_in_movptr_for_mode(insn_addr, o, movptr_size)) {
     // Move wide OOP
-    return patch_addr_in_movptr1(insn_addr, o);
-  } else if (MacroAssembler::is_movptr2_at(insn_addr)) {
-    // Move wide OOP
-    return patch_addr_in_movptr2(insn_addr, o);
-  } else if (MacroAssembler::is_movptr_sv39_at(insn_addr)) {
-    // Move wide OOP
-    return patch_addr_in_movptr_sv39(insn_addr, o);
+    return movptr_size;
   }
   ShouldNotReachHere();
   return -1;
@@ -3136,19 +3171,56 @@ void MacroAssembler::movptr(Register Rd, address addr, int32_t &offset, Register
   assert(uimm64 < (1ull << VM_Version::max_va_bits()),
          "%d-bit overflow in address constant", VM_Version::max_va_bits());
 
-  if (use_movptr_sv39()) {
-    movptr_sv39(Rd, uimm64, offset);
-    return;
-  }
+  movptr_for_mode(Rd, uimm64, offset, temp);
+}
 
-  if (temp == noreg) {
-    movptr1(Rd, uimm64, offset);
-  } else {
-    movptr2(Rd, uimm64, offset, temp);
+void MacroAssembler::movptr_for_mode(Register Rd, uint64_t addr, int32_t &offset, Register temp) {
+  switch (VM_Version::satp_mode.value()) {
+    case VM_Version::VM_SV39:
+      movptr_sv39(Rd, addr, offset);
+      break;
+    case VM_Version::VM_SV48:
+      if (temp == noreg) {
+        movptr1_sv48(Rd, addr, offset);
+      } else {
+        movptr2_sv48(Rd, addr, offset, temp);
+      }
+      break;
+    default:
+      ShouldNotReachHere();
   }
 }
 
-void MacroAssembler::movptr1(Register Rd, uint64_t imm64, int32_t &offset) {
+int MacroAssembler::movptr_instruction_size() {
+  switch (VM_Version::satp_mode.value()) {
+    case VM_Version::VM_SV39:
+      return movptr_sv39_instruction_size;
+    case VM_Version::VM_SV48:
+      return movptr2_sv48_instruction_size;
+    default: ShouldNotReachHere(); return 0;
+  }
+}
+
+void MacroAssembler::movptr_sv39(Register Rd, uint64_t addr, int32_t &offset) {
+  // addr: [upper30[hi20, low12], lower9]
+  //
+  // Load upper 30 bits, i.e. addr >> 9. Since addr < 2^39, upper30 < 2^30,
+  // so even when the sign-extended low12 borrows from hi20 (see movptr1_sv48
+  // below for the trick), hi20 never reaches the sign bit of the lui
+  // immediate. This covers the whole [0, 2^39) range exactly.
+  uint64_t upper30 = addr >> 9;
+  int64_t lower12 = ((int64_t)(upper30 << 52)) >> 52;
+  int64_t hi20 = upper30 - lower12;
+  lui(Rd, hi20);
+  addi(Rd, Rd, lower12);
+
+  slli(Rd, Rd, 9);
+
+  // This offset will be used by following jalr/ld.
+  offset = addr & 0x1ff;
+}
+
+void MacroAssembler::movptr1_sv48(Register Rd, uint64_t imm64, int32_t &offset) {
   // Load upper 31 bits
   //
   // In case of 11th bit of `lower` is 0, it's straightforward to understand.
@@ -3184,7 +3256,7 @@ void MacroAssembler::movptr1(Register Rd, uint64_t imm64, int32_t &offset) {
   offset = imm64 & 0x3f;
 }
 
-void MacroAssembler::movptr2(Register Rd, uint64_t addr, int32_t &offset, Register tmp) {
+void MacroAssembler::movptr2_sv48(Register Rd, uint64_t addr, int32_t &offset, Register tmp) {
   assert_different_registers(Rd, tmp, noreg);
 
   // addr: [upper18, lower30[mid18, lower12]]
@@ -3196,7 +3268,7 @@ void MacroAssembler::movptr2(Register Rd, uint64_t addr, int32_t &offset, Regist
   int64_t mid18 = lower30, lower12 = lower30;
   lower12 = (lower12 << 52) >> 52;
   // For this tricky part (`mid18 -= lower12;` + `offset = lower12;`),
-  // please refer to movptr1 above.
+  // please refer to movptr1_sv48 above.
   mid18 -= (int32_t)lower12;
   lui(Rd, mid18);
 
@@ -3204,29 +3276,6 @@ void MacroAssembler::movptr2(Register Rd, uint64_t addr, int32_t &offset, Regist
   add(Rd, Rd, tmp);
 
   offset = lower12;
-}
-
-bool MacroAssembler::use_movptr_sv39() {
-  return VM_Version::max_va_bits() == 39;
-}
-
-void MacroAssembler::movptr_sv39(Register Rd, uint64_t addr, int32_t &offset) {
-  // addr: [upper30[hi20, low12], lower9]
-  //
-  // Load upper 30 bits, i.e. addr >> 9. Since addr < 2^39, upper30 < 2^30,
-  // so even when the sign-extended low12 borrows from hi20 (see movptr1
-  // above for the trick), hi20 never reaches the sign bit of the lui
-  // immediate. This covers the whole [0, 2^39) range exactly.
-  uint64_t upper30 = addr >> 9;
-  int64_t lower12 = ((int64_t)(upper30 << 52)) >> 52;
-  int64_t hi20 = upper30 - lower12;
-  lui(Rd, hi20);
-  addi(Rd, Rd, lower12);
-
-  slli(Rd, Rd, 9);
-
-  // This offset will be used by following jalr/ld.
-  offset = addr & 0x1ff;
 }
 
 // floating point imm move
@@ -5774,12 +5823,15 @@ int MacroAssembler::max_reloc_call_address_stub_size() {
 }
 
 int MacroAssembler::static_call_stub_size() {
-  if (use_movptr_sv39()) {
-    // (lui, addi, slli, addi) + (lui, addi, slli) + jalr
-    return 8 * MacroAssembler::instruction_size;
+  switch (VM_Version::satp_mode.value()) {
+    case VM_Version::VM_SV39:
+      return 2 * movptr_sv39_instruction_size;
+    case VM_Version::VM_SV48:
+      return movptr1_sv48_instruction_size + movptr2_sv48_instruction_size;
+    default:
+      ShouldNotReachHere();
+      return 0;
   }
-  // (lui, addi, slli, addi, slli, addi) + (lui + lui + slli + add) + jalr
-  return 11 * MacroAssembler::instruction_size;
 }
 
 Address MacroAssembler::add_memory_helper(const Address dst, Register tmp) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -955,7 +955,7 @@ public:
   void movptr(Register Rd, address addr, Register tmp = noreg);
   void movptr(Register Rd, address addr, int32_t &offset, Register tmp = noreg);
 
-  static int movptr_instruction_size();
+  static int movptr_instruction_size(bool use_temp);
 
  private:
   void movptr_for_mode(Register Rd, uintptr_t addr, int32_t &offset, Register tmp);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -956,9 +956,17 @@ public:
   void movptr(Register Rd, address addr, Register tmp = noreg);
   void movptr(Register Rd, address addr, int32_t &offset, Register tmp = noreg);
 
+  // True when the shorter sv39 movptr sequence is emitted (satp mode is sv39).
+  static bool use_movptr_sv39();
+
+  static int movptr_instruction_size() {
+    return use_movptr_sv39() ? movptr_sv39_instruction_size : movptr2_instruction_size;
+  }
+
  private:
   void movptr1(Register Rd, uintptr_t addr, int32_t &offset);
   void movptr2(Register Rd, uintptr_t addr, int32_t &offset, Register tmp);
+  void movptr_sv39(Register Rd, uintptr_t addr, int32_t &offset);
  public:
   // float imm move
   static bool can_hf_imm_load(short imm);
@@ -1701,6 +1709,7 @@ public:
     // movptr
     movptr1_instruction_size = 6 * MacroAssembler::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
     movptr2_instruction_size = 5 * MacroAssembler::instruction_size, // lui, lui, slli, add, addi.  See movptr2().
+    movptr_sv39_instruction_size = 4 * MacroAssembler::instruction_size, // lui, addi, slli, addi.  See movptr_sv39().
     load_pc_relative_instruction_size = 2 * MacroAssembler::instruction_size // auipc, ld
   };
 
@@ -1738,6 +1747,7 @@ public:
 
   static bool is_movptr1_at(address instr);
   static bool is_movptr2_at(address instr);
+  static bool is_movptr_sv39_at(address instr);
 
   static bool is_lwu_to_zr(address instr);
 
@@ -1790,6 +1800,23 @@ public:
            extract_rs1(slli) == extract_rd(lui1) &&
            extract_rd(slli) == extract_rd(lui1) &&
            extract_rs1(last_instr) == extract_rd(add);
+  }
+
+  // the instruction sequence of movptr_sv39 is as below:
+  //     lui
+  //     addi
+  //     slli
+  //     addi/jalr/load
+  static bool check_movptr_sv39_data_dependency(address instr) {
+    address lui = instr;
+    address addi = lui + MacroAssembler::instruction_size;
+    address slli = addi + MacroAssembler::instruction_size;
+    address last_instr = slli + MacroAssembler::instruction_size;
+    return extract_rs1(addi) == extract_rd(lui) &&
+           extract_rs1(addi) == extract_rd(addi) &&
+           extract_rs1(slli) == extract_rd(addi) &&
+           extract_rs1(slli) == extract_rd(slli) &&
+           extract_rs1(last_instr) == extract_rd(slli);
   }
 
   // the instruction sequence of li16u is as below:

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -948,25 +948,21 @@ public:
     }
   }
 
-  // Generates a load of a 48-bit constant which can be
-  // patched to any 48-bit constant, i.e. address.
+  // Generates a load of an address constant for the active satp mode.
   // If common case supply additional temp register
   // to shorten the instruction sequence.
   void movptr(Register Rd, const Address &addr, Register tmp = noreg);
   void movptr(Register Rd, address addr, Register tmp = noreg);
   void movptr(Register Rd, address addr, int32_t &offset, Register tmp = noreg);
 
-  // True when the shorter sv39 movptr sequence is emitted (satp mode is sv39).
-  static bool use_movptr_sv39();
-
-  static int movptr_instruction_size() {
-    return use_movptr_sv39() ? movptr_sv39_instruction_size : movptr2_instruction_size;
-  }
+  static int movptr_instruction_size();
 
  private:
-  void movptr1(Register Rd, uintptr_t addr, int32_t &offset);
-  void movptr2(Register Rd, uintptr_t addr, int32_t &offset, Register tmp);
+  void movptr_for_mode(Register Rd, uintptr_t addr, int32_t &offset, Register tmp);
   void movptr_sv39(Register Rd, uintptr_t addr, int32_t &offset);
+  void movptr1_sv48(Register Rd, uintptr_t addr, int32_t &offset);
+  void movptr2_sv48(Register Rd, uintptr_t addr, int32_t &offset, Register tmp);
+
  public:
   // float imm move
   static bool can_hf_imm_load(short imm);
@@ -1707,9 +1703,9 @@ public:
 public:
   enum {
     // movptr
-    movptr1_instruction_size = 6 * MacroAssembler::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
-    movptr2_instruction_size = 5 * MacroAssembler::instruction_size, // lui, lui, slli, add, addi.  See movptr2().
     movptr_sv39_instruction_size = 4 * MacroAssembler::instruction_size, // lui, addi, slli, addi.  See movptr_sv39().
+    movptr1_sv48_instruction_size = 6 * MacroAssembler::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1_sv48().
+    movptr2_sv48_instruction_size = 5 * MacroAssembler::instruction_size, // lui, lui, slli, add, addi.  See movptr2_sv48().
     load_pc_relative_instruction_size = 2 * MacroAssembler::instruction_size // auipc, ld
   };
 
@@ -1745,9 +1741,9 @@ public:
             Assembler::extract(Assembler::ld_instr(instr), 25, 20) == shift);    // shamt field
   }
 
-  static bool is_movptr1_at(address instr);
-  static bool is_movptr2_at(address instr);
   static bool is_movptr_sv39_at(address instr);
+  static bool is_movptr1_sv48_at(address instr);
+  static bool is_movptr2_sv48_at(address instr);
 
   static bool is_lwu_to_zr(address instr);
 
@@ -1757,14 +1753,31 @@ public:
   static uint32_t extract_opcode(address instr);
   static uint32_t extract_funct3(address instr);
 
-  // the instruction sequence of movptr is as below:
+  // the instruction sequence of movptr_sv39 is as below:
+  //     lui
+  //     addi
+  //     slli
+  //     addi/jalr/load
+  static bool check_movptr_sv39_data_dependency(address instr) {
+    address lui = instr;
+    address addi = lui + MacroAssembler::instruction_size;
+    address slli = addi + MacroAssembler::instruction_size;
+    address last_instr = slli + MacroAssembler::instruction_size;
+    return extract_rs1(addi) == extract_rd(lui) &&
+           extract_rs1(addi) == extract_rd(addi) &&
+           extract_rs1(slli) == extract_rd(addi) &&
+           extract_rs1(slli) == extract_rd(slli) &&
+           extract_rs1(last_instr) == extract_rd(slli);
+  }
+
+  // the instruction sequence of movptr1_sv48 is as below:
   //     lui
   //     addi
   //     slli
   //     addi
   //     slli
   //     addi/jalr/load
-  static bool check_movptr1_data_dependency(address instr) {
+  static bool check_movptr1_sv48_data_dependency(address instr) {
     address lui = instr;
     address addi1 = lui + MacroAssembler::instruction_size;
     address slli1 = addi1 + MacroAssembler::instruction_size;
@@ -1782,13 +1795,13 @@ public:
            extract_rs1(last_instr) == extract_rd(slli2);
   }
 
-  // the instruction sequence of movptr2 is as below:
+  // the instruction sequence of movptr2_sv48 is as below:
   //     lui
   //     lui
   //     slli
   //     add
   //     addi/jalr/load
-  static bool check_movptr2_data_dependency(address instr) {
+  static bool check_movptr2_sv48_data_dependency(address instr) {
     address lui1 = instr;
     address lui2 = lui1 + MacroAssembler::instruction_size;
     address slli = lui2 + MacroAssembler::instruction_size;
@@ -1800,23 +1813,6 @@ public:
            extract_rs1(slli) == extract_rd(lui1) &&
            extract_rd(slli) == extract_rd(lui1) &&
            extract_rs1(last_instr) == extract_rd(add);
-  }
-
-  // the instruction sequence of movptr_sv39 is as below:
-  //     lui
-  //     addi
-  //     slli
-  //     addi/jalr/load
-  static bool check_movptr_sv39_data_dependency(address instr) {
-    address lui = instr;
-    address addi = lui + MacroAssembler::instruction_size;
-    address slli = addi + MacroAssembler::instruction_size;
-    address last_instr = slli + MacroAssembler::instruction_size;
-    return extract_rs1(addi) == extract_rd(lui) &&
-           extract_rs1(addi) == extract_rd(addi) &&
-           extract_rs1(slli) == extract_rd(addi) &&
-           extract_rs1(slli) == extract_rd(slli) &&
-           extract_rs1(last_instr) == extract_rd(slli);
   }
 
   // the instruction sequence of li16u is as below:

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -340,17 +340,18 @@ bool NativeInstruction::is_stop() {
 //-------------------------------------------------------------------
 
 void NativeGeneralJump::insert_unconditional(address code_pos, address entry) {
-  CodeBuffer cb(code_pos, instruction_size);
+  int jump_size = NativeGeneralJump::insn_size();
+  CodeBuffer cb(code_pos, jump_size);
   MacroAssembler a(&cb);
-  Assembler::IncompressibleScope scope(&a); // Fixed length: see NativeGeneralJump::get_instruction_size()
+  Assembler::IncompressibleScope scope(&a); // Fixed length: see NativeGeneralJump::insn_size()
 
   MacroAssembler::assert_alignment(code_pos);
 
   int32_t offset = 0;
-  a.movptr(t1, entry, offset, t0); // lui, lui, slli, add
+  a.movptr(t1, entry, offset, t0); // lui, lui, slli, add (sv39: lui, addi, slli)
   a.jr(t1, offset); // jalr
 
-  ICache::invalidate_range(code_pos, instruction_size);
+  ICache::invalidate_range(code_pos, jump_size);
 }
 
 // MT-safe patching of a long jump instruction.

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -34,6 +34,7 @@
 #include "runtime/safepoint.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
+#include "runtime/vm_version.hpp"
 #include "utilities/align.hpp"
 #include "utilities/ostream.hpp"
 #ifdef COMPILER1
@@ -42,6 +43,28 @@
 
 //-----------------------------------------------------------------------------
 // NativeInstruction
+
+static int current_mode_movptr_size_at(address addr) {
+  switch (VM_Version::satp_mode.value()) {
+    case VM_Version::VM_SV39:
+      return MacroAssembler::is_movptr_sv39_at(addr)
+             ? MacroAssembler::movptr_sv39_instruction_size : 0;
+    case VM_Version::VM_SV48:
+      if (MacroAssembler::is_movptr1_sv48_at(addr)) {
+        return MacroAssembler::movptr1_sv48_instruction_size;
+      } else if (MacroAssembler::is_movptr2_sv48_at(addr)) {
+        return MacroAssembler::movptr2_sv48_instruction_size;
+      }
+      return 0;
+    default:
+      ShouldNotReachHere();
+      return 0;
+  }
+}
+
+bool NativeInstruction::is_movptr() const {
+  return current_mode_movptr_size_at(addr_at(0)) != 0;
+}
 
 bool NativeInstruction::is_call_at(address addr) {
   return NativeCall::is_at(addr);
@@ -223,6 +246,25 @@ NativeCall* nativeCall_before(address return_address) {
 
 //-------------------------------------------------------------------
 
+address NativeMovConstReg::next_instruction_address() const {
+  int movptr_size = current_mode_movptr_size_at(instruction_address());
+
+  if (movptr_size != 0) {
+    // The final immediate may be a standalone addi or folded into the
+    // following load/jalr. In the latter case, that instruction is next.
+    int last_instruction_offset = movptr_size - NativeInstruction::instruction_size;
+    return MacroAssembler::is_addi_at(addr_at(last_instruction_offset))
+           ? addr_at(movptr_size)
+           : addr_at(last_instruction_offset);
+  } else if (MacroAssembler::is_load_pc_relative_at(instruction_address())) {
+    // Assume: auipc, ld
+    return addr_at(load_pc_relative_instruction_size);
+  }
+
+  guarantee(false, "Unknown instruction in NativeMovConstReg");
+  return nullptr;
+}
+
 void NativeMovConstReg::verify() {
   NativeInstruction* ni = nativeInstruction_at(instruction_address());
   if (ni->is_movptr() || ni->is_auipc()) {
@@ -246,8 +288,8 @@ void NativeMovConstReg::set_data(intptr_t x) {
     Bytes::put_native_u8(addr, x);
   } else {
     // Store x into the instruction stream.
-    MacroAssembler::pd_patch_instruction_size(instruction_address(), (address)x);
-    ICache::invalidate_range(instruction_address(), movptr1_instruction_size /* > movptr2_instruction_size */ );
+    int bytes = MacroAssembler::pd_patch_instruction_size(instruction_address(), (address)x);
+    ICache::invalidate_range(instruction_address(), bytes);
   }
 
   // Find and replace the oop/metadata corresponding to this
@@ -348,7 +390,7 @@ void NativeGeneralJump::insert_unconditional(address code_pos, address entry) {
   MacroAssembler::assert_alignment(code_pos);
 
   int32_t offset = 0;
-  a.movptr(t1, entry, offset, t0); // lui, lui, slli, add (sv39: lui, addi, slli)
+  a.movptr(t1, entry, offset, t0);
   a.jr(t1, offset); // jalr
 
   ICache::invalidate_range(code_pos, jump_size);

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -259,7 +259,7 @@ public:
   };
 
   static int insn_size() {
-    return MacroAssembler::movptr_instruction_size();
+    return MacroAssembler::movptr_instruction_size(/* use_temp */ true);
   }
 
   address jump_destination() const;

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2018, Red Hat Inc. All rights reserved.
  * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -62,12 +62,10 @@ class NativeInstruction {
   }
 
   bool is_jal()                             const { return MacroAssembler::is_jal_at(addr_at(0));         }
-  bool is_movptr()                          const { return MacroAssembler::is_movptr1_at(addr_at(0)) ||
-                                                           MacroAssembler::is_movptr2_at(addr_at(0)) ||
-                                                           MacroAssembler::is_movptr_sv39_at(addr_at(0)); }
-  bool is_movptr1()                         const { return MacroAssembler::is_movptr1_at(addr_at(0));     }
-  bool is_movptr2()                         const { return MacroAssembler::is_movptr2_at(addr_at(0));     }
-  bool is_movptr_sv39()                     const { return MacroAssembler::is_movptr_sv39_at(addr_at(0)); }
+  bool is_movptr() const;
+  bool is_movptr_sv39()                     const { return MacroAssembler::is_movptr_sv39_at(addr_at(0));  }
+  bool is_movptr1_sv48()                    const { return MacroAssembler::is_movptr1_sv48_at(addr_at(0)); }
+  bool is_movptr2_sv48()                    const { return MacroAssembler::is_movptr2_sv48_at(addr_at(0)); }
   bool is_auipc()                           const { return MacroAssembler::is_auipc_at(addr_at(0));       }
   bool is_jump()                            const { return MacroAssembler::is_jump_at(addr_at(0));        }
   bool is_call()                            const { return is_call_at(addr_at(0));                        }
@@ -169,50 +167,15 @@ class NativeCall: private NativeInstruction {
 class NativeMovConstReg: public NativeInstruction {
  public:
   enum RISCV_specific_constants {
-    movptr1_instruction_size            =    MacroAssembler::movptr1_instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
-    movptr2_instruction_size            =    MacroAssembler::movptr2_instruction_size, // lui, lui, slli, add, addi.  See movptr2().
-    movptr_sv39_instruction_size        =    MacroAssembler::movptr_sv39_instruction_size, // lui, addi, slli, addi.  See movptr_sv39().
+    movptr_sv39_instruction_size        =    MacroAssembler::movptr_sv39_instruction_size,
+    movptr1_sv48_instruction_size       =    MacroAssembler::movptr1_sv48_instruction_size,
+    movptr2_sv48_instruction_size       =    MacroAssembler::movptr2_sv48_instruction_size,
+
     load_pc_relative_instruction_size   =    MacroAssembler::load_pc_relative_instruction_size // auipc, ld
   };
 
   address instruction_address() const       { return addr_at(0); }
-  address next_instruction_address() const  {
-    // if the instruction at 5 * instruction_size is addi,
-    // it means a lui + addi + slli + addi + slli + addi instruction sequence,
-    // and the next instruction address should be addr_at(6 * instruction_size).
-    // However, when the instruction at 5 * instruction_size isn't addi,
-    // the next instruction address should be addr_at(5 * instruction_size)
-    if (MacroAssembler::is_movptr1_at(instruction_address())) {
-      if (MacroAssembler::is_addi_at(addr_at(movptr1_instruction_size - NativeInstruction::instruction_size))) {
-        // Assume: lui, addi, slli, addi, slli, addi
-        return addr_at(movptr1_instruction_size);
-      } else {
-        // Assume: lui, addi, slli, addi, slli
-        return addr_at(movptr1_instruction_size - NativeInstruction::instruction_size);
-      }
-    } else if (MacroAssembler::is_movptr2_at(instruction_address())) {
-      if (MacroAssembler::is_addi_at(addr_at(movptr2_instruction_size - NativeInstruction::instruction_size))) {
-        // Assume: lui, lui, slli, add, addi
-        return addr_at(movptr2_instruction_size);
-      } else {
-        // Assume: lui, lui, slli, add
-        return addr_at(movptr2_instruction_size - NativeInstruction::instruction_size);
-      }
-    } else if (MacroAssembler::is_movptr_sv39_at(instruction_address())) {
-      if (MacroAssembler::is_addi_at(addr_at(movptr_sv39_instruction_size - NativeInstruction::instruction_size))) {
-        // Assume: lui, addi, slli, addi
-        return addr_at(movptr_sv39_instruction_size);
-      } else {
-        // Assume: lui, addi, slli
-        return addr_at(movptr_sv39_instruction_size - NativeInstruction::instruction_size);
-      }
-    } else if (MacroAssembler::is_load_pc_relative_at(instruction_address())) {
-      // Assume: auipc, ld
-      return addr_at(load_pc_relative_instruction_size);
-    }
-    guarantee(false, "Unknown instruction in NativeMovConstReg");
-    return nullptr;
-  }
+  address next_instruction_address() const;
 
   intptr_t data() const;
   void set_data(intptr_t x);
@@ -289,12 +252,14 @@ inline NativeJump* nativeJump_at(address addr) {
 class NativeGeneralJump: public NativeJump {
 public:
   enum RISCV_specific_constants {
-    instruction_size            =    5 * NativeInstruction::instruction_size, // lui, lui, slli, add, jalr
+    // Maximum sequence size, used by shared C1 code-buffer estimates.
+    instruction_size            =    5 * NativeInstruction::instruction_size, // sv48: lui, lui, slli, add, jalr
     instruction_size_sv39       =    4 * NativeInstruction::instruction_size, // lui, addi, slli, jalr
+    instruction_size_sv48       =    5 * NativeInstruction::instruction_size, // lui, lui, slli, add, jalr
   };
 
   static int insn_size() {
-    return MacroAssembler::use_movptr_sv39() ? instruction_size_sv39 : instruction_size;
+    return MacroAssembler::movptr_instruction_size();
   }
 
   address jump_destination() const;

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -63,9 +63,11 @@ class NativeInstruction {
 
   bool is_jal()                             const { return MacroAssembler::is_jal_at(addr_at(0));         }
   bool is_movptr()                          const { return MacroAssembler::is_movptr1_at(addr_at(0)) ||
-                                                           MacroAssembler::is_movptr2_at(addr_at(0));     }
+                                                           MacroAssembler::is_movptr2_at(addr_at(0)) ||
+                                                           MacroAssembler::is_movptr_sv39_at(addr_at(0)); }
   bool is_movptr1()                         const { return MacroAssembler::is_movptr1_at(addr_at(0));     }
   bool is_movptr2()                         const { return MacroAssembler::is_movptr2_at(addr_at(0));     }
+  bool is_movptr_sv39()                     const { return MacroAssembler::is_movptr_sv39_at(addr_at(0)); }
   bool is_auipc()                           const { return MacroAssembler::is_auipc_at(addr_at(0));       }
   bool is_jump()                            const { return MacroAssembler::is_jump_at(addr_at(0));        }
   bool is_call()                            const { return is_call_at(addr_at(0));                        }
@@ -169,6 +171,7 @@ class NativeMovConstReg: public NativeInstruction {
   enum RISCV_specific_constants {
     movptr1_instruction_size            =    MacroAssembler::movptr1_instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
     movptr2_instruction_size            =    MacroAssembler::movptr2_instruction_size, // lui, lui, slli, add, addi.  See movptr2().
+    movptr_sv39_instruction_size        =    MacroAssembler::movptr_sv39_instruction_size, // lui, addi, slli, addi.  See movptr_sv39().
     load_pc_relative_instruction_size   =    MacroAssembler::load_pc_relative_instruction_size // auipc, ld
   };
 
@@ -194,6 +197,14 @@ class NativeMovConstReg: public NativeInstruction {
       } else {
         // Assume: lui, lui, slli, add
         return addr_at(movptr2_instruction_size - NativeInstruction::instruction_size);
+      }
+    } else if (MacroAssembler::is_movptr_sv39_at(instruction_address())) {
+      if (MacroAssembler::is_addi_at(addr_at(movptr_sv39_instruction_size - NativeInstruction::instruction_size))) {
+        // Assume: lui, addi, slli, addi
+        return addr_at(movptr_sv39_instruction_size);
+      } else {
+        // Assume: lui, addi, slli
+        return addr_at(movptr_sv39_instruction_size - NativeInstruction::instruction_size);
       }
     } else if (MacroAssembler::is_load_pc_relative_at(instruction_address())) {
       // Assume: auipc, ld
@@ -279,7 +290,12 @@ class NativeGeneralJump: public NativeJump {
 public:
   enum RISCV_specific_constants {
     instruction_size            =    5 * NativeInstruction::instruction_size, // lui, lui, slli, add, jalr
+    instruction_size_sv39       =    4 * NativeInstruction::instruction_size, // lui, addi, slli, jalr
   };
+
+  static int insn_size() {
+    return MacroAssembler::use_movptr_sv39() ? instruction_size_sv39 : instruction_size;
+  }
 
   address jump_destination() const;
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1215,7 +1215,7 @@ int MachCallStaticJavaNode::ret_addr_offset() const
 
 int MachCallDynamicJavaNode::ret_addr_offset() const
 {
-  return MacroAssembler::movptr_instruction_size() + (3 * NativeInstruction::instruction_size); // movptr, auipc + ld + jal
+  return MacroAssembler::movptr_instruction_size(/* use_temp */ true) + (3 * NativeInstruction::instruction_size); // movptr, auipc + ld + jal
 }
 
 int MachCallRuntimeNode::ret_addr_offset() const {
@@ -1235,7 +1235,7 @@ int MachCallRuntimeNode::ret_addr_offset() const {
     return 1 * NativeInstruction::instruction_size;
   } else {
     // movptr_instruction_size() includes the trailing jalr
-    return 3 * NativeInstruction::instruction_size + MacroAssembler::movptr_instruction_size();
+    return 3 * NativeInstruction::instruction_size + MacroAssembler::movptr_instruction_size(/* use_temp */ true);
   }
 }
 
@@ -1261,7 +1261,7 @@ int CallDynamicJavaDirectNode::compute_padding(int current_offset) const
   // lui, lui, slli, add, addi (sv39: lui, addi, slli, addi)
   // Though movptr() has already 4-byte aligned with or without RVC,
   // We need to prevent from further changes by explicitly calculating the size.
-  current_offset += MacroAssembler::movptr_instruction_size();
+  current_offset += MacroAssembler::movptr_instruction_size(/* use_temp */ true);
   // to make sure the address of jal 4-byte aligned.
   return align_up(current_offset, alignment_required()) - current_offset;
 }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1215,13 +1215,14 @@ int MachCallStaticJavaNode::ret_addr_offset() const
 
 int MachCallDynamicJavaNode::ret_addr_offset() const
 {
-  return NativeMovConstReg::movptr2_instruction_size + (3 * NativeInstruction::instruction_size); // movptr2, auipc + ld + jal
+  return MacroAssembler::movptr_instruction_size() + (3 * NativeInstruction::instruction_size); // movptr, auipc + ld + jal
 }
 
 int MachCallRuntimeNode::ret_addr_offset() const {
   // For address inside the code cache the call will be:
   //   auipc + jalr
   // For real runtime callouts it will be 8 instructions
+  // (7 on sv39, whose movptr is one instruction shorter)
   // see riscv_enc_java_to_runtime
   //   la(t0, retaddr)                                             ->  auipc + addi
   //   sd(t0, Address(xthread, JavaThread::last_Java_pc_offset())) ->  sd
@@ -1233,7 +1234,8 @@ int MachCallRuntimeNode::ret_addr_offset() const {
     // See CallLeafNoFPIndirect
     return 1 * NativeInstruction::instruction_size;
   } else {
-    return 8 * NativeInstruction::instruction_size;
+    // movptr_instruction_size() includes the trailing jalr
+    return 3 * NativeInstruction::instruction_size + MacroAssembler::movptr_instruction_size();
   }
 }
 
@@ -1255,11 +1257,11 @@ int CallStaticJavaDirectNode::compute_padding(int current_offset) const
 // ensure that it does not span a cache line so that it can be patched.
 int CallDynamicJavaDirectNode::compute_padding(int current_offset) const
 {
-  // skip the movptr2 in MacroAssembler::ic_call():
-  // lui, lui, slli, add, addi
-  // Though movptr2() has already 4-byte aligned with or without RVC,
+  // skip the movptr in MacroAssembler::ic_call():
+  // lui, lui, slli, add, addi (sv39: lui, addi, slli, addi)
+  // Though movptr() has already 4-byte aligned with or without RVC,
   // We need to prevent from further changes by explicitly calculating the size.
-  current_offset += NativeMovConstReg::movptr2_instruction_size;
+  current_offset += MacroAssembler::movptr_instruction_size();
   // to make sure the address of jal 4-byte aligned.
   return align_up(current_offset, alignment_required()) - current_offset;
 }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -87,7 +87,7 @@ void VM_Version::common_initialize() {
   setup_cpu_available_features();
 
   // check if satp.mode is supported, currently supports up to SV48(RV64)
-  if (satp_mode.value() > VM_SV48 || satp_mode.value() < VM_MBARE) {
+  if (satp_mode.value() > VM_SV48 || satp_mode.value() <= VM_MBARE) {
     vm_exit_during_initialization(
       err_msg(
          "Unsupported satp mode: SV%d. Only satp modes up to sv48 are supported for now.",

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -527,6 +527,17 @@ private:
   static bool supports_fast_class_init_checks() { return true; }
   static bool supports_fencei_barrier() { return ext_Zifencei.enabled(); }
 
+  // Max virtual address width implied by the satp mode. Returns 48 when
+  // the mode is unknown (mbare, or before feature initialization).
+  static int max_va_bits() {
+    if (!satp_mode.enabled()) return 48;
+    switch ((int)satp_mode.value()) {
+      case VM_SV39: return 39;
+      case VM_SV48: return 48;
+      default:      return 48;
+    }
+  }
+
   static bool supports_float16_float_conversion() {
     return UseZfh || UseZfhmin;
   }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -459,6 +459,7 @@ private:
 
   static void useRVA23U64Profile();
 
+ public:
   // VM modes (satp.mode) privileged ISA 1.10
   enum VM_MODE : int {
     VM_NOTSET = -1,
@@ -469,6 +470,7 @@ private:
     VM_SV64   = 64
   };
 
+ private:
   static VM_MODE parse_satp_mode(const char* vm_mode);
 
   // Values from riscv_hwprobe()

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -49,6 +49,7 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "runtime/timer.hpp"
+#include "runtime/vm_version.hpp"
 #include "signals_posix.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/events.hpp"
@@ -93,7 +94,7 @@ char* os::non_memory_address_word() {
   // even in its subfields (as defined by the CPU immediate fields,
   // if the CPU splits constants across multiple instructions).
 
-  return (char*) 0xffffffffffff;
+  return (char*) ((1ull << VM_Version::max_va_bits()) - 1);
 }
 
 address os::Posix::ucontext_get_pc(const ucontext_t * uc) {


### PR DESCRIPTION
Hi, please consider.
`MacroAssembler::movptr` always materializes patchable addresses assuming a 48-bit virtual address space: movptr1 takes 6 instructions and movptr2 takes 5 (with a temp register). However, much of the RISC-V hardware in the field runs Linux with sv39, where virtual addresses have at most 39 bits.
When satp mode is sv39, this patch emits a shorter fixed-length sequence instead: `lui, addi, slli(9) + 9-bit offset in the trailing addi/jalr/load`

### Correctness Testing
- [x] Run tier1-tier3 test with release on SG2044

### Specjbb2015 Testing on k3 with sv39
without this patch
```
RUN RESULT: hbIR (max attempted) = 1528, hbIR (settled) = 1469, max-jOPS = 1574, critical-jOPS = 502
```

with this patch
```
RUN RESULT: hbIR (max attempted) = 1642, hbIR (settled) = 1613, max-jOPS = 1609, critical-jOPS = 518
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390316](https://bugs.openjdk.org/browse/JDK-8390316): RISC-V: Materialize pointers with fewer instructions on sv39 (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) 🔄 Re-review required (review applies to [c8e13d5f](https://git.openjdk.org/jdk/pull/32346/files/c8e13d5f60b1bfd5c6f6fed316b9d1af0814c241))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32346/head:pull/32346` \
`$ git checkout pull/32346`

Update a local copy of the PR: \
`$ git checkout pull/32346` \
`$ git pull https://git.openjdk.org/jdk.git pull/32346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32346`

View PR using the GUI difftool: \
`$ git pr show -t 32346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32346.diff">https://git.openjdk.org/jdk/pull/32346.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32346#issuecomment-5503809927)
</details>
