### PR TITLE
8390310: Shenandoah: Abbreviated cycles should allow promotion-in-place

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -80,7 +80,8 @@ void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
   adjust_reserves_for_abbreviated(heap);
 
   ShenandoahInPlacePromotionPlanner in_place_promotions(heap);
-  if (heap->age_census()->get_tenurable_bytes() != 0) {
+  ShenandoahAgeCensus* census = heap->age_census();
+  if (census->get_tenurable_bytes(census->effective_threshold()) != 0) {
     prepare_regions_for_promotion(in_place_promotions, heap, nullptr);
   }
   in_place_promotions.complete_planning();
@@ -364,15 +365,22 @@ size_t ShenandoahGenerationalHeuristics::select_aged_regions(ShenandoahInPlacePr
   return old_consumed;
 }
 
-size_t ShenandoahGenerationalHeuristics::compute_promotion_potential(ShenandoahGenerationalHeap* const heap, size_t tenurable_this_cycle) {
-  const uint tenuring_threshold = heap->age_census()->tenuring_threshold();
-  const size_t tenurable_next_cycle = heap->age_census()->get_tenurable_bytes(tenuring_threshold - 1);
+size_t ShenandoahGenerationalHeuristics::compute_promotion_potential(ShenandoahGenerationalHeap* const heap,
+                                                                     size_t tenurable_this_cycle) {
+  const uint effective_threshold = heap->age_census()->effective_threshold();
+  const uint next_threshold = effective_threshold > 0 ? effective_threshold - 1 : 0;
+  const size_t tenurable_next_cycle = heap->age_census()->get_tenurable_bytes(next_threshold);
+
+  // This assertion still holds even when tenurable_this_cycle is derived from in-place-promotions
+  // alone. The census cohort index is the region age plus the object's age, so every byte in a pip
+  // region is counted in the census.
   assert(tenurable_next_cycle >= tenurable_this_cycle,
          "Tenurable next cycle (" PROPERFMT ") should include tenurable this cycle (" PROPERFMT ")",
          PROPERFMTARGS(tenurable_next_cycle), PROPERFMTARGS(tenurable_this_cycle));
 
   // Don't include the bytes we expect to promote in this cycle in the next cycle
-  const size_t promo_potential = (tenurable_next_cycle - tenurable_this_cycle) * ShenandoahPromoEvacWaste;
+  const size_t remaining = tenurable_next_cycle > tenurable_this_cycle ? tenurable_next_cycle - tenurable_this_cycle : 0;
+  const size_t promo_potential = remaining * ShenandoahPromoEvacWaste;
   heap->old_generation()->set_promotion_potential(promo_potential);
   log_info(gc, ergo)("Promotion potential of aged regions with sufficient garbage: " PROPERFMT, PROPERFMTARGS(promo_potential));
   return tenurable_this_cycle * ShenandoahPromoEvacWaste;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -88,7 +88,7 @@ void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
   prepare_regions_for_promotion(in_place_promotions, heap, nullptr);
 
   // Only these in-place promotion regions will be tenured this cycle
-  const size_t tenurable_this_cycle = in_place_promotions.humongous_region_stats().usage;
+  const size_t tenurable_this_cycle = in_place_promotions.regular_region_stats().usage;
   compute_promotion_potential(heap, tenurable_this_cycle);
 
   ShenandoahTracer::report_promotion_info(heap->collection_set(), in_place_promotions);

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -79,13 +79,11 @@ void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
   auto const heap = ShenandoahGenerationalHeap::heap();
   adjust_reserves_for_abbreviated(heap);
 
-  if (heap->age_census()->get_tenurable_bytes() == 0) {
-    // Nothing at all to tenure, don't look for regions to promote in place
-    return;
-  }
-
   ShenandoahInPlacePromotionPlanner in_place_promotions(heap);
-  prepare_regions_for_promotion(in_place_promotions, heap, nullptr);
+  if (heap->age_census()->get_tenurable_bytes() != 0) {
+    prepare_regions_for_promotion(in_place_promotions, heap, nullptr);
+  }
+  in_place_promotions.complete_planning();
 
   // Only these in-place promotion regions will be tenured this cycle
   const size_t tenurable_this_cycle = in_place_promotions.regular_region_stats().usage;
@@ -139,8 +137,6 @@ size_t ShenandoahGenerationalHeuristics::prepare_regions_for_promotion(Shenandoa
       }
     }
   }
-
-  in_place_promotions.complete_planning();
 
   return candidates;
 }
