### PR TITLE
8389310: Virtual thread can miss deoptimization when propagating exception

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -592,10 +592,13 @@ address SharedRuntime::raw_exception_handler_for_return_address(JavaThread* curr
     // native nmethods don't have exception handlers
     assert(!nm->is_native_method() || nm->method()->is_continuation_enter_intrinsic(), "no exception handler");
     assert(nm->header_begin() != nm->exception_begin(), "no exception handler");
-    // For virtual threads, we need to check if the nmethod is marked for
-    // deoptimization because the return pc may not have been patched if
-    // the nmethod was deoptimized while the frame was frozen. Since this
-    // check is benign for platform threads, we do it unconditionally.
+    // For platform threads, checking the return pc already covers the case
+    // where only this compiled frame was deoptimized, as well as the case
+    // where the nmethod was marked for deoptimization. For virtual threads,
+    // we also need to check if the nmethod is marked for deoptimization because
+    // the return pc may not have been patched if the nmethod was deoptimized
+    // while the frame was frozen. Since this check is benign for platform
+    // threads, we do it unconditionally.
     if (nm->is_deopt_pc(return_address) || nm->is_marked_for_deoptimization()) {
       // If we come here because of a stack overflow, the stack may be
       // unguarded. Reguard the stack otherwise if we return to the

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -592,7 +592,11 @@ address SharedRuntime::raw_exception_handler_for_return_address(JavaThread* curr
     // native nmethods don't have exception handlers
     assert(!nm->is_native_method() || nm->method()->is_continuation_enter_intrinsic(), "no exception handler");
     assert(nm->header_begin() != nm->exception_begin(), "no exception handler");
-    if (nm->is_deopt_pc(return_address)) {
+    // For virtual threads, we need to check if the nmethod is marked for
+    // deoptimization because the return pc may not have been patched if
+    // the nmethod was deoptimized while the frame was frozen. Since this
+    // check is benign for platform threads, we do it unconditionally.
+    if (nm->is_deopt_pc(return_address) || nm->is_marked_for_deoptimization()) {
       // If we come here because of a stack overflow, the stack may be
       // unguarded. Reguard the stack otherwise if we return to the
       // deopt blob and the stack bang causes a stack overflow we

--- a/test/jdk/java/lang/Thread/virtual/DeoptimizedMethodOnException.java
+++ b/test/jdk/java/lang/Thread/virtual/DeoptimizedMethodOnException.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=default
+ * @bug 8389310
+ * @summary Test exception propagation when caller nmethod is marked for deoptimization
+ * @requires vm.continuations
+ * @library /test/lib /test/hotspot/jtreg
+ * @run main/othervm -XX:CompileCommand=dontinline,*::bar DeoptimizedMethodOnException
+ */
+
+/*
+ * @test id=Xcomp
+ * @bug 8389310
+ * @summary Test exception propagation when caller nmethod is marked for deoptimization
+ * @requires vm.continuations
+ * @library /test/lib /test/hotspot/jtreg
+ * @run main/othervm -XX:CompileCommand=dontinline,*::bar -Xcomp DeoptimizedMethodOnException
+ */
+
+import java.util.concurrent.CountDownLatch;
+
+import jdk.test.lib.Asserts;
+
+public class DeoptimizedMethodOnException {
+    private static CountDownLatch sync = new CountDownLatch(0);
+    private static A receiver = new A();
+    private static int resultInt;
+    private static String resultStr;
+
+    public static void main(String args[]) throws Exception {
+        warmUp();
+        Asserts.assertTrue(resultInt == 1, "resultInt=" + resultInt);
+        Asserts.assertTrue(resultStr.equals("MyExceptionWithExtraFields"), "resultStr=" + resultStr);
+
+        var started = new CountDownLatch(1);
+        Thread vthread = Thread.ofVirtual().unstarted(() -> {
+            started.countDown();
+            foo();
+         });
+
+        sync = new CountDownLatch(1);
+        vthread.start();
+        started.await();
+        // wait until vthread blocks in sync
+        await(vthread, Thread.State.WAITING);
+        receiver = new B();
+        sync.countDown();
+
+        vthread.join();
+        Asserts.assertTrue(resultInt == 3, "resultInt=" + resultInt);
+        Asserts.assertTrue(resultStr.equals("MyExceptionWithoutExtraFields"), "resultStr=" + resultStr);
+    }
+
+    public static void foo() {
+        try {
+            bar();
+        } catch (MyException e) {
+            resultInt = receiver.m();
+            String tmp = e.getExceptionName();
+            Asserts.assertTrue(tmp.length() > 0, "length=" + tmp.length());
+            resultStr = tmp;
+            return;
+        }
+        throw new RuntimeException("Should not reach here");
+    }
+
+    public static void bar() {
+        try {
+            sync.await();
+        } catch (InterruptedException ie) {}
+        receiver.throwException();
+    }
+
+    private static void warmUp() {
+        for (int i = 0; i < 30_000; i++) {
+            foo();
+        }
+    }
+
+    /**
+     * Waits for the given thread to reach a given state.
+     */
+    private static void await(Thread thread, Thread.State expectedState) throws InterruptedException {
+        Thread.State state = thread.getState();
+        while (state != expectedState) {
+            Asserts.assertTrue(state != Thread.State.TERMINATED, "Thread has terminated");
+            Thread.sleep(10);
+            state = thread.getState();
+        }
+    }
+}
+
+abstract class MyException extends RuntimeException {
+    abstract String getExceptionName();
+}
+
+class MyExceptionWithExtraFields extends MyException {
+    Integer l1, l2, l3, l4, l5, l6, l7, l8, l9, l10, l11, l12, l13, l14, l15;
+    String exceptionName;
+    MyExceptionWithExtraFields() {
+        l1=1;l2=2;l3=3;l4=4;l5=5;l6=6;l7=7;l8=8;l9=9;l10=10;l11=11;l12=12;l13=13;l14=14;l15=15;
+        exceptionName = new String("MyExceptionWithExtraFields");
+    }
+    @Override
+    String getExceptionName() { return exceptionName; }
+}
+
+class MyExceptionWithoutExtraFields extends MyException {
+    String exceptionName;
+    MyExceptionWithoutExtraFields() {
+        exceptionName = new String("MyExceptionWithoutExtraFields");
+    }
+    @Override
+    String getExceptionName() { return exceptionName; }
+}
+
+class A {
+    int m() {
+        return 1;
+    }
+    void throwException() {
+        throw new MyExceptionWithExtraFields();
+    }
+}
+
+class B extends A {
+    int m() {
+        return 3;
+    }
+    void throwException() {
+        throw new MyExceptionWithoutExtraFields();
+    }
+}


### PR DESCRIPTION
When propagating an exception to the caller, we call `SharedRuntime::raw_exception_handler_for_return_address`. This method returns the appropriate continuation address for exception handling in the caller.

If the caller is deoptimized, we should not return to the compiled exception handler. Instead, we should deoptimize the caller first, and then continue the exception handling in the interpreter. `SharedRuntime::raw_exception_handler_for_return_address` currently handles this case as follows:

```
If (nm->is_deopt_pc(return_address)) {
     …
     return SharedRuntime::deopt_blob()->unpack_with_exception();
}
```

This check is enough for platform threads because, when deoptimizing a method, we walk the stacks of all JavaThreads and patch the return PCs to that method (if found on the stack) to point to the deopt handler, i.e. deoptimized method implies patched PC to deopt handler.

But this is not the case for virtual threads. When deoptimizing a method we don’t walk unmounted stacks, as that would be too costly.  Instead, the post-call instructions in the nmethod are patched to jump to the deopt handler. This means that there is no return PC patching for those frames. Since the check above returns false for this case, method `SharedRuntime::raw_exception_handler_for_return_address` just dispatches to the compiled exception handler in the caller, which incorrectly bypasses deoptimization.

The fix is to check if the nmethod is marked for deoptimization. Given that this check is benign for platform threads I made it unconditional.

I included a reproducer test that crashes without this fix (or it might fail depending on values in the heap). It recreates a scenario similar to the one described in the original report. After a new subtype of `MyException` is loaded, `foo` is marked for deoptimization. Failing to deoptimize it before returning to it causes `exceptionName` to be accessed with an invalid field offset, leading to a later crash when reading the String’s fields.

I also tested the fix in mach5 tiers1-6.

Thanks,
Patricio


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389310](https://bugs.openjdk.org/browse/JDK-8389310): Virtual thread can miss deoptimization when propagating exception (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32364/head:pull/32364` \
`$ git checkout pull/32364`

Update a local copy of the PR: \
`$ git checkout pull/32364` \
`$ git pull https://git.openjdk.org/jdk.git pull/32364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32364`

View PR using the GUI difftool: \
`$ git pr show -t 32364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32364.diff">https://git.openjdk.org/jdk/pull/32364.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32364#issuecomment-5288736871)
</details>
