### PR TITLE
8390353: AllocateHeapAt option can cause a HotSpot crash

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3243,7 +3243,8 @@ int os::create_file_for_heap(const char* dir) {
     return -1;
   }
 
-  assert(heap_file_handle == INVALID_HANDLE_VALUE, "Heap backing file already exists");
+  guarantee(heap_file_handle == INVALID_HANDLE_VALUE,
+            "Heap backing file already exists");
 
   HANDLE process = GetCurrentProcess();
   HANDLE file_handle = (HANDLE)_get_osfhandle(fd);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -124,6 +124,7 @@ static FILETIME process_creation_time;
 static FILETIME process_exit_time;
 static FILETIME process_user_time;
 static FILETIME process_kernel_time;
+static HANDLE heap_file_handle = INVALID_HANDLE_VALUE;
 
 #if defined(_M_ARM64)
   #define __CPU__ aarch64
@@ -3241,6 +3242,19 @@ int os::create_file_for_heap(const char* dir) {
     warning("Problem opening file for heap (%s)", os::strerror(errno));
     return -1;
   }
+
+  assert(heap_file_handle == INVALID_HANDLE_VALUE, "Heap backing file already exists");
+
+  HANDLE process = GetCurrentProcess();
+  HANDLE file_handle = (HANDLE)_get_osfhandle(fd);
+
+  if (!DuplicateHandle(process, file_handle, process, &heap_file_handle,
+                       0, FALSE, DUPLICATE_SAME_ACCESS)) {
+    warning("Could not retain handle to heap backing file (error %lu)", GetLastError());
+    ::close(fd);
+    return -1;
+  }
+
   return fd;
 }
 


### PR DESCRIPTION
Unlike POSIX-based systems, on Windows, even if a mapping object handle
exists, if the underlying file handle (created using the `O_TEMPORARY`
flag) is closed, then the file is deleted.  This causes HotSpot to
attempt writing to the heap file (specified using the `AllocateHeapAt`
flag) after the file has been deleted, resulting in a crash.

This patch fixes the problem by duplicating the file handle and
persisting it throughout the lifetime of the JVM process on Windows.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390353](https://bugs.openjdk.org/browse/JDK-8390353): AllocateHeapAt option can cause a HotSpot crash (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32369/head:pull/32369` \
`$ git checkout pull/32369`

Update a local copy of the PR: \
`$ git checkout pull/32369` \
`$ git pull https://git.openjdk.org/jdk.git pull/32369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32369`

View PR using the GUI difftool: \
`$ git pr show -t 32369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32369.diff">https://git.openjdk.org/jdk/pull/32369.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32369#issuecomment-5291054218)
</details>
