### PR TITLE
8378071: Class ThreadSnapshot$ThreadLock is not initialized by VM

### DIFF
--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1503,11 +1503,12 @@ oop ThreadSnapshotFactory::get_thread_snapshot(jobject jthread, TRAPS) {
   if (cl._locks != nullptr && cl._locks->length() > 0) {
     Symbol* lock_sym = vmSymbols::jdk_internal_vm_ThreadLock();
     Klass* lock_k = SystemDictionary::resolve_or_fail(lock_sym, true, CHECK_NULL);
+    if (lock_k->should_be_initialized()) {
+      lock_k->initialize(CHECK_NULL);
+    }
+
     InstanceKlass* lock_klass = InstanceKlass::cast(lock_k);
     locks = oopFactory::new_refArray_handle(lock_klass, cl._locks->length(), CHECK_NULL);
-    if (lock_klass->should_be_initialized()) {
-      lock_klass->initialize(CHECK_NULL);
-    }
     for (int n = 0; n < cl._locks->length(); n++) {
       GetThreadSnapshotHandshakeClosure::OwnedLock* lock_info = cl._locks->adr_at(n);
 

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1499,12 +1499,11 @@ oop ThreadSnapshotFactory::get_thread_snapshot(jobject jthread, TRAPS) {
   }
 
   // Locks
-  Symbol* lock_sym = vmSymbols::jdk_internal_vm_ThreadLock();
-  Klass* lock_k = SystemDictionary::resolve_or_fail(lock_sym, true, CHECK_NULL);
-  InstanceKlass* lock_klass = InstanceKlass::cast(lock_k);
-
   refArrayHandle locks;
   if (cl._locks != nullptr && cl._locks->length() > 0) {
+    Symbol* lock_sym = vmSymbols::jdk_internal_vm_ThreadLock();
+    Klass* lock_k = SystemDictionary::resolve_or_fail(lock_sym, true, CHECK_NULL);
+    InstanceKlass* lock_klass = InstanceKlass::cast(lock_k);
     locks = oopFactory::new_refArray_handle(lock_klass, cl._locks->length(), CHECK_NULL);
     if (lock_klass->should_be_initialized()) {
       lock_klass->initialize(CHECK_NULL);

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1506,6 +1506,9 @@ oop ThreadSnapshotFactory::get_thread_snapshot(jobject jthread, TRAPS) {
   refArrayHandle locks;
   if (cl._locks != nullptr && cl._locks->length() > 0) {
     locks = oopFactory::new_refArray_handle(lock_klass, cl._locks->length(), CHECK_NULL);
+    if (lock_klass->should_be_initialized()) {
+      lock_klass->initialize(CHECK_NULL);
+    }
     for (int n = 0; n < cl._locks->length(); n++) {
       GetThreadSnapshotHandshakeClosure::OwnedLock* lock_info = cl._locks->adr_at(n);
 

--- a/test/jdk/jdk/internal/vm/ThreadSnapshot/ThreadLockClassInit.java
+++ b/test/jdk/jdk/internal/vm/ThreadSnapshot/ThreadLockClassInit.java
@@ -24,15 +24,16 @@
 /*
  * @test
  * @bug 8378071
- * @summary Test jdk.internal.vm.ThreadSnapshot.of(Thread) when thread has monitors
+ * @summary Test jdk.internal.vm.ThreadSnapshot.of(Thread) correctly initialize ThreadLock class
+ *
  * @modules java.base/jdk.internal.vm
- * @run main ThreadWithMonitors
- * @run main/othervm -Xcomp -XX:-Inline -XX:CompileCommand=compileonly,*ThreadSnapshot*::* ThreadWithMonitors
+ * @run main ThreadLockClassInit
+ * @run main/othervm -Xcomp -XX:-Inline -XX:CompileCommand=compileonly,*ThreadSnapshot*::* ThreadLockClassInit
  */
 
 import jdk.internal.vm.ThreadSnapshot;
 
-public class ThreadWithMonitors {
+public class ThreadLockClassInit {
     public static final Object LOCK = new Object();
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/jdk/internal/vm/ThreadSnapshot/ThreadWithMonitors.java
+++ b/test/jdk/jdk/internal/vm/ThreadSnapshot/ThreadWithMonitors.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8378071
+ * @summary Test jdk.internal.vm.ThreadSnapshot.of(Thread) when thread has monitors
+ * @modules java.base/jdk.internal.vm
+ * @run main ThreadWithMonitors
+ * @run main/othervm -Xcomp -XX:-Inline -XX:CompileCommand=compileonly,*ThreadSnapshot*::* ThreadWithMonitors
+ */
+
+import jdk.internal.vm.ThreadSnapshot;
+
+public class ThreadWithMonitors {
+    public static final Object LOCK = new Object();
+
+    public static void main(String[] args) throws Exception {
+        synchronized (LOCK) {
+            // The ThreadSnapshot doesn't have any public methods so nothing to check.
+            ThreadSnapshot.of(Thread.currentThread());
+        }
+     }
+}


### PR DESCRIPTION
The class `ThreadSnapshot$ThreadLock` is internal ThreadSnapshot class.
The `ThreadSnapshot` and `ThreadSnapshot$ThreadLock` are  created and filled by VM.  Class `ThreadSnapshot$ThreadLock` is not initialized in this native VM code.

The crash originally appeared when jcmd ThreadDump was called for timed-out test `compiler/c2/Test6603011.java`. The test is executed with `-Xcomp -XX:-Inline` which is required to reproduce the issue. 
In other cases the klass initialized by interpreter or compiler.  

This is why this crash was not find by jcmd test that test how jcmd works for monitors.
created but the class is not initialized. 

BTW, the `ThreadSnapshot` is initialized 
```
  if (snapshot_klass->should_be_initialized()) {
    snapshot_klass->initialize(CHECK_NULL);
  }
```

Note: `-XX:CompileCommand=compileonly,*ThreadSnapshot*::*` in test is to reduce execution time only, test fails without it.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8378071](https://bugs.openjdk.org/browse/JDK-8378071): Class ThreadSnapshot$ThreadLock is not initialized by VM (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32363/head:pull/32363` \
`$ git checkout pull/32363`

Update a local copy of the PR: \
`$ git checkout pull/32363` \
`$ git pull https://git.openjdk.org/jdk.git pull/32363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32363`

View PR using the GUI difftool: \
`$ git pr show -t 32363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32363.diff">https://git.openjdk.org/jdk/pull/32363.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32363#issuecomment-5296059831)
</details>
