### PR TITLE
8390049: Zero-copy vector alternative to a scalar loop over charAt

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -53,6 +53,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import jdk.internal.foreign.SegmentFactories;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
@@ -5254,6 +5255,10 @@ public final class String
 
     byte[] value() {
         return value;
+    }
+
+    MemorySegment asReadOnlyMemorySegment() {
+        return SegmentFactories.fromArrayReadOnly(value);
     }
 
     boolean isLatin1() {

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2224,8 +2224,8 @@ public final class System {
                 return str.coder();
             }
 
-            public byte[] stringValue(String str) {
-                return str.value();
+            public MemorySegment asReadOnlyMemorySegment(String str) {
+                return MemorySegment.ofArray(str.value()).asReadOnly();
             }
 
             public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2224,6 +2224,10 @@ public final class System {
                 return str.coder();
             }
 
+            public byte[] stringValue(String str) {
+                return str.value();
+            }
+
             public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
                 return String.join(prefix, suffix, delimiter, elements, size);
             }

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2226,7 +2226,7 @@ public final class System {
             }
 
             public MemorySegment asReadOnlyMemorySegment(String str) {
-                return SegmentFactories.fromArrayReadOnly(str.value());
+                return str.asReadOnlyMemorySegment();
             }
 
             public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -59,6 +59,7 @@ import java.util.function.Supplier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
+import jdk.internal.foreign.SegmentFactories;
 import jdk.internal.javac.Restricted;
 import jdk.internal.loader.NativeLibraries;
 import jdk.internal.logger.LoggerFinderLoader.TemporaryLoggerFinder;
@@ -2225,7 +2226,7 @@ public final class System {
             }
 
             public MemorySegment asReadOnlyMemorySegment(String str) {
-                return MemorySegment.ofArray(str.value()).asReadOnly();
+                return SegmentFactories.fromArrayReadOnly(str.value());
             }
 
             public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -491,7 +491,10 @@ public interface JavaLangAccess {
      */
     byte stringCoder(String str);
 
-    byte[] stringValue(String str);
+    /**
+     * {@return a {@linkplain MemorySegment#isReadOnly() read-only} {@link MemorySegment} of the given {@link String}}
+     */
+    MemorySegment asReadOnlyMemorySegment(String str);
 
     /**
      * Join strings

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -491,6 +491,8 @@ public interface JavaLangAccess {
      */
     byte stringCoder(String str);
 
+    byte[] stringValue(String str);
+
     /**
      * Join strings
      */

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -91,6 +91,14 @@ public class SegmentFactories {
                 MemorySessionImpl.createHeap(arr));
     }
 
+    public static OfByte fromArrayReadOnly(byte[] arr) {
+        ensureInitialized();
+        Objects.requireNonNull(arr);
+        long byteSize = (long)arr.length * Utils.BaseAndScale.BYTE.scale();
+        return new OfByte(Utils.BaseAndScale.BYTE.base(), arr, byteSize, true,
+                MemorySessionImpl.createHeap(arr));
+    }
+
     public static OfShort fromArray(short[] arr) {
         ensureInitialized();
         Objects.requireNonNull(arr);

--- a/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
@@ -370,4 +370,12 @@ public final class StringSupport {
     public static void copyToSegmentRaw(String string, MemorySegment segment, long offset, int srcIndex, int srcLength) {
         JAVA_LANG_ACCESS.copyToSegmentRaw(string, segment, offset, srcIndex, srcLength);
     }
+
+    public static MemorySegment asReadOnlyMemorySegment(String string) {
+        return JAVA_LANG_ACCESS.asReadOnlyMemorySegment(string);
+    }
+
+    public static byte stringCoder(String string) {
+        return JAVA_LANG_ACCESS.stringCoder(string);
+    }
 }

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -168,7 +168,8 @@ module java.base {
         jdk.management,
         jdk.net,
         jdk.sctp,
-        jdk.crypto.cryptoki;
+        jdk.crypto.cryptoki,
+        jdk.incubator.vector;
     exports jdk.internal.classfile.components to
         jdk.jfr;
     exports jdk.internal.foreign to

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -168,8 +168,7 @@ module java.base {
         jdk.management,
         jdk.net,
         jdk.sctp,
-        jdk.crypto.cryptoki,
-        jdk.incubator.vector;
+        jdk.crypto.cryptoki;
     exports jdk.internal.classfile.components to
         jdk.jfr;
     exports jdk.internal.foreign to

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -27,14 +27,10 @@ package jdk.incubator.vector;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
-import jdk.internal.access.JavaLangAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
@@ -3470,49 +3466,6 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         return vsp.dummyVector().fromMemorySegment0(ms, offset, m, OFFSET_OUT_OF_RANGE).maybeSwap(bo);
     }
 
-    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
-
-    /**
-     * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} as bytes in the
-     * specified {@link Charset}}
-     *
-     * @param string the string
-     * @param charset the charset representing the single-byte character encoding
-     * @see ByteVector#fromString(VectorSpecies, String, Charset, int)
-     */
-    @ForceInline
-    public static boolean compatibleWith(String string, Charset charset) {
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
-        return LANG_ACCESS.stringCoder(string) == 0
-                && (charset == StandardCharsets.ISO_8859_1 || charset == StandardCharsets.US_ASCII);
-    }
-
-    /**
-     * {@return a {@link ByteVector} loaded from the given {@link String} encoded in the given {@link Charset}}
-     *
-     * @param species species of the desired vector
-     * @param string the string
-     * @param charset the charset
-     * @param offset the byte offset into the string's encoded data
-     * @throws IllegalArgumentException if the string and charset are not
-     *         {@linkplain #compatibleWith(String, Charset) compatible}
-     * @throws IndexOutOfBoundsException
-     *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
-     *         for any lane {@code N} in the vector
-     */
-    @ForceInline
-    public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset) {
-        Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
-        VectorIntrinsics.indexInRange(offset, species.length(), string.length());
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
-        }
-        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
-    }
-
     // Memory store operations
 
     /**
@@ -3831,6 +3784,82 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
                  int j = indexMap[mapOffset + i];
                  arr[off + j] = (e & 1) != 0;
              });
+    }
+
+    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
+
+    /**
+     * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} using the
+     * specified single-byte {@link Charset}}
+     *
+     * @param string the string
+     * @param charset the charset representing the single-byte character encoding
+     * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
+     * @see ByteVector#fromString(VectorSpecies, String, Charset, int)
+     * @since 28
+     */
+    @ForceInline
+    public static boolean compatibleWith(String string, Charset charset) {
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        return LANG_ACCESS.stringCoder(string) == 0
+                && (charset == StandardCharsets.ISO_8859_1 || charset == StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * {@return a {@link ByteVector} loaded with bytes from the given {@link String},
+     * interpreted using the specified single-byte {@link Charset}}
+     *
+     * @param species the species of the desired vector
+     * @param string the string to load from
+     * @param charset the single-byte charset
+     * @param offset the character index in the string to begin loading from
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset < 0} or {@code offset > string.length() - species.length()}
+     * @throws NullPointerException if {@code species}, {@code string}, or {@code charset} is {@code null}
+     * @since 28
+     */
+    @ForceInline
+    public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        offset = checkFromIndexSize(offset, species.length(), string.length());
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
+    }
+
+    /**
+     * {@return a {@link ByteVector} loaded with bytes from the given {@link String},
+     * interpreted using the specified single-byte {@link Charset}}
+     *
+     * @param species the species of the desired vector
+     * @param string the string to load from
+     * @param charset the single-byte charset
+     * @param offset the character index in the string to begin loading from
+     * @param m the mask controlling lane selection
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
+     *         for any lane {@code N} in the vector where the mask is set
+     * @throws NullPointerException if {@code species}, {@code string}, {@code charset}, or {@code m} is {@code null}
+     * @since 28
+     */
+    @ForceInline
+    public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset, VectorMask<Byte> m) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        Objects.requireNonNull(m);
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3510,7 +3510,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException();
         }
-        return ByteVector.fromArray(species, LANG_ACCESS.stringValue(string), offset);
+        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
 
     // Memory store operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -28,6 +28,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
@@ -39,8 +40,6 @@ import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
-import sun.nio.cs.ISO_8859_1;
-import sun.nio.cs.US_ASCII;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
 import static jdk.incubator.vector.VectorIntrinsics.*;
@@ -3473,23 +3472,45 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
 
     private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
 
+    /**
+     * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} as bytes in the
+     * specified {@link Charset}}
+     *
+     * @param string the string
+     * @param charset the charset representing the single-byte character encoding
+     * @see ByteVector#fromString(VectorSpecies, String, Charset, int)
+     */
     @ForceInline
     public static boolean compatibleWith(String string, Charset charset) {
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        return LANG_ACCESS.stringCoder(string) == 0 && (charset == ISO_8859_1.INSTANCE || charset == US_ASCII.INSTANCE);
+        return LANG_ACCESS.stringCoder(string) == 0
+                && (charset == StandardCharsets.ISO_8859_1 || charset == StandardCharsets.US_ASCII);
     }
 
