### PR TITLE
8389576: Test resourcehogs/runtime/ValueTearingTest.java fails due to ArrayIndexOutOfBoundsException on many-core machines

### DIFF
--- a/test/hotspot/jtreg/resourcehogs/runtime/ValueTearingTest.java
+++ b/test/hotspot/jtreg/resourcehogs/runtime/ValueTearingTest.java
@@ -122,8 +122,7 @@ public class ValueTearingTest {
       static final int BATCH_SIZE = 10_000;
 
       static int incrementIndex(int idx, int n) {
-          idx += INCREMENTS[n];
-          if (idx >= N_PRECOMPUTED) idx -= N_PRECOMPUTED;
+          idx = (idx + INCREMENTS[n]) % N_PRECOMPUTED;
           return idx;
       }
 


### PR DESCRIPTION
Hi,

Simple fix: The code meant to do a wrap around, but it just decremented by 100 once. Just use modulo to fix it.

Edit: The fix has been confirmed to work (See JBS comments)

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389576](https://bugs.openjdk.org/browse/JDK-8389576): Test resourcehogs/runtime/ValueTearingTest.java fails due to ArrayIndexOutOfBoundsException on many-core machines (**Bug** - P4)


### Reviewers
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32370/head:pull/32370` \
`$ git checkout pull/32370`

Update a local copy of the PR: \
`$ git checkout pull/32370` \
`$ git pull https://git.openjdk.org/jdk.git pull/32370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32370`

View PR using the GUI difftool: \
`$ git pr show -t 32370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32370.diff">https://git.openjdk.org/jdk/pull/32370.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32370#issuecomment-5327015693)
</details>
