### PR TITLE
8067946: StackYellowPages and StackRedPages have no effect on Windows

### DIFF
--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -91,7 +91,8 @@ ifeq ($(call isTargetOs, windows), true)
 else
   HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exeGetCreatedJavaVMs := java.base:libjvm
 
-  HOTSPOT_JTREG_EXCLUDE += libNativeException.c exeGetProcessorInfo.c
+  HOTSPOT_JTREG_EXCLUDE += libNativeException.c exeGetProcessorInfo.c \
+      libTestWindowsStackPages.c
 endif
 
 ################################################################################

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -63,10 +63,10 @@ define_pd_global(intx, InlineSmallCode,          1000);
 
 // Java_java_net_SocketOutputStream_socketWrite0() uses a 64k buffer on the
 // stack if compiled for unix. To pass stack overflow tests we need 20 shadow pages.
-#define DEFAULT_STACK_SHADOW_PAGES (NOT_WIN64(20) WIN64_ONLY(8) DEBUG_ONLY(+4))
+#define DEFAULT_STACK_SHADOW_PAGES (20 DEBUG_ONLY(+4))
 // For those clients that do not use write socket, we allow
 // the min range value to be below that of the default
-#define MIN_STACK_SHADOW_PAGES (NOT_WIN64(10) WIN64_ONLY(8) DEBUG_ONLY(+4))
+#define MIN_STACK_SHADOW_PAGES (10 DEBUG_ONLY(+4))
 
 define_pd_global(intx, StackYellowPages, DEFAULT_STACK_YELLOW_PAGES);
 define_pd_global(intx, StackRedPages, DEFAULT_STACK_RED_PAGES);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3966,17 +3966,17 @@ bool os::pd_release_memory(char* addr, size_t bytes) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  // Windows lets us specify the minimum size of the stack using a call to the
-  // `SetThreadStackGuarantee()` function.  Since red pages are part of the
-  // unusable portion of the stack, only the yellow page count influences the
-  // argument to `SetThreadStackGuarantee()`.  The red page count continues to
-  // be used in the calculation of the total stack memory to reserve.
+  // `SetThreadStackGuarantee()` specifies the minimum amount of stack that
+  // remains available when Windows raises `EXCEPTION_STACK_OVERFLOW`.  HotSpot
+  // uses the yellow and reserved zones to handle recoverable stack overflows,
+  // so their combined size decides the argument to `SetThreadStackGuarantee().
+  // The red zone is used only for unrecoverable overflows and is therefore
+  // excluded, although it remains part of the total stack guard-zone size.
   //
-  // However, there is an additional subtlety that because Windows doesn't
-  // commit all requested stack pages in one go (and instead commits pages as
-  // needed using an additional guard page), the minimum stack size (and thus
-  // the argument to `SetThreadStackGuarantee()`) needs to be one page less,
-  // relative to the yellow page count.
+  // One page of the yellow and reserved zones is the guard page whose access
+  // triggers the stack overflow exception.  That page is not part of the stack
+  // that is available to handle the exception, so we request one page less than
+  // the combined yellow and reserved zone size.
   const size_t requested = StackOverflow::stack_yellow_reserved_zone_size()
                            - os::vm_page_size();
   ULONG ulong_requested = checked_cast<ULONG>(requested);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2746,17 +2746,24 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
                                 exceptionInfo->ContextRecord);
       }
     } else if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
+      // Decide the next steps based on the address that caused the exception.
+      address addr = (address) exception_record->ExceptionInformation[1];
+      StackOverflow* overflow_state = thread->stack_overflow_state();
+      if (overflow_state->in_stack_yellow_reserved_zone(addr)) {
+        assert(!in_vm, "Undersized StackShadowPages");
+        overflow_state->disable_stack_yellow_reserved_zone();
+        return in_java
+            ? Handle_Exception(exceptionInfo, SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::STACK_OVERFLOW))
+            : EXCEPTION_CONTINUE_EXECUTION;
+      } else if (overflow_state->in_stack_red_zone(addr)) {
+        overflow_state->disable_stack_red_zone();
+        tty->print_raw_cr("An unrecoverable stack overflow has occurred.");
+        VMError::report_and_die(t, exception_code, pc, exception_record,
+                                exceptionInfo->ContextRecord);
+      }
+
       if (in_java) {
         // Either stack overflow or null pointer exception.
-        address addr = (address) exception_record->ExceptionInformation[1];
-        address stack_end = thread->stack_end();
-        if (addr < stack_end && addr >= stack_end - os::vm_page_size()) {
-          // Stack overflow.
-          assert(!os::uses_stack_guard_pages(),
-                 "should be caught by red zone code above.");
-          return Handle_Exception(exceptionInfo,
-                                  SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::STACK_OVERFLOW));
-        }
         // Check for safepoint polling and implicit null
         // We only expect null pointers in the stubs (vtable)
         // the rest are checked explicitly now.
