### PR TITLE
8389880: Test: inlinetypes/DirectMethodTest.java needs to assert something

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/DirectMethodTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/DirectMethodTest.java
@@ -31,7 +31,7 @@
  * @library /test/lib
  * @enablePreview
  * @compile --source 28 DirectMethodTest.java
- * @run main/othervm -Djdk.reflect.useNativeAccessorOnly=true -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseArrayFlattening -XX:+UseFieldFlattening -XX:+UseNullFreeAtomicValueFlattening -XX:+UseNullableAtomicValueFlattening runtime.valhalla.inlinetypes.DirectMethodTest
+ * @run main/othervm -Djdk.reflect.useNativeAccessorOnly=true -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseArrayFlattening -XX:+UseFieldFlattening -XX:+UseNullFreeAtomicValueFlattening -XX:+UseNullableAtomicValueFlattening runtime.valhalla.inlinetypes.DirectMethodTest flat
  */
 
 /*
@@ -44,7 +44,7 @@
  * @library /test/lib
  * @enablePreview
  * @compile --source 28 DirectMethodTest.java
- * @run main/othervm -Djdk.reflect.useNativeAccessorOnly=true -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:-UseArrayFlattening -XX:+UseNullFreeAtomicValueFlattening -XX:+UseNullableAtomicValueFlattening runtime.valhalla.inlinetypes.DirectMethodTest
+ * @run main/othervm -Djdk.reflect.useNativeAccessorOnly=true -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:-UseArrayFlattening -XX:+UseNullFreeAtomicValueFlattening -XX:+UseNullableAtomicValueFlattening runtime.valhalla.inlinetypes.DirectMethodTest noflat
  */
 
 package runtime.valhalla.inlinetypes;
@@ -54,17 +54,16 @@ import java.lang.reflect.Method;
 import jdk.internal.value.ValueClass;
 
 public class DirectMethodTest {
+    static boolean expectFlat = false;
 
     public int method1(int i, int j, int k) {
-        System.out.println("i = " + i + " j = " + j + " k = " + k);
         return i + j * k;
     }
 
-    public static void printFlat(Object[] array) {
-        if (!ValueClass.isFlatArray(array)) {
-            System.out.println("not flat " + array);
-        } else {
-            System.out.println("yay flat " + array);
+    public static void checkFlat(Object[] array) {
+        boolean isFlat = ValueClass.isFlatArray(array);
+        if (isFlat != expectFlat) {
+            throw new RuntimeException("Expected array to be " + (expectFlat ? "flat" : "not flat") + ", it wasn't");
         }
     }
 
@@ -76,30 +75,34 @@ public class DirectMethodTest {
     }
 
     public int method2(SmallValue i, SmallValue j, SmallValue k) {
-        System.out.println("i = " + i + " j = " + j + " k = " + k);
         return i.s + j.s * k.s;
     }
 
     static final int ARRAY_SIZE = 3;
 
-    public static void main(java.lang.String[] unused) throws Exception {
+    public static void main(String[] args) throws Exception {
+        expectFlat = args[0].equals("flat");
         DirectMethodTest d = new DirectMethodTest();
 
         Method m = DirectMethodTest.class.getMethod("method1", int.class, int.class, int.class);
         Integer[] intarray = new Integer[]{1, 2, 3};  // is this flattened?
-        printFlat(intarray);
+        checkFlat(intarray);
         Object[] array = (Object[])Array.newInstance(Integer.class, 3);
-        printFlat(array);
+        checkFlat(array);
         array = ValueClass.newNullableAtomicArray(Integer.class, ARRAY_SIZE);
-        printFlat(array);
-        System.out.println("value is " + m.invoke(d, 1, 2, 3));
+        checkFlat(array);
+        if (!m.invoke(d, 1, 2, 3).equals(7)) {
+            throw new RuntimeException("Unexpected method1 result");
+        }
 
         Method m2 = DirectMethodTest.class.getMethod("method2", SmallValue.class, SmallValue.class, SmallValue.class);
         Object[] smallValueArray = (Object[])Array.newInstance(SmallValue.class, ARRAY_SIZE);
-        printFlat(smallValueArray);
+        checkFlat(smallValueArray);
         smallValueArray = ValueClass.newNullableAtomicArray(SmallValue.class, ARRAY_SIZE);
-        printFlat(smallValueArray);
-        System.out.println("value is " + m2.invoke(d, new SmallValue((short)1), new SmallValue((short)2), new SmallValue((short)3)));
+        checkFlat(smallValueArray);
+        if (!m2.invoke(d, new SmallValue((short)1), new SmallValue((short)2), new SmallValue((short)3)).equals(7)) {
+            throw new RuntimeException("Unexpected method1 result");
+        }
     }
 }
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/DirectMethodTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/DirectMethodTest.java
@@ -63,7 +63,6 @@ public class DirectMethodTest {
     public static void checkFlat(Object[] array) {
         boolean isFlat = ValueClass.isFlatArray(array);
         Asserts.assertEquals(expectFlat, isFlat);
-        }
     }
 
     static value class SmallValue {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/DirectMethodTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/DirectMethodTest.java
@@ -52,7 +52,7 @@ package runtime.valhalla.inlinetypes;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import jdk.internal.value.ValueClass;
-
+import jdk.test.lib.Asserts;
 public class DirectMethodTest {
     static boolean expectFlat = false;
 
@@ -62,8 +62,7 @@ public class DirectMethodTest {
 
     public static void checkFlat(Object[] array) {
         boolean isFlat = ValueClass.isFlatArray(array);
-        if (isFlat != expectFlat) {
-            throw new RuntimeException("Expected array to be " + (expectFlat ? "flat" : "not flat") + ", it wasn't");
+        Asserts.assertEquals(expectFlat, isFlat);
         }
     }
 


### PR DESCRIPTION
Hi,

This test used to just print stuff to stdout, I converted it to throw on failure. The point of the test is to see whether we incorrectly pass in non-reference arrays to `Method::invoke`.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389880](https://bugs.openjdk.org/browse/JDK-8389880): Test: inlinetypes/DirectMethodTest.java needs to assert something (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) Review applies to [b6e618bf](https://git.openjdk.org/jdk/pull/32367/files/b6e618bf19a6f072edbb1b5ceb4b99c99382302c)
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)

### Contributors
 * Coleen Phillimore `<coleenp@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32367/head:pull/32367` \
`$ git checkout pull/32367`

Update a local copy of the PR: \
`$ git checkout pull/32367` \
`$ git pull https://git.openjdk.org/jdk.git pull/32367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32367`

View PR using the GUI difftool: \
`$ git pr show -t 32367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32367.diff">https://git.openjdk.org/jdk/pull/32367.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32367#issuecomment-5290786419)
</details>