+    /**
+     * {@return a {@link ByteVector} loaded from the given {@link String} encoded in the given {@link Charset}}
+     *
+     * @param species species of the desired vector
+     * @param string the string
+     * @param charset the charset
+     * @param offset the byte offset into the string's encoded data
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
+     *         for any lane {@code N} in the vector
+     */
     @ForceInline
-    public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int charOffset) {
+    public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset) {
         Objects.requireNonNull(species);
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        VectorIntrinsics.indexInRange(charOffset, species.length(), string.length());
+        VectorIntrinsics.indexInRange(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException();
         }
-        return ByteVector.fromArray(species, LANG_ACCESS.stringValue(string), charOffset);
+        return ByteVector.fromArray(species, LANG_ACCESS.stringValue(string), offset);
     }
 
     // Memory store operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -27,15 +27,20 @@ package jdk.incubator.vector;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
+import sun.nio.cs.ISO_8859_1;
+import sun.nio.cs.US_ASCII;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
 import static jdk.incubator.vector.VectorIntrinsics.*;
@@ -3464,6 +3469,27 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         ((AbstractMask<Byte>)m)
             .checkIndexByLane(offset, ms.byteSize(), vsp.iota(), 1);
         return vsp.dummyVector().fromMemorySegment0(ms, offset, m, OFFSET_OUT_OF_RANGE).maybeSwap(bo);
+    }
+
+    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
+
+    @ForceInline
+    public static boolean compatibleWith(String string, Charset charset) {
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        return LANG_ACCESS.stringCoder(string) == 0 && (charset == ISO_8859_1.INSTANCE || charset == US_ASCII.INSTANCE);
+    }
+
+    @ForceInline
+    public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int charOffset) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        VectorIntrinsics.indexInRange(charOffset, species.length(), string.length());
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        return ByteVector.fromArray(species, LANG_ACCESS.stringValue(string), charOffset);
     }
 
     // Memory store operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -27,10 +27,14 @@ package jdk.incubator.vector;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
@@ -3802,8 +3806,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
     public static boolean compatibleWith(String string, Charset charset) {
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        return LANG_ACCESS.stringCoder(string) == 0
-                && (charset == StandardCharsets.ISO_8859_1 || charset == StandardCharsets.US_ASCII);
+        return LANG_ACCESS.stringCoder(string) == 0 && charset == StandardCharsets.ISO_8859_1;
     }
 
     /**
@@ -3828,7 +3831,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         Objects.requireNonNull(charset);
         offset = checkFromIndexSize(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
         return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
@@ -3857,7 +3860,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         Objects.requireNonNull(charset);
         Objects.requireNonNull(m);
         if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
         return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3790,11 +3790,11 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
     }
 
     /**
-     * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} using the
-     * specified single-byte {@link Charset}}
+     * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} as 8-bit
+     * code units in the specified {@link Charset}}
      *
      * @param string the string
-     * @param charset the charset representing the single-byte character encoding
+     * @param charset the charset representing the 8-bit character encoding
      * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
      * @see ByteVector#fromString(VectorSpecies, String, Charset, int)
      * @since 28
@@ -3807,18 +3807,19 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
     }
 
     /**
-     * {@return a {@link ByteVector} loaded with bytes from the given {@link String},
-     * interpreted using the specified single-byte {@link Charset}}
+     * {@return a {@link ByteVector} loaded with 8-bit code units from the given {@link String},
+     * interpreted using the specified {@link Charset}}
      *
      * @param species the species of the desired vector
      * @param string the string to load from
-     * @param charset the single-byte charset
+     * @param charset the 8-bit charset
      * @param offset the character index in the string to begin loading from
      * @throws IllegalArgumentException if the string and charset are not
      *         {@linkplain #compatibleWith(String, Charset) compatible}
      * @throws IndexOutOfBoundsException
      *         if {@code offset < 0} or {@code offset > string.length() - species.length()}
      * @throws NullPointerException if {@code species}, {@code string}, or {@code charset} is {@code null}
+     * @see #compatibleWith(String, Charset)
      * @since 28
      */
     @ForceInline
@@ -3826,20 +3827,20 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         Objects.requireNonNull(species);
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        offset = checkFromIndexSize(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
+        offset = checkFromIndexSize(offset, species.length(), string.length());
         return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
 
     /**
-     * {@return a {@link ByteVector} loaded with bytes from the given {@link String},
-     * interpreted using the specified single-byte {@link Charset}}
+     * {@return a {@link ByteVector} loaded with 8-bit code units from the given {@link String},
+     * interpreted using the specified {@link Charset}}
      *
      * @param species the species of the desired vector
      * @param string the string to load from
-     * @param charset the single-byte charset
+     * @param charset the 8-bit charset
      * @param offset the character index in the string to begin loading from
      * @param m the mask controlling lane selection
      * @throws IllegalArgumentException if the string and charset are not
@@ -3848,6 +3849,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
      *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
      *         for any lane {@code N} in the vector where the mask is set
      * @throws NullPointerException if {@code species}, {@code string}, {@code charset}, or {@code m} is {@code null}
+     * @see #compatibleWith(String, Charset)
      * @since 28
      */
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -33,9 +33,8 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
-import jdk.internal.access.JavaLangAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
+import jdk.internal.foreign.StringSupport;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
@@ -3790,8 +3789,6 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
              });
     }
 
-    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
-
     /**
      * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} using the
      * specified single-byte {@link Charset}}
@@ -3806,7 +3803,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
     public static boolean compatibleWith(String string, Charset charset) {
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        return LANG_ACCESS.stringCoder(string) == 0 && charset == StandardCharsets.ISO_8859_1;
+        return StringSupport.stringCoder(string) == 0 && charset == StandardCharsets.ISO_8859_1;
     }
 
     /**
@@ -3833,7 +3830,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
-        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
+        return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
 
     /**
@@ -3862,7 +3859,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
-        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
+        return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
     }
 
     /**

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -37,6 +37,7 @@ import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.StringSupport;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
+import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
 
@@ -3793,6 +3794,9 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
      * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} as 8-bit
      * code units in the specified {@link Charset}}
      *
+     * <p>This method runs in constant time, and is intended to be used as a guard for
+     * {@link ByteVector#fromString(VectorSpecies, String, Charset, int)}.
+     *
      * @param string the string
      * @param charset the charset representing the 8-bit character encoding
      * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
@@ -3804,6 +3808,18 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
         return StringSupport.stringCoder(string) == 0 && charset == StandardCharsets.ISO_8859_1;
+    }
+
+    @DontInline
+    private static void throwNotCompatible(Charset charset) {
+        throw new IllegalArgumentException("String is not compatible with: " + charset);
+    }
+
+    @ForceInline
+    private static void checkCompatibleWith(String string, Charset charset) {
+        if (!compatibleWith(string, charset)) {
+            throwNotCompatible(charset);
+        }
     }
 
     /**
@@ -3825,11 +3841,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
     @ForceInline
     public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset) {
         Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException("String is not compatible with: " + charset);
-        }
+        checkCompatibleWith(string, charset);
         offset = checkFromIndexSize(offset, species.length(), string.length());
         return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
@@ -3855,12 +3867,8 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
     @ForceInline
     public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset, VectorMask<Byte> m) {
         Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
         Objects.requireNonNull(m);
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException("String is not compatible with: " + charset);
-        }
+        checkCompatibleWith(string, charset);
         return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
     }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3460,21 +3460,30 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
 
     private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
 
-    /** Loads a vector of UTF-16 code units from {@code string} starting at {@code charOffset}. */
+    /**
+     * {@return a {@link ShortVector} of UTF-16 code units from {@code string}}
+     *
+     * @param species species of the desired vector
+     * @param string the string
+     * @param offset the UTF-16 code unit offset into the string
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
+     *         for any lane {@code N} in the vector
+     */
     @ForceInline