@@ -3966,26 +3973,6 @@ bool os::pd_release_memory(char* addr, size_t bytes) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  // `SetThreadStackGuarantee()` specifies the minimum amount of stack that
-  // remains available when Windows raises `EXCEPTION_STACK_OVERFLOW`.  HotSpot
-  // uses the yellow and reserved zones to handle recoverable stack overflows,
-  // so their combined size decides the argument to `SetThreadStackGuarantee().
-  // The red zone is used only for unrecoverable overflows and is therefore
-  // excluded, although it remains part of the total stack guard-zone size.
-  //
-  // One page of the yellow and reserved zones is the guard page whose access
-  // triggers the stack overflow exception.  That page is not part of the stack
-  // that is available to handle the exception, so we request one page less than
-  // the combined yellow and reserved zone size.
-  const size_t requested = StackOverflow::stack_yellow_reserved_zone_size()
-                           - os::vm_page_size();
-  ULONG ulong_requested = checked_cast<ULONG>(requested);
-
-  if (SetThreadStackGuarantee(&ulong_requested) == 0) {
-    log_warning(os, thread)("Failed to set thread stack guarantee to %zu bytes "
-                            "(error %lu)", requested, GetLastError());
-  }
-
   return os::commit_memory(addr, size, !ExecMem);
 }
 
