### PR TITLE
8390370: [Valhalla] PPC64 C1 LIR_Assembler::emit_alloc_array() doesn't check LIR_OpAllocArray::always_slow_path()

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2250,7 +2250,7 @@ void LIR_Assembler::emit_alloc_obj(LIR_OpAllocObj* op) {
 
 void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
   LP64_ONLY( __ extsw(op->len()->as_register(), op->len()->as_register()); )
-  if (UseSlowPath ||
+  if (UseSlowPath || op->always_slow_path() ||
       (!UseFastNewObjectArray && (is_reference_type(op->type()))) ||
       (!UseFastNewTypeArray   && (!is_reference_type(op->type())))) {
     __ b(*op->stub()->entry());


### PR DESCRIPTION
This pr changes `LIR_Assembler::emit_alloc_obj()` to respect `LIR_OpAllocArray::always_slow_path()`.
With this (and https://github.com/openjdk/jdk/pull/32345) we pass test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayMetadata.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390370](https://bugs.openjdk.org/browse/JDK-8390370): [Valhalla] PPC64 C1 LIR_Assembler::emit_alloc_array() doesn't check LIR_OpAllocArray::always_slow_path() (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32374/head:pull/32374` \
`$ git checkout pull/32374`

Update a local copy of the PR: \
`$ git checkout pull/32374` \
`$ git pull https://git.openjdk.org/jdk.git pull/32374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32374`

View PR using the GUI difftool: \
`$ git pr show -t 32374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32374.diff">https://git.openjdk.org/jdk/pull/32374.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32374#issuecomment-5293515618)
</details>
