### PR TITLE
8390330: Remove deprecated Log() constructor and logTo() method from nsk.share.Log

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>Accessible</code> works fine with
  * the <code>ArrayType</code> sub-interface.
  */
-public class accipp001 extends Log {
+public class accipp001 {
     final static boolean MODE_VERBOSE = false;
 
     /** The main class names of the debugger & debugee applications. */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.io.*;
  * for ArrayType, ClassType, InterfaceType
  */
 
-public class isPrivate001 extends Log {
+public class isPrivate001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.io.*;
  * for ArrayType, ClassType, InterfaceType
  */
 
-public class isProtected001 extends Log {
+public class isProtected001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.io.*;
  * for ArrayType, ClassType, InterfaceType
  */
 
-public class isPublic001 extends Log {
+public class isPublic001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001.java
@@ -37,7 +37,7 @@ import java.io.*;
  * for ClassType, InterfaceType
  */
 
-public class modifiers001 extends Log {
+public class modifiers001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import nsk.share.jdi.*;
  * a target VM via <code>com.sun.jdi.SharedMemoryAttach</code> connector.<br>
  * The test also analyzes exit code of debugee's process.
  */
-public class attach002 extends Log {
+public class attach002 {
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int JCK_STATUS_BASE = 95;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>ClassObjectReference</code> of com.sun.jdi package
  */
 
-public class reflectype001 extends Log {
+public class reflectype001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,11 @@ import java.io.*;
  * of the JDI interface <code>ClassObjectReference</code> of com.sun.jdi package
  */
 
-public class reflectype002 extends Log {
+public class reflectype002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -79,7 +80,7 @@ public class reflectype002 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     private static void print_log_without_verbose(String message) {
@@ -105,11 +106,9 @@ public class reflectype002 extends Log {
         argv = argHandler.getArguments();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = debugee.createIOPipe();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class allfields001 extends Log {
+public class allfields001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -148,7 +149,7 @@ public class allfields001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -167,11 +168,9 @@ public class allfields001 extends Log {
         out_stream.println("    of the com.sun.jdi package\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class allfields002 extends Log {
+public class allfields002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class allfields003 extends Log {
+public class allfields003 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -80,7 +81,7 @@ public class allfields003 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     private static void print_log_without_verbose(String message) {
@@ -105,11 +106,9 @@ public class allfields003 extends Log {
         verbose_mode = argHandler.verbose();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = debugee.createIOPipe();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class allfields004 extends Log {
+public class allfields004 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -78,7 +79,7 @@ public class allfields004 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -97,11 +98,9 @@ public class allfields004 extends Log {
         out_stream.println("    of the com.sun.jdi package for class without any declarated fields\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class allmethods001 extends Log {
+public class allmethods001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -203,7 +204,7 @@ public class allmethods001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -222,11 +223,9 @@ public class allmethods001 extends Log {
         out_stream.println("    of the com.sun.jdi package\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class allmethods002 extends Log {
+public class allmethods002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class allmethods003 extends Log {
+public class allmethods003 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -80,7 +81,7 @@ public class allmethods003 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     private static void print_log_without_verbose(String message) {
@@ -106,11 +107,9 @@ public class allmethods003 extends Log {
         argv = argHandler.getArguments();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = debugee.createIOPipe();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class allmethods004 extends Log {
+public class allmethods004 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -78,7 +79,7 @@ public class allmethods004 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -97,11 +98,9 @@ public class allmethods004 extends Log {
         out_stream.println("    of the com.sun.jdi package for class without any methods\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class classobj001 extends Log {
+public class classobj001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -104,7 +105,7 @@ public class classobj001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -123,11 +124,9 @@ public class classobj001 extends Log {
         out_stream.println("    of the com.sun.jdi package for ArraType, ClassType, InterfaceType\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class classobj002 extends Log {
+public class classobj002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -79,7 +80,7 @@ public class classobj002 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     private static void print_log_without_verbose(String message) {
@@ -105,11 +106,9 @@ public class classobj002 extends Log {
         argv = argHandler.getArguments();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = debugee.createIOPipe();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedToInitialize001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedToInitialize001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,9 +37,10 @@ import java.io.*;
  * for ClassType, InterfaceType
  */
 
-public class failedToInitialize001 extends Log {
+public class failedToInitialize001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -93,7 +94,7 @@ public class failedToInitialize001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -112,11 +113,9 @@ public class failedToInitialize001 extends Log {
         out_stream.println("    of the com.sun.jdi package for ClassType, InterfaceType\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class fieldbyname001 extends Log {
+public class fieldbyname001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -141,7 +142,7 @@ public class fieldbyname001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -160,11 +161,9 @@ public class fieldbyname001 extends Log {
         out_stream.println("    of the com.sun.jdi package\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class fieldbyname002 extends Log {
+public class fieldbyname002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class fieldbyname003 extends Log {
+public class fieldbyname003 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -81,7 +82,7 @@ public class fieldbyname003 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     private static void print_log_without_verbose(String message) {
@@ -107,11 +108,9 @@ public class fieldbyname003 extends Log {
         argv = argHandler.getArguments();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = debugee.createIOPipe();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isAbstract001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isAbstract001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,9 +37,10 @@ import java.io.*;
  * for ClassType, InterfaceType
  */
 
-public class isAbstract001 extends Log {
+public class isAbstract001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -91,7 +92,7 @@ public class isAbstract001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -110,11 +111,9 @@ public class isAbstract001 extends Log {
         verbose_mode = argHandler.verbose();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.io.*;
  * for ClassType, InterfaceType
  */
 
-public class isVerified001 extends Log {
+public class isVerified001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;
 
@@ -97,7 +97,7 @@ public class isVerified001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        logHandler.display(message);
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class methbyname_s001 extends Log {
+public class methbyname_s001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -183,7 +184,7 @@ public class methbyname_s001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -202,11 +203,9 @@ public class methbyname_s001 extends Log {
         out_stream.println("    of the com.sun.jdi package\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class methbyname_s002 extends Log {
+public class methbyname_s002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class methbyname_s003 extends Log {
+public class methbyname_s003 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -80,7 +81,7 @@ public class methbyname_s003 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     private static void print_log_without_verbose(String message) {
@@ -106,11 +107,9 @@ public class methbyname_s003 extends Log {
         argv = argHandler.getArguments();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = debugee.createIOPipe();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class methbyname_s004 extends Log {
+public class methbyname_s004 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -109,7 +110,7 @@ public class methbyname_s004 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -128,11 +129,9 @@ public class methbyname_s004 extends Log {
         out_stream.println("    of the com.sun.jdi package for overloaded methods\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class methbyname_ss001 extends Log {
+public class methbyname_ss001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -196,7 +197,7 @@ public class methbyname_ss001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -215,11 +216,9 @@ public class methbyname_ss001 extends Log {
         out_stream.println("    ReferenceType interface of the com.sun.jdi package\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class methbyname_ss002 extends Log {
+public class methbyname_ss002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibfield001 extends Log {
+public class visibfield001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -135,7 +136,7 @@ public class visibfield001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -154,11 +155,9 @@ public class visibfield001 extends Log {
         out_stream.println("    of the com.sun.jdi package\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibfield002 extends Log {
+public class visibfield002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibfield003 extends Log {
+public class visibfield003 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -80,7 +81,7 @@ public class visibfield003 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     private static void print_log_without_verbose(String message) {
@@ -106,11 +107,9 @@ public class visibfield003 extends Log {
         argv = argHandler.getArguments();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = debugee.createIOPipe();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibfield004 extends Log {
+public class visibfield004 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -78,7 +79,7 @@ public class visibfield004 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -97,11 +98,9 @@ public class visibfield004 extends Log {
         out_stream.println("    of the com.sun.jdi package for class without visible fields\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibmethod001 extends Log {
+public class visibmethod001 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -181,7 +182,7 @@ public class visibmethod001 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -200,11 +201,9 @@ public class visibmethod001 extends Log {
         out_stream.println("    of the com.sun.jdi package\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibmethod002 extends Log {
+public class visibmethod002 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibmethod003 extends Log {
+public class visibmethod003 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to true
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -80,7 +81,7 @@ public class visibmethod003 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     private static void print_log_without_verbose(String message) {
@@ -106,11 +107,9 @@ public class visibmethod003 extends Log {
         argv = argHandler.getArguments();
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = debugee.createIOPipe();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibmethod004 extends Log {
+public class visibmethod004 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -78,7 +79,7 @@ public class visibmethod004 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -97,11 +98,9 @@ public class visibmethod004 extends Log {
         out_stream.println("    of the com.sun.jdi package for class without visible methods\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import java.io.*;
  * of the JDI interface <code>ReferenceType</code> of com.sun.jdi package
  */
 
-public class visibmethod005 extends Log {
+public class visibmethod005 {
     static java.io.PrintStream out_stream;
     static boolean verbose_mode = false;  // test argument -vbs or -verbose switches to static
                                           // - for more easy failure evaluation
+    static Log log;
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -90,7 +91,7 @@ public class visibmethod005 extends Log {
     }
 
     private void print_log_on_verbose(String message) {
-        display(message);
+        log.display(message);
     }
 
     /**
@@ -109,11 +110,9 @@ public class visibmethod005 extends Log {
         out_stream.println("    of the com.sun.jdi package for multiple inherited abstract methods\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            logTo(out_stream);
-        }
+        log = new Log(out_stream, argHandler);
 
-        Binder binder = new Binder(argHandler,this);
+        Binder binder = new Binder(argHandler, log);
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -144,25 +144,14 @@ public class Log {
 
     /////////////////////////////////////////////////////////////////
 
-    /**
-     * Create new Log's only with <code>Log(out)</code> or with
-     * <code>Log(out,argsHandler)</code> constructors.
-     *
-     * @deprecated  Extending test class with Log is obsolete.
-     */
-    @Deprecated
-    protected Log() {
-        // Don't log exceptions from this method. It would just add unnecessary logs.
-        loggedExceptions.add("nsk.share.jdi.SerialExecutionDebugger.executeTests");
-    }
-
 
     /**
      * Incarnate new Log for the given <code>stream</code> and
      * for non-verbose mode.
      */
     public Log(PrintStream stream) {
-        this();
+        // Don't log exceptions from this method. It would just add unnecessary logs.
+        loggedExceptions.add("nsk.share.jdi.SerialExecutionDebugger.executeTests");
         out = stream;
     }
 
@@ -336,19 +325,6 @@ public class Log {
     }
 
     /////////////////////////////////////////////////////////////////
-
-    /**
-     * Redirect log to the given <code>stream</code>.
-     *
-     * @deprecated  This method is obsolete.
-     */
-    @Deprecated
-    protected synchronized void logTo(PrintStream stream) {
-        if (out != null) {
-            out.flush();
-        }
-        out = stream;
-    }
 
     /////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The shared Log kept a protected empty constructor and logTo only for tests that extend Log. 39 old jdi tests still did. 24 of them wired their output through logTo in verbose mode, those now create a Log with the args handler and hand it to Binder like the newer tests do. the other 15 already had their own Log instance and inherited nothing, they just drop the extends. both leftover members are removed. one behavior note, with no stream wired the old setup sent display messages to stderr in non verbose runs, they now go to the log stream.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390330](https://bugs.openjdk.org/browse/JDK-8390330): Remove deprecated Log() constructor and logTo() method from nsk.share.Log (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32350/head:pull/32350` \
`$ git checkout pull/32350`

Update a local copy of the PR: \
`$ git checkout pull/32350` \
`$ git pull https://git.openjdk.org/jdk.git pull/32350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32350`

View PR using the GUI difftool: \
`$ git pr show -t 32350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32350.diff">https://git.openjdk.org/jdk/pull/32350.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32350#issuecomment-5288460738)
</details>
