### PR TITLE
8388476: [Valhalla] C2 incorrectly eliminates store to flat array

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2307,15 +2307,16 @@ void Compile::adjust_flat_array_access_aliases(PhaseIterGVN& igvn) {
     }
   }
 
-#ifdef ASSERT
+  int start_alias = num_alias_types(); // Start of new aliases
   for (uint i = 0; i < memnodes.size(); i++) {
     Node* m = memnodes.at(i);
     const TypePtr* adr_type = m->adr_type();
+#ifdef ASSERT
     m->as_Mem()->set_adr_type(adr_type);
-  }
 #endif // ASSERT
+    get_alias_index(adr_type);
+  }
 
-  int start_alias = num_alias_types(); // Start of new aliases
   Node_Stack stack(0);
 #ifdef ASSERT
   VectorSet seen(Thread::current()->resource_area());

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2314,6 +2314,7 @@ void Compile::adjust_flat_array_access_aliases(PhaseIterGVN& igvn) {
 #ifdef ASSERT
     m->as_Mem()->set_adr_type(adr_type);
 #endif // ASSERT
+    // This has the side effect of allocating new aliases for flat array accesses
     get_alias_index(adr_type);
   }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIncorrectlyEliminatedStoreToFlatArray.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIncorrectlyEliminatedStoreToFlatArray.java
@@ -32,9 +32,11 @@
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-UseArrayLoadStoreProfile
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test
  *                   -XX:+AlwaysIncrementalInline ${test.main.class}
+ * @run main ${test.main.class}
  */
 
 
+package compiler.valhalla.inlinetypes;
 import jdk.internal.value.ValueClass;
 
 public class TestIncorrectlyEliminatedStoreToFlatArray {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIncorrectlyEliminatedStoreToFlatArray.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIncorrectlyEliminatedStoreToFlatArray.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8388476
+ * @summary [Valhalla] C2 incorrectly eliminates store to flat array
+ *
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:-UseArrayLoadStoreProfile
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:+AlwaysIncrementalInline ${test.main.class}
+ */
+
+                               
+import jdk.internal.value.ValueClass;
+ 
+public class TestIncorrectlyEliminatedStoreToFlatArray {
+    static value class IntegerBox {
+        int value;
+        IntegerBox(int value) { this.value = value; }
+        public String toString() { return "value: " + value; }
+    }
+
+    static Object test(Object obj, IntegerBox box) {
+        Object[] array = (Object[])obj;
+        try {
+            array[0] = null;
+            throw new NullPointerException("No NPE thrown");
+        } catch (NullPointerException expected) {
+            array[0] = box;
+        }
+        return array[0];
+    }
+
+    public static void main(String[] args) {
+        IntegerBox[] array = (IntegerBox[])ValueClass.newNullRestrictedAtomicArray(IntegerBox.class, 1, new IntegerBox(1));
+
+        for (int i = 0; i < 50_000; i++) {
+            IntegerBox box = new IntegerBox(i);
+            Object res = test(array, box);
+            if (res != box) {
+                throw new AssertionError(res + " vs. " + box);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIncorrectlyEliminatedStoreToFlatArray.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIncorrectlyEliminatedStoreToFlatArray.java
@@ -34,9 +34,9 @@
  *                   -XX:+AlwaysIncrementalInline ${test.main.class}
  */
 
-                               
+
 import jdk.internal.value.ValueClass;
- 
+
 public class TestIncorrectlyEliminatedStoreToFlatArray {
     static value class IntegerBox {
         int value;


### PR DESCRIPTION
I think a bug was introduced by 8372259. The expectation is that once
the loop that moves nodes to new slices, alias indexes for new slices
are all allocated. Allocating alias indexes is done by calling
`get_alias_index()` for all memory nodes. That code was removed by
8372259.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388476](https://bugs.openjdk.org/browse/JDK-8388476): [Valhalla] C2 incorrectly eliminates store to flat array (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32347/head:pull/32347` \
`$ git checkout pull/32347`

Update a local copy of the PR: \
`$ git checkout pull/32347` \
`$ git pull https://git.openjdk.org/jdk.git pull/32347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32347`

View PR using the GUI difftool: \
`$ git pr show -t 32347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32347.diff">https://git.openjdk.org/jdk/pull/32347.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32347#issuecomment-5282076886)
</details>