-    public static ShortVector fromString(VectorSpecies<Short> species, String string, int charOffset) {
+    public static ShortVector fromString(VectorSpecies<Short> species, String string, int offset) {
         Objects.requireNonNull(species);
         Objects.requireNonNull(string);
-        VectorIntrinsics.indexInRange(charOffset, species.length(), string.length());
+        VectorIntrinsics.indexInRange(offset, species.length(), string.length());
         byte coder = LANG_ACCESS.stringCoder(string);
         byte[] value = LANG_ACCESS.stringValue(string);
         VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
         if (coder == 0) {
             VectorMask<Byte> byteMask = byteSpecies.indexInRange(0, species.length());
-            ByteVector byteVector = ByteVector.fromArray(byteSpecies, value, charOffset, byteMask);
+            ByteVector byteVector = ByteVector.fromArray(byteSpecies, value, offset, byteMask);
             return (ShortVector) byteVector.convertShape(ZERO_EXTEND_B2S, species, 0);
         } else {
-            return ByteVector.fromArray(byteSpecies, value, charOffset << 1).reinterpretAsShorts();
+            return ByteVector.fromArray(byteSpecies, value, offset << 1).reinterpretAsShorts();
         }
     }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -27,6 +27,8 @@ package jdk.incubator.vector;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
@@ -3461,20 +3463,42 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
     private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
 
     /**
-     * {@return a {@link ShortVector} of UTF-16 code units from {@code string}}
+     * {@return {@code true} if the given {@link String} can be loaded into a {@link ShortVector} as shorts in the
+     * specified {@link Charset}}
+     *
+     * @param string the string
+     * @param charset the charset representing the 16-bit character encoding
+     * @see ShortVector#fromString(VectorSpecies, String, Charset, int)
+     */
+    @ForceInline
+    public static boolean compatibleWith(String string, Charset charset) {
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        return charset == StandardCharsets.UTF_16;
+    }
+
+    /**
+     * {@return a {@link ShortVector} loaded from the given {@link String} encoded in the given {@link Charset}}
      *
      * @param species species of the desired vector
      * @param string the string
-     * @param offset the UTF-16 code unit offset into the string
+     * @param charset the charset
+     * @param offset the offset into the string's encoded data
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
      * @throws IndexOutOfBoundsException
      *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
      *         for any lane {@code N} in the vector
      */
     @ForceInline
-    public static ShortVector fromString(VectorSpecies<Short> species, String string, int offset) {
+    public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset) {
         Objects.requireNonNull(species);
         Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
         VectorIntrinsics.indexInRange(offset, species.length(), string.length());
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
         byte coder = LANG_ACCESS.stringCoder(string);
         MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
         if (coder == 0) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3476,14 +3476,15 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         Objects.requireNonNull(string);
         VectorIntrinsics.indexInRange(offset, species.length(), string.length());
         byte coder = LANG_ACCESS.stringCoder(string);
-        byte[] value = LANG_ACCESS.stringValue(string);
-        VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
+        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
         if (coder == 0) {
+            VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
             VectorMask<Byte> byteMask = byteSpecies.indexInRange(0, species.length());
-            ByteVector byteVector = ByteVector.fromArray(byteSpecies, value, offset, byteMask);
+            ByteVector byteVector =
+                    ByteVector.fromMemorySegment(byteSpecies, segment, offset, ByteOrder.nativeOrder(), byteMask);
             return (ShortVector) byteVector.convertShape(ZERO_EXTEND_B2S, species, 0);
         } else {
-            return ByteVector.fromArray(byteSpecies, value, offset << 1).reinterpretAsShorts();
+            return fromMemorySegment(species, segment, (long) offset << 1, ByteOrder.nativeOrder());
         }
     }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -27,10 +27,14 @@ package jdk.incubator.vector;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
@@ -3397,7 +3401,7 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         Objects.requireNonNull(charset);
         offset = checkFromIndexSize(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
         byte coder = LANG_ACCESS.stringCoder(string);
         MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
@@ -3441,7 +3445,7 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         Objects.requireNonNull(charset);
         Objects.requireNonNull(m);
         if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
         byte coder = LANG_ACCESS.stringCoder(string);
         MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -31,6 +31,8 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
@@ -3454,6 +3456,26 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         ((AbstractMask<Short>)m)
             .checkIndexByLane(offset, ms.byteSize(), vsp.iota(), 2);
         return vsp.dummyVector().fromMemorySegment0(ms, offset, m, OFFSET_OUT_OF_RANGE).maybeSwap(bo);
+    }
+
+    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
+
+    /** Loads a vector of UTF-16 code units from {@code string} starting at {@code charOffset}. */
+    @ForceInline
+    public static ShortVector fromString(VectorSpecies<Short> species, String string, int charOffset) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        VectorIntrinsics.indexInRange(charOffset, species.length(), string.length());
+        byte coder = LANG_ACCESS.stringCoder(string);
+        byte[] value = LANG_ACCESS.stringValue(string);
+        VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
+        if (coder == 0) {
+            VectorMask<Byte> byteMask = byteSpecies.indexInRange(0, species.length());
+            ByteVector byteVector = ByteVector.fromArray(byteSpecies, value, charOffset, byteMask);
+            return (ShortVector) byteVector.convertShape(ZERO_EXTEND_B2S, species, 0);
+        } else {
+            return ByteVector.fromArray(byteSpecies, value, charOffset << 1).reinterpretAsShorts();
+        }
     }
 
     // Memory store operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -27,14 +27,10 @@ package jdk.incubator.vector;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
-import jdk.internal.access.JavaLangAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
@@ -3359,6 +3355,107 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         return vsp.vOp(m, n -> (short) a[offset + indexMap[mapOffset + n]]);
     }
 
+    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
+
+    /**
+     * {@return {@code true} if the given {@link String} can be loaded into a {@link ShortVector} as 16-bit
+     * code units in the specified {@link Charset}}
+     *
+     * @param string the string
+     * @param charset the charset representing the 16-bit character encoding
+     * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
+     * @see ShortVector#fromString(VectorSpecies, String, Charset, int)
+     * @since 28
+     */
+    @ForceInline
+    public static boolean compatibleWith(String string, Charset charset) {
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        return charset == StandardCharsets.UTF_16;
+    }
+
+    /**
+     * {@return a {@link ShortVector} loaded with 16-bit code units from the given {@link String},
+     * interpreted using the specified {@link Charset}}
+     *
+     * @param species species of the desired vector
+     * @param string the string to load from
+     * @param charset the 16-bit charset
+     * @param offset the character index in the string to load from
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset < 0} or {@code offset > string.length() - species.length()}
+     * @throws NullPointerException if {@code species}, {@code string}, or {@code charset} is {@code null}
+     * @see #compatibleWith(String, Charset)
+     * @since 28
+     */
+    @ForceInline
+    public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        offset = checkFromIndexSize(offset, species.length(), string.length());
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        byte coder = LANG_ACCESS.stringCoder(string);
+        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
+        if (coder == 0) {
+            VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
+            ByteVector byteVector;
+            if (VectorIntrinsics.indexInRange(offset, byteSpecies.vectorByteSize(), string.length())) {
+                byteVector = ByteVector.fromMemorySegment(byteSpecies, segment, offset, ByteOrder.nativeOrder());
+            } else {
+                VectorMask<Byte> byteMask = byteSpecies.indexInRange(0, species.length());
+                byteVector = ByteVector.fromMemorySegment(byteSpecies, segment, offset, ByteOrder.nativeOrder(), byteMask);
+            }
+            return (ShortVector) byteVector.convertShape(ZERO_EXTEND_B2S, species, 0);
+        } else {
+            return fromMemorySegment(species, segment, (long) offset << 1, ByteOrder.nativeOrder());
+        }
+    }
+
+    /**
+     * {@return a {@link ShortVector} loaded with 16-bit code units from the given {@link String},
+     * interpreted using the specified {@link Charset}}
+     *
+     * @param species species of the desired vector
+     * @param string the string to load from
+     * @param charset the 16-bit charset
+     * @param offset the character index in the string to load from
+     * @param m the mask controlling lane selection
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
+     *         for any lane {@code N} in the vector where the mask is set
+     * @throws NullPointerException if {@code species}, {@code string}, {@code charset}, or {@code m} is {@code null}
+     * @see #compatibleWith(String, Charset)
+     * @since 28
+     */
+    @ForceInline
+    public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset, VectorMask<Short> m) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        Objects.requireNonNull(m);
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        byte coder = LANG_ACCESS.stringCoder(string);
+        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
+        if (coder == 0) {
+            VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
+            VectorMask<Byte> byteMask = VectorMask.fromLong(byteSpecies, m.toLong());
+            ByteVector byteVector =
+                    ByteVector.fromMemorySegment(byteSpecies, segment, offset, ByteOrder.nativeOrder(), byteMask);
+            return (ShortVector) byteVector.convertShape(ZERO_EXTEND_B2S, species, 0);
+        } else {
+            return fromMemorySegment(species, segment, (long) offset << 1, ByteOrder.nativeOrder(), m);
+        }
+    }
+
 
     /**
      * Loads a vector from a {@linkplain MemorySegment memory segment}
@@ -3458,58 +3555,6 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         ((AbstractMask<Short>)m)
             .checkIndexByLane(offset, ms.byteSize(), vsp.iota(), 2);
         return vsp.dummyVector().fromMemorySegment0(ms, offset, m, OFFSET_OUT_OF_RANGE).maybeSwap(bo);
-    }
-
-    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
-
-    /**
-     * {@return {@code true} if the given {@link String} can be loaded into a {@link ShortVector} as shorts in the
-     * specified {@link Charset}}
-     *
-     * @param string the string
-     * @param charset the charset representing the 16-bit character encoding
-     * @see ShortVector#fromString(VectorSpecies, String, Charset, int)
-     */
-    @ForceInline
-    public static boolean compatibleWith(String string, Charset charset) {
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
-        return charset == StandardCharsets.UTF_16;
-    }
-
-    /**
-     * {@return a {@link ShortVector} loaded from the given {@link String} encoded in the given {@link Charset}}
-     *
-     * @param species species of the desired vector
-     * @param string the string
-     * @param charset the charset
-     * @param offset the offset into the string's encoded data
-     * @throws IllegalArgumentException if the string and charset are not
-     *         {@linkplain #compatibleWith(String, Charset) compatible}
-     * @throws IndexOutOfBoundsException
-     *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
-     *         for any lane {@code N} in the vector
-     */
-    @ForceInline
-    public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset) {
-        Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
-        VectorIntrinsics.indexInRange(offset, species.length(), string.length());
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
-        }
-        byte coder = LANG_ACCESS.stringCoder(string);
-        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
-        if (coder == 0) {
-            VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
-            VectorMask<Byte> byteMask = byteSpecies.indexInRange(0, species.length());
-            ByteVector byteVector =
-                    ByteVector.fromMemorySegment(byteSpecies, segment, offset, ByteOrder.nativeOrder(), byteMask);
-            return (ShortVector) byteVector.convertShape(ZERO_EXTEND_B2S, species, 0);
-        } else {
-            return fromMemorySegment(species, segment, (long) offset << 1, ByteOrder.nativeOrder());
-        }
     }
 
     // Memory store operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -33,9 +33,8 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