@@ -4072,7 +4059,7 @@ bool os::protect_memory(char* addr, size_t bytes, ProtType prot,
 
 bool os::guard_memory(char* addr, size_t bytes) {
   DWORD old_status;
-  return VirtualProtect(addr, bytes, PAGE_READWRITE | PAGE_GUARD, &old_status) != 0;
+  return VirtualProtect(addr, bytes, PAGE_NOACCESS, &old_status) != 0;
 }
 
 bool os::unguard_memory(char* addr, size_t bytes) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3979,9 +3979,9 @@ bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
   // relative to the yellow page count.
   const size_t requested = StackOverflow::stack_yellow_reserved_zone_size()
                            - os::vm_page_size();
-  ULONG uload_requested = checked_cast<ULONG>(requested);
+  ULONG ulong_requested = checked_cast<ULONG>(requested);
 
-  if (SetThreadStackGuarantee(&uload_requested) == 0) {
+  if (SetThreadStackGuarantee(&ulong_requested) == 0) {
     log_warning(os, thread)("Failed to set thread stack guarantee to %zu bytes "
                             "(error %lu)", requested, GetLastError());
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3966,6 +3966,26 @@ bool os::pd_release_memory(char* addr, size_t bytes) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
+  // Windows lets us specify the minimum size of the stack using a call to the
+  // `SetThreadStackGuarantee()` function.  Since red pages are part of the
+  // unusable portion of the stack, only the yellow page count influences the
+  // argument to `SetThreadStackGuarantee()`.  The red page count continues to
+  // be used in the calculation of the total stack memory to reserve.
+  //
+  // However, there is an additional subtlety that because Windows doesn't
+  // commit all requested stack pages in one go (and instead commits pages as
+  // needed using an additional guard page), the minimum stack size (and thus
+  // the argument to `SetThreadStackGuarantee()`) needs to be one page less,
+  // relative to the yellow page count.
+  const size_t requested = StackOverflow::stack_yellow_reserved_zone_size()
+                           - os::vm_page_size();
+  ULONG uload_requested = checked_cast<ULONG>(requested);
+
+  if (SetThreadStackGuarantee(&uload_requested) == 0) {
+    log_warning(os, thread)("Failed to set thread stack guarantee to %zu bytes "
+                            "(error %lu)", requested, GetLastError());
+  }
+
   return os::commit_memory(addr, size, !ExecMem);
 }
 

--- a/test/hotspot/jtreg/runtime/StackGuardPages/TestWindowsStackPages.java
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/TestWindowsStackPages.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, Microsoft and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8067946 8390002
+ * @summary Verifies that the Windows thread stack guarantee covers HotSpot's
+ *          recoverable stack zones specified using the number of yellow pages
+ * @requires os.family == "windows"
+ * @library /test/lib
+ * @run main/native TestWindowsStackPages
+ */
+
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestWindowsStackPages {
+    private static final String RED_PAGES_FLAG = "StackRedPages";
+    private static final String YELLOW_PAGES_FLAG = "StackYellowPages";
+
+    static {
+        System.loadLibrary("TestWindowsStackPages");
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0) {
+            checkStackGuarantee(Integer.parseInt(args[0]));
+            return;
+        }
+
+        // Check the default value.
+        ProcessTools.executeTestJava("-XX:+PrintFlagsFinal", "-version")
+                    .shouldMatch(YELLOW_PAGES_FLAG + "[ ]+=[ ]+3")
+                    .shouldHaveExitValue(0);
+
+        // Check to make sure that the minimum value is three.
+        ProcessTools.executeTestJava("-XX:" + YELLOW_PAGES_FLAG + "=2", "-version")
+                    .shouldContain(YELLOW_PAGES_FLAG + "=2 is outside the allowed range")
+                    .shouldNotHaveExitValue(0);
+
+        // Check that the thread stack guarantee includes the yellow pages, excluding
+        // the stack-growth guard page, with the default number of red pages.
+        ProcessTools.executeTestJava("-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                "-XX:" + YELLOW_PAGES_FLAG + "=8", "-XX:" + RED_PAGES_FLAG + "=1",
+                TestWindowsStackPages.class.getName(), "8")
+                .shouldHaveExitValue(0);
+
+        // Check that the thread stack guarantee does not include the fatal red pages.
+        ProcessTools.executeTestJava("-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                "-XX:" + YELLOW_PAGES_FLAG + "=8", "-XX:" + RED_PAGES_FLAG + "=3",
+                TestWindowsStackPages.class.getName(), "8")
+                .shouldHaveExitValue(0);
+    }
+
+    private static void checkStackGuarantee(int yellowPages) throws Exception {
+        long startupValue = getStackGuarantee();
+        long expectedValue = (yellowPages - /* stack growth guard page */ 1) * 4096;
+
+        if (startupValue != expectedValue) {
+            throw new RuntimeException("invariant failure for startup value: " +
+                startupValue + " v/s " + expectedValue);
+        }
+
+        ProbeThread thread = new ProbeThread();
+        thread.start();
+        thread.join();
+
+        if (thread.guarantee() != expectedValue) {
+            throw new RuntimeException("invariant failure for thread value: " +
+                thread.guarantee() + " v/s " + expectedValue);
+        }
+    }
+
+    private static final class ProbeThread extends Thread {
+        private long stackGuarantee;
+
+        @Override
+        public void run() {
+            stackGuarantee = getStackGuarantee();
+        }
+
+        long guarantee() {
+            return stackGuarantee;
+        }
+    }
+
+    private static native long getStackGuarantee();
+}

--- a/test/hotspot/jtreg/runtime/StackGuardPages/TestWindowsStackPages.java
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/TestWindowsStackPages.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8067946 8390002
- * @summary Verifies that the Windows thread stack guarantee covers HotSpot's
- *          recoverable stack zones specified using the number of yellow pages
+ * @summary Verifies that Windows stack guard-zone protection follows the
+ *          configured number of red and yellow pages
  * @requires os.family == "windows"
  * @library /test/lib
  * @run main/native TestWindowsStackPages
@@ -44,7 +44,7 @@ public class TestWindowsStackPages {
 
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            checkStackGuarantee(Integer.parseInt(args[0]));
+            checkStackGuardPages(Integer.parseInt(args[0]));
             return;
         }
 
@@ -53,56 +53,59 @@ public class TestWindowsStackPages {
                     .shouldMatch(YELLOW_PAGES_FLAG + "[ ]+=[ ]+3")
                     .shouldHaveExitValue(0);
 
-        // Check to make sure that the minimum value is three.
+        // Check that the minimum value is three.
         ProcessTools.executeTestJava("-XX:" + YELLOW_PAGES_FLAG + "=2", "-version")
                     .shouldContain(YELLOW_PAGES_FLAG + "=2 is outside the allowed range")
                     .shouldNotHaveExitValue(0);
 
-        // Check that the thread stack guarantee includes the yellow pages, excluding
-        // the stack-growth guard page, with the default number of red pages.
+        // Check the minimum yellow zone with the default red zone.
         ProcessTools.executeTestJava("-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
-                "-XX:" + YELLOW_PAGES_FLAG + "=8", "-XX:" + RED_PAGES_FLAG + "=1",
-                TestWindowsStackPages.class.getName(), "8")
+                "-XX:" + YELLOW_PAGES_FLAG + "=3", "-XX:" + RED_PAGES_FLAG + "=1",
+                TestWindowsStackPages.class.getName(), "4")
                 .shouldHaveExitValue(0);
 
-        // Check that the thread stack guarantee does not include the fatal red pages.
+        // Check that increasing the yellow zone increases the protected region.
+        ProcessTools.executeTestJava("-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                "-XX:" + YELLOW_PAGES_FLAG + "=8", "-XX:" + RED_PAGES_FLAG + "=1",
+                TestWindowsStackPages.class.getName(), "9")
+                .shouldHaveExitValue(0);
+
+        // Check that increasing the red zone also increases the protected region.
         ProcessTools.executeTestJava("-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
                 "-XX:" + YELLOW_PAGES_FLAG + "=8", "-XX:" + RED_PAGES_FLAG + "=3",
-                TestWindowsStackPages.class.getName(), "8")
+                TestWindowsStackPages.class.getName(), "11")
                 .shouldHaveExitValue(0);
     }
 