@@ -355,6 +351,7 @@ size_t ShenandoahGenerationalHeuristics::select_aged_regions(ShenandoahInPlacePr
   ResourceMark rm;
   AgedRegionData* sorted_regions = NEW_RESOURCE_ARRAY(AgedRegionData, heap->num_regions());
   const size_t candidates = prepare_regions_for_promotion(in_place_promotions, heap, sorted_regions);
+  in_place_promotions.complete_planning();
 
   add_tenured_regions_to_collection_set(old_promotion_reserve, heap, candidates, sorted_regions);
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -86,7 +86,7 @@ void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
   in_place_promotions.complete_planning();
 
   // Only these in-place promotion regions will be tenured this cycle
-  const size_t tenurable_this_cycle = in_place_promotions.regular_region_stats().usage;
+  const size_t tenurable_this_cycle = in_place_promotions.live_bytes();
   compute_promotion_potential(heap, tenurable_this_cycle);
 
   ShenandoahTracer::report_promotion_info(heap->collection_set(), in_place_promotions);

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -88,7 +88,7 @@ void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
   prepare_regions_for_promotion(in_place_promotions, heap, nullptr);
 
   // Only these in-place promotion regions will be tenured this cycle
-  const size_t tenurable_this_cycle = in_place_promotions.humongous_region_stats().usage + in_place_promotions.humongous_region_stats().usage;
+  const size_t tenurable_this_cycle = in_place_promotions.humongous_region_stats().usage;
   compute_promotion_potential(heap, tenurable_this_cycle);
 
   ShenandoahTracer::report_promotion_info(heap->collection_set(), in_place_promotions);

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -91,7 +91,7 @@ void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
   const size_t tenurable_this_cycle = in_place_promotions.humongous_region_stats().usage + in_place_promotions.humongous_region_stats().usage;
   compute_promotion_potential(heap, tenurable_this_cycle);
 
-  ShenandoahTracer::report_promotion_info(heap->collection_set(), &in_place_promotions);
+  ShenandoahTracer::report_promotion_info(heap->collection_set(), in_place_promotions);
 }
 
 void ShenandoahGenerationalHeuristics::adjust_reserves_for_abbreviated(ShenandoahGenerationalHeap* heap) {
@@ -167,7 +167,7 @@ void ShenandoahGenerationalHeuristics::choose_collection_set_from_regiondata(She
     heap->shenandoah_policy()->record_mixed_cycle();
   }
 
-  ShenandoahTracer::report_promotion_info(collection_set, &in_place_promotions);
+  ShenandoahTracer::report_promotion_info(collection_set, in_place_promotions);
 }
 
 void ShenandoahGenerationalHeuristics::compute_evacuation_budgets(ShenandoahInPlacePromotionPlanner& in_place_promotions,

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -77,6 +77,57 @@ ShenandoahGenerationalHeuristics::ShenandoahGenerationalHeuristics(ShenandoahGen
         : ShenandoahAdaptiveHeuristics(generation), _generation(generation), _add_regions_to_old(0) {
 }
 
+void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
+  // There should be no regions configured for subsequent in-place-promotions carried over from the previous cycle.
+
+  auto const heap = ShenandoahGenerationalHeap::heap();
+
+  adjust_reserves_for_abbreviated(heap);
+
+  select_regions_for_in_place_promotion(heap);
+}
+
+void ShenandoahGenerationalHeuristics::adjust_reserves_for_abbreviated(ShenandoahGenerationalHeap* heap) {
+  // We are not going to evacuate because this is an abbreviated cycle.  Reset the reserves.
+  heap->young_generation()->set_evacuation_reserve(0UL);
+  heap->old_generation()->set_evacuation_reserve(0UL);
+  heap->old_generation()->set_promoted_reserve(0UL);
+}
+
+void ShenandoahGenerationalHeuristics::select_regions_for_in_place_promotion(ShenandoahGenerationalHeap* heap) {
+  assert_no_in_place_promotions();
+  ShenandoahInPlacePromotionPlanner in_place_promotions(heap);
+
+  for (size_t i = 0, num_regions = heap->num_regions(); i < num_regions; i++) {
+    ShenandoahHeapRegion* const r = heap->get_region(i);
+    if (r->is_empty() || !r->has_live() || !r->is_young()) {
+      // skip over regions that aren't young with some live data
+      continue;
+    }
+
+    if (!r->is_regular()) {
+      if (r->is_humongous_start() && heap->is_tenurable(r)) {
+        in_place_promotions.prepare(r);
+      }
+      // Nothing else to be done for humongous regions
+      continue;
+    }
+
+    if (heap->is_tenurable(r)) {
+      if (in_place_promotions.is_eligible(r)) {
+        // We prefer to promote this region in place because it has a small amount of garbage and a large usage.
+        // Note that if this region has been used recently for allocation, it will not be promoted, and it will
+        // not be selected for promotion by evacuation.
+        in_place_promotions.prepare(r);
+      }
+    }
+  }
+
+  in_place_promotions.complete_planning();
+
+  ShenandoahTracer::report_promotion_info(heap->collection_set(), &in_place_promotions);
+}
+
 void ShenandoahGenerationalHeuristics::choose_collection_set_from_regiondata(ShenandoahCollectionSet* collection_set,
                                                                              RegionData* data, size_t data_size,
                                                                              size_t free) {
@@ -99,13 +150,7 @@ void ShenandoahGenerationalHeuristics::choose_collection_set_from_regiondata(She
     heap->shenandoah_policy()->record_mixed_cycle();
   }
 
-  ShenandoahTracer::report_promotion_info(collection_set,
-                                          in_place_promotions.humongous_region_stats().count,
-                                          in_place_promotions.humongous_region_stats().garbage,
-                                          in_place_promotions.humongous_region_stats().free,
-                                          in_place_promotions.regular_region_stats().count,
-                                          in_place_promotions.regular_region_stats().garbage,
-                                          in_place_promotions.regular_region_stats().free);
+  ShenandoahTracer::report_promotion_info(collection_set, &in_place_promotions);
 }
 
 void ShenandoahGenerationalHeuristics::compute_evacuation_budgets(ShenandoahInPlacePromotionPlanner& in_place_promotions,

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -79,6 +79,11 @@ void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
   auto const heap = ShenandoahGenerationalHeap::heap();
   adjust_reserves_for_abbreviated(heap);
 
+  if (heap->age_census()->get_tenurable_bytes() == 0) {
+    // Nothing at all to tenure, don't look for regions to promote in place
+    return;
+  }
+
   ShenandoahInPlacePromotionPlanner in_place_promotions(heap);
   prepare_regions_for_promotion(in_place_promotions, heap, nullptr);
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -38,8 +38,6 @@
 #include "logging/log.hpp"
 #include "utilities/quickSort.hpp"
 
-using idx_t = ShenandoahSimpleBitMap::idx_t;
-
 static int compare_by_aged_live(AgedRegionData a, AgedRegionData b) {
   if (a._live_data < b._live_data)
     return -1;
@@ -84,7 +82,10 @@ void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
 
   adjust_reserves_for_abbreviated(heap);
 
-  select_regions_for_in_place_promotion(heap);
+  ShenandoahInPlacePromotionPlanner in_place_promotions(heap);
+  prepare_regions_for_promotion(in_place_promotions, heap, nullptr);
+  compute_promotion_potential(heap);
+  ShenandoahTracer::report_promotion_info(heap->collection_set(), &in_place_promotions);
 }
 
 void ShenandoahGenerationalHeuristics::adjust_reserves_for_abbreviated(ShenandoahGenerationalHeap* heap) {
@@ -94,10 +95,12 @@ void ShenandoahGenerationalHeuristics::adjust_reserves_for_abbreviated(Shenandoa
   heap->old_generation()->set_promoted_reserve(0UL);
 }
 
-void ShenandoahGenerationalHeuristics::select_regions_for_in_place_promotion(ShenandoahGenerationalHeap* heap) {
+size_t ShenandoahGenerationalHeuristics::prepare_regions_for_promotion(ShenandoahInPlacePromotionPlanner& in_place_promotions,
+                                                                       ShenandoahGenerationalHeap* heap,
+                                                                       AgedRegionData* sorted_regions) {
+  // There should be no regions configured for subsequent in-place-promotions carried over from the previous cycle.
   assert_no_in_place_promotions();
-  ShenandoahInPlacePromotionPlanner in_place_promotions(heap);
-
+  size_t candidates = 0;
   for (size_t i = 0, num_regions = heap->num_regions(); i < num_regions; i++) {
     ShenandoahHeapRegion* const r = heap->get_region(i);
     if (r->is_empty() || !r->has_live() || !r->is_young()) {
@@ -119,13 +122,21 @@ void ShenandoahGenerationalHeuristics::select_regions_for_in_place_promotion(She
         // Note that if this region has been used recently for allocation, it will not be promoted, and it will
         // not be selected for promotion by evacuation.
         in_place_promotions.prepare(r);
+      } else if (sorted_regions != nullptr) {
+        // Record this promotion-eligible candidate region. After sorting and selecting the best candidates below,
+        // we may still decide to exclude this promotion-eligible region from the current collection set.  If this
+        // happens, we will consider this region as part of the anticipated promotion potential for the next GC
+        // pass; see further below.
+        sorted_regions[candidates]._region = r;
+        sorted_regions[candidates]._live_data = r->get_live_data_bytes();
+        candidates++;
       }
     }
   }
 
   in_place_promotions.complete_planning();
 
-  ShenandoahTracer::report_promotion_info(heap->collection_set(), &in_place_promotions);
+  return candidates;
 }
 
 void ShenandoahGenerationalHeuristics::choose_collection_set_from_regiondata(ShenandoahCollectionSet* collection_set,
@@ -330,75 +341,35 @@ void ShenandoahGenerationalHeuristics::add_tenured_regions_to_collection_set(con
 // reserved in the young generation.
 size_t ShenandoahGenerationalHeuristics::select_aged_regions(ShenandoahInPlacePromotionPlanner& in_place_promotions,
                                                              const size_t old_promotion_reserve) {
-
-  // There should be no regions configured for subsequent in-place-promotions carried over from the previous cycle.
-  assert_no_in_place_promotions();
-
   auto const heap = ShenandoahGenerationalHeap::heap();
-
-  size_t candidates = 0;
 
   // Sort the promotion-eligible regions in order of increasing live-data-bytes so that we can first reclaim regions that require
   // less evacuation effort.  This prioritizes garbage first, expanding the allocation pool early before we reclaim regions that
-  // have more live data.
-  const idx_t num_regions = heap->num_regions();
-
+  // have more live data. This also prepares regions for in-place promotions
   ResourceMark rm;
-  AgedRegionData* sorted_regions = NEW_RESOURCE_ARRAY(AgedRegionData, num_regions);
-
-  for (idx_t i = 0; i < num_regions; i++) {
-    ShenandoahHeapRegion* const r = heap->get_region(i);
-    if (r->is_empty() || !r->has_live() || !r->is_young()) {
-      // skip over regions that aren't young with some live data
-      continue;
-    }
-
-    if (!r->is_regular()) {
-      if (r->is_humongous_start() && heap->is_tenurable(r)) {
-        in_place_promotions.prepare(r);
-      }
-      // Nothing else to be done for humongous regions
-      continue;
-    }
-
-    if (heap->is_tenurable(r)) {
-      if (in_place_promotions.is_eligible(r)) {
-        // We prefer to promote this region in place because it has a small amount of garbage and a large usage.
-        // Note that if this region has been used recently for allocation, it will not be promoted and it will
-        // not be selected for promotion by evacuation.
-        in_place_promotions.prepare(r);
-      } else {
-        // Record this promotion-eligible candidate region. After sorting and selecting the best candidates below,
-        // we may still decide to exclude this promotion-eligible region from the current collection set.  If this
-        // happens, we will consider this region as part of the anticipated promotion potential for the next GC
-        // pass; see further below.
-        sorted_regions[candidates]._region = r;
-        sorted_regions[candidates]._live_data = r->get_live_data_bytes();
-        candidates++;
-      }
-    }
-  }
-
-  in_place_promotions.complete_planning();
+  AgedRegionData* sorted_regions = NEW_RESOURCE_ARRAY(AgedRegionData, heap->num_regions());
+  const size_t candidates = prepare_regions_for_promotion(in_place_promotions, heap, sorted_regions);
 
   add_tenured_regions_to_collection_set(old_promotion_reserve, heap, candidates, sorted_regions);
 
+  const size_t max_promotions = compute_promotion_potential(heap);
+  const size_t old_consumed = MIN2(max_promotions, old_promotion_reserve);
+  return old_consumed;
+}
+
+size_t ShenandoahGenerationalHeuristics::compute_promotion_potential(ShenandoahGenerationalHeap* const heap) {
   const uint tenuring_threshold = heap->age_census()->tenuring_threshold();
   const size_t tenurable_this_cycle = heap->age_census()->get_tenurable_bytes(tenuring_threshold);
   const size_t tenurable_next_cycle = heap->age_census()->get_tenurable_bytes(tenuring_threshold - 1);
   assert(tenurable_next_cycle >= tenurable_this_cycle,
-          "Tenurable next cycle (" PROPERFMT ") should include tenurable this cycle (" PROPERFMT ")",
-          PROPERFMTARGS(tenurable_next_cycle), PROPERFMTARGS(tenurable_this_cycle));
-
-  const size_t max_promotions = tenurable_this_cycle * ShenandoahPromoEvacWaste;
-  const size_t old_consumed = MIN2(max_promotions, old_promotion_reserve);
+         "Tenurable next cycle (" PROPERFMT ") should include tenurable this cycle (" PROPERFMT ")",
+         PROPERFMTARGS(tenurable_next_cycle), PROPERFMTARGS(tenurable_this_cycle));
 
   // Don't include the bytes we expect to promote in this cycle in the next cycle
   const size_t promo_potential = (tenurable_next_cycle - tenurable_this_cycle) * ShenandoahPromoEvacWaste;
   heap->old_generation()->set_promotion_potential(promo_potential);
   log_info(gc, ergo)("Promotion potential of aged regions with sufficient garbage: " PROPERFMT, PROPERFMTARGS(promo_potential));
-
-  return old_consumed;
+  return tenurable_this_cycle * ShenandoahPromoEvacWaste;
 }
 
 // Having chosen the collection set, adjust the budgets for generational mode based on its composition.  Note

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -76,15 +76,16 @@ ShenandoahGenerationalHeuristics::ShenandoahGenerationalHeuristics(ShenandoahGen
 }
 
 void ShenandoahGenerationalHeuristics::prepare_for_abbreviated_cycle() {
-  // There should be no regions configured for subsequent in-place-promotions carried over from the previous cycle.
-
   auto const heap = ShenandoahGenerationalHeap::heap();
-
   adjust_reserves_for_abbreviated(heap);
 
   ShenandoahInPlacePromotionPlanner in_place_promotions(heap);
   prepare_regions_for_promotion(in_place_promotions, heap, nullptr);
-  compute_promotion_potential(heap);
+
+  // Only these in-place promotion regions will be tenured this cycle
+  const size_t tenurable_this_cycle = in_place_promotions.humongous_region_stats().usage + in_place_promotions.humongous_region_stats().usage;
+  compute_promotion_potential(heap, tenurable_this_cycle);
+
   ShenandoahTracer::report_promotion_info(heap->collection_set(), &in_place_promotions);
 }
 
@@ -352,14 +353,17 @@ size_t ShenandoahGenerationalHeuristics::select_aged_regions(ShenandoahInPlacePr
 
   add_tenured_regions_to_collection_set(old_promotion_reserve, heap, candidates, sorted_regions);
 
-  const size_t max_promotions = compute_promotion_potential(heap);
+  // Act as though everything that can be tenured, will be tenured. This overestimates how much will be promoted,
+  // but has the effect of tending to keep the old generation smaller because it believes less will be tenured
+  // on the next cycle.
+  const size_t tenurable_this_cycle = heap->age_census()->get_tenurable_bytes();
+  const size_t max_promotions = compute_promotion_potential(heap, tenurable_this_cycle);
   const size_t old_consumed = MIN2(max_promotions, old_promotion_reserve);
   return old_consumed;
 }
 
-size_t ShenandoahGenerationalHeuristics::compute_promotion_potential(ShenandoahGenerationalHeap* const heap) {
+size_t ShenandoahGenerationalHeuristics::compute_promotion_potential(ShenandoahGenerationalHeap* const heap, size_t tenurable_this_cycle) {
   const uint tenuring_threshold = heap->age_census()->tenuring_threshold();
-  const size_t tenurable_this_cycle = heap->age_census()->get_tenurable_bytes(tenuring_threshold);
   const size_t tenurable_next_cycle = heap->age_census()->get_tenurable_bytes(tenuring_threshold - 1);
   assert(tenurable_next_cycle >= tenurable_this_cycle,
          "Tenurable next cycle (" PROPERFMT ") should include tenurable this cycle (" PROPERFMT ")",

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.hpp
@@ -33,6 +33,7 @@ class ShenandoahGeneration;
 class ShenandoahHeap;
 class ShenandoahCollectionSet;
 class RegionData;
+class ShenandoahGenerationalHeap;
 
 typedef struct {
   ShenandoahHeapRegion* _region;
@@ -58,12 +59,21 @@ public:
   void record_cycle_end() override;
 
 protected:
+  // Select regions for in place promotion and zero evacuation reserves
+  void prepare_for_abbreviated_cycle() override;
+
   // Wraps budget computation, subclass region selection, budget adjustment, and tracing.
   void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set,
                                              RegionData* data, size_t data_size,
                                              size_t free) override;
 
 private:
+  // When we decide to do an abbreviated cycle, withdraw reserves so memory can be made available to mutators.
+  void adjust_reserves_for_abbreviated(ShenandoahGenerationalHeap* heap);
+
+  // Select regions for in place promotion during an abbreviated cycle
+  void select_regions_for_in_place_promotion(ShenandoahGenerationalHeap* heap);
+
   // Compute evacuation budgets prior to choosing collection set.
   void compute_evacuation_budgets(ShenandoahInPlacePromotionPlanner& in_place_promotions, ShenandoahHeap* const heap);
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.hpp
@@ -104,7 +104,7 @@ private:
                                              size_t candidates, AgedRegionData* sorted_regions);
 
   // Updates the anticipated promotions for the next cycle and returns the maximum promotions for the current cycle
-  size_t compute_promotion_potential(ShenandoahGenerationalHeap* heap);
+  size_t compute_promotion_potential(ShenandoahGenerationalHeap* heap, size_t tenurable_this_cycle);
 
   // Adjust evacuation budgets after choosing collection set.  On entry, the instance variable _regions_to_xfer
   // represents regions to be transferred to old based on decisions made in top_off_collection_set()

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.hpp
@@ -90,11 +90,10 @@ private:
   // being those of at least tenuring_threshold age that have lower garbage
   // density.
   //
-  // Updates promotion_potential and pad_for_promote_in_place fields
-  // of the heap. Returns bytes of live object memory in the preselected
-  // regions, which are marked in the preselected_regions() indicator
-  // array of the heap's collection set, which should be initialized
-  // to false.
+  // Updates promotion_potential field of the heap. Returns bytes of live object
+  // memory in the preselected regions, which are marked in the
+  // preselected_regions() indicator array of the heap's collection set, which
+  // should be initialized to false.
   size_t select_aged_regions(ShenandoahInPlacePromotionPlanner& in_place_promotions, const size_t old_promotion_reserve);
 
   // Select regions for inclusion in the collection set that are tenured, but do

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.hpp
@@ -71,8 +71,11 @@ private:
   // When we decide to do an abbreviated cycle, withdraw reserves so memory can be made available to mutators.
   void adjust_reserves_for_abbreviated(ShenandoahGenerationalHeap* heap);
 
-  // Select regions for in place promotion during an abbreviated cycle
-  void select_regions_for_in_place_promotion(ShenandoahGenerationalHeap* heap);
+  // Select regions for in place promotion and optionally record tenurable regions that are not eligible
+  // for in-place promotion in the given sorted_regions array for possible inclusion in the collection set.
+  size_t prepare_regions_for_promotion(ShenandoahInPlacePromotionPlanner& in_place_promotions,
+                                       ShenandoahGenerationalHeap* heap,
+                                       AgedRegionData* sorted_regions);
 
   // Compute evacuation budgets prior to choosing collection set.
   void compute_evacuation_budgets(ShenandoahInPlacePromotionPlanner& in_place_promotions, ShenandoahHeap* const heap);
@@ -99,6 +102,9 @@ private:
   void add_tenured_regions_to_collection_set(size_t old_promotion_reserve,
                                              ShenandoahGenerationalHeap *const heap,
                                              size_t candidates, AgedRegionData* sorted_regions);
+
+  // Updates the anticipated promotions for the next cycle and returns the maximum promotions for the current cycle
+  size_t compute_promotion_potential(ShenandoahGenerationalHeap* heap);
 
   // Adjust evacuation budgets after choosing collection set.  On entry, the instance variable _regions_to_xfer
   // represents regions to be transferred to old based on decisions made in top_off_collection_set()

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -152,22 +152,16 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   if (immediate_percent <= ShenandoahImmediateThreshold) {
     choose_collection_set_from_regiondata(collection_set, candidates, cand_idx, immediate_garbage + free);
-  } else if (heap->mode()->is_generational()) {
-    adjust_reserves_for_abbreviated(heap);
+  } else {
+    prepare_for_abbreviated_cycle();
   }
+
   collection_set->summarize(total_garbage, immediate_garbage, immediate_regions);
   ShenandoahTracer::report_evacuation_info(collection_set, free_regions, immediate_regions, immediate_garbage);
 }
 
 void ShenandoahHeuristics::start_idle_span() {
   // do nothing
-}
-
-void ShenandoahHeuristics::adjust_reserves_for_abbreviated(ShenandoahHeap* heap) {
-  // We are not going to evacuate because this is an abbreviated cycle.  Reset the reserves.
-  heap->young_generation()->set_evacuation_reserve(0UL);
-  heap->old_generation()->set_evacuation_reserve(0UL);
-  heap->old_generation()->set_promoted_reserve(0UL);
 }
 
 void ShenandoahHeuristics::record_degenerated_cycle_start(bool out_of_cycle) {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -83,9 +83,6 @@ private:
   double _most_recent_trigger_evaluation_time;
   double _most_recent_planned_sleep_interval;
 
-  // When we decide to do an abbreviated cycle, withdraw reserves so memory can be made available to mutators.
-  void adjust_reserves_for_abbreviated(ShenandoahHeap* heap);
-
 protected:
   static constexpr uint Moving_Average_Samples = 10; // Number of samples to store in moving averages
 
@@ -195,6 +192,9 @@ protected:
   virtual void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set,
                                                      RegionData* data, size_t data_size,
                                                      size_t free) = 0;
+
+  // Called when immediate garbage threshold is reached.
+  virtual void prepare_for_abbreviated_cycle() {}
 
   virtual void adjust_penalty(intx step);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAgeCensus.hpp
@@ -189,6 +189,13 @@ class ShenandoahAgeCensus: public CHeapObj<mtGC> {
   // Visible for testing. Use is_tenurable for consistent tenuring comparisons.
   uint tenuring_threshold() const { return _tenuring_threshold[_epoch]; }
 
+  // Returns zero when always_tenure is true (which is only true when the gc
+  // is triggered by WB.fullGC()). Note that zero itself is the floor, so do
+  // not subtract from it to get the younger cohort.
+  uint effective_threshold() const {
+    return is_always_tenure() ? 0 : tenuring_threshold();
+  }
+
   // Return true if this age is at or above the tenuring threshold, or if always tenure is enabled.
   bool is_tenurable(uint age) const {
     return age >= tenuring_threshold() || _always_tenure;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -514,6 +514,7 @@ public:
   }
 
   void reset_age() {
+    assert(get_top_before_promote() == nullptr, "Cannot reset age on region (%zu) schedule for promotion", index());
     CENSUS_NOISE(_youth += _age;)
     _age = 0;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -514,7 +514,7 @@ public:
   }
 
   void reset_age() {
-    assert(get_top_before_promote() == nullptr, "Cannot reset age on region (%zu) schedule for promotion", index());
+    assert(get_top_before_promote() == nullptr, "Cannot reset age on region (%zu) scheduled for promotion", index());
     CENSUS_NOISE(_youth += _age;)
     _age = 0;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
@@ -133,37 +133,32 @@ void ShenandoahInPlacePromotionPlanner::complete_planning() const {
 }
 
 void ShenandoahInPlacePromoter::maybe_promote_region(ShenandoahHeapRegion* r) const {
-  if (r->is_young() && r->is_active() && _heap->is_tenurable(r)) {
-    if (r->is_humongous_start()) {
-      // We promote humongous_start regions along with their affiliated continuations during evacuation rather than
-      // doing this work during a safepoint.  We cannot put humongous regions into the collection set because that
-      // triggers the load-reference barrier (LRB) to copy on reference fetch.
-      //
-      // Aged humongous continuation regions are handled with their start region.  If an aged regular region has
-      // more garbage than ShenandoahOldGarbageThreshold, we'll promote by evacuation.  If there is room for evacuation
-      // in this cycle, the region will be in the collection set.  If there is no room, the region will be promoted
-      // by evacuation in some future GC cycle.
+  if (r->is_regular_or_regular_pinned() && (r->get_top_before_promote() != nullptr)) {
+    // This region was scheduled for promotion. The promotion must be completed.
+    // The 'always_tenure' override flag set by WB.fullGC() is not carried over
+    // into the degenerated cycle so we cannot rely on is_tenurable again. We checked
+    // it when we made the plan for this region, that plan is authoritative.
+    assert(r->is_young() && r->is_active(), "Region scheduled for promotion must still be young and active");
+    promote(r);
+    return;
+  }
 
-      // We do not promote primitive arrays because there's no performance penalty keeping them in young.  When/if they
-      // become garbage, reclaiming the memory from young is much quicker and more efficient than reclaiming them from old.
-      oop obj = cast_to_oop(r->bottom());
-      if (!obj->is_typeArray()) {
-        promote_humongous(r);
-      }
-    } else if (r->is_regular_or_regular_pinned() && (r->get_top_before_promote() != nullptr)) {
-      // Likewise, we cannot put promote-in-place regions into the collection set because that would also trigger
-      // the LRB to copy on reference fetch.
-      //
-      // If an aged regular region has received allocations during the current cycle, we do not promote because the
-      // newly allocated objects do not have appropriate age; this region's age will be reset to zero at end of cycle.
-      promote(r);
+  if (r->is_young() && r->is_active() && r->is_humongous_start() && _heap->is_tenurable(r)) {
+    // We promote humongous_start regions along with their affiliated continuations during evacuation rather than
+    // doing this work during a safepoint.  We cannot put humongous regions into the collection set because that
+    // triggers the load-reference barrier (LRB) to copy on reference fetch.
+    //
+    // Aged humongous continuation regions are handled with their start region.  If an aged regular region has
+    // more garbage than ShenandoahOldGarbageThreshold, we'll promote by evacuation.  If there is room for evacuation
+    // in this cycle, the region will be in the collection set.  If there is no room, the region will be promoted
+    // by evacuation in some future GC cycle.
+
+    // We do not promote primitive arrays because there's no performance penalty keeping them in young.  When/if they
+    // become garbage, reclaiming the memory from young is much quicker and more efficient than reclaiming them from old.
+    oop obj = cast_to_oop(r->bottom());
+    if (!obj->is_typeArray()) {
+      promote_humongous(r);
     }
-  } else if (r->get_top_before_promote() != nullptr) {
-    LogTarget(Warning, gc) lt;
-    LogStream ls(lt);
-    ls.print_cr("Not promoting region already scheduled for it");
-    r->print_on(&ls);
-    fatal("Did not promote region: %zu as expected", r->index());
   }
 }
 
@@ -185,7 +180,6 @@ void ShenandoahInPlacePromoter::promote(ShenandoahHeapRegion* region) const {
            "Region %zu has too much garbage for promotion", region->index());
     assert(region->is_young(), "Only young regions can be promoted");
     assert(region->is_regular_or_regular_pinned(), "Use different service to promote humongous regions");
-    assert(_heap->is_tenurable(region), "Only promote regions that are sufficiently aged");
     assert(region->get_top_before_promote() == tams, "Region %zu has been used for allocations before promotion", region->index());
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
@@ -117,7 +117,6 @@ void ShenandoahInPlacePromotionPlanner::prepare(ShenandoahHeapRegion* r) {
 }
 
 void ShenandoahInPlacePromotionPlanner::complete_planning() const {
-  _heap->old_generation()->set_pad_for_promote_in_place(_pip_padding_bytes);
   _heap->old_generation()->set_expected_humongous_region_promotions(_pip_humongous_stats.count);
   _heap->old_generation()->set_expected_regular_region_promotions(_pip_regular_stats.count);
   log_info(gc, ergo)("Planning to promote in place %zu humongous regions and %zu"

--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
@@ -39,7 +39,6 @@ ShenandoahInPlacePromotionPlanner::ShenandoahInPlacePromotionPlanner(const Shena
   , _marking_context(_heap->marking_context())
   , _mutator_regions(_free_set)
   , _collector_regions(_free_set)
-  , _pip_padding_bytes(0)
 {
 }
 
@@ -105,7 +104,6 @@ void ShenandoahInPlacePromotionPlanner::prepare(ShenandoahHeapRegion* r) {
       remnant_bytes = 0;
     }
 
-    _pip_padding_bytes += remnant_bytes;
     _free_set->prepare_to_promote_in_place(i, remnant_bytes);
   } else {
     // Since the remnant is so small that this region has already been retired, we don't have to worry about any

--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
@@ -163,6 +163,7 @@ void ShenandoahInPlacePromoter::maybe_promote_region(ShenandoahHeapRegion* r) co
     LogStream ls(lt);
     ls.print_cr("Not promoting region already scheduled for it");
     r->print_on(&ls);
+    fatal("Did not promote region: %zu as expected", r->index());
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
@@ -161,6 +161,11 @@ void ShenandoahInPlacePromoter::maybe_promote_region(ShenandoahHeapRegion* r) co
       // newly allocated objects do not have appropriate age; this region's age will be reset to zero at end of cycle.
       promote(r);
     }
+  } else if (r->get_top_before_promote() != nullptr) {
+    LogTarget(Warning, gc) lt;
+    LogStream ls(lt);
+    ls.print_cr("Not promoting region already scheduled for it");
+    r->print_on(&ls);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.hpp
@@ -84,7 +84,7 @@ class ShenandoahInPlacePromotionPlanner {
     RegionPromotionStats() : count(0), usage(0), free(0), garbage(0) {}
     void update(ShenandoahHeapRegion* region) {
       count++;
-      usage += region->used();
+      usage += region->get_live_data_bytes();
       free += region->free();
       garbage += region->garbage();
     }
@@ -121,6 +121,11 @@ public:
   const RegionPromotionStats& humongous_region_stats() const { return _pip_humongous_stats; }
 
   size_t old_garbage_threshold() const { return _old_garbage_threshold; }
+
+  // Return the total amount of live bytes that will be promoted in place
+  size_t live_bytes() const {
+    return regular_region_stats().usage + humongous_region_stats().usage;
+  }
 };
 
 // For regions that have been selected and prepared for promotion, this class

--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.hpp
@@ -101,9 +101,6 @@ class ShenandoahInPlacePromotionPlanner {
   RegionPromotions _mutator_regions;
   RegionPromotions _collector_regions;
 
-  // Tracks the padding of space above top in regions eligible for promotion in place
-  size_t _pip_padding_bytes;
-
   // Tracks stats for in place promotions
   RegionPromotionStats _pip_regular_stats;
   RegionPromotionStats _pip_humongous_stats;

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -109,7 +109,6 @@ ShenandoahOldGeneration::ShenandoahOldGeneration(uint max_queues)
     _promoted_reserve(0),
     _promoted_expended(0),
     _promotion_potential(0),
-    _pad_for_promote_in_place(0),
     _promotable_humongous_regions(0),
     _promotable_regular_regions(0),
     _is_parsable(true),

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -74,11 +74,6 @@ private:
   // It is also used when computing the optimum size for the old generation.
   size_t _promotion_potential;
 
-  // When a region is selected to be promoted in place, the remaining free memory is filled
-  // in to prevent additional allocations (preventing premature promotion of newly allocated
-  // objects). This field records the total amount of padding used for such regions.
-  size_t _pad_for_promote_in_place;
-
   // During construction of the collection set, we keep track of regions that are eligible
   // for promotion in place. These fields track the count of those humongous and regular regions.
   // This data is used to force the evacuation phase even when the collection set is otherwise
@@ -152,10 +147,6 @@ public:
   // See description in field declaration
   void set_promotion_potential(size_t val) { _promotion_potential = val; }
   size_t get_promotion_potential() const { return _promotion_potential; }
-
-  // See description in field declaration
-  void set_pad_for_promote_in_place(size_t pad) { _pad_for_promote_in_place = pad; }
-  size_t get_pad_for_promote_in_place() const { return _pad_for_promote_in_place; }
 
   // See description in field declaration
   void set_expected_humongous_region_promotions(size_t region_count) { _promotable_humongous_regions = region_count; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahTrace.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTrace.cpp
@@ -44,19 +44,19 @@ void ShenandoahTracer::report_evacuation_info(const ShenandoahCollectionSet* cse
   }
 }
 
-void ShenandoahTracer::report_promotion_info(const ShenandoahCollectionSet* cset, const ShenandoahInPlacePromotionPlanner* planner) {
+void ShenandoahTracer::report_promotion_info(const ShenandoahCollectionSet* cset, const ShenandoahInPlacePromotionPlanner& planner) {
   EventShenandoahPromotionInformation e;
   if (e.should_commit()) {
     e.set_gcId(GCId::current());
     e.set_collectedOld(cset->get_live_bytes_in_old_regions());
     e.set_collectedPromoted(cset->get_live_bytes_in_tenurable_regions());
     e.set_collectedYoung(cset->get_live_bytes_in_untenurable_regions());
-    e.set_regionsPromotedHumongous(planner->humongous_region_stats().count);
-    e.set_humongousPromotedGarbage(planner->humongous_region_stats().garbage);
-    e.set_humongousPromotedFree(planner->humongous_region_stats().free);
-    e.set_regionsPromotedRegular(planner->regular_region_stats().count);
-    e.set_regularPromotedGarbage(planner->regular_region_stats().garbage);
-    e.set_regularPromotedFree(planner->regular_region_stats().free);
+    e.set_regionsPromotedHumongous(planner.humongous_region_stats().count);
+    e.set_humongousPromotedGarbage(planner.humongous_region_stats().garbage);
+    e.set_humongousPromotedFree(planner.humongous_region_stats().free);
+    e.set_regionsPromotedRegular(planner.regular_region_stats().count);
+    e.set_regularPromotedGarbage(planner.regular_region_stats().garbage);
+    e.set_regularPromotedFree(planner.regular_region_stats().free);
 
     e.commit();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahTrace.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTrace.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "gc/shenandoah/shenandoahCollectionSet.inline.hpp"
+#include "gc/shenandoah/shenandoahInPlacePromoter.hpp"
 #include "gc/shenandoah/shenandoahTrace.hpp"
 #include "jfr/jfrEvents.hpp"
 
@@ -43,22 +44,19 @@ void ShenandoahTracer::report_evacuation_info(const ShenandoahCollectionSet* cse
   }
 }
 
-void ShenandoahTracer::report_promotion_info(const ShenandoahCollectionSet* cset,
-    size_t regions_promoted_humongous, size_t humongous_promoted_garbage, size_t humongous_promoted_free,
-    size_t regions_promoted_regular, size_t regular_promoted_garbage, size_t regular_promoted_free) {
-
+void ShenandoahTracer::report_promotion_info(const ShenandoahCollectionSet* cset, const ShenandoahInPlacePromotionPlanner* planner) {
   EventShenandoahPromotionInformation e;
   if (e.should_commit()) {
     e.set_gcId(GCId::current());
     e.set_collectedOld(cset->get_live_bytes_in_old_regions());
     e.set_collectedPromoted(cset->get_live_bytes_in_tenurable_regions());
     e.set_collectedYoung(cset->get_live_bytes_in_untenurable_regions());
-    e.set_regionsPromotedHumongous(regions_promoted_humongous);
-    e.set_humongousPromotedGarbage(humongous_promoted_garbage);
-    e.set_humongousPromotedFree(humongous_promoted_free);
-    e.set_regionsPromotedRegular(regions_promoted_regular);
-    e.set_regularPromotedGarbage(regular_promoted_garbage);
-    e.set_regularPromotedFree(regular_promoted_free);
+    e.set_regionsPromotedHumongous(planner->humongous_region_stats().count);
+    e.set_humongousPromotedGarbage(planner->humongous_region_stats().garbage);
+    e.set_humongousPromotedFree(planner->humongous_region_stats().free);
+    e.set_regionsPromotedRegular(planner->regular_region_stats().count);
+    e.set_regularPromotedGarbage(planner->regular_region_stats().garbage);
+    e.set_regularPromotedFree(planner->regular_region_stats().free);
 
     e.commit();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahTrace.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTrace.hpp
@@ -29,6 +29,7 @@
 #include "memory/allocation.hpp"
 
 class ShenandoahCollectionSet;
+class ShenandoahInPlacePromotionPlanner;
 
 class ShenandoahTracer : public GCTracer, public CHeapObj<mtGC> {
 public:
@@ -39,9 +40,7 @@ public:
     size_t free_regions, size_t regions_immediate, size_t immediate_size);
 
   // Sends a JFR event summarizing in-place promotion activity (generational mode only)
-  static void report_promotion_info(const ShenandoahCollectionSet* cset,
-    size_t regions_promoted_humongous, size_t humongous_promoted_garbage, size_t humongous_promoted_free,
-    size_t regions_promoted_regular, size_t regular_promoted_garbage, size_t regular_promoted_free);
+  static void report_promotion_info(const ShenandoahCollectionSet* cset, const ShenandoahInPlacePromotionPlanner* planner);
 };
 
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahTrace.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTrace.hpp
@@ -40,7 +40,7 @@ public:
     size_t free_regions, size_t regions_immediate, size_t immediate_size);
 
   // Sends a JFR event summarizing in-place promotion activity (generational mode only)
-  static void report_promotion_info(const ShenandoahCollectionSet* cset, const ShenandoahInPlacePromotionPlanner* planner);
+  static void report_promotion_info(const ShenandoahCollectionSet* cset, const ShenandoahInPlacePromotionPlanner& planner);
 };
 
 #endif

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -24,15 +24,20 @@
 
 package gc.shenandoah.generational;
 
-import jdk.test.whitebox.WhiteBox;
-import java.util.concurrent.atomic.*;
-import javax.management.*;
-import java.lang.management.*;
-import javax.management.openmbean.*;
-
-import jdk.test.lib.Utils;
-
 import com.sun.management.GarbageCollectionNotificationInfo;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.TimeUnit;
+
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+
+import jdk.test.whitebox.WhiteBox;
+
 
 /*
  * @test id=generational
@@ -86,6 +91,11 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
         return n.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION);
     }
 
+    private static boolean isIllegalPause(GarbageCollectionNotificationInfo info) {
+      return info.getGcName().equals("Shenandoah Pauses")
+          && (info.getGcAction().contains("Update Refs") || info.getGcAction().contains("Degen"));
+    }
+
     private static void subscribeToCollectorNotifications(NotificationListener listener) {
         for (GarbageCollectorMXBean b : ManagementFactory.getGarbageCollectorMXBeans()) {
             ((NotificationEmitter) b).addNotificationListener(listener, null, null);
@@ -112,22 +122,24 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
         regular = new Object[REGULAR_REFS];
 
         // Listen for events to detect if a non-abbreviated cycle runs
-        final AtomicLong updateReferencePauses = new AtomicLong();
-        final AtomicLong cycleNotifications   = new AtomicLong();
+        final GarbageCollectorMXBean cycles = cycleBean();
+        final AtomicLong illegalPauses = new AtomicLong();
+        final AtomicLong maxCycleId = new AtomicLong();
         NotificationListener listener = (Notification n, Object o) -> {
             if (isCollectorNotification(n)) {
                 GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) n.getUserData());
-                if (info.getGcName().equals("Shenandoah Pauses") && info.getGcAction().contains("Update Refs")) {
-                    updateReferencePauses.incrementAndGet();
+                if (isIllegalPause(info)) {
+                    illegalPauses.incrementAndGet();
                 } else if (info.getGcName().equals("Shenandoah Cycles")) {
-                    cycleNotifications.incrementAndGet();
+                    long gcId = info.getGcInfo().getId();
+                    if (gcId > maxCycleId.get()) {
+                        maxCycleId.set(gcId);
+                    }
                 }
             }
         };
 
         subscribeToCollectorNotifications(listener);
-
-        GarbageCollectorMXBean cycles = cycleBean();
 
         if (WB.isObjectInOldGen(humongous)) {
             throw new IllegalStateException("Expected young humongous array");
@@ -153,9 +165,9 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
 
         // Flush gc notification events
         long targetCycles = cycles.getCollectionCount();
-        long deadlineMillis = System.currentTimeMillis() + 30_000;
-        while (cycleNotifications.get() < targetCycles) {
-            if (System.currentTimeMillis() > deadlineMillis) {
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        while (maxCycleId.get() < targetCycles) {
+            if (System.nanoTime() > deadlineNanos) {
                 throw new RuntimeException("Timed out flushing GC notifications: delivered "
                                            + cycleNotifications.get() + " of "
                                            + targetCycles + " cycle notifications");
@@ -165,9 +177,8 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
 
         unsubscribeToCollectorNotifications(listener);
 
-        if (updateReferencePauses.get() != 0) {
-            throw new RuntimeException(updateReferencePauses.get()
-                                       + " non-abbreviated cycles happened");
+        if (illegalPauses.get() != 0) {
+            throw new RuntimeException(illegalPauses.get() + " non-abbreviated cycles happened");
         }
 
         if (!WB.isObjectInOldGen(humongous)) {

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -169,7 +169,7 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
         while (maxCycleId.get() < targetCycles) {
             if (System.nanoTime() > deadlineNanos) {
                 throw new RuntimeException("Timed out flushing GC notifications: delivered "
-                                           + cycleNotifications.get() + " of "
+                                           + maxCycleId.get() + " of "
                                            + targetCycles + " cycle notifications");
             }
             Thread.sleep(10);

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -31,7 +31,7 @@ import jdk.test.whitebox.WhiteBox;
  * @requires vm.gc.Shenandoah
  * @summary Aged regions must be promoted in place during an abbreviated cycle
  *          (one that skips the evacuation and update-refs phases).
- * @bug 8387539
+ * @bug 8390310
  * @library /testlibrary /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -89,8 +89,8 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
             garbage = new byte[GARBAGE_BYTES];
             garbage = null;
 
-            // Runs a concurrent young cycle and blocks until it completes.
-            WB.youngGC();
+            // Runs a concurrent global cycle and blocks until it completes.
+            System.gc();
 
             if (WB.isObjectInOldGen(humongous) && WB.isObjectInOldGen(regular)) {
                 System.out.println(

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package gc.shenandoah.generational;
+
+import jdk.test.whitebox.WhiteBox;
+
+/*
+ * @test id=generational
+ * @requires vm.gc.Shenandoah
+ * @summary Aged regions must be promoted in place during an abbreviated cycle
+ *          (one that skips the evacuation and update-refs phases).
+ * @bug 8387539
+ * @library /testlibrary /test/lib /
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:.
+ *      -Xms512m -Xmx512m
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *      -XX:ShenandoahRegionSize=1m
+ *      -XX:ShenandoahImmediateThreshold=0
+ *      -XX:ShenandoahGenerationalMinTenuringAge=1
+ *      -XX:ShenandoahGenerationalMaxTenuringAge=1
+ *      gc.shenandoah.generational.TestPromoteInPlaceDuringAbbreviatedCycle
+ */
+public class TestPromoteInPlaceDuringAbbreviatedCycle {
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+    // Make a humongous array (with 1MB regions, this will be humongous with and with out compressed oops).
+    private static final int HUMONGOUS_REFS = 512 * 1024;
+
+    // Used to create pure garbage regions to satisfy immediate garbage threshold
+    private static final int GARBAGE_BYTES = 2 * 1024 * 1024;
+
+    // Test will fail if our humongous object isn't promoted in this many cycles
+    private static final int MAX_CYCLES = 5;
+
+    // Strong reference so the array under test stays live and ages in young.
+    private static Object[] humongous;
+
+    // Strong reference used to publish, then drop, the per-cycle garbage.
+    private static Object garbage;
+
+    public static void main(String[] args) throws Exception {
+        humongous = new Object[HUMONGOUS_REFS];
+
+        if (WB.isObjectInOldGen(humongous)) {
+            throw new IllegalStateException(
+                    "Precondition failed: the humongous array should start in the young generation");
+        }
+
+        for (int cycle = 1; cycle <= MAX_CYCLES; cycle++) {
+            // Produce one whole dead region so the upcoming cycle is abbreviated.
+            garbage = new byte[GARBAGE_BYTES];
+            garbage = null;
+
+            // Runs a concurrent (global) cycle and blocks until it completes.
+            WB.youngGC();
+
+            if (WB.isObjectInOldGen(humongous)) {
+                System.out.println("Humongous array promoted in place during an abbreviated cycle after "
+                        + cycle + " cycle(s)");
+                return;
+            }
+        }
+
+        throw new RuntimeException("Humongous array was never promoted in place during an abbreviated cycle after "
+                + MAX_CYCLES + " cycles; in-place promotion is not happening on the abbreviated path");
+    }
+}
+

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -28,19 +28,19 @@ import jdk.test.whitebox.WhiteBox;
 
 /*
  * @test id=generational
+ * @bug 8390310
  * @requires vm.gc.Shenandoah
  * @summary Aged regions must be promoted in place during an abbreviated cycle
  *          (one that skips the evacuation and update-refs phases).
- * @bug 8390310
  * @library /testlibrary /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
  *      -Xms512m -Xmx512m
- *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *      -XX:ShenandoahGenerationalMinPIPUsage=1 -XX:ShenandoahOldGarbageThreshold=100
  *      -XX:ShenandoahRegionSize=1m
  *      -XX:ShenandoahImmediateThreshold=0
  *      -XX:ShenandoahGenerationalMinTenuringAge=1
@@ -51,8 +51,11 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
 
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
 
-    // Make a humongous array (with 1MB regions, this will be humongous with and with out compressed oops).
+    // Make a humongous array (with 1MB regions, this will be humongous with and without compressed oops).
     private static final int HUMONGOUS_REFS = 512 * 1024;
+
+    // Also make a not humongous array to test regular region promotion path
+    private static final int REGULAR_REFS = 256;
 
     // Used to create pure garbage regions to satisfy immediate garbage threshold
     private static final int GARBAGE_BYTES = 2 * 1024 * 1024;
@@ -60,16 +63,18 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
     // Test will fail if our humongous object isn't promoted in this many cycles
     private static final int MAX_CYCLES = 5;
 
-    // Strong reference so the array under test stays live and ages in young.
+    // Keep references so the arrays under test stay live and age in young.
     private static Object[] humongous;
+    private static Object[] regular;
 
-    // Strong reference used to publish, then drop, the per-cycle garbage.
+    // Reference used to publish, then drop, the per-cycle garbage (to keep local var from being eliminated)
     private static Object garbage;
 
     public static void main(String[] args) throws Exception {
         humongous = new Object[HUMONGOUS_REFS];
+        regular = new Object[REGULAR_REFS];
 
-        if (WB.isObjectInOldGen(humongous)) {
+        if (WB.isObjectInOldGen(humongous) || WB.isObjectInOldGen(regular)) {
             throw new IllegalStateException(
                     "Precondition failed: the humongous array should start in the young generation");
         }
@@ -79,18 +84,18 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
             garbage = new byte[GARBAGE_BYTES];
             garbage = null;
 
-            // Runs a concurrent (global) cycle and blocks until it completes.
+            // Runs a concurrent young cycle and blocks until it completes.
             WB.youngGC();
 
-            if (WB.isObjectInOldGen(humongous)) {
-                System.out.println("Humongous array promoted in place during an abbreviated cycle after "
-                        + cycle + " cycle(s)");
+            if (WB.isObjectInOldGen(humongous) && WB.isObjectInOldGen(regular)) {
+                System.out.println("Humongous array and regular object were promoted in place during"
+                                   + "an abbreviated cycle after " + cycle + " cycle(s)");
                 return;
             }
         }
 
-        throw new RuntimeException("Humongous array was never promoted in place during an abbreviated cycle after "
-                + MAX_CYCLES + " cycles; in-place promotion is not happening on the abbreviated path");
+        throw new RuntimeException("Humongous array or regular object was never promoted in place during "
+                                  + "an abbreviated cycle after " + MAX_CYCLES + " cycles; in-place promotion "
+                                  + "is not happening on the abbreviated path");
     }
 }
-

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -59,8 +59,33 @@ import jdk.test.whitebox.WhiteBox;
  *      -XX:ShenandoahImmediateThreshold=0
  *      -XX:ShenandoahGenerationalMinTenuringAge=1
  *      -XX:ShenandoahGenerationalMaxTenuringAge=1
+ *      -XX:-DisableExplicitGC -XX:+ExplicitGCInvokesConcurrent
  *      gc.shenandoah.generational.TestPromoteInPlaceDuringAbbreviatedCycle
  */
+
+ /*
+  * @test id=generational-always-tenure
+  * @bug 8390310
+  * @requires vm.gc.Shenandoah
+  * @summary Tests that promotion potential is correct when the always tenure
+  *          override is in effect (set by WB.fullGC())
+  * @library /testlibrary /test/lib /
+  * @build jdk.test.whitebox.WhiteBox
+  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+  * @run main/othervm -Xbootclasspath/a:.
+  *      -Xms512m -Xmx512m
+  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+  *      -XX:+UnlockExperimentalVMOptions
+  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+  *      -XX:ShenandoahGenerationalMinPIPUsage=1
+  *      -XX:ShenandoahOldGarbageThreshold=100
+  *      -XX:ShenandoahRegionSize=1m
+  *      -XX:ShenandoahImmediateThreshold=0
+  *      -XX:ShenandoahGenerationalMinTenuringAge=2
+  *      -XX:ShenandoahGenerationalMaxTenuringAge=2
+  *      -XX:-DisableExplicitGC -XX:+ExplicitGCInvokesConcurrent
+  *      gc.shenandoah.generational.TestPromoteInPlaceDuringAbbreviatedCycle always-tenure
+  */
 public class TestPromoteInPlaceDuringAbbreviatedCycle {
 
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
@@ -93,7 +118,9 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
 
     private static boolean isIllegalPause(GarbageCollectionNotificationInfo info) {
       return info.getGcName().equals("Shenandoah Pauses")
-          && (info.getGcAction().contains("Update Refs") || info.getGcAction().contains("Degen"));
+          &&  (info.getGcAction().contains("Update Refs")
+            || info.getGcAction().contains("Degen")
+            || info.getGcAction().contains("Full"));
     }
 
     private static void subscribeToCollectorNotifications(NotificationListener listener) {
@@ -118,6 +145,7 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
     }
 
     public static void main(String[] args) throws Exception {
+        boolean alwaysTenure = args.length > 0 && "always-tenure".equals(args[0]);
         humongous = new Object[HUMONGOUS_REFS];
         regular = new Object[REGULAR_REFS];
 
@@ -154,8 +182,13 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
             garbage = new byte[GARBAGE_BYTES];
             garbage = null;
 
-            // Runs a concurrent global cycle and blocks until it completes.
-            System.gc();
+            if (alwaysTenure) {
+                // This also runs a global cycle, but with an effective tenuring threshold of zero
+                WB.fullGC();
+            } else {
+                // Runs a concurrent global cycle and blocks until it completes.
+                System.gc();
+            }
 
             // Both objects are in old, exit the test loop
             if (WB.isObjectInOldGen(humongous) && WB.isObjectInOldGen(regular)) {

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -40,7 +40,8 @@ import jdk.test.whitebox.WhiteBox;
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
- *      -XX:ShenandoahGenerationalMinPIPUsage=1 -XX:ShenandoahOldGarbageThreshold=100
+ *      -XX:ShenandoahGenerationalMinPIPUsage=1
+ *      -XX:ShenandoahOldGarbageThreshold=100
  *      -XX:ShenandoahRegionSize=1m
  *      -XX:ShenandoahImmediateThreshold=0
  *      -XX:ShenandoahGenerationalMinTenuringAge=1
@@ -51,13 +52,15 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
 
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
 
-    // Make a humongous array (with 1MB regions, this will be humongous with and without compressed oops).
+    // Make a humongous array (with 1MB regions, this will be humongous with
+    // and without compressed oops).
     private static final int HUMONGOUS_REFS = 512 * 1024;
 
     // Also make a not humongous array to test regular region promotion path
     private static final int REGULAR_REFS = 256;
 
-    // Used to create pure garbage regions to satisfy immediate garbage threshold
+    // Used to create pure garbage regions to satisfy immediate garbage
+    // threshold
     private static final int GARBAGE_BYTES = 2 * 1024 * 1024;
 
     // Test will fail if our humongous object isn't promoted in this many cycles
@@ -67,7 +70,8 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
     private static Object[] humongous;
     private static Object[] regular;
 
-    // Reference used to publish, then drop, the per-cycle garbage (to keep local var from being eliminated)
+    // Reference used to publish, then drop, the per-cycle garbage (to keep
+    // local var from being eliminated)
     private static Object garbage;
 
     public static void main(String[] args) throws Exception {
@@ -76,7 +80,8 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
 
         if (WB.isObjectInOldGen(humongous) || WB.isObjectInOldGen(regular)) {
             throw new IllegalStateException(
-                    "Precondition failed: the humongous array should start in the young generation");
+                    "Precondition failed: the humongous array should start "
+                    + "in the young generation");
         }
 
         for (int cycle = 1; cycle <= MAX_CYCLES; cycle++) {
@@ -88,14 +93,17 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
             WB.youngGC();
 
             if (WB.isObjectInOldGen(humongous) && WB.isObjectInOldGen(regular)) {
-                System.out.println("Humongous array and regular object were promoted in place during"
-                                   + "an abbreviated cycle after " + cycle + " cycle(s)");
+                System.out.println(
+                    "Humongous array and regular object were promoted in "
+                    + "place during an abbreviated cycle after "
+                    + cycle + " cycle(s)");
                 return;
             }
         }
 
-        throw new RuntimeException("Humongous array or regular object was never promoted in place during "
-                                  + "an abbreviated cycle after " + MAX_CYCLES + " cycles; in-place promotion "
-                                  + "is not happening on the abbreviated path");
+        throw new RuntimeException(
+            "Humongous array or regular object was never promoted in place "
+            + "during an abbreviated cycle after " + MAX_CYCLES + " cycles; "
+            + "in-place promotion is not happening on the abbreviated path");
     }
 }

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestPromoteInPlaceDuringAbbreviatedCycle.java
@@ -25,6 +25,14 @@
 package gc.shenandoah.generational;
 
 import jdk.test.whitebox.WhiteBox;
+import java.util.concurrent.atomic.*;
+import javax.management.*;
+import java.lang.management.*;
+import javax.management.openmbean.*;
+
+import jdk.test.lib.Utils;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
 
 /*
  * @test id=generational
@@ -74,14 +82,59 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
     // local var from being eliminated)
     private static Object garbage;
 
+    private static boolean isCollectorNotification(Notification n) {
+        return n.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION);
+    }
+
+    private static void subscribeToCollectorNotifications(NotificationListener listener) {
+        for (GarbageCollectorMXBean b : ManagementFactory.getGarbageCollectorMXBeans()) {
+            ((NotificationEmitter) b).addNotificationListener(listener, null, null);
+        }
+    }
+
+    private static void unsubscribeToCollectorNotifications(NotificationListener listener) throws Exception {
+        for (GarbageCollectorMXBean b : ManagementFactory.getGarbageCollectorMXBeans()) {
+            ((NotificationEmitter) b).removeNotificationListener(listener, null, null);
+        }
+    }
+
+    private static GarbageCollectorMXBean cycleBean() {
+        for (GarbageCollectorMXBean b : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (b.getName().equals("Shenandoah Cycles")) {
+                return b;
+            }
+        }
+        throw new IllegalStateException("No \"Shenandoah Cycles\" bean found");
+    }
+
     public static void main(String[] args) throws Exception {
         humongous = new Object[HUMONGOUS_REFS];
         regular = new Object[REGULAR_REFS];
 
-        if (WB.isObjectInOldGen(humongous) || WB.isObjectInOldGen(regular)) {
-            throw new IllegalStateException(
-                    "Precondition failed: the humongous array should start "
-                    + "in the young generation");
+        // Listen for events to detect if a non-abbreviated cycle runs
+        final AtomicLong updateReferencePauses = new AtomicLong();
+        final AtomicLong cycleNotifications   = new AtomicLong();
+        NotificationListener listener = (Notification n, Object o) -> {
+            if (isCollectorNotification(n)) {
+                GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) n.getUserData());
+                if (info.getGcName().equals("Shenandoah Pauses") && info.getGcAction().contains("Update Refs")) {
+                    updateReferencePauses.incrementAndGet();
+                } else if (info.getGcName().equals("Shenandoah Cycles")) {
+                    cycleNotifications.incrementAndGet();
+                }
+            }
+        };
+
+        subscribeToCollectorNotifications(listener);
+
+        GarbageCollectorMXBean cycles = cycleBean();
+
+        if (WB.isObjectInOldGen(humongous)) {
+            throw new IllegalStateException("Expected young humongous array");
+        }
+
+        if (WB.isObjectInOldGen(regular)) {
+            throw new IllegalStateException("Expected young regular array");
         }
 
         for (int cycle = 1; cycle <= MAX_CYCLES; cycle++) {
@@ -92,18 +145,37 @@ public class TestPromoteInPlaceDuringAbbreviatedCycle {
             // Runs a concurrent global cycle and blocks until it completes.
             System.gc();
 
+            // Both objects are in old, exit the test loop
             if (WB.isObjectInOldGen(humongous) && WB.isObjectInOldGen(regular)) {
-                System.out.println(
-                    "Humongous array and regular object were promoted in "
-                    + "place during an abbreviated cycle after "
-                    + cycle + " cycle(s)");
-                return;
+                break;
             }
         }
 
-        throw new RuntimeException(
-            "Humongous array or regular object was never promoted in place "
-            + "during an abbreviated cycle after " + MAX_CYCLES + " cycles; "
-            + "in-place promotion is not happening on the abbreviated path");
+        // Flush gc notification events
+        long targetCycles = cycles.getCollectionCount();
+        long deadlineMillis = System.currentTimeMillis() + 30_000;
+        while (cycleNotifications.get() < targetCycles) {
+            if (System.currentTimeMillis() > deadlineMillis) {
+                throw new RuntimeException("Timed out flushing GC notifications: delivered "
+                                           + cycleNotifications.get() + " of "
+                                           + targetCycles + " cycle notifications");
+            }
+            Thread.sleep(10);
+        }
+
+        unsubscribeToCollectorNotifications(listener);
+
+        if (updateReferencePauses.get() != 0) {
+            throw new RuntimeException(updateReferencePauses.get()
+                                       + " non-abbreviated cycles happened");
+        }
+
+        if (!WB.isObjectInOldGen(humongous)) {
+            throw new RuntimeException("Humongous region was not promoted in place.");
+        }
+
+        if (!WB.isObjectInOldGen(regular)) {
+            throw new RuntimeException("Regular region was not promoted in place");
+        }
     }
 }


### PR DESCRIPTION
Shenandoah's generational mode used to expend considerable effort to chose a collection set _before_ deciding if there was sufficient immediate garbage to skip evacuation (thereby tossing out the collection set). Unfortunately, the [refactoring that addressed that wasted effort](https://bugs.openjdk.org/browse/JDK-8377396) also prevented Shenandoah from promoting regions in place when evacuation was skipped. The change here builds on an existing path to plan in-place-promotions when the cycle is abbreviated. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390310](https://bugs.openjdk.org/browse/JDK-8390310): Shenandoah: Abbreviated cycles should allow promotion-in-place (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32360/head:pull/32360` \
`$ git checkout pull/32360`

Update a local copy of the PR: \
`$ git checkout pull/32360` \
`$ git pull https://git.openjdk.org/jdk.git pull/32360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32360`

View PR using the GUI difftool: \
`$ git pr show -t 32360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32360.diff">https://git.openjdk.org/jdk/pull/32360.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32360#issuecomment-5348708585)
</details>