-import jdk.internal.access.JavaLangAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
+import jdk.internal.foreign.StringSupport;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
@@ -3359,8 +3358,6 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         return vsp.vOp(m, n -> (short) a[offset + indexMap[mapOffset + n]]);
     }
 
-    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
-
     /**
      * {@return {@code true} if the given {@link String} can be loaded into a {@link ShortVector} as 16-bit
      * code units in the specified {@link Charset}}
@@ -3403,8 +3400,8 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
-        byte coder = LANG_ACCESS.stringCoder(string);
-        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
+        byte coder = StringSupport.stringCoder(string);
+        MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
         if (coder == 0) {
             VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
             ByteVector byteVector;
@@ -3447,8 +3444,8 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
-        byte coder = LANG_ACCESS.stringCoder(string);
-        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
+        byte coder = StringSupport.stringCoder(string);
+        MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
         if (coder == 0) {
             VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
             VectorMask<Byte> byteMask = VectorMask.fromLong(byteSpecies, m.toLong());

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3379,10 +3379,10 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
      * {@return a {@link ShortVector} loaded with 16-bit code units from the given {@link String},
      * interpreted using the specified {@link Charset}}
      *
-     * @param species species of the desired vector
+     * @param species the species of the desired vector
      * @param string the string to load from
      * @param charset the 16-bit charset
-     * @param offset the character index in the string to load from
+     * @param offset the character index in the string to begin loading from
      * @throws IllegalArgumentException if the string and charset are not
      *         {@linkplain #compatibleWith(String, Charset) compatible}
      * @throws IndexOutOfBoundsException
@@ -3396,10 +3396,10 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         Objects.requireNonNull(species);
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        offset = checkFromIndexSize(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
+        offset = checkFromIndexSize(offset, species.length(), string.length());
         byte coder = StringSupport.stringCoder(string);
         MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
         if (coder == 0) {
@@ -3421,10 +3421,10 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
      * {@return a {@link ShortVector} loaded with 16-bit code units from the given {@link String},
      * interpreted using the specified {@link Charset}}
      *
-     * @param species species of the desired vector
+     * @param species the species of the desired vector
      * @param string the string to load from
      * @param charset the 16-bit charset
-     * @param offset the character index in the string to load from
+     * @param offset the character index in the string to begin loading from
      * @param m the mask controlling lane selection
      * @throws IllegalArgumentException if the string and charset are not
      *         {@linkplain #compatibleWith(String, Charset) compatible}

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -37,6 +37,7 @@ import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.StringSupport;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
+import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
 
@@ -3362,6 +3363,9 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
      * {@return {@code true} if the given {@link String} can be loaded into a {@link ShortVector} as 16-bit
      * code units in the specified {@link Charset}}
      *
+     * <p>This method runs in constant time, and is intended to be used as a guard for
+     * {@link ShortVector#fromString(VectorSpecies, String, Charset, int)}.
+     *
      * @param string the string
      * @param charset the charset representing the 16-bit character encoding
      * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
@@ -3373,6 +3377,18 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
         return charset == StandardCharsets.UTF_16;
+    }
+
+    @DontInline
+    private static void throwNotCompatible(Charset charset) {
+        throw new IllegalArgumentException("String is not compatible with: " + charset);
+    }
+
+    @ForceInline
+    private static void checkCompatibleWith(String string, Charset charset) {
+        if (!compatibleWith(string, charset)) {
+            throwNotCompatible(charset);
+        }
     }
 
     /**
@@ -3394,11 +3410,7 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
     @ForceInline
     public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset) {
         Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException("String is not compatible with: " + charset);
-        }
+        checkCompatibleWith(string, charset);
         offset = checkFromIndexSize(offset, species.length(), string.length());
         byte coder = StringSupport.stringCoder(string);
         MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
@@ -3438,12 +3450,8 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
     @ForceInline
     public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset, VectorMask<Short> m) {
         Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
         Objects.requireNonNull(m);
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException("String is not compatible with: " + charset);
-        }
+        checkCompatibleWith(string, charset);
         byte coder = StringSupport.stringCoder(string);
         MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
         if (coder == 0) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -4251,6 +4251,107 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         $Type$Species vsp = ($Type$Species) species;
         return vsp.vOp(m, n -> (short) a[offset + indexMap[mapOffset + n]]);
     }
+
+    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
+
+    /**
+     * {@return {@code true} if the given {@link String} can be loaded into a {@link ShortVector} as 16-bit
+     * code units in the specified {@link Charset}}
+     *
+     * @param string the string
+     * @param charset the charset representing the 16-bit character encoding
+     * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
+     * @see ShortVector#fromString(VectorSpecies, String, Charset, int)
+     * @since 28
+     */
+    @ForceInline
+    public static boolean compatibleWith(String string, Charset charset) {
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        return charset == StandardCharsets.UTF_16;
+    }
+
+    /**
+     * {@return a {@link ShortVector} loaded with 16-bit code units from the given {@link String},
+     * interpreted using the specified {@link Charset}}
+     *
+     * @param species species of the desired vector
+     * @param string the string to load from
+     * @param charset the 16-bit charset
+     * @param offset the character index in the string to load from
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset < 0} or {@code offset > string.length() - species.length()}
+     * @throws NullPointerException if {@code species}, {@code string}, or {@code charset} is {@code null}
+     * @see #compatibleWith(String, Charset)
+     * @since 28
+     */
+    @ForceInline
+    public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        offset = checkFromIndexSize(offset, species.length(), string.length());
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        byte coder = LANG_ACCESS.stringCoder(string);
+        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
+        if (coder == 0) {
+            VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
+            ByteVector byteVector;
+            if (VectorIntrinsics.indexInRange(offset, byteSpecies.vectorByteSize(), string.length())) {
+                byteVector = ByteVector.fromMemorySegment(byteSpecies, segment, offset, ByteOrder.nativeOrder());
+            } else {
+                VectorMask<Byte> byteMask = byteSpecies.indexInRange(0, species.length());
+                byteVector = ByteVector.fromMemorySegment(byteSpecies, segment, offset, ByteOrder.nativeOrder(), byteMask);
+            }
+            return (ShortVector) byteVector.convertShape(ZERO_EXTEND_B2S, species, 0);
+        } else {
+            return fromMemorySegment(species, segment, (long) offset << 1, ByteOrder.nativeOrder());
+        }
+    }
+
+    /**
+     * {@return a {@link ShortVector} loaded with 16-bit code units from the given {@link String},
+     * interpreted using the specified {@link Charset}}
+     *
+     * @param species species of the desired vector
+     * @param string the string to load from
+     * @param charset the 16-bit charset
+     * @param offset the character index in the string to load from
+     * @param m the mask controlling lane selection
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
+     *         for any lane {@code N} in the vector where the mask is set
+     * @throws NullPointerException if {@code species}, {@code string}, {@code charset}, or {@code m} is {@code null}
+     * @see #compatibleWith(String, Charset)
+     * @since 28
+     */
+    @ForceInline
+    public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset, VectorMask<Short> m) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        Objects.requireNonNull(m);
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        byte coder = LANG_ACCESS.stringCoder(string);
+        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
+        if (coder == 0) {
+            VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
+            VectorMask<Byte> byteMask = VectorMask.fromLong(byteSpecies, m.toLong());
+            ByteVector byteVector =
+                    ByteVector.fromMemorySegment(byteSpecies, segment, offset, ByteOrder.nativeOrder(), byteMask);
+            return (ShortVector) byteVector.convertShape(ZERO_EXTEND_B2S, species, 0);
+        } else {
+            return fromMemorySegment(species, segment, (long) offset << 1, ByteOrder.nativeOrder(), m);
+        }
+    }
 #end[strictShort]
 
 #if[byte]
@@ -5063,6 +5164,82 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
                  int j = indexMap[mapOffset + i];
                  arr[off + j] = (e & 1) != 0;
              });