-    private static void checkStackGuarantee(int yellowPages) throws Exception {
-        long startupValue = getStackGuarantee();
-        long expectedValue = (yellowPages - /* stack growth guard page */ 1) * 4096;
-
-        if (startupValue != expectedValue) {
-            throw new RuntimeException("invariant failure for startup value: " +
-                startupValue + " v/s " + expectedValue);
+    private static void checkStackGuardPages(int expectedPages) throws Exception {
+        long startupValue = getStackGuardPages();
+        if (startupValue != expectedPages) {
+            throw new RuntimeException("invariant failure for startup thread: " +
+                startupValue + " pages v/s " + expectedPages);
         }
 
         ProbeThread thread = new ProbeThread();
         thread.start();
         thread.join();
 
-        if (thread.guarantee() != expectedValue) {
-            throw new RuntimeException("invariant failure for thread value: " +
-                thread.guarantee() + " v/s " + expectedValue);
+        if (thread.guardPages() != expectedPages) {
+            throw new RuntimeException("invariant failure for Java thread: " +
+                thread.guardPages() + " pages v/s " + expectedPages);
         }
     }
 
     private static final class ProbeThread extends Thread {
-        private long stackGuarantee;
+        private long stackGuardPages;
 
         @Override
         public void run() {
-            stackGuarantee = getStackGuarantee();
+            stackGuardPages = getStackGuardPages();
         }
 
-        long guarantee() {
-            return stackGuarantee;
+        long guardPages() {
+            return stackGuardPages;
         }
     }
 
-    private static native long getStackGuarantee();
+    private static native long getStackGuardPages();
 }

--- a/test/hotspot/jtreg/runtime/StackGuardPages/libTestWindowsStackPages.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/libTestWindowsStackPages.c
@@ -21,29 +21,18 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 8390002
- * @summary Verifies that on Windows, there is are three yellow stack pages,
- *          since Windows requires an additional yellow stack page for the
- *          OS-managed stack-growth guard page
- * @requires os.family == "windows"
- * @library /test/lib
- * @run driver TestWindowsStackYellowPages
- */
+#include <jni.h>
+#include <windows.h>
 
-import jdk.test.lib.process.ProcessTools;
-
-public class TestWindowsStackYellowPages {
-    private static final String FLAG = "StackYellowPages";
-
-    public static void main(String[] args) throws Exception {
-        ProcessTools.executeTestJava("-XX:+PrintFlagsFinal", "-version")
-                    .shouldMatch(FLAG + "[ ]+=[ ]+3")
-                    .shouldHaveExitValue(0);
-
-        ProcessTools.executeTestJava("-XX:" + FLAG + "=2", "-version")
-                    .shouldContain(FLAG + "=2 is outside the allowed range")
-                    .shouldNotHaveExitValue(0);
+JNIEXPORT jlong JNICALL
+Java_TestWindowsStackPages_getStackGuarantee(JNIEnv* env, jclass cls) {
+    ULONG stack_guarantee = 0;
+    if (SetThreadStackGuarantee(&stack_guarantee) == 0) {
+        jclass exception = (*env)->FindClass(env, "java/lang/RuntimeException");
+        if (exception != NULL) {
+            (*env)->ThrowNew(env, exception, "SetThreadStackGuarantee query failed");
+        }
+        return 0;
     }
+    return (jlong)stack_guarantee;
 }

--- a/test/hotspot/jtreg/runtime/StackGuardPages/libTestWindowsStackPages.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/libTestWindowsStackPages.c
@@ -25,14 +25,28 @@
 #include <windows.h>
 
 JNIEXPORT jlong JNICALL
-Java_TestWindowsStackPages_getStackGuarantee(JNIEnv* env, jclass cls) {
-    ULONG stack_guarantee = 0;
-    if (SetThreadStackGuarantee(&stack_guarantee) == 0) {
+Java_TestWindowsStackPages_getStackGuardPages(JNIEnv* env, jclass cls) {
+    MEMORY_BASIC_INFORMATION stack_info;
+    MEMORY_BASIC_INFORMATION guard_info;
+    SYSTEM_INFO system_info;
+    char stack_address;
+
+    if (VirtualQuery(&stack_address, &stack_info, sizeof(stack_info)) == 0 ||
+        VirtualQuery(stack_info.AllocationBase, &guard_info, sizeof(guard_info)) == 0) {
         jclass exception = (*env)->FindClass(env, "java/lang/RuntimeException");
         if (exception != NULL) {
-            (*env)->ThrowNew(env, exception, "SetThreadStackGuarantee query failed");
+            (*env)->ThrowNew(env, exception, "VirtualQuery failed");
         }
         return 0;
     }
-    return (jlong)stack_guarantee;
+
+    // Return the count of committed pages that are marked with `PAGE_NOACCESS`.
+    // We expect this count to match the number of Red and Yellow pages.
+    if (guard_info.State == MEM_COMMIT && guard_info.Protect == PAGE_NOACCESS) {
+        // We need the page count, not bytes.
+        GetSystemInfo(&system_info);
+        return (jlong)(guard_info.RegionSize / system_info.dwPageSize);
+    }
+
+    return -1;
 }


### PR DESCRIPTION
Prior to this patch, the `StackYellowPages` and `StackRedPages`
influenced the total reserved stack memory, but they didn't change the
minimum stack size specified as required by HotSpot to Windows.  This
patch adds the call to `SetThreadStackGuarantee()` to set the minimum
stack size.

The key change here is that the argument to `SetThreadStackGuarantee()`
is set to one less than the total number of yellow pages.  The one less
page is because Windows uses a guard page (access to which tells Windows
to commit more stack pages); in the terminal case, we want the guard
page to coincide with the top-most yellow stack page, thus leaving all
except one yellow page available as the stack size.

Importantly, however, we do not use the red page count as the argument
to `SetThreadStackGurantee()`, since the red stack pages are unavailable
for handling recoverable overflows.  The red page count impacts the
_total reserved_ stack size, just not the _minimum_ stack size.  Still,
forcing the red stack page count to be included into the computation of
the argument to `SetThreadStackGurantee()` causes HotSpot to fail with
the assertion `assert(!in_vm) failed: Undersized StackShadowPages`,
since Windows is unable to commit more stack pages due to the minimum
stack size now being larger than just the yellow page count minus one.

The accompanying test passes zero to `SetThreadStackGuarantee()` to
probe the current minimum stack size, which we then compare against the
expected size based on the yellow page count.  The same test fails
without this patch on both Windows/x64 and on Windows/ARM64.

Validated this patch by running through all tier 1, 2, and 3 HotSpot
jtreg tests on Windows/x64 and Windows/ARM64 in FastDebug config.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8067946](https://bugs.openjdk.org/browse/JDK-8067946): StackYellowPages and StackRedPages have no effect on Windows (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32365/head:pull/32365` \
`$ git checkout pull/32365`

Update a local copy of the PR: \
`$ git checkout pull/32365` \
`$ git pull https://git.openjdk.org/jdk.git pull/32365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32365`

View PR using the GUI difftool: \
`$ git pr show -t 32365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32365.diff">https://git.openjdk.org/jdk/pull/32365.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32365#issuecomment-5289506898)
</details>
