### PR TITLE
8381564: [IR Framework] Fix race between accept thread and Driver VM thread

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -36,6 +36,8 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -49,12 +51,15 @@ import java.util.regex.Pattern;
  * @see TestFrameworkSocket
  */
 public class TestVMProcess {
-    private static final boolean VERBOSE = Boolean.getBoolean("Verbose");
     private static final boolean PREFER_COMMAND_LINE_FLAGS = Boolean.getBoolean("PreferCommandLineFlags");
     private static final int WARMUP_ITERATIONS = Integer.getInteger("Warmup", -1);
     private static final boolean VERIFY_VM = Boolean.getBoolean("VerifyVM") && Platform.isDebugBuild();
-    private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
+    private static final boolean VERBOSE = Boolean.getBoolean("Verbose");
     private static final boolean EXCLUDE_RANDOM = Boolean.getBoolean("ExcludeRandom");
+    private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");
+    private static final boolean DUMP_OUTPUT = VERBOSE || EXCLUDE_RANDOM || REPORT_STDOUT;
+
+    private static final String FATAL_ERROR_MARKER = "# A fatal error has been detected by the Java Runtime Environment:";
 
     private static String lastTestVMOutput = "";
 
@@ -72,11 +77,131 @@ public class TestVMProcess {
             prepareTestVMFlags(additionalFlags, socket, testClass, helperClasses, defaultWarmup,
                                allowNotCompilable, testClassesOnBootClassPath);
             start();
+            // Test VM has exited. Do not close the socket, yet, because the accept and/or reader threads could still
+            // be processing its connection. We wait for the socket result and only then close the socket by leaving
+            // this scope.
+            testVmData = processTestVmResult(socket, allowNotCompilable);
+        } // Socket closed here.
+    }
+
+    private TestVMData processTestVmResult(TestFrameworkSocket socket, boolean allowNotCompilable) {
+        if (oa.getExitValue() == 0) {
+            dumpTestVmOutputIfRequested();
+            return readAndDumpTestVmData(socket, allowNotCompilable);
         }
-        checkTestVMExitCode();
+
+        if (isTestFormatViolation()) {
+            // When a test is malformed, we only show the violation. This kind of failure should be caught during the
+            // development phase of new tests.
+            dumpTestVmOutputIfRequested();
+            throw createTestFormatException();
+        }
+        if (noTestsRun()) {
+            // If no test was selected, we just show the exception message. This kind of failure only happens during
+            // debugging when specifying an empty test set with property flags.
+            dumpTestVmOutputIfRequested();
+            throw createNoTestsRunException();
+        }
+        throw createTestVMExceptionForNonZeroExit(socket, allowNotCompilable);
+    }
+
+    /**
+     * Dump the Test VM output if flags request it.
+     */
+    private void dumpTestVmOutputIfRequested() {
+        if (DUMP_OUTPUT) {
+            System.out.println("Test VM Output");
+            System.out.println("--------------");
+            System.out.println(oa.getOutput());
+        }
+    }
+
+    private TestVMData readAndDumpTestVmData(TestFrameworkSocket socket, boolean allowNotCompilable) {
         String hotspotPidFileName = String.format("hotspot_pid%d.log", oa.pid());
-        testVmData = socket.testVmData(hotspotPidFileName, allowNotCompilable);
-        testVmData.printJavaMessages();
+        TestVMData testVMData = socket.testVmData(hotspotPidFileName, allowNotCompilable);
+        testVMData.printJavaMessages();
+        return testVMData;
+    }
+
+    private boolean isTestFormatViolation() {
+        return oa.getStderr().contains("TestFormat.throwIfAnyFailures");
+    }
+
+    private TestFormatException createTestFormatException() {
+        Pattern pattern = Pattern.compile("Violations \\(\\d+\\)[\\s\\S]*(?=/============/)");
+        Matcher matcher = pattern.matcher(oa.getStderr());
+        TestFramework.check(matcher.find(), "Must find violation matches");
+        return new TestFormatException(System.lineSeparator() + System.lineSeparator() + matcher.group());
+    }
+
+    private boolean noTestsRun() {
+        return oa.getStderr().contains("NoTestsRunException");
+    }
+
+    private NoTestsRunException createNoTestsRunException() {
+        return new NoTestsRunException(">>> No tests run due to empty set specified with -DTest and/or -DExclude. " +
+                                       "Make sure to define a set of at least one @Test method");
+    }
+
+    private TestVMException createTestVMExceptionForNonZeroExit(TestFrameworkSocket socket, boolean allowNotCompilable) {
+        String secondaryException = "";
+        try {
+            readAndDumpTestVmData(socket, allowNotCompilable);
+        } catch (RuntimeException e) {
+            // We observed a message processing exception. We treat it as secondary failure because messages could be
+            // incomplete when the VM crashed or not even sent by the Test VM when it exits early on start-up
+            // (e.g. passing in an unknown VM flag).
+            secondaryException = buildSecondaryExceptionInfo(e);
+        }
+        // Primary exception: non-zero Test VM exit.
+        return new TestVMException(buildExceptionInfo() + secondaryException);
+    }
+
+    private String buildSecondaryExceptionInfo(RuntimeException e) {
+        String secondaryException;
+        StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter));
+
+        secondaryException = System.lineSeparator() +
+                             "Secondary Message-Processing Exception" + System.lineSeparator() +
+                             "--------------------------------------" + System.lineSeparator() +
+                             stringWriter;
+        return secondaryException;
+    }
+
+    /**
+     * Get more detailed information about the exception in a pretty format.
+     */
+    private String buildExceptionInfo() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Test VM exited with code ").append(oa.getExitValue()).append(System.lineSeparator());
+        if (hasFatalErrorMarker() || DUMP_OUTPUT) {
+            // Also dump the Test VM output if we experience a JVM error to show assertion failures etc.
+            builder.append(System.lineSeparator())
+                   .append(System.lineSeparator())
+                   .append("Test VM - Standard Output").append(System.lineSeparator())
+                   .append("-------------------------").append(System.lineSeparator())
+                   .append(oa.getStdout());
+        }
+        builder.append(System.lineSeparator())
+               .append(commandLine)
+               .append(System.lineSeparator())
+               .append(System.lineSeparator())
+               .append("Test VM - Error Output").append(System.lineSeparator())
+               .append("----------------------").append(System.lineSeparator())
+               .append(oa.getStderr())
+               .append(System.lineSeparator())
+               .append(System.lineSeparator());
+        return builder.toString();
+    }
+
+    /**
+     * Best-effort VM crash detection by matching the start of the fatal error message. This covers most of the crashes
+     * but fails when the Test VM was killed externally or when the output is unavailable or truncated which could
+     * happen in native stack overflow cases.
+     */
+    private boolean hasFatalErrorMarker() {
+        return oa.getExitValue() != 0 && oa.getOutput().contains(FATAL_ERROR_MARKER);
     }
 
     public String getCommandLine() {
@@ -172,56 +297,5 @@ public class TestVMProcess {
         commandLine = "Command Line:" + System.lineSeparator() + String.join(" ", process.command())
                       + System.lineSeparator();
         lastTestVMOutput = oa.getOutput();
-    }
-
-    private void checkTestVMExitCode() {
-        final int exitCode = oa.getExitValue();
-        if (EXCLUDE_RANDOM || REPORT_STDOUT || (VERBOSE && exitCode == 0)) {
-            System.out.println("--- OUTPUT TestFramework Test VM ---");
-            System.out.println(oa.getOutput());
-        }
-
-        if (exitCode != 0) {
-            throwTestVMException();
-        }
-    }
-
-    /**
-     * Exit code was non-zero of Test VM. Check the stderr to determine what kind of exception that should be thrown to
-     * react accordingly later.
-     */
-    private void throwTestVMException() {
-        String stdErr = oa.getStderr();
-        if (stdErr.contains("TestFormat.throwIfAnyFailures")) {
-            Pattern pattern = Pattern.compile("Violations \\(\\d+\\)[\\s\\S]*(?=/============/)");
-            Matcher matcher = pattern.matcher(stdErr);
-            TestFramework.check(matcher.find(), "Must find violation matches");
-            throw new TestFormatException(System.lineSeparator() + System.lineSeparator() + matcher.group());
-        } else if (stdErr.contains("NoTestsRunException")) {
-            throw new NoTestsRunException(">>> No tests run due to empty set specified with -DTest and/or -DExclude. " +
-                                          "Make sure to define a set of at least one @Test method");
-        } else {
-            throw new TestVMException(getExceptionInfo());
-        }
-    }
-
-    /**
-     * Get more detailed information about the exception in a pretty format.
-     */
-    private String getExceptionInfo() {
-        int exitCode = oa.getExitValue();
-        String stdErr = oa.getStderr();
-        String stdOut = "";
-        boolean osIsWindows = Platform.isWindows();
-        boolean JVMHadError = (!osIsWindows && exitCode == 134) || (osIsWindows && exitCode == -1);
-        if (JVMHadError) {
-            // Also dump the stdout if we experience a JVM error (e.g. to show hit assertions etc.).
-            stdOut = System.lineSeparator() + System.lineSeparator() + "Standard Output" + System.lineSeparator()
-                     + "---------------" + System.lineSeparator() + oa.getOutput();
-        }
-        return "TestFramework Test VM exited with code " + exitCode + System.lineSeparator() + stdOut
-               + System.lineSeparator() + commandLine + System.lineSeparator() + System.lineSeparator()
-               + "Error Output" + System.lineSeparator() + "------------" + System.lineSeparator() + stdErr
-               + System.lineSeparator() + System.lineSeparator();
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
@@ -30,6 +30,8 @@ import compiler.lib.ir_framework.driver.network.testvm.java.JavaMessageParser;
 import compiler.lib.ir_framework.driver.network.testvm.java.JavaMessages;
 import compiler.lib.ir_framework.test.network.TestVmSocket;
 
+import jdk.test.lib.Utils;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -41,16 +43,36 @@ import java.util.concurrent.*;
  */
 public class TestFrameworkSocket implements AutoCloseable {
     private static final String SERVER_PORT_PROPERTY = "ir.framework.server.port";
+    private static final int SOCKET_TIMEOUT_IN_MS = (int)Utils.adjustTimeout(10_000L);
 
     private final int serverSocketPort;
     private final ServerSocket serverSocket;
     private final ExecutorService acceptExecutor;
     private final ExecutorService clientExecutor;
 
-    // Make these volatile such that the main thread can observe an update written by the worker threads in the executor
-    // services to avoid stale values.
+    /*
+     * CompletableFuture shared by the Driver VM and the accept/reader threads.
+     *
+     * Lifecycle:
+     * 1. The future is created before the accept loop task is submitted.
+     * 2. The Driver VM starts the Test VM. The socket and the executors remain open while the Driver VM waits on the
+     *    future to be completed.
+     * 3. The accept thread accepts the Test VM connection and reads the identity handshake.
+     * 4. The accept thread now schedules a reader for incoming Test VM messages.
+     * 5. During normal execution, the Test VM closes the connection before exiting. The reader completes the future
+     *    with the parsed Test VM messages.
+     * 6. Accepting, identity handshake, task submission, or message reading failures complete the future exceptionally.
+     * 7. The Driver VM obtains the result, observes a failure, or times out before the socket and executors are closed.
+     *
+     * Note: The future must be created eagerly such that the Driver VM can wait on it even before the accept thread
+     *       has accepted the Test VM connection. The accept thread might only be scheduled after the Test VM has exited.
+     *       This is possible because the server socket is already listening and the OS can queue the connection until
+     *       the accept thread processes it.
+     */
+    private final CompletableFuture<JavaMessages> javaMessagesFuture;
+
+    // Written by the Driver VM thread and read by the accept thread.
     private volatile boolean running;
-    private volatile Future<JavaMessages> javaFuture;
 
     public TestFrameworkSocket() {
         try {
@@ -62,6 +84,7 @@ public class TestFrameworkSocket implements AutoCloseable {
         serverSocketPort = serverSocket.getLocalPort();
         acceptExecutor = Executors.newSingleThreadExecutor();
         clientExecutor = Executors.newCachedThreadPool();
+        javaMessagesFuture = new CompletableFuture<>();
         if (TestFramework.VERBOSE) {
             System.out.println("TestFramework server socket uses port " + serverSocketPort);
         }
@@ -73,48 +96,38 @@ public class TestFrameworkSocket implements AutoCloseable {
 
     public void start() {
         running = true;
-        CountDownLatch calledAcceptLoopLatch = new CountDownLatch(1);
-        startAcceptLoop(calledAcceptLoopLatch);
-    }
-
-    private void startAcceptLoop(CountDownLatch calledAcceptLoopLatch) {
-        acceptExecutor.submit(() -> acceptLoop(calledAcceptLoopLatch));
-        waitUntilAcceptLoopRuns(calledAcceptLoopLatch);
-    }
-
-    private void waitUntilAcceptLoopRuns(CountDownLatch calledAcceptLoopLatch) {
-        try {
-            if (!calledAcceptLoopLatch.await(10, TimeUnit.SECONDS)) {
-                throw new IllegalStateException("acceptLoop did not start in time");
-            }
-        } catch (Exception e) {
-            throw new TestFrameworkException("Could not start TestFrameworkSocket", e);
-        }
+        acceptExecutor.submit(this::acceptLoop);
     }
 
     /**
      * Main loop to wait for new client connections and handling them upon connection request.
      */
-    private void acceptLoop(CountDownLatch calledAcceptLoopLatch) {
-        calledAcceptLoopLatch.countDown();
+    private void acceptLoop() {
         while (running) {
             try {
                 acceptNewClientConnection();
-            }  catch (SocketException e) {
+            } catch (SocketException e) {
                 if (!running || serverSocket.isClosed()) {
                     // Normal shutdown
                     return;
                 }
-                running = false;
-                throw new TestFrameworkException("Server socket error", e);
+                throwServerSocketError(e);
             } catch (TestFrameworkException e) {
-                running = false;
-                throw e;
+                throwTestFrameworkException(e);
             } catch (Exception e) {
-                running = false;
-                throw new TestFrameworkException("Server socket error", e);
+                throwServerSocketError(e);
             }
         }
+    }
+
+    private void throwServerSocketError(Exception e) {
+        throwTestFrameworkException(new TestFrameworkException("Server socket error", e));
+    }
+
+    private void throwTestFrameworkException(TestFrameworkException testFrameworkException) {
+        running = false;
+        javaMessagesFuture.completeExceptionally(testFrameworkException);
+        throw testFrameworkException;
     }
 
     /**
@@ -137,11 +150,11 @@ public class TestFrameworkSocket implements AutoCloseable {
     private String readIdentity(Socket client, BufferedReader reader) throws IOException {
         String identity;
         try {
-            client.setSoTimeout(10000);
+            client.setSoTimeout(SOCKET_TIMEOUT_IN_MS);
             identity = reader.readLine();
             TestFramework.check(identity != null, "end of stream has been reached without reading the identity");
         } catch (SocketTimeoutException e) {
-            throw new TestFrameworkException("Did not receive initial identity message after 10s", e);
+            throw new TestFrameworkException("Timed out while waiting for initial identity message", e);
         } finally {
             client.setSoTimeout(0);
         }
@@ -154,7 +167,9 @@ public class TestFrameworkSocket implements AutoCloseable {
      */
     private void submitTask(String identity, Socket client, BufferedReader reader) {
         if (identity.equals(TestVmSocket.IDENTITY)) {
-            javaFuture = clientExecutor.submit(new TestVmMessageReader<>(client, reader, new JavaMessageParser()));
+            TestVmMessageReader<JavaMessages> messageReader =
+                    new TestVmMessageReader<>(client, reader, new JavaMessageParser());
+            javaMessagesFuture.completeAsync(messageReader::call, clientExecutor);
         } else {
             throw new TestFrameworkException("Unrecognized identity: " + identity);
         }
@@ -179,9 +194,26 @@ public class TestFrameworkSocket implements AutoCloseable {
 
     private JavaMessages testVmMessages() {
         try {
-            return javaFuture.get();
+            // Note: The Test VM may have already exited while the accept and message reader thread are still processing
+            //       the connection. Let's wait until they are finished.
+            return javaMessagesFuture.get(SOCKET_TIMEOUT_IN_MS, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
             throw new TestFrameworkException("No test VM messages were received", e);
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Timed out while waiting for Test VM messages." + System.lineSeparator() +
+                                        System.lineSeparator() +
+                                        "Did any of the following happen?" + System.lineSeparator() +
+                                        "(1) TestFramework.addFlags(-DReproduce=true)" + System.lineSeparator() +
+                                        "(2) TestFramework.addFlags(--version) or any other VM flag that prevents " +
+                                        " TestVM.main() from being called?" + System.lineSeparator() +
+                                        "(3) The Test VM crashed before calling TestVM.main()" + System.lineSeparator() +
+                                        System.lineSeparator() +
+                                        "(1) and (2) are unsupported and are expected to fail." + System.lineSeparator() +
+                                        "-> Please change your test!" + System.lineSeparator() +
+                                        "(3) The IR Framework cannot handle early VM crashes." + System.lineSeparator() +
+                                        "-> Please change your test if such a crash was anticipated!" +
+                                        System.lineSeparator() + System.lineSeparator() +
+                                        "In all other cases, please file an IR Framework bug!", e);
         } catch (Exception e) {
             throw new TestFrameworkException("Error while fetching Test VM Future", e);
         }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestNoMainExecution.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestNoMainExecution.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8381564
+ * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
+ * @summary Test that different ways to avoid executing main() are reported as correctly as failure.
+ * @library /test/lib /testlibrary_tests /
+ * @run driver ${test.main.class}
+ */
+
+package testlibrary_tests.ir_framework.tests;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class TestNoMainExecution {
+    public static void main(String[] args) {
+        // We do not handshake because this flag disables socket communication
+        run("-DReproduce=true");
+
+        // We do not reach main() because there is no source file involved.
+        run("--version");
+
+        // We do not reach main() because we crash already at start-up.
+        runWithVmCrash();
+    }
+
+    private static void run(String... flags) {
+        try {
+            TestFramework.runWithFlags(flags);
+            Asserts.fail("should throw");
+        } catch (RuntimeException e) {
+            String errorMessage = e.getMessage();
+            // We expect a useful help message - match its header.
+            Asserts.assertTrue(errorMessage.contains("Did any of the following happen?"), errorMessage);
+        }
+    }
+
+    private static void runWithVmCrash() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream oldErr = System.err;
+
+        try (PrintStream ps = new PrintStream(baos)) {
+            System.setErr(ps);
+
+            try {
+                TestFramework.runWithFlags("-Xcomp", "-XX:+CICountNative", "-XX:CICrashAt=1");
+                Asserts.fail("should throw");
+            } catch (RuntimeException e) {
+                // With a VM crash, the message is found on the normal stderr instead.
+                System.setErr(oldErr);
+                String output = baos.toString();
+                Asserts.assertTrue(output.contains("Did any of the following happen?"));
+            }
+        }
+    }
+
+    @Test
+    public void test() {}
+}


### PR DESCRIPTION
This patch fixes a race between the accept thread publishing the `javaFuture` and the Driver VM thread continuing after the Test VM process has exited. 

### Failure Mode
The problem is that the `javaFuture`, which represents the task that receives and parses messages from the Test VM, is only (lazily) initialized after the accept thread has accepted the Test VM connection. This works well most of the time because the workflow is:

1. Test VM is spawned.
2. The accept thread accepts the Test VM connection.
https://github.com/openjdk/jdk/blob/aa0fbef91aa8d4f69353c40cd01a6d3b502fc477/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java#L98-L102

3. The accept thread reads the identity handshake initially sent from `TestVM.main()`.
https://github.com/openjdk/jdk/blob/aa0fbef91aa8d4f69353c40cd01a6d3b502fc477/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java#L124-L129

4. The accept thread submits a message reader task and assigns the returned non-null `Future` object to `javaFuture`.
https://github.com/openjdk/jdk/blob/aa0fbef91aa8d4f69353c40cd01a6d3b502fc477/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java#L155-L157

5. The Test VM eventually exits and closes the connection again.

### Listening Is Not the Same as Accepting
[JDK-8380945](https://bugs.openjdk.org/browse/JDK-8380945) missed that the server socked owned by `TestFrameworkSocket` can already be listening before the actual accept thread for the Test VM connection runs. Under heavy contention, the following could happen:
1. The `TestFrameworkSocket` is created and the corresponding OS socket listens for new connections.
2. The Test VM is spawned and initiates a connection which is queued up in the OS but has not been accepted by the accept thread in the Driver VM yet.
3. The Test VM sends the initial handshake message and then starts to send general Test VM messages. The accept thread has already entered `acceptLoop()` and counted down the latch but has not yet accepted the Test VM connection. The sent messages are queued in the OS.
4. The Test VM finishes and closes the connection. The accept thread is still stalled.
5. The Driver VM continues, leaves the socket scope, closes the socket, and then queries the `javaFuture`. Since the accept thread has not yet had the chance to accept the connection, the `javaFuture` is still `null` and we throw a `NullPointerException`.

The `CountDownLatch` added by JDK-8380945 does not prevent this race. It only proves that the `acceptLoop()` was entered.

### New Fix Proposal
This patch provides a new fix proposal by reverting the `CountDownLatch` approach. We now eagerly create the `CompletableFuture` object and obtain the result before leaving the socket scope and closing the socket. This allows the Driver VM to wait on the `Future` object for the result even if the accept loop is delayed. This keeps the socket and executors open to complete the accept and reader task. The complete new lifecycle, including failure handling, is described in a code comment here:
https://github.com/openjdk/jdk/blob/651ec2f1c4fc077d3387529977b8bbbf71bc17e7/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java#L53-L72

### Other Changes
While working on the fix, I've applied some additional refactorings and improved two more things:

#### Exit Code Check for VM Crashes
I've noticed that on Windows, when crashing the Test VM with `Unsafe`, the process exits with code 1. But our code currently only recognizes Windows VM crashes if the exit code is -1:
https://github.com/openjdk/jdk/blob/aa0fbef91aa8d4f69353c40cd01a6d3b502fc477/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java#L216

I've changed this to no longer rely on specific exit codes but instead try to find the "A fatal error has been detected" fatal error marker:
https://github.com/openjdk/jdk/blob/651ec2f1c4fc077d3387529977b8bbbf71bc17e7/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java#L203-L205

This is a best-effort detection because the marker could still be absent if the crash truncates the output or makes it unavailable for some reason.

#### Best-Effort Dumping of Test VM Messages
We currently only dump Test VM messages after checking the exit code and reporting an error in case of a non-zero exit code:
https://github.com/openjdk/jdk/blob/aa0fbef91aa8d4f69353c40cd01a6d3b502fc477/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java#L76-L79

This is unfortunate if the Test VM messages provide some useful information to better narrow down the source of the crash. I now try to dump the Test VM messages before reporting other non-zero Test VM exits. This could fail if a VM crash interfered with socket dumping. If dumping fails in this case, we fall back to reporting the non-zero exit as primary failure and report the additional parsing/reading error as secondary failure:
https://github.com/openjdk/jdk/blob/651ec2f1c4fc077d3387529977b8bbbf71bc17e7/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java#L146-L157

### Testing
This issue was only observed very intermittently and was hard to trigger in a standalone test. But I think the newly established workflow should fix the issue now.

While working on this, I've noticed that short-circuiting `TestVM.main()` with flags like `--version` also resulted in the same `NullPointerException` but for a different reason: Providing such a flag will never call `TestVM.main()` and thus never initiates a connection. As a result, the `javaFuture` is never initialized. 

The null pointer is no longer a problem with the new `CompletableFuture`. But the future will remain incomplete and we time out after waiting for its completion here:
https://github.com/openjdk/jdk/blob/651ec2f1c4fc077d3387529977b8bbbf71bc17e7/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java#L196-L199

Since using such flags is highly unexpected, I provide a hint in the exception message that this should not be used:
https://github.com/openjdk/jdk/blob/651ec2f1c4fc077d3387529977b8bbbf71bc17e7/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java#L202-L216

Testing: tier1-4,hs-comp-stress,valhalla-comp-stress

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381564](https://bugs.openjdk.org/browse/JDK-8381564): [IR Framework] Fix race between accept thread and Driver VM thread (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32371/head:pull/32371` \
`$ git checkout pull/32371`

Update a local copy of the PR: \
`$ git checkout pull/32371` \
`$ git pull https://git.openjdk.org/jdk.git pull/32371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32371`

View PR using the GUI difftool: \
`$ git pr show -t 32371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32371.diff">https://git.openjdk.org/jdk/pull/32371.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32371#issuecomment-5291561118)
</details>