+    }
+
+    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
+
+    /**
+     * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} using the
+     * specified single-byte {@link Charset}}
+     *
+     * @param string the string
+     * @param charset the charset representing the single-byte character encoding
+     * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
+     * @see ByteVector#fromString(VectorSpecies, String, Charset, int)
+     * @since 28
+     */
+    @ForceInline
+    public static boolean compatibleWith(String string, Charset charset) {
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        return LANG_ACCESS.stringCoder(string) == 0
+                && (charset == StandardCharsets.ISO_8859_1 || charset == StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * {@return a {@link ByteVector} loaded with bytes from the given {@link String},
+     * interpreted using the specified single-byte {@link Charset}}
+     *
+     * @param species the species of the desired vector
+     * @param string the string to load from
+     * @param charset the single-byte charset
+     * @param offset the character index in the string to begin loading from
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset < 0} or {@code offset > string.length() - species.length()}
+     * @throws NullPointerException if {@code species}, {@code string}, or {@code charset} is {@code null}
+     * @since 28
+     */
+    @ForceInline
+    public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        offset = checkFromIndexSize(offset, species.length(), string.length());
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
+    }
+
+    /**
+     * {@return a {@link ByteVector} loaded with bytes from the given {@link String},
+     * interpreted using the specified single-byte {@link Charset}}
+     *
+     * @param species the species of the desired vector
+     * @param string the string to load from
+     * @param charset the single-byte charset
+     * @param offset the character index in the string to begin loading from
+     * @param m the mask controlling lane selection
+     * @throws IllegalArgumentException if the string and charset are not
+     *         {@linkplain #compatibleWith(String, Charset) compatible}
+     * @throws IndexOutOfBoundsException
+     *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
+     *         for any lane {@code N} in the vector where the mask is set
+     * @throws NullPointerException if {@code species}, {@code string}, {@code charset}, or {@code m} is {@code null}
+     * @since 28
+     */
+    @ForceInline
+    public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset, VectorMask<Byte> m) {
+        Objects.requireNonNull(species);
+        Objects.requireNonNull(string);
+        Objects.requireNonNull(charset);
+        Objects.requireNonNull(m);
+        if (!compatibleWith(string, charset)) {
+            throw new IllegalArgumentException();
+        }
+        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
     }
 #end[byte]
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -27,10 +27,18 @@ package jdk.incubator.vector;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
+#if[byteOrStrictShort]
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+#end[byteOrStrictShort]
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
+#if[byteOrStrictShort]
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+#end[byteOrStrictShort]
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
@@ -4294,7 +4302,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         Objects.requireNonNull(charset);
         offset = checkFromIndexSize(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
         byte coder = LANG_ACCESS.stringCoder(string);
         MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
@@ -4338,7 +4346,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         Objects.requireNonNull(charset);
         Objects.requireNonNull(m);
         if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
         byte coder = LANG_ACCESS.stringCoder(string);
         MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
@@ -5182,8 +5190,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     public static boolean compatibleWith(String string, Charset charset) {
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        return LANG_ACCESS.stringCoder(string) == 0
-                && (charset == StandardCharsets.ISO_8859_1 || charset == StandardCharsets.US_ASCII);
+        return LANG_ACCESS.stringCoder(string) == 0 && charset == StandardCharsets.ISO_8859_1;
     }
 
     /**
@@ -5208,7 +5215,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         Objects.requireNonNull(charset);
         offset = checkFromIndexSize(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
         return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
@@ -5237,7 +5244,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         Objects.requireNonNull(charset);
         Objects.requireNonNull(m);
         if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
         return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -4280,10 +4280,10 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
      * {@return a {@link ShortVector} loaded with 16-bit code units from the given {@link String},
      * interpreted using the specified {@link Charset}}
      *
-     * @param species species of the desired vector
+     * @param species the species of the desired vector
      * @param string the string to load from
      * @param charset the 16-bit charset
-     * @param offset the character index in the string to load from
+     * @param offset the character index in the string to begin loading from
      * @throws IllegalArgumentException if the string and charset are not
      *         {@linkplain #compatibleWith(String, Charset) compatible}
      * @throws IndexOutOfBoundsException
@@ -4297,10 +4297,10 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         Objects.requireNonNull(species);
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        offset = checkFromIndexSize(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
+        offset = checkFromIndexSize(offset, species.length(), string.length());
         byte coder = StringSupport.stringCoder(string);
         MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
         if (coder == 0) {
@@ -4322,10 +4322,10 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
      * {@return a {@link ShortVector} loaded with 16-bit code units from the given {@link String},
      * interpreted using the specified {@link Charset}}
      *
-     * @param species species of the desired vector
+     * @param species the species of the desired vector
      * @param string the string to load from
      * @param charset the 16-bit charset
-     * @param offset the character index in the string to load from
+     * @param offset the character index in the string to begin loading from
      * @param m the mask controlling lane selection
      * @throws IllegalArgumentException if the string and charset are not
      *         {@linkplain #compatibleWith(String, Charset) compatible}
@@ -5172,11 +5172,11 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     }
 
     /**
-     * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} using the
-     * specified single-byte {@link Charset}}
+     * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} as 8-bit
+     * code units in the specified {@link Charset}}
      *
      * @param string the string
-     * @param charset the charset representing the single-byte character encoding
+     * @param charset the charset representing the 8-bit character encoding
      * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
      * @see ByteVector#fromString(VectorSpecies, String, Charset, int)
      * @since 28
@@ -5189,18 +5189,19 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     }
 
     /**
-     * {@return a {@link ByteVector} loaded with bytes from the given {@link String},
-     * interpreted using the specified single-byte {@link Charset}}
+     * {@return a {@link ByteVector} loaded with 8-bit code units from the given {@link String},
+     * interpreted using the specified {@link Charset}}
      *
      * @param species the species of the desired vector
      * @param string the string to load from
-     * @param charset the single-byte charset
+     * @param charset the 8-bit charset
      * @param offset the character index in the string to begin loading from
      * @throws IllegalArgumentException if the string and charset are not
      *         {@linkplain #compatibleWith(String, Charset) compatible}
      * @throws IndexOutOfBoundsException
      *         if {@code offset < 0} or {@code offset > string.length() - species.length()}
      * @throws NullPointerException if {@code species}, {@code string}, or {@code charset} is {@code null}
+     * @see #compatibleWith(String, Charset)
      * @since 28
      */
     @ForceInline
@@ -5208,20 +5209,20 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         Objects.requireNonNull(species);
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        offset = checkFromIndexSize(offset, species.length(), string.length());
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
+        offset = checkFromIndexSize(offset, species.length(), string.length());
         return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
 
     /**
-     * {@return a {@link ByteVector} loaded with bytes from the given {@link String},
-     * interpreted using the specified single-byte {@link Charset}}
+     * {@return a {@link ByteVector} loaded with 8-bit code units from the given {@link String},
+     * interpreted using the specified {@link Charset}}
      *
      * @param species the species of the desired vector
      * @param string the string to load from
-     * @param charset the single-byte charset
+     * @param charset the 8-bit charset
      * @param offset the character index in the string to begin loading from
      * @param m the mask controlling lane selection
      * @throws IllegalArgumentException if the string and charset are not
@@ -5230,6 +5231,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
      *         if {@code offset+N < 0} or {@code offset+N >= string.length()}
      *         for any lane {@code N} in the vector where the mask is set
      * @throws NullPointerException if {@code species}, {@code string}, {@code charset}, or {@code m} is {@code null}
+     * @see #compatibleWith(String, Charset)
      * @since 28
      */
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -35,11 +35,10 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
-#if[byteOrStrictShort]
-import jdk.internal.access.JavaLangAccess;
-import jdk.internal.access.SharedSecrets;
-#end[byteOrStrictShort]
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
+#if[byteOrStrictShort]
+import jdk.internal.foreign.StringSupport;
+#end[byteOrStrictShort]
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
@@ -4260,8 +4259,6 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         return vsp.vOp(m, n -> (short) a[offset + indexMap[mapOffset + n]]);
     }
 
