### PR TITLE
8390175: FFM upcallstub can skip reinit_heapbase() right before restore_callee_saved_registers

### DIFF
--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -351,7 +351,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
   __ lea(c_rarg0, Address(rsp, frame_data_offset));
   // stack already aligned
   __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, UpcallLinker::on_exit)));
-  __ reinit_heapbase();
+  assert(!UseCompressedOops || !abi.is_volatile_reg(r12_heapbase), "r12_heapbase is not a volatile_reg!");
   __ block_comment("} on_exit");
 
   restore_callee_saved_registers(_masm, abi, reg_save_area_offset);


### PR DESCRIPTION
…re_callee_saved_registers

This patch is x86_64-specific micro optimization. reinit_heapbase after UpcallLinker::on_exit is redundant because r12 is callee-saved register and it has saved in reg area. Aarch64 uses r27 as heapbase and doesn't generate reinit_heapbase right after on_exit. This patch just matches the behavior of aarch64. Besides, we install an assertion in case we change heapbase register in the future(very unlikely).

eg. xor %r12,%r12 is redundant because 'mov 0x8(%rsp),%r12' writes %r12 immediately. 

```
[5.682s][trace][foreign,upcall] 0x00007f7888529714: call 0x00007f789a2896c0 = UpcallLinker::on_exit(UpcallStub::FrameData*)
[5.682s][trace][foreign,upcall] 0x00007f7888529719: xor %r12,%r12
[5.682s][trace][foreign,upcall] ;; } on_exit
[5.682s][trace][foreign,upcall] ;; { restore_callee_saved_regs
[5.682s][trace][foreign,upcall] 0x00007f788852971c: mov (%rsp),%rbx
[5.682s][trace][foreign,upcall] 0x00007f7888529720: mov 0x8(%rsp),%r12
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390175](https://bugs.openjdk.org/browse/JDK-8390175): FFM upcallstub can skip reinit_heapbase() right before restore_callee_saved_registers (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32366/head:pull/32366` \
`$ git checkout pull/32366`

Update a local copy of the PR: \
`$ git checkout pull/32366` \
`$ git pull https://git.openjdk.org/jdk.git pull/32366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32366`

View PR using the GUI difftool: \
`$ git pr show -t 32366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32366.diff">https://git.openjdk.org/jdk/pull/32366.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32366#issuecomment-5289949675)
</details>
