### PR TITLE
8390240: Full chunk thawing path misses deoptimization check in monitorenter case

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2100,6 +2100,7 @@ protected:
   template<bool check_stub>
   int remove_top_compiled_frame_from_chunk(stackChunkOop chunk, int &argsize);
   int remove_scalarized_frames(StackChunkFrameStream<ChunkFrames::CompiledOnly>& scfs, int &argsize);
+  void check_top_for_deoptimization(stackChunkOop chunk);
   void copy_from_chunk(intptr_t* from, intptr_t* to, int size);
 
   void thaw_lockstack(stackChunkOop chunk);
@@ -2210,6 +2211,23 @@ public:
 inline void ThawBase::clear_chunk(stackChunkOop chunk) {
   chunk->set_sp(chunk->bottom());
   chunk->set_max_thawing_size(0);
+}
+
+void ThawBase::check_top_for_deoptimization(stackChunkOop chunk) {
+  StackChunkFrameStream<ChunkFrames::CompiledOnly> f(chunk);
+  if (f.is_stub()) {
+    f.next(SmallRegisterMap::instance_no_args(), true /* stop */);
+    assert(!f.is_done(), "");
+
+    f.get_cb();
+    assert(f.is_compiled(), "");
+    if (f.cb()->as_nmethod()->is_marked_for_deoptimization()) {
+      // The caller of the runtime stub when the continuation is preempted is not at a
+      // Java call instruction, and so cannot rely on nmethod patching for deopt.
+      log_develop_trace(continuations)("Deoptimizing runtime stub caller");
+      f.to_frame().deoptimize(nullptr); // the null thread simply avoids the assertion in deoptimize which we're not set up for
+    }
+  }
 }
 
 int ThawBase::remove_scalarized_frames(StackChunkFrameStream<ChunkFrames::CompiledOnly>& f, int &argsize) {
@@ -2349,6 +2367,9 @@ NOINLINE intptr_t* Thaw<ConfigT>::thaw_fast(stackChunkOop chunk) {
   if (LIKELY(!ForceSingleFrameThaw && (full_chunk_size < threshold))) {
     prefetch_chunk_pd(chunk->start_address(), full_chunk_size); // prefetch anticipating memcpy starting at highest address
 
+    if (check_stub) {
+      check_top_for_deoptimization(chunk);
+    }
     partial = false;
     argsize = chunk->argsize(); // must be called *before* clearing the chunk
     clear_chunk(chunk);

--- a/test/jdk/java/lang/Thread/virtual/DeoptimizedMethodAtMonitorEnter.java
+++ b/test/jdk/java/lang/Thread/virtual/DeoptimizedMethodAtMonitorEnter.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=thaw_fast_full
+ * @bug 8390240
+ * @summary Test the full thaw path when the runtime stub's compiled
+ *          caller is marked for deoptimization
+ * @requires vm.continuations
+ * @library /test/lib /test/hotspot/jtreg
+ * @run main/othervm -Xcomp DeoptimizedMethodAtMonitorEnter
+ */
+
+/*
+ * @test id=thaw_fast_partial
+ * @bug 8390240
+ * @summary Test the partial thaw path when the runtime stub's compiled
+ *          caller is marked for deoptimization
+ * @requires vm.debug == true & vm.continuations
+ * @library /test/lib /test/hotspot/jtreg
+ * @run main/othervm -Xcomp -XX:+ForceSingleFrameThaw DeoptimizedMethodAtMonitorEnter
+ */
+
+/*
+ * @test id=thaw_slow
+ * @bug 8390240
+ * @summary Test the slow thaw path when the runtime stub's compiled
+ *          caller is marked for deoptimization
+ * @requires vm.continuations
+ * @library /test/lib /test/hotspot/jtreg
+ * @run main/othervm DeoptimizedMethodAtMonitorEnter
+ */
+
+import java.util.concurrent.CountDownLatch;
+
+import jdk.test.lib.Asserts;
+
+public class DeoptimizedMethodAtMonitorEnter {
+    private static final Object lock = new Object();
+    private static A receiver = new A();
+    private static int result;
+
+    public static void main(String[] args) throws Exception {
+        warmUp();
+        Asserts.assertTrue(receiver.m() == 1, "unexpected value=" + receiver.m());
+
+        var started = new CountDownLatch(1);
+        Thread vthread = Thread.ofVirtual().unstarted(() -> {
+            started.countDown();
+            foo();
+        });
+
+        synchronized (lock) {
+            vthread.start();
+            started.await();
+            await(vthread, Thread.State.BLOCKED);
+            receiver = new B();
+        }
+
+        vthread.join();
+        Asserts.assertTrue(result == 3, "unexpected result=" + result);
+    }
+
+    public static void foo() {
+        synchronized (lock) {
+            result = receiver.m();
+        }
+    }
+
+    private static void warmUp() {
+        for (int i = 0; i < 30_000; i++) {
+            foo();
+        }
+    }
+
+    /**
+     * Waits for the given thread to reach a given state.
+     */
+    private static void await(Thread thread, Thread.State expectedState) throws InterruptedException {
+        Thread.State state = thread.getState();
+        while (state != expectedState) {
+            Asserts.assertTrue(state != Thread.State.TERMINATED, "Thread has terminated");
+            Thread.sleep(10);
+            state = thread.getState();
+        }
+    }
+
+    static class A {
+        int m() {
+            return 1;
+        }
+    }
+
+    static class B extends A {
+        int m() {
+            return 3;
+        }
+    }
+}


### PR DESCRIPTION
When thawing the full chunk in the fast path for the monitorenter case, we are missing to check if the caller of the runtime stub frame is marked for deoptimization, as we cannot rely on the post-call nop deoptimization mechanism. This check is already done in the slow path [here](https://github.com/openjdk/jdk/blob/910c71ce2f09f8895bd893a68c4813037197733a/src/hotspot/share/runtime/continuationFreezeThaw.cpp#L2931) and also in the fast path when thawing only the top frame [here](https://github.com/openjdk/jdk/blob/910c71ce2f09f8895bd893a68c4813037197733a/src/hotspot/share/runtime/continuationFreezeThaw.cpp#L2251).

I added a new test that fails without this fix. For completeness, the test also exercises the slow thaw path and the partial thaw fast path. Also tested the fix in mach5 tiers1-6.

Thanks,
Patricio

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390240](https://bugs.openjdk.org/browse/JDK-8390240): Full chunk thawing path misses deoptimization check in monitorenter case (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32349/head:pull/32349` \
`$ git checkout pull/32349`

Update a local copy of the PR: \
`$ git checkout pull/32349` \
`$ git pull https://git.openjdk.org/jdk.git pull/32349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32349`

View PR using the GUI difftool: \
`$ git pr show -t 32349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32349.diff">https://git.openjdk.org/jdk/pull/32349.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32349#issuecomment-5283764331)
</details>
