### PR TITLE
8390296: Swing MultiUIDefaults#containsKey inconsistancy

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java
+++ b/src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,6 +117,20 @@ class MultiUIDefaults extends UIDefaults
         }
         set.addAll(super.keySet());
         return set;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (super.containsKey(key)) {
+            return true;
+        }
+
+        for (UIDefaults table : tables) {
+            if (table != null && table.containsKey(key)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/test/jdk/javax/swing/MultiUIDefaults/MultiUIDefaultsContainsKeyTest.java
+++ b/test/jdk/javax/swing/MultiUIDefaults/MultiUIDefaultsContainsKeyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390296
+ * @summary Verifies MultiUIDefaults#containsKey and
+ *          MultiUIDefaults#keySet().contains(key) produce same result
+ * @run main MultiUIDefaultsContainsKeyTest
+ */
+
+import javax.swing.UIManager;
+import javax.swing.UIDefaults;
+import javax.swing.LookAndFeel;
+
+public class MultiUIDefaultsContainsKeyTest {
+    private static final String KEY = "TabbedPane.isTabRollover";
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel(new KeyProvidingLookAndFeel());
+
+        boolean containsKey = UIManager.getDefaults().containsKey(KEY);
+        boolean keySetContains = UIManager.getDefaults().keySet().contains(KEY);
+
+        System.out.println("key: " + KEY);
+        System.out.println("defaults class: "
+                + UIManager.getDefaults().getClass().getName());
+        System.out.println("containsKey: " + containsKey);
+        System.out.println("keySet().contains: " + keySetContains);
+
+        if (containsKey != keySetContains) {
+            throw new RuntimeException("containsKey and keySet().contains disagree");
+        }
+
+        System.out.println("No inconsistency observed.");
+    }
+
+    private static final class KeyProvidingLookAndFeel extends LookAndFeel {
+        @Override
+        public String getName() {
+            return "auxiliary Look and Feel";
+        }
+
+        @Override
+        public String getID() {
+            return "Auxiliary";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Adds a defaults key for the MultiUIDefaults reproducer";
+        }
+
+        @Override
+        public boolean isNativeLookAndFeel() {
+            return false;
+        }
+
+        @Override
+        public boolean isSupportedLookAndFeel() {
+            return true;
+        }
+
+        @Override
+        public UIDefaults getDefaults() {
+            UIDefaults defaults = new UIDefaults();
+            defaults.put(KEY, Boolean.TRUE);
+            return defaults;
+        }
+    }
+}


### PR DESCRIPTION
Calling `UIManager.getDefaults().keySet().contains(key)` and `UIManager.getDefaults().containsKey(key)` produce different results.
This is a regression from [JDK-8146330](https://github.com/openjdk/jdk/commit/1e217e7b8bc9bea5e1214c93e5ccb198418a4aa3), 
where it fixed keys() vs keySet() size mismatch by overriding only` MultiUIDefaults.keySet()`
but MultiUIDefaults combines defaults from several places:

- its own local defaults

- defaults supplied by the active Look and Feel

After JDK-8146330, `keySet() `was changed to list keys from all those places. So it can see a key such as "TabbedPane.isTabRollover" supplied by the Look and Feel. 
But `containsKey()` was not changed. It still only looks in the object’s own local defaults, not the Look-and-Feel defaults

Adding containsKey() to MultiUIDefaults makes it search the same combined set of defaults as keySet()

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390296](https://bugs.openjdk.org/browse/JDK-8390296): Swing MultiUIDefaults#containsKey inconsistancy (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32368/head:pull/32368` \
`$ git checkout pull/32368`

Update a local copy of the PR: \
`$ git checkout pull/32368` \
`$ git pull https://git.openjdk.org/jdk.git pull/32368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32368`

View PR using the GUI difftool: \
`$ git pr show -t 32368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32368.diff">https://git.openjdk.org/jdk/pull/32368.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32368#issuecomment-5290795609)
</details>
