### PR TITLE
8326087: PKCS12 keystore throws NPE if there is no authSafe

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -2243,14 +2243,18 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
             s.getInteger(); // skip version
 
             ContentInfo authSafe = new ContentInfo(s);
-            DerInputStream as = new DerInputStream(authSafe.getData());
-            for (DerValue seq : as.getSequence(2)) {
-                DerInputStream sci = new DerInputStream(seq.toByteArray());
-                ContentInfo safeContents = new ContentInfo(sci);
-                if (safeContents.getContentType()
-                        .equals(ContentInfo.ENCRYPTED_DATA_OID)) {
-                    // Certificate encrypted
-                    return false;
+            byte[] authSafeData = authSafe.getData();
+
+            if (authSafeData != null) {
+                DerInputStream as = new DerInputStream(authSafeData);
+                for (DerValue seq : as.getSequence(2)) {
+                    DerInputStream sci = new DerInputStream(seq.toByteArray());
+                    ContentInfo safeContents = new ContentInfo(sci);
+                    if (safeContents.getContentType()
+                            .equals(ContentInfo.ENCRYPTED_DATA_OID)) {
+                        // Certificate encrypted
+                        return false;
+                    }
                 }
             }
 

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -2503,7 +2503,8 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
     }
 
     /*
-     * PKCS12 permitted first 24 bytes:
+     * PKCS12 permitted first 24 bytes. The last entry is 18 bytes representing
+     * no authSafe content and no MacData.
      *
      * 30 80 02 01 03 30 80 06 09 2A 86 48 86 F7 0D 01 07 01 A0 80 24 80 04 --
      * 30 82 -- -- 02 01 03 30 82 -- -- 06 09 2A 86 48 86 F7 0D 01 07 01 A0 8-
@@ -2515,6 +2516,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      * 30 83 -- -- -- 02 01 03 30 83 -- -- -- 06 09 2A 86 48 86 F7 0D 01 07 01
      * 30 84 -- -- -- -- 02 01 03 30 83 -- -- -- 06 09 2A 86 48 86 F7 0D 01 07
      * 30 84 -- -- -- -- 02 01 03 30 84 -- -- -- -- 06 09 2A 86 48 86 F7 0D 01
+     * 30 -- 02 01 03 30 0B 06 09 2A 86 48 86 F7 0D 01 07 01
      */
 
     private static final long[][] PKCS12_HEADER_PATTERNS = {
@@ -2527,7 +2529,8 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         { 0x3083000000020103L, 0x3082000006092A86L, 0x4886F70D010701A0L },
         { 0x3083000000020103L, 0x308300000006092AL, 0x864886F70D010701L },
         { 0x3084000000000201L, 0x0330830000000609L, 0x2A864886F70D0107L },
-        { 0x3084000000000201L, 0x0330840000000006L, 0x092A864886F70D01L }
+        { 0x3084000000000201L, 0x0330840000000006L, 0x092A864886F70D01L },
+        { 0x3000020103300B06L, 0x092A864886F70D01L, 0x0701300000000000L }
     };
 
     private static final long[][] PKCS12_HEADER_MASKS = {
@@ -2540,8 +2543,25 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         { 0xFFFF000000FFFFFFL, 0xFFFF0000FFFFFFFFL, 0xFFFFFFFFFFFFFFFFL },
         { 0xFFFF000000FFFFFFL, 0xFFFF000000FFFFFFL, 0xFFFFFFFFFFFFFFFFL },
         { 0xFFFF00000000FFFFL, 0xFFFFFF000000FFFFL, 0xFFFFFFFFFFFFFFFFL },
-        { 0xFFFF00000000FFFFL, 0xFFFFFF00000000FFL, 0xFFFFFFFFFFFFFFFFL }
+        { 0xFFFF00000000FFFFL, 0xFFFFFF00000000FFL, 0xFFFFFFFFFFFFFFFFL },
+        { 0xFF00FFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFFFL, 0xFFFFFF0000000000L }
     };
+
+    private static final long[] PKCS12_HEADER_PATTERNS_SHORT = {
+        0x3010020103300B06L, 0x092A864886F70D01L, 0x0701000000000000L
+    };
+
+    private static final long[] PKCS12_HEADER_MASKS_SHORT = {
+        0xFFFFFFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFFFL, 0xFFFF000000000000L
+    };
+
+    private static long bytesToLong(byte[] bytes) {
+        long value = 0;
+        for (byte b : bytes) {
+            value = (value << Byte.SIZE) | Byte.toUnsignedLong(b);
+        }
+        return value << ((Long.BYTES - bytes.length) * Byte.SIZE);
+    }
 
     /**
      * Probe the first few bytes of the keystore data stream for a valid
@@ -2559,21 +2579,34 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
 
         long firstPeek = dataStream.readLong();
         long nextPeek = dataStream.readLong();
-        long finalPeek = dataStream.readLong();
+        long finalPeek;
+        byte[] finalBytes = dataStream.readNBytes(Long.BYTES);
         boolean result = false;
 
-        for (int i = 0; i < PKCS12_HEADER_PATTERNS.length; i++) {
-            if (PKCS12_HEADER_PATTERNS[i][0] ==
-                    (firstPeek & PKCS12_HEADER_MASKS[i][0]) &&
-                (PKCS12_HEADER_PATTERNS[i][1] ==
-                    (nextPeek & PKCS12_HEADER_MASKS[i][1])) &&
-                (PKCS12_HEADER_PATTERNS[i][2] ==
-                    (finalPeek & PKCS12_HEADER_MASKS[i][2]))) {
+        if (finalBytes.length == Long.BYTES) {
+            finalPeek = bytesToLong(finalBytes);
+            for (int i = 0; i < PKCS12_HEADER_PATTERNS.length; i++) {
+                if (PKCS12_HEADER_PATTERNS[i][0] ==
+                        (firstPeek & PKCS12_HEADER_MASKS[i][0]) &&
+                    (PKCS12_HEADER_PATTERNS[i][1] ==
+                        (nextPeek & PKCS12_HEADER_MASKS[i][1])) &&
+                    (PKCS12_HEADER_PATTERNS[i][2] ==
+                        (finalPeek & PKCS12_HEADER_MASKS[i][2]))) {
+                    result = true;
+                    break;
+                }
+            }
+        } else if (finalBytes.length == Short.BYTES) {
+            finalPeek = bytesToLong(finalBytes);
+            if (PKCS12_HEADER_PATTERNS_SHORT[0] ==
+                    (firstPeek & PKCS12_HEADER_MASKS_SHORT[0]) &&
+                (PKCS12_HEADER_PATTERNS_SHORT[1] ==
+                    (nextPeek & PKCS12_HEADER_MASKS_SHORT[1])) &&
+                (PKCS12_HEADER_PATTERNS_SHORT[2] ==
+                    (finalPeek & PKCS12_HEADER_MASKS_SHORT[2]))) {
                 result = true;
-                break;
             }
         }
-
         return result;
     }
 

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -1938,16 +1938,15 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
            throw new IOException("public key protected PKCS12 not supported");
         }
 
+        // reset the counters at the start
+        privateKeyCount = 0;
+        secretKeyCount = 0;
+        certificateCount = 0;
+
         if (authSafeData != null) {
             DerInputStream as = new DerInputStream(authSafeData);
             DerValue[] safeContentsArray = as.getSequence(2);
             int count = safeContentsArray.length;
-
-            // reset the counters at the start
-            privateKeyCount = 0;
-            secretKeyCount = 0;
-            certificateCount = 0;
-
             boolean seeEncBag = false;
 
             /*

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -1938,140 +1938,142 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
            throw new IOException("public key protected PKCS12 not supported");
         }
 
-        DerInputStream as = new DerInputStream(authSafeData);
-        DerValue[] safeContentsArray = as.getSequence(2);
-        int count = safeContentsArray.length;
+        if (authSafeData != null) {
+            DerInputStream as = new DerInputStream(authSafeData);
+            DerValue[] safeContentsArray = as.getSequence(2);
+            int count = safeContentsArray.length;
 
-        // reset the counters at the start
-        privateKeyCount = 0;
-        secretKeyCount = 0;
-        certificateCount = 0;
+            // reset the counters at the start
+            privateKeyCount = 0;
+            secretKeyCount = 0;
+            certificateCount = 0;
 
-        boolean seeEncBag = false;
+            boolean seeEncBag = false;
 
-        /*
-         * Spin over the ContentInfos.
-         */
-        for (int i = 0; i < count; i++) {
-            ContentInfo safeContents;
-            DerInputStream sci;
-            byte[] eAlgId = null;
+            /*
+             * Spin over the ContentInfos.
+             */
+            for (int i = 0; i < count; i++) {
+                ContentInfo safeContents;
+                DerInputStream sci;
+                byte[] eAlgId = null;
 
-            sci = new DerInputStream(safeContentsArray[i].toByteArray());
-            safeContents = new ContentInfo(sci);
-            contentType = safeContents.getContentType();
-            if (contentType.equals(ContentInfo.DATA_OID)) {
-
-                if (debug != null) {
-                    debug.println("Loading PKCS#7 data");
-                }
-
-                loadSafeContents(new DerInputStream(safeContents.getData()));
-            } else if (contentType.equals(ContentInfo.ENCRYPTED_DATA_OID)) {
-                if (password == null) {
+                sci = new DerInputStream(safeContentsArray[i].toByteArray());
+                safeContents = new ContentInfo(sci);
+                contentType = safeContents.getContentType();
+                if (contentType.equals(ContentInfo.DATA_OID)) {
 
                     if (debug != null) {
-                        debug.println("Warning: skipping PKCS#7 encryptedData" +
-                            " - no password was supplied");
-                    }
-                    // No password to decrypt ENCRYPTED_DATA_OID. *Skip it*.
-                    // This means user will see a PrivateKeyEntry without
-                    // certificates and a whole TrustedCertificateEntry will
-                    // be lost. This is not a perfect solution but alternative
-                    // solutions are more disruptive:
-                    //
-                    // We cannot just fail, since KeyStore.load(is, null)
-                    // has been known to never fail because of a null password.
-                    //
-                    // We cannot just throw away the whole PrivateKeyEntry,
-                    // this is too silent and no one will notice anything.
-                    //
-                    // We also cannot fail when getCertificate() on such a
-                    // PrivateKeyEntry is called, since the method has not
-                    // specified this behavior.
-                    continue;
-                }
-
-                DerInputStream edi =
-                                safeContents.getContent().toDerInputStream();
-                int edVersion = edi.getInteger();
-                DerValue[] seq = edi.getSequence(3);
-                if (seq.length != 3) {
-                    // We require the encryptedContent field, even though
-                    // it is optional
-                    throw new IOException("Invalid length for EncryptedContentInfo");
-                }
-                ObjectIdentifier edContentType = seq[0].getOID();
-                eAlgId = seq[1].toByteArray();
-                if (!seq[2].isContextSpecific((byte)0)) {
-                    throw new IOException("unsupported encrypted content type "
-                                          + seq[2].tag);
-                }
-                byte newTag = DerValue.tag_OctetString;
-                if (seq[2].isConstructed())
-                   newTag |= 0x20;
-                seq[2].resetTag(newTag);
-                byte[] rawData = seq[2].getOctetString();
-
-                // parse Algorithm parameters
-                AlgorithmId aid = AlgorithmId.parse(seq[1]);
-                AlgorithmParameters algParams = aid.getParameters();
-
-                PBEParameterSpec pbeSpec;
-                int ic = 0;
-
-                if (algParams != null) {
-                    try {
-                        pbeSpec =
-                            algParams.getParameterSpec(PBEParameterSpec.class);
-                    } catch (InvalidParameterSpecException ipse) {
-                        throw new IOException(
-                            "Invalid PBE algorithm parameters");
-                    }
-                    ic = pbeSpec.getIterationCount();
-
-                    if (ic > MAX_ITERATION_COUNT) {
-                        throw new IOException("cert PBE iteration count too large");
+                        debug.println("Loading PKCS#7 data");
                     }
 
-                    certProtectionAlgorithm = aid.getName();
-                    certPbeIterationCount = ic;
-                    seeEncBag = true;
-                }
+                    loadSafeContents(new DerInputStream(safeContents.getData()));
+                } else if (contentType.equals(ContentInfo.ENCRYPTED_DATA_OID)) {
+                    if (password == null) {
 
-                if (debug != null) {
-                    debug.println("Loading PKCS#7 encryptedData " +
-                        "(" + certProtectionAlgorithm +
-                        " iterations: " + ic + ")");
-                }
-
-                try {
-                    RetryWithZero.run(pass -> {
-                        // Use JCE
-                        Cipher cipher = Cipher.getInstance(certProtectionAlgorithm);
-                        SecretKey skey = getPBEKey(pass);
-                        try {
-                            cipher.init(Cipher.DECRYPT_MODE, skey, algParams);
-                        } finally {
-                            KeyUtil.destroySecretKeys(skey);
+                        if (debug != null) {
+                            debug.println("Warning: skipping PKCS#7 encryptedData" +
+                                " - no password was supplied");
                         }
-                        loadSafeContents(new DerInputStream(cipher.doFinal(rawData)));
-                        return null;
-                    }, password);
-                } catch (Exception e) {
-                    throw new IOException("keystore password was incorrect",
-                            new UnrecoverableKeyException(
-                                    "failed to decrypt safe contents entry: " + e));
-                }
-            } else {
-                throw new IOException("public key protected PKCS12" +
-                                        " not supported");
-            }
-        }
+                        // No password to decrypt ENCRYPTED_DATA_OID. *Skip it*.
+                        // This means user will see a PrivateKeyEntry without
+                        // certificates and a whole TrustedCertificateEntry will
+                        // be lost. This is not a perfect solution but alternative
+                        // solutions are more disruptive:
+                        //
+                        // We cannot just fail, since KeyStore.load(is, null)
+                        // has been known to never fail because of a null password.
+                        //
+                        // We cannot just throw away the whole PrivateKeyEntry,
+                        // this is too silent and no one will notice anything.
+                        //
+                        // We also cannot fail when getCertificate() on such a
+                        // PrivateKeyEntry is called, since the method has not
+                        // specified this behavior.
+                        continue;
+                    }
 
-        // No ENCRYPTED_DATA_OID but see certificate. Must be passwordless.
-        if (!seeEncBag && certificateCount > 0) {
-            certProtectionAlgorithm = "NONE";
+                    DerInputStream edi =
+                                    safeContents.getContent().toDerInputStream();
+                    int edVersion = edi.getInteger();
+                    DerValue[] seq = edi.getSequence(3);
+                    if (seq.length != 3) {
+                        // We require the encryptedContent field, even though
+                        // it is optional
+                        throw new IOException("Invalid length for EncryptedContentInfo");
+                    }
+                    ObjectIdentifier edContentType = seq[0].getOID();
+                    eAlgId = seq[1].toByteArray();
+                    if (!seq[2].isContextSpecific((byte)0)) {
+                        throw new IOException("unsupported encrypted content type "
+                                              + seq[2].tag);
+                    }
+                    byte newTag = DerValue.tag_OctetString;
+                    if (seq[2].isConstructed())
+                       newTag |= 0x20;
+                    seq[2].resetTag(newTag);
+                    byte[] rawData = seq[2].getOctetString();
+
+                    // parse Algorithm parameters
+                    AlgorithmId aid = AlgorithmId.parse(seq[1]);
+                    AlgorithmParameters algParams = aid.getParameters();
+
+                    PBEParameterSpec pbeSpec;
+                    int ic = 0;
+
+                    if (algParams != null) {
+                        try {
+                            pbeSpec =
+                                algParams.getParameterSpec(PBEParameterSpec.class);
+                        } catch (InvalidParameterSpecException ipse) {
+                            throw new IOException(
+                                "Invalid PBE algorithm parameters");
+                        }
+                        ic = pbeSpec.getIterationCount();
+
+                        if (ic > MAX_ITERATION_COUNT) {
+                            throw new IOException("cert PBE iteration count too large");
+                        }
+
+                        certProtectionAlgorithm = aid.getName();
+                        certPbeIterationCount = ic;
+                        seeEncBag = true;
+                    }
+
+                    if (debug != null) {
+                        debug.println("Loading PKCS#7 encryptedData " +
+                            "(" + certProtectionAlgorithm +
+                            " iterations: " + ic + ")");
+                    }
+
+                    try {
+                        RetryWithZero.run(pass -> {
+                            // Use JCE
+                            Cipher cipher = Cipher.getInstance(certProtectionAlgorithm);
+                            SecretKey skey = getPBEKey(pass);
+                            try {
+                                cipher.init(Cipher.DECRYPT_MODE, skey, algParams);
+                            } finally {
+                                KeyUtil.destroySecretKeys(skey);
+                            }
+                            loadSafeContents(new DerInputStream(cipher.doFinal(rawData)));
+                            return null;
+                        }, password);
+                    } catch (Exception e) {
+                        throw new IOException("keystore password was incorrect",
+                                new UnrecoverableKeyException(
+                                        "failed to decrypt safe contents entry: " + e));
+                    }
+                } else {
+                    throw new IOException("public key protected PKCS12" +
+                                            " not supported");
+                }
+            }
+
+            // No ENCRYPTED_DATA_OID but see certificate. Must be passwordless.
+            if (!seeEncBag && certificateCount > 0) {
+                certProtectionAlgorithm = "NONE";
+            }
         }
 
         // The MacData is optional.

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -2516,7 +2516,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      * 30 83 -- -- -- 02 01 03 30 83 -- -- -- 06 09 2A 86 48 86 F7 0D 01 07 01
      * 30 84 -- -- -- -- 02 01 03 30 83 -- -- -- 06 09 2A 86 48 86 F7 0D 01 07
      * 30 84 -- -- -- -- 02 01 03 30 84 -- -- -- -- 06 09 2A 86 48 86 F7 0D 01
-     * 30 -- 02 01 03 30 0B 06 09 2A 86 48 86 F7 0D 01 07 01
+     * 30 -- 02 01 03 30 0B 06 09 2A 86 48 86 F7 0D 01 07 01 -- -- -- -- -- --
      */
 
     private static final long[][] PKCS12_HEADER_PATTERNS = {
@@ -2530,7 +2530,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         { 0x3083000000020103L, 0x308300000006092AL, 0x864886F70D010701L },
         { 0x3084000000000201L, 0x0330830000000609L, 0x2A864886F70D0107L },
         { 0x3084000000000201L, 0x0330840000000006L, 0x092A864886F70D01L },
-        { 0x3000020103300B06L, 0x092A864886F70D01L, 0x0701300000000000L }
+        { 0x3000020103300B06L, 0x092A864886F70D01L, 0x0701000000000000L }
     };
 
     private static final long[][] PKCS12_HEADER_MASKS = {
@@ -2544,15 +2544,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         { 0xFFFF000000FFFFFFL, 0xFFFF000000FFFFFFL, 0xFFFFFFFFFFFFFFFFL },
         { 0xFFFF00000000FFFFL, 0xFFFFFF000000FFFFL, 0xFFFFFFFFFFFFFFFFL },
         { 0xFFFF00000000FFFFL, 0xFFFFFF00000000FFL, 0xFFFFFFFFFFFFFFFFL },
-        { 0xFF00FFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFFFL, 0xFFFFFF0000000000L }
-    };
-
-    private static final long[] PKCS12_HEADER_PATTERNS_SHORT = {
-        0x3010020103300B06L, 0x092A864886F70D01L, 0x0701000000000000L
-    };
-
-    private static final long[] PKCS12_HEADER_MASKS_SHORT = {
-        0xFFFFFFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFFFL, 0xFFFF000000000000L
+        { 0xFF00FFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFFFL, 0xFFFF000000000000L }
     };
 
     private static long bytesToLong(byte[] bytes) {
@@ -2583,7 +2575,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         byte[] finalBytes = dataStream.readNBytes(Long.BYTES);
         boolean result = false;
 
-        if (finalBytes.length == Long.BYTES) {
+        if (finalBytes.length == Long.BYTES || finalBytes.length == Short.BYTES) {
             finalPeek = bytesToLong(finalBytes);
             for (int i = 0; i < PKCS12_HEADER_PATTERNS.length; i++) {
                 if (PKCS12_HEADER_PATTERNS[i][0] ==
@@ -2595,16 +2587,6 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
                     result = true;
                     break;
                 }
-            }
-        } else if (finalBytes.length == Short.BYTES) {
-            finalPeek = bytesToLong(finalBytes);
-            if (PKCS12_HEADER_PATTERNS_SHORT[0] ==
-                    (firstPeek & PKCS12_HEADER_MASKS_SHORT[0]) &&
-                (PKCS12_HEADER_PATTERNS_SHORT[1] ==
-                    (nextPeek & PKCS12_HEADER_MASKS_SHORT[1])) &&
-                (PKCS12_HEADER_PATTERNS_SHORT[2] ==
-                    (finalPeek & PKCS12_HEADER_MASKS_SHORT[2]))) {
-                result = true;
             }
         }
         return result;

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -1943,136 +1943,135 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         secretKeyCount = 0;
         certificateCount = 0;
 
-        if (authSafeData != null) {
-            DerInputStream as = new DerInputStream(authSafeData);
-            DerValue[] safeContentsArray = as.getSequence(2);
-            int count = safeContentsArray.length;
-            boolean seeEncBag = false;
+        DerValue[] safeContentsArray = authSafeData == null
+                ? new DerValue[0]
+                : new DerInputStream(authSafeData).getSequence(2);
+        int count = safeContentsArray.length;
+        boolean seeEncBag = false;
 
-            /*
-             * Spin over the ContentInfos.
-             */
-            for (int i = 0; i < count; i++) {
-                ContentInfo safeContents;
-                DerInputStream sci;
-                byte[] eAlgId = null;
+        /*
+         * Spin over the ContentInfos.
+         */
+        for (int i = 0; i < count; i++) {
+            ContentInfo safeContents;
+            DerInputStream sci;
+            byte[] eAlgId = null;
 
-                sci = new DerInputStream(safeContentsArray[i].toByteArray());
-                safeContents = new ContentInfo(sci);
-                contentType = safeContents.getContentType();
-                if (contentType.equals(ContentInfo.DATA_OID)) {
+            sci = new DerInputStream(safeContentsArray[i].toByteArray());
+            safeContents = new ContentInfo(sci);
+            contentType = safeContents.getContentType();
+            if (contentType.equals(ContentInfo.DATA_OID)) {
 
-                    if (debug != null) {
-                        debug.println("Loading PKCS#7 data");
-                    }
-
-                    loadSafeContents(new DerInputStream(safeContents.getData()));
-                } else if (contentType.equals(ContentInfo.ENCRYPTED_DATA_OID)) {
-                    if (password == null) {
-
-                        if (debug != null) {
-                            debug.println("Warning: skipping PKCS#7 encryptedData" +
-                                " - no password was supplied");
-                        }
-                        // No password to decrypt ENCRYPTED_DATA_OID. *Skip it*.
-                        // This means user will see a PrivateKeyEntry without
-                        // certificates and a whole TrustedCertificateEntry will
-                        // be lost. This is not a perfect solution but alternative
-                        // solutions are more disruptive:
-                        //
-                        // We cannot just fail, since KeyStore.load(is, null)
-                        // has been known to never fail because of a null password.
-                        //
-                        // We cannot just throw away the whole PrivateKeyEntry,
-                        // this is too silent and no one will notice anything.
-                        //
-                        // We also cannot fail when getCertificate() on such a
-                        // PrivateKeyEntry is called, since the method has not
-                        // specified this behavior.
-                        continue;
-                    }
-
-                    DerInputStream edi =
-                                    safeContents.getContent().toDerInputStream();
-                    int edVersion = edi.getInteger();
-                    DerValue[] seq = edi.getSequence(3);
-                    if (seq.length != 3) {
-                        // We require the encryptedContent field, even though
-                        // it is optional
-                        throw new IOException("Invalid length for EncryptedContentInfo");
-                    }
-                    ObjectIdentifier edContentType = seq[0].getOID();
-                    eAlgId = seq[1].toByteArray();
-                    if (!seq[2].isContextSpecific((byte)0)) {
-                        throw new IOException("unsupported encrypted content type "
-                                              + seq[2].tag);
-                    }
-                    byte newTag = DerValue.tag_OctetString;
-                    if (seq[2].isConstructed())
-                       newTag |= 0x20;
-                    seq[2].resetTag(newTag);
-                    byte[] rawData = seq[2].getOctetString();
-
-                    // parse Algorithm parameters
-                    AlgorithmId aid = AlgorithmId.parse(seq[1]);
-                    AlgorithmParameters algParams = aid.getParameters();
-
-                    PBEParameterSpec pbeSpec;
-                    int ic = 0;
-
-                    if (algParams != null) {
-                        try {
-                            pbeSpec =
-                                algParams.getParameterSpec(PBEParameterSpec.class);
-                        } catch (InvalidParameterSpecException ipse) {
-                            throw new IOException(
-                                "Invalid PBE algorithm parameters");
-                        }
-                        ic = pbeSpec.getIterationCount();
-
-                        if (ic > MAX_ITERATION_COUNT) {
-                            throw new IOException("cert PBE iteration count too large");
-                        }
-
-                        certProtectionAlgorithm = aid.getName();
-                        certPbeIterationCount = ic;
-                        seeEncBag = true;
-                    }
-
-                    if (debug != null) {
-                        debug.println("Loading PKCS#7 encryptedData " +
-                            "(" + certProtectionAlgorithm +
-                            " iterations: " + ic + ")");
-                    }
-
-                    try {
-                        RetryWithZero.run(pass -> {
-                            // Use JCE
-                            Cipher cipher = Cipher.getInstance(certProtectionAlgorithm);
-                            SecretKey skey = getPBEKey(pass);
-                            try {
-                                cipher.init(Cipher.DECRYPT_MODE, skey, algParams);
-                            } finally {
-                                KeyUtil.destroySecretKeys(skey);
-                            }
-                            loadSafeContents(new DerInputStream(cipher.doFinal(rawData)));
-                            return null;
-                        }, password);
-                    } catch (Exception e) {
-                        throw new IOException("keystore password was incorrect",
-                                new UnrecoverableKeyException(
-                                        "failed to decrypt safe contents entry: " + e));
-                    }
-                } else {
-                    throw new IOException("public key protected PKCS12" +
-                                            " not supported");
+                if (debug != null) {
+                    debug.println("Loading PKCS#7 data");
                 }
-            }
 
-            // No ENCRYPTED_DATA_OID but see certificate. Must be passwordless.
-            if (!seeEncBag && certificateCount > 0) {
-                certProtectionAlgorithm = "NONE";
+                loadSafeContents(new DerInputStream(safeContents.getData()));
+            } else if (contentType.equals(ContentInfo.ENCRYPTED_DATA_OID)) {
+                if (password == null) {
+
+                    if (debug != null) {
+                        debug.println("Warning: skipping PKCS#7 encryptedData" +
+                            " - no password was supplied");
+                    }
+                    // No password to decrypt ENCRYPTED_DATA_OID. *Skip it*.
+                    // This means user will see a PrivateKeyEntry without
+                    // certificates and a whole TrustedCertificateEntry will
+                    // be lost. This is not a perfect solution but alternative
+                    // solutions are more disruptive:
+                    //
+                    // We cannot just fail, since KeyStore.load(is, null)
+                    // has been known to never fail because of a null password.
+                    //
+                    // We cannot just throw away the whole PrivateKeyEntry,
+                    // this is too silent and no one will notice anything.
+                    //
+                    // We also cannot fail when getCertificate() on such a
+                    // PrivateKeyEntry is called, since the method has not
+                    // specified this behavior.
+                    continue;
+                }
+
+                DerInputStream edi =
+                                safeContents.getContent().toDerInputStream();
+                int edVersion = edi.getInteger();
+                DerValue[] seq = edi.getSequence(3);
+                if (seq.length != 3) {
+                    // We require the encryptedContent field, even though
+                    // it is optional
+                    throw new IOException("Invalid length for EncryptedContentInfo");
+                }
+                ObjectIdentifier edContentType = seq[0].getOID();
+                eAlgId = seq[1].toByteArray();
+                if (!seq[2].isContextSpecific((byte)0)) {
+                    throw new IOException("unsupported encrypted content type "
+                                          + seq[2].tag);
+                }
+                byte newTag = DerValue.tag_OctetString;
+                if (seq[2].isConstructed())
+                   newTag |= 0x20;
+                seq[2].resetTag(newTag);
+                byte[] rawData = seq[2].getOctetString();
+
+                // parse Algorithm parameters
+                AlgorithmId aid = AlgorithmId.parse(seq[1]);
+                AlgorithmParameters algParams = aid.getParameters();
+
+                PBEParameterSpec pbeSpec;
+                int ic = 0;
+
+                if (algParams != null) {
+                    try {
+                        pbeSpec =
+                            algParams.getParameterSpec(PBEParameterSpec.class);
+                    } catch (InvalidParameterSpecException ipse) {
+                        throw new IOException(
+                            "Invalid PBE algorithm parameters");
+                    }
+                    ic = pbeSpec.getIterationCount();
+
+                    if (ic > MAX_ITERATION_COUNT) {
+                        throw new IOException("cert PBE iteration count too large");
+                    }
+
+                    certProtectionAlgorithm = aid.getName();
+                    certPbeIterationCount = ic;
+                    seeEncBag = true;
+                }
+
+                if (debug != null) {
+                    debug.println("Loading PKCS#7 encryptedData " +
+                        "(" + certProtectionAlgorithm +
+                        " iterations: " + ic + ")");
+                }
+
+                try {
+                    RetryWithZero.run(pass -> {
+                        // Use JCE
+                        Cipher cipher = Cipher.getInstance(certProtectionAlgorithm);
+                        SecretKey skey = getPBEKey(pass);
+                        try {
+                            cipher.init(Cipher.DECRYPT_MODE, skey, algParams);
+                        } finally {
+                            KeyUtil.destroySecretKeys(skey);
+                        }
+                        loadSafeContents(new DerInputStream(cipher.doFinal(rawData)));
+                        return null;
+                    }, password);
+                } catch (Exception e) {
+                    throw new IOException("keystore password was incorrect",
+                            new UnrecoverableKeyException(
+                                    "failed to decrypt safe contents entry: " + e));
+                }
+            } else {
+                throw new IOException("public key protected PKCS12" +
+                                        " not supported");
             }
+        }
+
+        // No ENCRYPTED_DATA_OID but see certificate. Must be passwordless.
+        if (!seeEncBag && certificateCount > 0) {
+            certProtectionAlgorithm = "NONE";
         }
 
         // The MacData is optional.

--- a/test/jdk/sun/security/pkcs12/EmptyAuthSafeTest.java
+++ b/test/jdk/sun/security/pkcs12/EmptyAuthSafeTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8326087
+ * @summary Verify keystore loads when authSafe content is absent.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.security.KeyStore;
+import java.util.Base64;
+
+public class EmptyAuthSafeTest {
+
+    static final char[] PASSWORD = "1234".toCharArray();
+
+    public static void main(String[] args) throws Exception {
+        var authsafe = """
+                MFsCAQMwCwYJKoZIhvcNAQcBMEkwMTANBglghkgBZQMEAgEFAAQgX2iKyj065lT1hA8c7H+NREUaXuTdy/W2aHjeVJNT/N0EEAARIjNEVWZ3iJmqu8zd7v8CAggA""";
+
+        loadAndStore(authsafe);
+    }
+
+    static void loadAndStore(String data) throws Exception {
+        var bytes = Base64.getMimeDecoder().decode(data);
+        var ks = KeyStore.getInstance("PKCS12");
+        ks.load(new ByteArrayInputStream(bytes), PASSWORD);
+        var baos = new ByteArrayOutputStream();
+        ks.store(baos, PASSWORD);
+        var newBytes = baos.toByteArray();
+        var bais = new ByteArrayInputStream(newBytes);
+        ks.load(bais, PASSWORD);
+    }
+}

--- a/test/jdk/sun/security/pkcs12/EmptyAuthSafeTest.java
+++ b/test/jdk/sun/security/pkcs12/EmptyAuthSafeTest.java
@@ -25,32 +25,66 @@
  * @test
  * @bug 8326087
  * @summary Verify keystore loads when authSafe content is absent.
+ * @modules java.base/sun.security.pkcs12
  */
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.util.Base64;
 
+import sun.security.pkcs12.PKCS12KeyStore;
+
 public class EmptyAuthSafeTest {
 
-    static final char[] PASSWORD = "1234".toCharArray();
+    private static final char[] PASSWORD = "1234".toCharArray();
+
+    // No authSafe content but with MacData present
+    private static final String ks1 = "MFsCAQMwCwYJKoZIhvcNAQcBMEkwMTANBglghk"
+            + "gBZQMEAgEFAAQgX2iKyj065lT1hA8c7H+NREUaXuTdy/W2aHjeVJNT/N0EEAAR"
+            + "IjNEVWZ3iJmqu8zd7v8CAggA";
+
+    // No authSafe content and no MacData
+    private static final String ks2 = "MBACAQMwCwYJKoZIhvcNAQcB";
 
     public static void main(String[] args) throws Exception {
-        var authsafe = """
-                MFsCAQMwCwYJKoZIhvcNAQcBMEkwMTANBglghkgBZQMEAgEFAAQgX2iKyj065lT1hA8c7H+NREUaXuTdy/W2aHjeVJNT/N0EEAARIjNEVWZ3iJmqu8zd7v8CAggA""";
 
-        loadAndStore(authsafe);
+        assertLoadAndStore(ks1);
+
+        assertIsPasswordless(ks1, false);
+        assertIsPasswordless(ks2, true);
     }
 
-    static void loadAndStore(String data) throws Exception {
+    static void assertLoadAndStore(String data) throws Exception {
         var bytes = Base64.getMimeDecoder().decode(data);
         var ks = KeyStore.getInstance("PKCS12");
         ks.load(new ByteArrayInputStream(bytes), PASSWORD);
+        if (ks.size() != 0) {
+            throw new Exception("Expected no entries");
+        }
         var baos = new ByteArrayOutputStream();
         ks.store(baos, PASSWORD);
         var newBytes = baos.toByteArray();
         var bais = new ByteArrayInputStream(newBytes);
         ks.load(bais, PASSWORD);
+        if (ks.size() != 0) {
+            throw new Exception("Expected no entries");
+        }
+    }
+
+    private static void assertIsPasswordless(
+            String encoded, boolean expected) throws Exception {
+        Path keyStoreFile = Files.createTempFile(
+                Path.of(System.getProperty("test.classes")),
+                "empty-auth-safe-", ".p12");
+        Files.write(keyStoreFile, Base64.getMimeDecoder().decode(encoded));
+
+        boolean actual = PKCS12KeyStore.isPasswordless(keyStoreFile.toFile());
+        if (actual != expected) {
+            throw new Exception("Expected isPasswordless() to return "
+                    + expected + ", got " + actual);
+        }
     }
 }

--- a/test/jdk/sun/security/pkcs12/EmptyAuthSafeTest.java
+++ b/test/jdk/sun/security/pkcs12/EmptyAuthSafeTest.java
@@ -53,6 +53,9 @@ public class EmptyAuthSafeTest {
 
         assertLoadAndStore(ks1);
 
+        assertProbe(ks1);
+        assertProbe(ks2);
+
         assertIsPasswordless(ks1, false);
         assertIsPasswordless(ks2, true);
     }
@@ -85,6 +88,18 @@ public class EmptyAuthSafeTest {
         if (actual != expected) {
             throw new Exception("Expected isPasswordless() to return "
                     + expected + ", got " + actual);
+        }
+    }
+
+    private static void assertProbe(String encoded) throws Exception {
+        Path file = Files.createTempFile(
+                Path.of(System.getProperty("test.classes")),
+                "empty-auth-safe-", ".p12");
+        Files.write(file, Base64.getMimeDecoder().decode(encoded));
+
+        KeyStore ks = KeyStore.getInstance(file.toFile(), PASSWORD);
+        if (!ks.getType().equalsIgnoreCase("PKCS12") || ks.size() != 0) {
+            throw new Exception("PKCS12 keystore was not correctly probed");
         }
     }
 }


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8326087

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8326087](https://bugs.openjdk.org/browse/JDK-8326087): PKCS12 keystore throws NPE if there is no authSafe (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32357/head:pull/32357` \
`$ git checkout pull/32357`

Update a local copy of the PR: \
`$ git checkout pull/32357` \
`$ git pull https://git.openjdk.org/jdk.git pull/32357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32357`

View PR using the GUI difftool: \
`$ git pr show -t 32357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32357.diff">https://git.openjdk.org/jdk/pull/32357.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32357#issuecomment-5286355041)
</details>