-    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
-
     /**
      * {@return {@code true} if the given {@link String} can be loaded into a {@link ShortVector} as 16-bit
      * code units in the specified {@link Charset}}
@@ -4304,8 +4301,8 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
-        byte coder = LANG_ACCESS.stringCoder(string);
-        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
+        byte coder = StringSupport.stringCoder(string);
+        MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
         if (coder == 0) {
             VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
             ByteVector byteVector;
@@ -4348,8 +4345,8 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
-        byte coder = LANG_ACCESS.stringCoder(string);
-        MemorySegment segment = LANG_ACCESS.asReadOnlyMemorySegment(string);
+        byte coder = StringSupport.stringCoder(string);
+        MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
         if (coder == 0) {
             VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
             VectorMask<Byte> byteMask = VectorMask.fromLong(byteSpecies, m.toLong());
@@ -5174,8 +5171,6 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
              });
     }
 
-    private static final JavaLangAccess LANG_ACCESS = SharedSecrets.getJavaLangAccess();
-
     /**
      * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} using the
      * specified single-byte {@link Charset}}
@@ -5190,7 +5185,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     public static boolean compatibleWith(String string, Charset charset) {
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
-        return LANG_ACCESS.stringCoder(string) == 0 && charset == StandardCharsets.ISO_8859_1;
+        return StringSupport.stringCoder(string) == 0 && charset == StandardCharsets.ISO_8859_1;
     }
 
     /**
@@ -5217,7 +5212,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
-        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
+        return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
 
     /**
@@ -5246,7 +5241,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         if (!compatibleWith(string, charset)) {
             throw new IllegalArgumentException("String is not compatible with: " + charset);
         }
-        return fromMemorySegment(species, LANG_ACCESS.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
+        return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
     }
 #end[byte]
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -41,6 +41,9 @@ import jdk.internal.foreign.StringSupport;
 #end[byteOrStrictShort]
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
+#if[byteOrStrictShort]
+import jdk.internal.vm.annotation.DontInline;
+#end[byteOrStrictShort]
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.vector.VectorSupport;
 
@@ -4263,6 +4266,9 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
      * {@return {@code true} if the given {@link String} can be loaded into a {@link ShortVector} as 16-bit
      * code units in the specified {@link Charset}}
      *
+     * <p>This method runs in constant time, and is intended to be used as a guard for
+     * {@link ShortVector#fromString(VectorSpecies, String, Charset, int)}.
+     *
      * @param string the string
      * @param charset the charset representing the 16-bit character encoding
      * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
@@ -4274,6 +4280,18 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
         return charset == StandardCharsets.UTF_16;
+    }
+
+    @DontInline
+    private static void throwNotCompatible(Charset charset) {
+        throw new IllegalArgumentException("String is not compatible with: " + charset);
+    }
+
+    @ForceInline
+    private static void checkCompatibleWith(String string, Charset charset) {
+        if (!compatibleWith(string, charset)) {
+            throwNotCompatible(charset);
+        }
     }
 
     /**
@@ -4295,11 +4313,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     @ForceInline
     public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset) {
         Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException("String is not compatible with: " + charset);
-        }
+        checkCompatibleWith(string, charset);
         offset = checkFromIndexSize(offset, species.length(), string.length());
         byte coder = StringSupport.stringCoder(string);
         MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
@@ -4339,12 +4353,8 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     @ForceInline
     public static ShortVector fromString(VectorSpecies<Short> species, String string, Charset charset, int offset, VectorMask<Short> m) {
         Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
         Objects.requireNonNull(m);
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException("String is not compatible with: " + charset);
-        }
+        checkCompatibleWith(string, charset);
         byte coder = StringSupport.stringCoder(string);
         MemorySegment segment = StringSupport.asReadOnlyMemorySegment(string);
         if (coder == 0) {
@@ -5175,6 +5185,9 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
      * {@return {@code true} if the given {@link String} can be loaded into a {@link ByteVector} as 8-bit
      * code units in the specified {@link Charset}}
      *
+     * <p>This method runs in constant time, and is intended to be used as a guard for
+     * {@link ByteVector#fromString(VectorSpecies, String, Charset, int)}.
+     *
      * @param string the string
      * @param charset the charset representing the 8-bit character encoding
      * @throws NullPointerException if {@code string} or {@code charset} is {@code null}
@@ -5186,6 +5199,18 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         Objects.requireNonNull(string);
         Objects.requireNonNull(charset);
         return StringSupport.stringCoder(string) == 0 && charset == StandardCharsets.ISO_8859_1;
+    }
+
+    @DontInline
+    private static void throwNotCompatible(Charset charset) {
+        throw new IllegalArgumentException("String is not compatible with: " + charset);
+    }
+
+    @ForceInline
+    private static void checkCompatibleWith(String string, Charset charset) {
+        if (!compatibleWith(string, charset)) {
+            throwNotCompatible(charset);
+        }
     }
 
     /**
@@ -5207,11 +5232,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     @ForceInline
     public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset) {
         Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException("String is not compatible with: " + charset);
-        }
+        checkCompatibleWith(string, charset);
         offset = checkFromIndexSize(offset, species.length(), string.length());
         return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder());
     }
@@ -5237,12 +5258,8 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     @ForceInline
     public static ByteVector fromString(VectorSpecies<Byte> species, String string, Charset charset, int offset, VectorMask<Byte> m) {
         Objects.requireNonNull(species);
-        Objects.requireNonNull(string);
-        Objects.requireNonNull(charset);
         Objects.requireNonNull(m);
-        if (!compatibleWith(string, charset)) {
-            throw new IllegalArgumentException("String is not compatible with: " + charset);
-        }
+        checkCompatibleWith(string, charset);
         return fromMemorySegment(species, StringSupport.asReadOnlyMemorySegment(string), offset, ByteOrder.nativeOrder(), m);
     }
 #end[byte]

--- a/test/jdk/jdk/incubator/vector/StringLoadTest.java
+++ b/test/jdk/jdk/incubator/vector/StringLoadTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2026, Google LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.vector
+ * @run testng StringLoadTest
+ */
+
+import static org.testng.Assert.*;
+
+import jdk.incubator.vector.*;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class StringLoadTest {
+
+    private static final List<VectorSpecies<Byte>> BYTE_SPECIES =
+            List.of(
+                    ByteVector.SPECIES_64,
+                    ByteVector.SPECIES_128,
+                    ByteVector.SPECIES_256,
+                    ByteVector.SPECIES_512,
+                    ByteVector.SPECIES_MAX);
+    private static final List<VectorSpecies<Short>> SHORT_SPECIES =
+            List.of(
+                    ShortVector.SPECIES_64,
+                    ShortVector.SPECIES_128,
+                    ShortVector.SPECIES_256,
+                    ShortVector.SPECIES_512,
+                    ShortVector.SPECIES_MAX);
+
+    @Test(dataProvider = "strings")
+    public void testShortVector(String string) {
+        for (VectorSpecies<Short> species : SHORT_SPECIES) {
+            assertTrue(ShortVector.compatibleWith(string, StandardCharsets.UTF_16));
+            for (int i = 0; i <= string.length() - species.length(); i++) {
+                ShortVector vec =
+                        ShortVector.fromString(species, string, StandardCharsets.UTF_16, i);
+                for (int lane = 0; lane < species.length(); lane++) {
+                    assertEquals(
+                            vec.lane(lane),
+                            (short) string.charAt(i + lane),
+                            String.format(
+                                    "mismatch at offset %d for lane %d in %s", i, lane, string));
+                }
+            }
+        }
+    }
+
+    @Test(dataProvider = "strings")
+    public void testShortVectorMask(String string) {
+        for (VectorSpecies<Short> species : SHORT_SPECIES) {
+            assertTrue(ShortVector.compatibleWith(string, StandardCharsets.UTF_16));
+            for (int i = 0; i <= string.length(); i++) {
+                VectorMask<Short> mask = species.indexInRange(i, string.length());
+                ShortVector vec =
+                        ShortVector.fromString(species, string, StandardCharsets.UTF_16, i, mask);
+                for (int lane = 0; lane < species.length(); lane++) {
+                    short expected =
+                            (i + lane < string.length()) ? (short) string.charAt(i + lane) : 0;
+                    assertEquals(
+                            vec.lane(lane),
+                            expected,
+                            String.format(
+                                    "mismatch at offset %d for lane %d in %s", i, lane, string));
+                }
+            }
+        }
+    }
+
+    @Test(dataProvider = "strings")
+    public void testByteVector(String string) {
+        boolean isLatin1 = string.chars().allMatch(c -> c <= 0xFF);
+        if (!isLatin1) {
+            assertFalse(ByteVector.compatibleWith(string, StandardCharsets.ISO_8859_1));
+            return;
+        }
+        for (VectorSpecies<Byte> species : BYTE_SPECIES) {
+            assertTrue(ByteVector.compatibleWith(string, StandardCharsets.ISO_8859_1));
+            for (int i = 0; i <= string.length() - species.length(); i++) {
+                ByteVector vec =
+                        ByteVector.fromString(species, string, StandardCharsets.ISO_8859_1, i);
+                for (int lane = 0; lane < species.length(); lane++) {
+                    assertEquals(
+                            vec.lane(lane),
+                            (byte) string.charAt(i + lane),
+                            String.format(
+                                    "mismatch at offset %d for lane %d in %s", i, lane, string));
+                }
+            }
+        }
+    }
+
+    @Test(dataProvider = "strings")
+    public void testByteVectorMask(String string) {
+        boolean isLatin1 = string.chars().allMatch(c -> c <= 0xFF);
+        if (!isLatin1) {
+            assertFalse(ByteVector.compatibleWith(string, StandardCharsets.ISO_8859_1));
+            return;
+        }
+        for (VectorSpecies<Byte> species : BYTE_SPECIES) {
+            assertTrue(ByteVector.compatibleWith(string, StandardCharsets.ISO_8859_1));
+            for (int i = 0; i <= string.length(); i++) {
+                VectorMask<Byte> mask = species.indexInRange(i, string.length());
+                ByteVector vec =
+                        ByteVector.fromString(
+                                species, string, StandardCharsets.ISO_8859_1, i, mask);
+                for (int lane = 0; lane < species.length(); lane++) {
+                    byte expected =
+                            (i + lane < string.length()) ? (byte) string.charAt(i + lane) : 0;
+                    assertEquals(
+                            vec.lane(lane),
+                            expected,
+                            String.format(
+                                    "mismatch at offset %d for lane %d in %s", i, lane, string));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testShortExceptions() {
+        VectorSpecies<Short> species = ShortVector.SPECIES_PREFERRED;
+        String string = "a".repeat(species.length());
+        VectorMask<Short> mask = species.indexInRange(0, string.length());
+
+        assertTrue(ShortVector.compatibleWith(string, StandardCharsets.UTF_16));
+        assertThrows(
+                NullPointerException.class,
+                () -> ShortVector.compatibleWith(null, StandardCharsets.UTF_16));
+        assertThrows(NullPointerException.class, () -> ShortVector.compatibleWith(string, null));
+
+        assertNotNull(ShortVector.fromString(species, string, StandardCharsets.UTF_16, 0));
+        assertThrows(
+                NullPointerException.class,
+                () -> ShortVector.fromString(null, string, StandardCharsets.UTF_16, 0));
+        assertThrows(
+                NullPointerException.class,
+                () -> ShortVector.fromString(species, null, StandardCharsets.UTF_16, 0));
+        assertThrows(
+                NullPointerException.class, () -> ShortVector.fromString(species, string, null, 0));
+
+        assertNotNull(ShortVector.fromString(species, string, StandardCharsets.UTF_16, 0, mask));
+        assertThrows(
+                NullPointerException.class,
+                () -> ShortVector.fromString(null, string, StandardCharsets.UTF_16, 0, mask));
+        assertThrows(
+                NullPointerException.class,
+                () -> ShortVector.fromString(species, null, StandardCharsets.UTF_16, 0, mask));
+        assertThrows(
+                NullPointerException.class,
+                () -> ShortVector.fromString(species, string, null, 0, mask));
+        assertThrows(
+                NullPointerException.class,
+                () -> ShortVector.fromString(species, string, StandardCharsets.UTF_16, 0, null));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ShortVector.fromString(species, string, StandardCharsets.UTF_8, 0));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ShortVector.fromString(species, string, StandardCharsets.UTF_8, 0, mask));
+
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> ShortVector.fromString(species, string, StandardCharsets.UTF_16, -1));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ShortVector.fromString(
+                                species, string, StandardCharsets.UTF_16, string.length()));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ShortVector.fromString(
+                                species,
+                                string,
+                                StandardCharsets.UTF_16,
+                                string.length() - species.length() + 1));
+
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> ShortVector.fromString(species, string, StandardCharsets.UTF_16, -1, mask));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ShortVector.fromString(
+                                species, string, StandardCharsets.UTF_16, string.length(), mask));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ShortVector.fromString(
+                                species,
+                                string,
+                                StandardCharsets.UTF_16,
+                                string.length() - species.length() + 1,
+                                mask));
+    }
+
+    @Test
+    public void testByteExceptions() {
+        VectorSpecies<Byte> species = ByteVector.SPECIES_PREFERRED;
+        String string = "a".repeat(species.length());
+        VectorMask<Byte> mask = species.indexInRange(0, string.length());
+
+        assertTrue(ByteVector.compatibleWith(string, StandardCharsets.ISO_8859_1));
+        assertThrows(
+                NullPointerException.class,
+                () -> ByteVector.compatibleWith(null, StandardCharsets.ISO_8859_1));
+        assertThrows(NullPointerException.class, () -> ByteVector.compatibleWith(string, null));
+
+        assertNotNull(ByteVector.fromString(species, string, StandardCharsets.ISO_8859_1, 0));
+        assertThrows(
+                NullPointerException.class,
+                () -> ByteVector.fromString(null, string, StandardCharsets.ISO_8859_1, 0));
+        assertThrows(
+                NullPointerException.class,
+                () -> ByteVector.fromString(species, null, StandardCharsets.ISO_8859_1, 0));
+        assertThrows(
+                NullPointerException.class, () -> ByteVector.fromString(species, string, null, 0));
+
+        assertNotNull(ByteVector.fromString(species, string, StandardCharsets.ISO_8859_1, 0, mask));
+        assertThrows(
+                NullPointerException.class,
+                () -> ByteVector.fromString(null, string, StandardCharsets.ISO_8859_1, 0, mask));
+        assertThrows(
+                NullPointerException.class,
+                () -> ByteVector.fromString(species, null, StandardCharsets.ISO_8859_1, 0, mask));
+        assertThrows(
+                NullPointerException.class,
+                () -> ByteVector.fromString(species, string, null, 0, mask));
+        assertThrows(
+                NullPointerException.class,
+                () -> ByteVector.fromString(species, string, StandardCharsets.ISO_8859_1, 0, null));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ByteVector.fromString(species, string, StandardCharsets.UTF_8, 0));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ByteVector.fromString(species, string, StandardCharsets.UTF_8, 0, mask));
+
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> ByteVector.fromString(species, string, StandardCharsets.ISO_8859_1, -1));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ByteVector.fromString(
+                                species, string, StandardCharsets.ISO_8859_1, string.length()));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ByteVector.fromString(
+                                species,
+                                string,
+                                StandardCharsets.ISO_8859_1,
+                                string.length() - species.length() + 1));
+
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ByteVector.fromString(
+                                species, string, StandardCharsets.ISO_8859_1, -1, mask));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ByteVector.fromString(
+                                species,
+                                string,
+                                StandardCharsets.ISO_8859_1,
+                                string.length(),
+                                mask));
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () ->
+                        ByteVector.fromString(
+                                species,
+                                string,
+                                StandardCharsets.ISO_8859_1,
+                                string.length() - species.length() + 1,
+                                mask));
+    }
+
+    @Test(dataProvider = "strings")
+    public void compatibleWith(String string) {
+        for (Charset charset : Charset.availableCharsets().values()) {
+            boolean isLatin1 = string.chars().allMatch(c -> c <= 0xFF);
+            boolean byteCompatible = isLatin1 && charset == StandardCharsets.ISO_8859_1;
+            assertEquals(ByteVector.compatibleWith(string, charset), byteCompatible);
+
+            boolean shortCompatible = charset == StandardCharsets.UTF_16;
+            assertEquals(ShortVector.compatibleWith(string, charset), shortCompatible);
+        }
+    }
+
+    @DataProvider
+    public static Object[][] strings() {
+        return new Object[][] {
+            {""},
+            {"hello world"},
+            {"123"},
+            {"a".repeat(128)},
+            {"\u1234".repeat(128)},
+            {"section \u00A7"},
+            {"snowman \u26C4"},
+            {"rainbow \uD83C\uDF08"},
+            {"cartwheel \uD83E\uDD38"},
+            {"cjk \u4E00\u4E8C"},
+            {"\uD83D\uDE00"},
+            {"\uFEFF"},
+            {"unpaired high surrogate: \uD83C"},
+            {"unpaired low surrogate: \uDC00"},
+            {"low surrogate followed by high surrogate: \uDC00\uD83C"},
+            {"high surrogate followed by high surrogate: \uD83C\uD83C"},
+            {"high surrogate followed by a non-low surrogate: \uD83C\uE000"},
+            {"valid pair followed by an unpaired low surrogate: \uD83D\uDE00\uDC00"},
+            {"unpaired low surrogate followed by valid pair: \uDC00\uD83D\uDE00"},
+        };
+    }
+}

