### PR TITLE
8378071: jcmd ThereadDump crashes with assert(!InstanceKlass::cast(receiver_klass)->is_not_initialized()) failed: receiver_klass must be

### DIFF
--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1374,6 +1374,7 @@ public:
   }
 
   static Handle create(InstanceKlass* klass, int depth, int type_ordinal, OopHandle obj, TRAPS) {
+    klass->initialize(CHECK_NH);
     init(klass, CHECK_NH);
     Handle result = klass->allocate_instance_handle(CHECK_NH);
     result->int_field_put(_depth_offset, depth);

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1374,6 +1374,7 @@ public:
   }
 
   static Handle create(InstanceKlass* klass, int depth, int type_ordinal, OopHandle obj, TRAPS) {
+    init(klass, CHECK_NH);
     Handle result = klass->allocate_instance_handle(CHECK_NH);
     result->int_field_put(_depth_offset, depth);
     result->int_field_put(_typeOrdinal_offset, type_ordinal);

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1374,8 +1374,6 @@ public:
   }
 
   static Handle create(InstanceKlass* klass, int depth, int type_ordinal, OopHandle obj, TRAPS) {
-    klass->initialize(CHECK_NH);
-    init(klass, CHECK_NH);
     Handle result = klass->allocate_instance_handle(CHECK_NH);
     result->int_field_put(_depth_offset, depth);
     result->int_field_put(_typeOrdinal_offset, type_ordinal);
@@ -1507,6 +1505,9 @@ oop ThreadSnapshotFactory::get_thread_snapshot(jobject jthread, TRAPS) {
   refArrayHandle locks;
   if (cl._locks != nullptr && cl._locks->length() > 0) {
     locks = oopFactory::new_refArray_handle(lock_klass, cl._locks->length(), CHECK_NULL);
+    if (lock_klass->should_be_initialized()) {
+      lock_klass->initialize(CHECK_NULL);
+    }
     for (int n = 0; n < cl._locks->length(); n++) {
       GetThreadSnapshotHandshakeClosure::OwnedLock* lock_info = cl._locks->adr_at(n);
 

--- a/test/jdk/jdk/internal/vm/ThreadSnapshot/ThreadWithMonitors.java
+++ b/test/jdk/jdk/internal/vm/ThreadSnapshot/ThreadWithMonitors.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8378071
+ * @summary Test jdk.internal.vm.ThreadSnapshot.of(Thread) when thread has monitors
+ * @modules java.base/jdk.internal.vm
+ * @run main ThreadWithMonitors
+ * @run main/othervm -Xcomp -XX:-Inline -XX:CompileCommand=compileonly,*ThreadSnapshot*::* ThreadWithMonitors
+ */
+
+import jdk.internal.vm.ThreadSnapshot;
+
+public class ThreadWithMonitors {
+    public static final Object LOCK = new Object();
+
+    public static void main(String[] args) throws Exception {
+        synchronized (LOCK) {
+            // The ThreadSnapshot doesn't have any public methods so nothing to check.
+            ThreadSnapshot.of(Thread.currentThread());
+        }
+     }
+}


### PR DESCRIPTION
The jcmd might crash while calling ThreadSnapshot.of() for thread that have monitors.

Originally, the jcmd crashed while calling by jtreg timeout failure handler for test `compiler/c2/Test6603011.java` while it was executed with `-XX:+StressBailout`. The `-XX:+StressBailout` is not related to crash, just cause test timeout. 

The main cause of crash is that test was executed with `-Xcomp -XX:-Inline`. See:
 * @run main/othervm/timeout=480 -Xcomp -Xbatch -XX:-Inline compiler.c2.Test6603011

That provokes the access to uninitialized ThreadSnapshot$ThreadLock class.

The ThreadSnapshot has a field
`private ThreadLock[] locks;`
that is initialized by VM native code.

The corresponding class is not initialized during this creation. 

The `-XX:CompileCommand=compileonly,*ThreadSnapshot*::*` in test is required only to optimize execution. It fails without it as well.

The ThreadSnapshot is initialized:
`
  Klass* snapshot_klass = SystemDictionary::resolve_or_fail(snapshot_klass_name, true, CHECK_NULL);
  if (snapshot_klass->should_be_initialized()) {
    snapshot_klass->initialize(CHECK_NULL);
  }

`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8378071: jcmd ThereadDump crashes with assert(!InstanceKlass::cast(receiver_klass)->is_not_initialized()) failed: receiver_klass must be`

### Issue
 * [JDK-8378071](https://bugs.openjdk.org/browse/JDK-8378071): jcmd ThereadDump crashes with assert(!InstanceKlass::cast(receiver_klass)-&gt;is_not_initialized()) failed: receiver_klass must be (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32362/head:pull/32362` \
`$ git checkout pull/32362`

Update a local copy of the PR: \
`$ git checkout pull/32362` \
`$ git pull https://git.openjdk.org/jdk.git pull/32362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32362`

View PR using the GUI difftool: \
`$ git pr show -t 32362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32362.diff">https://git.openjdk.org/jdk/pull/32362.diff</a>

</details>