--- a/test/jdk/jdk/incubator/vector/StringLoadTest.java
+++ b/test/jdk/jdk/incubator/vector/StringLoadTest.java
@@ -320,28 +320,24 @@ public class StringLoadTest {
         }
     }
 
+    private static String repeat(String string) {
+        return string.repeat((128 / string.length()) + 1);
+    }
+
     @DataProvider
     public static Object[][] strings() {
         return new Object[][] {
             {""},
             {"hello world"},
             {"123"},
-            {"a".repeat(128)},
-            {"\u1234".repeat(128)},
             {"section \u00A7"},
-            {"snowman \u26C4"},
-            {"rainbow \uD83C\uDF08"},
-            {"cartwheel \uD83E\uDD38"},
-            {"cjk \u4E00\u4E8C"},
-            {"\uD83D\uDE00"},
-            {"\uFEFF"},
-            {"unpaired high surrogate: \uD83C"},
-            {"unpaired low surrogate: \uDC00"},
-            {"low surrogate followed by high surrogate: \uDC00\uD83C"},
-            {"high surrogate followed by high surrogate: \uD83C\uD83C"},
-            {"high surrogate followed by a non-low surrogate: \uD83C\uE000"},
-            {"valid pair followed by an unpaired low surrogate: \uD83D\uDE00\uDC00"},
-            {"unpaired low surrogate followed by valid pair: \uDC00\uD83D\uDE00"},
+            {repeat("hello world")},
+            {repeat("123")},
+            {repeat("\u1234")},
+            {repeat("section \u00A7")},
+            {repeat("snowman \u26C4")},
+            {repeat("rainbow \uD83C\uDF08")},
+            {repeat("cartwheel \uD83E\uDD38")},
         };
     }
 }

--- a/test/jdk/jdk/incubator/vector/StringLoadTest.java
+++ b/test/jdk/jdk/incubator/vector/StringLoadTest.java
@@ -23,16 +23,18 @@
 
 /*
  * @test
+ * @bug 8390049
  * @modules jdk.incubator.vector
- * @run testng StringLoadTest
+ * @run junit/othervm -XX:+CompactStrings StringLoadTest
  */
 
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import jdk.incubator.vector.*;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -55,7 +57,8 @@ public class StringLoadTest {
                     ShortVector.SPECIES_512,
                     ShortVector.SPECIES_MAX);
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     public void testShortVector(String string) {
         for (VectorSpecies<Short> species : SHORT_SPECIES) {
             assertTrue(ShortVector.compatibleWith(string, StandardCharsets.UTF_16));
@@ -64,8 +67,8 @@ public class StringLoadTest {
                         ShortVector.fromString(species, string, StandardCharsets.UTF_16, i);
                 for (int lane = 0; lane < species.length(); lane++) {
                     assertEquals(
-                            vec.lane(lane),
                             (short) string.charAt(i + lane),
+                            vec.lane(lane),
                             String.format(
                                     "mismatch at offset %d for lane %d in %s", i, lane, string));
                 }
@@ -73,7 +76,8 @@ public class StringLoadTest {
         }
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     public void testShortVectorMask(String string) {
         for (VectorSpecies<Short> species : SHORT_SPECIES) {
             assertTrue(ShortVector.compatibleWith(string, StandardCharsets.UTF_16));
@@ -85,8 +89,8 @@ public class StringLoadTest {
                     short expected =
                             (i + lane < string.length()) ? (short) string.charAt(i + lane) : 0;
                     assertEquals(
-                            vec.lane(lane),
                             expected,
+                            vec.lane(lane),
                             String.format(
                                     "mismatch at offset %d for lane %d in %s", i, lane, string));
                 }
@@ -94,7 +98,8 @@ public class StringLoadTest {
         }
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     public void testByteVector(String string) {
         boolean isLatin1 = string.chars().allMatch(c -> c <= 0xFF);
         if (!isLatin1) {
@@ -108,8 +113,8 @@ public class StringLoadTest {
                         ByteVector.fromString(species, string, StandardCharsets.ISO_8859_1, i);
                 for (int lane = 0; lane < species.length(); lane++) {
                     assertEquals(
-                            vec.lane(lane),
                             (byte) string.charAt(i + lane),
+                            vec.lane(lane),
                             String.format(
                                     "mismatch at offset %d for lane %d in %s", i, lane, string));
                 }
@@ -117,7 +122,8 @@ public class StringLoadTest {
         }
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     public void testByteVectorMask(String string) {
         boolean isLatin1 = string.chars().allMatch(c -> c <= 0xFF);
         if (!isLatin1) {
@@ -135,8 +141,8 @@ public class StringLoadTest {
                     byte expected =
                             (i + lane < string.length()) ? (byte) string.charAt(i + lane) : 0;
                     assertEquals(
-                            vec.lane(lane),
                             expected,
+                            vec.lane(lane),
                             String.format(
                                     "mismatch at offset %d for lane %d in %s", i, lane, string));
                 }
@@ -308,15 +314,16 @@ public class StringLoadTest {
                                 mask));
     }
 
-    @Test(dataProvider = "strings")
+    @ParameterizedTest
+    @MethodSource("strings")
     public void compatibleWith(String string) {
         for (Charset charset : Charset.availableCharsets().values()) {
             boolean isLatin1 = string.chars().allMatch(c -> c <= 0xFF);
             boolean byteCompatible = isLatin1 && charset == StandardCharsets.ISO_8859_1;
-            assertEquals(ByteVector.compatibleWith(string, charset), byteCompatible);
+            assertEquals(byteCompatible, ByteVector.compatibleWith(string, charset));
 
             boolean shortCompatible = charset == StandardCharsets.UTF_16;
-            assertEquals(ShortVector.compatibleWith(string, charset), shortCompatible);
+            assertEquals(shortCompatible, ShortVector.compatibleWith(string, charset));
         }
     }
 
@@ -324,7 +331,6 @@ public class StringLoadTest {
         return string.repeat((512 / string.length()) + 1);
     }
 
-    @DataProvider
     public static Object[][] strings() {
         return new Object[][] {
             {""},

--- a/test/jdk/jdk/incubator/vector/StringLoadTest.java
+++ b/test/jdk/jdk/incubator/vector/StringLoadTest.java
@@ -321,7 +321,7 @@ public class StringLoadTest {
     }
 
     private static String repeat(String string) {
-        return string.repeat((128 / string.length()) + 1);
+        return string.repeat((512 / string.length()) + 1);
     }
 
     @DataProvider

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StringLoadBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StringLoadBenchmark.java
@@ -1,0 +1,191 @@
+/*
+ *  Copyright (c) 2026, Google LLC. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+package org.openjdk.bench.jdk.incubator.vector;
+
+import static jdk.incubator.vector.VectorOperators.*;
+import static jdk.incubator.vector.VectorOperators.EQ;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorSpecies;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/** Compares vector and scalar loops over a Latin-1 String. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(
+        value = 3,
+        jvmArgs = {"--add-modules=jdk.incubator.vector"})
+public class StringLoadBenchmark {
+    static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
+
+    static final byte NEEDLE = (byte) 'a';
+
+    @Param({"16", "32", "64", "128", "1024"})
+    private int size;
+
+    private String text;
+    private byte[] textBytes;
+    private MemorySegment heapSegment;
+    private MemorySegment nativeSegment;
+
+    @Setup
+    public void setup() {
+        System.out.println("# SPECIES: " + SPECIES + " (" + SPECIES.length() + " lanes)");
+        Random random = new Random(42);
+        StringBuilder sb = new StringBuilder(size);
+        for (int i = 0; i < size; i++) {
+            sb.append((char) random.nextInt(256));
+        }
+        text = sb.toString();
+        textBytes = text.getBytes(StandardCharsets.ISO_8859_1);
+        heapSegment = MemorySegment.ofArray(textBytes).asReadOnly();
+        nativeSegment = Arena.ofAuto().allocate(size, 1);
+        MemorySegment.copy(textBytes, 0, nativeSegment, ValueLayout.JAVA_BYTE, 0, size);
+    }
+
+    @Benchmark
+    public int scalar() {
+        return countScalar(text, (char) (NEEDLE & 0xFF), size);
+    }
+
+    @Benchmark
+    public int getBytesFromArray() {
+        return countArray(text.getBytes(StandardCharsets.ISO_8859_1), NEEDLE, size);
+    }
+
+    @Benchmark
+    public int fromString() {
+        return countString(text, NEEDLE, size);
+    }
+
+    @Benchmark
+    public int segment() {
+        return countSegment(heapSegment, NEEDLE, size);
+    }
+
+    @Benchmark
+    public int fromArray() {
+        return countArray(textBytes, NEEDLE, size);
+    }
+
+    @Benchmark
+    public int monomorphic() {
+        return countSegmentNotInlined(heapSegment, NEEDLE, size)
+                + countSegmentNotInlined(heapSegment, NEEDLE, size);
+    }
+
+    @Benchmark
+    public int polluted() {
+        return countSegmentNotInlined(heapSegment, NEEDLE, size)
+                + countSegmentNotInlined(nativeSegment, NEEDLE, size);
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private int countSegmentNotInlined(MemorySegment segment, byte needle, int len) {
+        return countSegment(segment, needle, len);
+    }
+
+    private static int countScalar(String s, char needle, int len) {
+        int count = 0;
+        for (int i = 0; i < len; i++) {
+            if (s.charAt(i) == needle) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static int countArray(byte[] bytes, byte needle, int len) {
+        int count = 0;
+        int i = 0;
+        for (; i < SPECIES.loopBound(len); i += SPECIES.length()) {
+            count += ByteVector.fromArray(SPECIES, bytes, i).compare(EQ, needle).trueCount();
+        }
+        for (; i < len; i++) {
+            if (bytes[i] == needle) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static int countString(String s, byte needle, int len) {
+        int count = 0;
+        int i = 0;
+        for (; i < SPECIES.loopBound(len); i += SPECIES.length()) {
+            count +=
+                    ByteVector.fromString(SPECIES, s, StandardCharsets.ISO_8859_1, i)
+                            .compare(EQ, needle)
+                            .trueCount();
+        }
+        for (; i < len; i++) {
+            if ((byte) s.charAt(i) == needle) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static int countSegment(MemorySegment segment, byte needle, int len) {
+        int count = 0;
+        int i = 0;
+        for (; i < SPECIES.loopBound(len); i += SPECIES.length()) {
+            count +=
+                    ByteVector.fromMemorySegment(SPECIES, segment, i, ByteOrder.nativeOrder())
+                            .compare(EQ, needle)
+                            .trueCount();
+        }
+        for (; i < len; i++) {
+            if (segment.get(ValueLayout.JAVA_BYTE, i) == needle) {
+                count++;
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
See

* [panama-dev@ thread 'String processing and Vector APIs'](https://mail.openjdk.org/archives/list/panama-dev@openjdk.org/thread/YSPX3TBXZTZEFZNXWDYOZCWLUQPC62P6/)
* [JDK-8390049: Immutable zero-copy String views of a String's code units](https://bugs.openjdk.org/browse/JDK-8390049)




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390049](https://bugs.openjdk.org/browse/JDK-8390049): Zero-copy vector alternative to a scalar loop over charAt (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32373/head:pull/32373` \
`$ git checkout pull/32373`

Update a local copy of the PR: \
`$ git checkout pull/32373` \
`$ git pull https://git.openjdk.org/jdk.git pull/32373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32373`

View PR using the GUI difftool: \
`$ git pr show -t 32373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32373.diff">https://git.openjdk.org/jdk/pull/32373.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32373#issuecomment-5602379556)
</details>
