### PR TITLE
8390350: Remove test-local verbose mode from vmTestbase nsk tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001.java
@@ -133,11 +133,7 @@ public class isPrivate001 extends Log {
         Binder binder   = new Binder(argsHandler, logHandler);
 
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         IOPipe pipe     = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001/TestDescription.java
@@ -50,7 +50,6 @@
  *        nsk.jdi.Accessible.isPrivate.isPrivate001a
  * @run driver
  *      nsk.jdi.Accessible.isPrivate.isPrivate001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isPrivate001 JDI test.
  */
 
 public class isPrivate001a {
-
-    static boolean verbose_mode = false;
 
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
@@ -82,31 +79,22 @@ public class isPrivate001a {
     pack_priv_interf_impl ppii0 = new pack_priv_interf_impl();
     pack_priv_interf ppi0, ppi1[]={ppi0}, ppi2[][]={ppi1};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> isPrivate001a: debugee started!");
+        display("**> isPrivate001a: debugee started!");
         isPrivate001a isPrivate001a_obj = new isPrivate001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        print_log_on_verbose("**> isPrivate001a: waiting for \"quit\" signal...");
+        display("**> isPrivate001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isPrivate001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isPrivate001a: completed succesfully!");
+            display("**> isPrivate001a: \"quit\" signal recieved!");
+            display("**> isPrivate001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isPrivate001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPrivate/isPrivate001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class isPrivate001a {
 
+    private static Log log = new Log(System.err);
+
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
     char    c0, c1[]={c0}, c2[][]={c1};
@@ -79,22 +81,18 @@ public class isPrivate001a {
     pack_priv_interf_impl ppii0 = new pack_priv_interf_impl();
     pack_priv_interf ppi0, ppi1[]={ppi0}, ppi2[][]={ppi1};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> isPrivate001a: debugee started!");
+        log.display("**> isPrivate001a: debugee started!");
         isPrivate001a isPrivate001a_obj = new isPrivate001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        display("**> isPrivate001a: waiting for \"quit\" signal...");
+        log.display("**> isPrivate001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isPrivate001a: \"quit\" signal recieved!");
-            display("**> isPrivate001a: completed succesfully!");
+            log.display("**> isPrivate001a: \"quit\" signal recieved!");
+            log.display("**> isPrivate001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isPrivate001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001.java
@@ -133,11 +133,7 @@ public class isProtected001 extends Log {
         Binder binder   = new Binder(argsHandler, logHandler);
 
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         IOPipe pipe     = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001/TestDescription.java
@@ -49,7 +49,6 @@
  *        nsk.jdi.Accessible.isProtected.isProtected001a
  * @run driver
  *      nsk.jdi.Accessible.isProtected.isProtected001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class isProtected001a {
 
+    private static Log log = new Log(System.err);
+
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
     char    c0, c1[]={c0}, c2[][]={c1};
@@ -79,22 +81,18 @@ public class isProtected001a {
     pack_priv_interf_impl ppii0 = new pack_priv_interf_impl();
     pack_priv_interf ppi0, ppi1[]={ppi0}, ppi2[][]={ppi1};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> isProtected001a: debugee started!");
+        log.display("**> isProtected001a: debugee started!");
         isProtected001a isProtected001a_obj = new isProtected001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        display("**> isProtected001a: waiting for \"quit\" signal...");
+        log.display("**> isProtected001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isProtected001a: \"quit\" signal recieved!");
-            display("**> isProtected001a: completed succesfully!");
+            log.display("**> isProtected001a: \"quit\" signal recieved!");
+            log.display("**> isProtected001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isProtected001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isProtected/isProtected001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isProtected001 JDI test.
  */
 
 public class isProtected001a {
-
-    static boolean verbose_mode = false;
 
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
@@ -82,31 +79,22 @@ public class isProtected001a {
     pack_priv_interf_impl ppii0 = new pack_priv_interf_impl();
     pack_priv_interf ppi0, ppi1[]={ppi0}, ppi2[][]={ppi1};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> isProtected001a: debugee started!");
+        display("**> isProtected001a: debugee started!");
         isProtected001a isProtected001a_obj = new isProtected001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        print_log_on_verbose("**> isProtected001a: waiting for \"quit\" signal...");
+        display("**> isProtected001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isProtected001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isProtected001a: completed succesfully!");
+            display("**> isProtected001a: \"quit\" signal recieved!");
+            display("**> isProtected001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isProtected001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001.java
@@ -133,11 +133,7 @@ public class isPublic001 extends Log {
         Binder binder   = new Binder(argsHandler, logHandler);
 
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         IOPipe pipe     = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001/TestDescription.java
@@ -49,7 +49,6 @@
  *        nsk.jdi.Accessible.isPublic.isPublic001a
  * @run driver
  *      nsk.jdi.Accessible.isPublic.isPublic001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isPublic001 JDI test.
  */
 
 public class isPublic001a {
-
-    static boolean verbose_mode = false;
 
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
@@ -81,31 +78,22 @@ public class isPublic001a {
     pack_priv_interf_impl ppii0 = new pack_priv_interf_impl();
     pack_priv_interf ppi0, ppi1[]={ppi0}, ppi2[][]={ppi1};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> isPublic001a: debugee started!");
+        display("**> isPublic001a: debugee started!");
         isPublic001a isPublic001a_obj = new isPublic001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        print_log_on_verbose("**> isPublic001a: waiting for \"quit\" signal...");
+        display("**> isPublic001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isPublic001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isPublic001a: completed succesfully!");
+            display("**> isPublic001a: \"quit\" signal recieved!");
+            display("**> isPublic001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isPublic001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPublic/isPublic001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class isPublic001a {
 
+    private static Log log = new Log(System.err);
+
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
     char    c0, c1[]={c0}, c2[][]={c1};
@@ -78,22 +80,18 @@ public class isPublic001a {
     pack_priv_interf_impl ppii0 = new pack_priv_interf_impl();
     pack_priv_interf ppi0, ppi1[]={ppi0}, ppi2[][]={ppi1};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> isPublic001a: debugee started!");
+        log.display("**> isPublic001a: debugee started!");
         isPublic001a isPublic001a_obj = new isPublic001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        display("**> isPublic001a: waiting for \"quit\" signal...");
+        log.display("**> isPublic001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isPublic001a: \"quit\" signal recieved!");
-            display("**> isPublic001a: completed succesfully!");
+            log.display("**> isPublic001a: \"quit\" signal recieved!");
+            log.display("**> isPublic001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isPublic001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001.java
@@ -125,11 +125,7 @@ public class modifiers001 extends Log {
         Binder binder   = new Binder(argsHandler, logHandler);
 
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         IOPipe pipe     = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001/TestDescription.java
@@ -50,7 +50,6 @@
  *        nsk.jdi.Accessible.modifiers.modifiers001a
  * @run driver
  *      nsk.jdi.Accessible.modifiers.modifiers001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class modifiers001a {
 
+    private static Log log = new Log(System.err);
+
     // Classes must be loaded and linked, so all fields must be
     // initialized
     Boolean   Z0 = Boolean.valueOf(false);
@@ -70,22 +72,18 @@ public class modifiers001a {
     interf_impl m_interf_impl_0 = new interf_impl();
     interf m_interf_0, m_interf_1[] = {m_interf_0};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> modifiers001a: debugee started!");
+        log.display("**> modifiers001a: debugee started!");
         modifiers001a obj = new modifiers001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        display("**> modifiers001a: waiting for \"quit\" signal...");
+        log.display("**> modifiers001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> modifiers001a: \"quit\" signal recieved!");
-            display("**> modifiers001a: completed succesfully!");
+            log.display("**> modifiers001a: \"quit\" signal recieved!");
+            log.display("**> modifiers001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> modifiers001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the modifiers001 JDI test.
  */
 
 public class modifiers001a {
-
-    static boolean verbose_mode = false;
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
@@ -73,31 +70,22 @@ public class modifiers001a {
     interf_impl m_interf_impl_0 = new interf_impl();
     interf m_interf_0, m_interf_1[] = {m_interf_0};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> modifiers001a: debugee started!");
+        display("**> modifiers001a: debugee started!");
         modifiers001a obj = new modifiers001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        print_log_on_verbose("**> modifiers001a: waiting for \"quit\" signal...");
+        display("**> modifiers001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> modifiers001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> modifiers001a: completed succesfully!");
+            display("**> modifiers001a: \"quit\" signal recieved!");
+            display("**> modifiers001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> modifiers001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001.java
@@ -128,11 +128,7 @@ public class reflectype001 extends Log {
         Binder binder   = new Binder(argsHandler, logHandler);
 
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         IOPipe pipe     = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001/TestDescription.java
@@ -53,7 +53,6 @@
  *        nsk.jdi.ClassObjectReference.reflectedType.reflectype001a
  * @run driver
  *      nsk.jdi.ClassObjectReference.reflectedType.reflectype001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the reflectype001 JDI test.
  */
 
 public class reflectype001a {
-
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
 
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
@@ -75,33 +71,24 @@ public class reflectype001a {
     package_interf_impl pii0 = new package_interf_impl();
     package_interf package_interf0, package_interf1[]={package_interf0},
                     package_interf2[][]={package_interf1};
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> reflectype001a: debugee started!");
+        display("**> reflectype001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         reflectype001a reflectype001a_obj = new reflectype001a();
 
-        print_log_on_verbose("**> reflectype001a: waiting for \"quit\" signal...");
+        display("**> reflectype001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> reflectype001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> reflectype001a: completed succesfully!");
+            display("**> reflectype001a: \"quit\" signal recieved!");
+            display("**> reflectype001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> reflectype001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class reflectype001a {
 
+    private static Log log = new Log(System.err);
+
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
     char    c0, c1[]={c0}, c2[][]={c1};
@@ -71,24 +73,21 @@ public class reflectype001a {
     package_interf_impl pii0 = new package_interf_impl();
     package_interf package_interf0, package_interf1[]={package_interf0},
                     package_interf2[][]={package_interf1};
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
-        display("**> reflectype001a: debugee started!");
+        log.display("**> reflectype001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         reflectype001a reflectype001a_obj = new reflectype001a();
 
-        display("**> reflectype001a: waiting for \"quit\" signal...");
+        log.display("**> reflectype001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> reflectype001a: \"quit\" signal recieved!");
-            display("**> reflectype001a: completed succesfully!");
+            log.display("**> reflectype001a: \"quit\" signal recieved!");
+            log.display("**> reflectype001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> reflectype001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ClassObjectReference.reflectedType.reflectype002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,59 +29,52 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the reflectype002 JDI test.
  */
 
 public class reflectype002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ClassObjectReference.reflectedType.";
     private final static String checked_class_name = package_prefix + "reflectype002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> reflectype002a: debugee started!");
+        display("**> reflectype002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
-        print_log_on_verbose("**> reflectype002a: waiting for \"checked class dir\" info...");
+        display("**> reflectype002a: waiting for \"checked class dir\" info...");
 
         ClassUnloader classUnloader = new ClassUnloader();
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> reflectype002a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> reflectype002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> reflectype002a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> reflectype002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> reflectype002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> reflectype002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> reflectype002a: completed!");
+            display("**> reflectype002a: \"quit\" signal recieved!");
+            display("**> reflectype002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -91,24 +84,24 @@ public class reflectype002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> reflectype002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> reflectype002a: enforce to unload checked class...");
+        display("**> reflectype002a: \"continue\" signal recieved!");
+        display("**> reflectype002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> reflectype002a: checked class may be NOT unloaded!");
+            display("**> reflectype002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> reflectype002a: checked class unloaded!");
+            display("**> reflectype002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> reflectype002a: waiting for \"quit\" signal...");
+        display("**> reflectype002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> reflectype002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> reflectype002a: completed!");
+            display("**> reflectype002a: \"quit\" signal recieved!");
+            display("**> reflectype002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> reflectype002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassObjectReference/reflectedType/reflectype002a.java
@@ -35,46 +35,42 @@ import nsk.share.jdi.*;
 
 public class reflectype002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ClassObjectReference.reflectedType.";
     private final static String checked_class_name = package_prefix + "reflectype002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> reflectype002a: debugee started!");
+        log.display("**> reflectype002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
-        display("**> reflectype002a: waiting for \"checked class dir\" info...");
+        log.display("**> reflectype002a: waiting for \"checked class dir\" info...");
 
         ClassUnloader classUnloader = new ClassUnloader();
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> reflectype002a: checked class loaded:" + checked_class_name);
+            log.display("--> reflectype002a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> reflectype002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> reflectype002a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> reflectype002a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> reflectype002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> reflectype002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> reflectype002a: \"quit\" signal recieved!");
-            display("**> reflectype002a: completed!");
+            log.display("**> reflectype002a: \"quit\" signal recieved!");
+            log.display("**> reflectype002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -84,24 +80,24 @@ public class reflectype002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> reflectype002a: \"continue\" signal recieved!");
-        display("**> reflectype002a: enforce to unload checked class...");
+        log.display("**> reflectype002a: \"continue\" signal recieved!");
+        log.display("**> reflectype002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> reflectype002a: checked class may be NOT unloaded!");
+            log.display("**> reflectype002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> reflectype002a: checked class unloaded!");
+            log.display("**> reflectype002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> reflectype002a: waiting for \"quit\" signal...");
+        log.display("**> reflectype002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> reflectype002a: \"quit\" signal recieved!");
-            display("**> reflectype002a: completed!");
+            log.display("**> reflectype002a: \"quit\" signal recieved!");
+            log.display("**> reflectype002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> reflectype002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields001/TestDescription.java
@@ -48,7 +48,6 @@
  *        nsk.jdi.ReferenceType.allFields.allfields001a
  * @run driver
  *      nsk.jdi.ReferenceType.allFields.allfields001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the allfields001 JDI test.
  */
 
 public class allfields001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> allfields001a: debugee started!");
+        display("**> allfields001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         allfields001aClassForCheck class_for_check = new allfields001aClassForCheck();
 
-        print_log_on_verbose("**> allfields001a: waiting for \"quit\" signal...");
+        display("**> allfields001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allfields001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allfields001a: completed succesfully!");
+            display("**> allfields001a: \"quit\" signal recieved!");
+            display("**> allfields001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allfields001a: unexpected signal (no \"quit\") - " + instruction);
@@ -157,6 +143,5 @@ interface allfields001aInterfaceForCheck {
 
     static final long    ambiguous_prim_field = 1;
     static final Object  ambiguous_ref_field = new Object();
-
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields001a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class allfields001a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> allfields001a: debugee started!");
+        log.display("**> allfields001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         allfields001aClassForCheck class_for_check = new allfields001aClassForCheck();
 
-        display("**> allfields001a: waiting for \"quit\" signal...");
+        log.display("**> allfields001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allfields001a: \"quit\" signal recieved!");
-            display("**> allfields001a: completed succesfully!");
+            log.display("**> allfields001a: \"quit\" signal recieved!");
+            log.display("**> allfields001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allfields001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002.java
@@ -100,11 +100,7 @@ public class allfields002 extends Log {
 
         Debugee debugee;
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         print_log_on_verbose("==> nsk/jdi/ReferenceType/allFields/allfields002 test LOG:");
         print_log_on_verbose("==> test checks allFields() method of ReferenceType interface ");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.allFields.allfields002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002a.java
@@ -34,16 +34,14 @@ import java.io.*;
 
 public class allfields002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.allFields.";
     private final static String checked_class_name = package_prefix + "allfields002b";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> allfields002a: debugee started!");
+        log.display("**> allfields002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -52,19 +50,17 @@ public class allfields002a {
         allfields002aClassLoader customClassLoader = new allfields002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> allfields002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> allfields002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> allfields002a: checked class NOT loaded: " + e);
+            log.display("--> allfields002a: checked class NOT loaded: " + e);
         }
 
-        display("**> allfields002a: waiting for \"quit\" signal...");
+        log.display("**> allfields002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allfields002a: \"quit\" signal recieved!");
-            display("**> allfields002a: completed succesfully!");
+            log.display("**> allfields002a: \"quit\" signal recieved!");
+            log.display("**> allfields002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allfields002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,35 +28,22 @@ import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 import java.io.*;
 
-
 /**
  * This class is used as debugee application for the allfields002 JDI test.
  */
 
 public class allfields002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.allFields.";
     private final static String checked_class_name = package_prefix + "allfields002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> allfields002a: debugee started!");
+        display("**> allfields002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -65,19 +52,19 @@ public class allfields002a {
         allfields002aClassLoader customClassLoader = new allfields002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> allfields002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> allfields002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> allfields002a: waiting for \"quit\" signal...");
+        display("**> allfields002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allfields002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allfields002a: completed succesfully!");
+            display("**> allfields002a: \"quit\" signal recieved!");
+            display("**> allfields002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allfields002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields003/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.allFields.allfields003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields003a.java
@@ -35,49 +35,43 @@ import nsk.share.jdi.*;
 
 public class allfields003a {
 
+    private static Log log = new Log(System.err);
+
     static String package_prefix = "nsk.jdi.ReferenceType.allFields.";
     static String checked_class_name = package_prefix + "allfields003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> allfields003a: debugee started!");
+        log.display("**> allfields003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> allfields003a: waiting for \"checked class dir\" info...");
+        log.display("**> allfields003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
-        display
-            ("--> allfields003a: checked class dir:" + checked_class_dir);
+        log.display("--> allfields003a: checked class dir:" + checked_class_dir);
 
         ClassUnloader classUnloader = new ClassUnloader();
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> allfields003a: checked class loaded:" + checked_class_name);
+            log.display("--> allfields003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
-            display
-                ("**> allfields003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> allfields003a: checked class NOT loaded:" + checked_class_name);
+            log.display("**> allfields003a: load class: exception thrown = " + e.toString());
+            log.display("--> allfields003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> allfields003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> allfields003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allfields003a: \"quit\" signal recieved!");
-            display("**> allfields003a: completed!");
+            log.display("**> allfields003a: \"quit\" signal recieved!");
+            log.display("**> allfields003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -87,24 +81,24 @@ public class allfields003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> allfields003a: \"continue\" signal recieved!");
-        display("**> allfields003a: enforce to unload checked class...");
+        log.display("**> allfields003a: \"continue\" signal recieved!");
+        log.display("**> allfields003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> allfields003a: checked class may be NOT unloaded!");
+            log.display("**> allfields003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> allfields003a: checked class unloaded!");
+            log.display("**> allfields003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> allfields003a: waiting for \"quit\" signal...");
+        log.display("**> allfields003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allfields003a: \"quit\" signal recieved!");
-            display("**> allfields003a: completed!");
+            log.display("**> allfields003a: \"quit\" signal recieved!");
+            log.display("**> allfields003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allfields003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,63 +29,55 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the allfields003 JDI test.
  */
 
 public class allfields003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
     static String package_prefix = "nsk.jdi.ReferenceType.allFields.";
     static String checked_class_name = package_prefix + "allfields003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> allfields003a: debugee started!");
+        display("**> allfields003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> allfields003a: waiting for \"checked class dir\" info...");
+        display("**> allfields003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
-        print_log_on_verbose
+        display
             ("--> allfields003a: checked class dir:" + checked_class_dir);
 
         ClassUnloader classUnloader = new ClassUnloader();
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> allfields003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("**> allfields003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> allfields003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> allfields003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> allfields003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allfields003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allfields003a: completed!");
+            display("**> allfields003a: \"quit\" signal recieved!");
+            display("**> allfields003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -95,24 +87,24 @@ public class allfields003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> allfields003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> allfields003a: enforce to unload checked class...");
+        display("**> allfields003a: \"continue\" signal recieved!");
+        display("**> allfields003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> allfields003a: checked class may be NOT unloaded!");
+            display("**> allfields003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> allfields003a: checked class unloaded!");
+            display("**> allfields003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> allfields003a: waiting for \"quit\" signal...");
+        display("**> allfields003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allfields003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allfields003a: completed!");
+            display("**> allfields003a: \"quit\" signal recieved!");
+            display("**> allfields003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allfields003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields004/TestDescription.java
@@ -46,7 +46,6 @@
  *        nsk.jdi.ReferenceType.allFields.allfields004a
  * @run driver
  *      nsk.jdi.ReferenceType.allFields.allfields004
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the allfields004 JDI test.
  */
 
 public class allfields004a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> allfields004a: debugee started!");
+        display("**> allfields004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         allfields004aClassForCheck class_for_check = new allfields004aClassForCheck();
 
-        print_log_on_verbose("**> allfields004a: waiting for \"quit\" signal...");
+        display("**> allfields004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allfields004a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allfields004a: completed succesfully!");
+            display("**> allfields004a: \"quit\" signal recieved!");
+            display("**> allfields004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> allfields004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allFields/allfields004a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class allfields004a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> allfields004a: debugee started!");
+        log.display("**> allfields004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         allfields004aClassForCheck class_for_check = new allfields004aClassForCheck();
 
-        display("**> allfields004a: waiting for \"quit\" signal...");
+        log.display("**> allfields004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allfields004a: \"quit\" signal recieved!");
-            display("**> allfields004a: completed succesfully!");
+            log.display("**> allfields004a: \"quit\" signal recieved!");
+            log.display("**> allfields004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> allfields004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods001/TestDescription.java
@@ -47,7 +47,6 @@
  *        nsk.jdi.ReferenceType.allMethods.allmethods001a
  * @run driver
  *      nsk.jdi.ReferenceType.allMethods.allmethods001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods001a.java
@@ -33,18 +33,16 @@ import nsk.share.jdi.*;
 
 public class allmethods001a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.allMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "allmethods001aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> allmethods001a: debugee started!");
+        log.display("**> allmethods001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -52,23 +50,21 @@ public class allmethods001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, allmethods001a.class.getClassLoader());
-            display
-                ("--> allmethods001a: checked class loaded:" + checked_class_name);
+            log.display("--> allmethods001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> allmethods001a: load class: Throwable thrown = " + thrown.toString());
-            display
-                ("--> allmethods001a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> allmethods001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> allmethods001a: waiting for \"quit\" signal...");
+        log.display("**> allmethods001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allmethods001a: \"quit\" signal recieved!");
-            display("**> allmethods001a: completed succesfully!");
+            log.display("**> allmethods001a: \"quit\" signal recieved!");
+            log.display("**> allmethods001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allmethods001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,37 +27,24 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the allmethods001 JDI test.
  */
 
 public class allmethods001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.allMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "allmethods001aClassForCheck";
 
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> allmethods001a: debugee started!");
+        display("**> allmethods001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -65,23 +52,23 @@ public class allmethods001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, allmethods001a.class.getClassLoader());
-            print_log_on_verbose
+            display
                 ("--> allmethods001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> allmethods001a: load class: Throwable thrown = " + thrown.toString());
-            print_log_on_verbose
+            display
                 ("--> allmethods001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> allmethods001a: waiting for \"quit\" signal...");
+        display("**> allmethods001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allmethods001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allmethods001a: completed succesfully!");
+            display("**> allmethods001a: \"quit\" signal recieved!");
+            display("**> allmethods001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allmethods001a: unexpected signal (no \"quit\") - " + instruction);
@@ -195,7 +182,6 @@ abstract class allmethods001aClassForCheck extends allmethods001aSuperClassForCh
 
     // static initializer
     static {}
-
 
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002.java
@@ -103,11 +103,7 @@ public class allmethods002 extends Log {
 
         Debugee debugee;
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         print_log_on_verbose("==> nsk/jdi/ReferenceType/allMethods/allmethods002 test LOG:");
         print_log_on_verbose("==> test checks allMethods() method of ReferenceType interface ");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.allMethods.allmethods002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,37 +28,24 @@ import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 import java.io.*;
 
-
 /**
  * This class is used as debugee application for the allmethods002 JDI test.
  */
 
 public class allmethods002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.allMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "allmethods002aClassForCheck";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> allmethods002a: debugee started!");
+        display("**> allmethods002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -67,19 +54,19 @@ public class allmethods002a {
         allmethods002aClassLoader customClassLoader = new allmethods002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> allmethods002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> allmethods002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> allmethods002a: waiting for \"quit\" signal...");
+        display("**> allmethods002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allmethods002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allmethods002a: completed succesfully!");
+            display("**> allmethods002a: \"quit\" signal recieved!");
+            display("**> allmethods002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allmethods002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods002a.java
@@ -34,18 +34,16 @@ import java.io.*;
 
 public class allmethods002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.allMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "allmethods002aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> allmethods002a: debugee started!");
+        log.display("**> allmethods002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -54,19 +52,17 @@ public class allmethods002a {
         allmethods002aClassLoader customClassLoader = new allmethods002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> allmethods002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> allmethods002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> allmethods002a: checked class NOT loaded: " + e);
+            log.display("--> allmethods002a: checked class NOT loaded: " + e);
         }
 
-        display("**> allmethods002a: waiting for \"quit\" signal...");
+        log.display("**> allmethods002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allmethods002a: \"quit\" signal recieved!");
-            display("**> allmethods002a: completed succesfully!");
+            log.display("**> allmethods002a: \"quit\" signal recieved!");
+            log.display("**> allmethods002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allmethods002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods003/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.allMethods.allmethods003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the allmethods003 JDI test.
  */
 
 public class allmethods003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     static String package_prefix = "nsk.jdi.ReferenceType.allMethods.";
     static String checked_class_name =  package_prefix + "allmethods003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> allmethods003a: debugee started!");
+        display("**> allmethods003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> allmethods003a: waiting for \"checked class dir\" info...");
+        display("**> allmethods003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
@@ -65,23 +58,23 @@ public class allmethods003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> allmethods003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> allmethods003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> allmethods003a: checked class NOT loaded:" + checked_class_name);
             // Debugger finds this fact itself
         }
 
-        print_log_on_verbose("**> allmethods003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> allmethods003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allmethods003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allmethods003a: completed!");
+            display("**> allmethods003a: \"quit\" signal recieved!");
+            display("**> allmethods003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -91,24 +84,24 @@ public class allmethods003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> allmethods003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> allmethods003a: enforce to unload checked class...");
+        display("**> allmethods003a: \"continue\" signal recieved!");
+        display("**> allmethods003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> allmethods003a: checked class may be NOT unloaded!");
+            display("**> allmethods003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> allmethods003a: checked class unloaded!");
+            display("**> allmethods003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> allmethods003a: waiting for \"quit\" signal...");
+        display("**> allmethods003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allmethods003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allmethods003a: completed!");
+            display("**> allmethods003a: \"quit\" signal recieved!");
+            display("**> allmethods003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allmethods003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods003a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class allmethods003a {
 
+    private static Log log = new Log(System.err);
+
     static String package_prefix = "nsk.jdi.ReferenceType.allMethods.";
     static String checked_class_name =  package_prefix + "allmethods003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> allmethods003a: debugee started!");
+        log.display("**> allmethods003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> allmethods003a: waiting for \"checked class dir\" info...");
+        log.display("**> allmethods003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
@@ -58,23 +56,21 @@ public class allmethods003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> allmethods003a: checked class loaded:" + checked_class_name);
+            log.display("--> allmethods003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> allmethods003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> allmethods003a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> allmethods003a: checked class NOT loaded:" + checked_class_name);
             // Debugger finds this fact itself
         }
 
-        display("**> allmethods003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> allmethods003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allmethods003a: \"quit\" signal recieved!");
-            display("**> allmethods003a: completed!");
+            log.display("**> allmethods003a: \"quit\" signal recieved!");
+            log.display("**> allmethods003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -84,24 +80,24 @@ public class allmethods003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> allmethods003a: \"continue\" signal recieved!");
-        display("**> allmethods003a: enforce to unload checked class...");
+        log.display("**> allmethods003a: \"continue\" signal recieved!");
+        log.display("**> allmethods003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> allmethods003a: checked class may be NOT unloaded!");
+            log.display("**> allmethods003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> allmethods003a: checked class unloaded!");
+            log.display("**> allmethods003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> allmethods003a: waiting for \"quit\" signal...");
+        log.display("**> allmethods003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allmethods003a: \"quit\" signal recieved!");
-            display("**> allmethods003a: completed!");
+            log.display("**> allmethods003a: \"quit\" signal recieved!");
+            log.display("**> allmethods003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> allmethods003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods004/TestDescription.java
@@ -45,7 +45,6 @@
  *        nsk.jdi.ReferenceType.allMethods.allmethods004a
  * @run driver
  *      nsk.jdi.ReferenceType.allMethods.allmethods004
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the allmethods004 JDI test.
  */
 
 public class allmethods004a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> allmethods004a: debugee started!");
+        display("**> allmethods004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         allmethods004aClassForCheck class_for_check = new allmethods004aClassForCheck();
 
-        print_log_on_verbose("**> allmethods004a: waiting for \"quit\" signal...");
+        display("**> allmethods004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> allmethods004a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> allmethods004a: completed succesfully!");
+            display("**> allmethods004a: \"quit\" signal recieved!");
+            display("**> allmethods004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> allmethods004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/allMethods/allmethods004a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class allmethods004a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> allmethods004a: debugee started!");
+        log.display("**> allmethods004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         allmethods004aClassForCheck class_for_check = new allmethods004aClassForCheck();
 
-        display("**> allmethods004a: waiting for \"quit\" signal...");
+        log.display("**> allmethods004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> allmethods004a: \"quit\" signal recieved!");
-            display("**> allmethods004a: completed succesfully!");
+            log.display("**> allmethods004a: \"quit\" signal recieved!");
+            log.display("**> allmethods004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> allmethods004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001/TestDescription.java
@@ -44,7 +44,6 @@
  *        nsk.jdi.ReferenceType.classObject.classobj001a
  * @run driver
  *      nsk.jdi.ReferenceType.classObject.classobj001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the classobj001 JDI test.
  */
 
 public class classobj001a {
-
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
 
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
@@ -75,33 +71,24 @@ public class classobj001a {
     package_interf package_interf0, package_interf1[]={package_interf0},
                     package_interf2[][]={package_interf1};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> classobj001a: debugee started!");
+        display("**> classobj001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         classobj001a classobj001a_obj = new classobj001a();
 
-        print_log_on_verbose("**> classobj001a: waiting for \"quit\" signal...");
+        display("**> classobj001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> classobj001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> classobj001a: completed succesfully!");
+            display("**> classobj001a: \"quit\" signal recieved!");
+            display("**> classobj001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> classobj001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class classobj001a {
 
+    private static Log log = new Log(System.err);
+
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
     char    c0, c1[]={c0}, c2[][]={c1};
@@ -71,24 +73,20 @@ public class classobj001a {
     package_interf package_interf0, package_interf1[]={package_interf0},
                     package_interf2[][]={package_interf1};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> classobj001a: debugee started!");
+        log.display("**> classobj001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         classobj001a classobj001a_obj = new classobj001a();
 
-        display("**> classobj001a: waiting for \"quit\" signal...");
+        log.display("**> classobj001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> classobj001a: \"quit\" signal recieved!");
-            display("**> classobj001a: completed succesfully!");
+            log.display("**> classobj001a: \"quit\" signal recieved!");
+            log.display("**> classobj001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> classobj001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.classObject.classobj002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the classobj002 JDI test.
  */
 
 public class classobj002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.classObject.";
     private final static String checked_class_name = package_prefix + "classobj002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> classobj002a: debugee started!");
+        display("**> classobj002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> classobj002a: waiting for \"checked class dir\" info...");
+        display("**> classobj002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
@@ -65,23 +58,23 @@ public class classobj002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> classobj002a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> classobj002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> classobj002a: checked class NOT loaded:" + checked_class_name);
             // Debugger finds this fact itself
         }
 
-        print_log_on_verbose("**> classobj002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> classobj002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> classobj002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> classobj002a: completed!");
+            display("**> classobj002a: \"quit\" signal recieved!");
+            display("**> classobj002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -91,24 +84,24 @@ public class classobj002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> classobj002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> classobj002a: enforce to unload checked class...");
+        display("**> classobj002a: \"continue\" signal recieved!");
+        display("**> classobj002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> classobj002a: checked class may be NOT unloaded!");
+            display("**> classobj002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> classobj002a: checked class unloaded!");
+            display("**> classobj002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> classobj002a: waiting for \"quit\" signal...");
+        display("**> classobj002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> classobj002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> classobj002a: completed!");
+            display("**> classobj002a: \"quit\" signal recieved!");
+            display("**> classobj002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> classobj002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/classObject/classobj002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class classobj002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.classObject.";
     private final static String checked_class_name = package_prefix + "classobj002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> classobj002a: debugee started!");
+        log.display("**> classobj002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> classobj002a: waiting for \"checked class dir\" info...");
+        log.display("**> classobj002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
@@ -58,23 +56,21 @@ public class classobj002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> classobj002a: checked class loaded:" + checked_class_name);
+            log.display("--> classobj002a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> classobj002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> classobj002a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> classobj002a: checked class NOT loaded:" + checked_class_name);
             // Debugger finds this fact itself
         }
 
-        display("**> classobj002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> classobj002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> classobj002a: \"quit\" signal recieved!");
-            display("**> classobj002a: completed!");
+            log.display("**> classobj002a: \"quit\" signal recieved!");
+            log.display("**> classobj002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -84,24 +80,24 @@ public class classobj002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> classobj002a: \"continue\" signal recieved!");
-        display("**> classobj002a: enforce to unload checked class...");
+        log.display("**> classobj002a: \"continue\" signal recieved!");
+        log.display("**> classobj002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> classobj002a: checked class may be NOT unloaded!");
+            log.display("**> classobj002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> classobj002a: checked class unloaded!");
+            log.display("**> classobj002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> classobj002a: waiting for \"quit\" signal...");
+        log.display("**> classobj002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> classobj002a: \"quit\" signal recieved!");
-            display("**> classobj002a: completed!");
+            log.display("**> classobj002a: \"quit\" signal recieved!");
+            log.display("**> classobj002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> classobj002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals001/TestDescription.java
@@ -50,7 +50,6 @@
  *        nsk.jdi.ReferenceType.equals.equals001a
  * @run driver
  *      nsk.jdi.ReferenceType.equals.equals001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class equals001a {
 
+    private static Log log = new Log(System.err);
+
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
     char    c0, c1[]={c0}, c2[][]={c1};
@@ -72,24 +74,20 @@ public class equals001a {
                       interf_for_check1[]={interf_for_check0},
                       interf_for_check2[][]={interf_for_check1};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> equals001a: debugee started!");
+        log.display("**> equals001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         equals001a equals001a_obj = new equals001a();
 
-        display("**> equals001a: waiting for \"quit\" signal...");
+        log.display("**> equals001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> equals001a: \"quit\" signal recieved!");
-            display("**> equals001a: completed succesfully!");
+            log.display("**> equals001a: \"quit\" signal recieved!");
+            log.display("**> equals001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> equals001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,16 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the equals001 JDI test.
  */
 
 public class equals001a {
-
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
 
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
@@ -77,33 +72,24 @@ public class equals001a {
                       interf_for_check1[]={interf_for_check0},
                       interf_for_check2[][]={interf_for_check1};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> equals001a: debugee started!");
+        display("**> equals001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         equals001a equals001a_obj = new equals001a();
 
-        print_log_on_verbose("**> equals001a: waiting for \"quit\" signal...");
+        display("**> equals001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> equals001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> equals001a: completed succesfully!");
+            display("**> equals001a: \"quit\" signal recieved!");
+            display("**> equals001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> equals001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.equals.equals002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class equals002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.equals.";
     private final static String checked_class_name = package_prefix + "equals002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> equals002a: debugee started!");
+        log.display("**> equals002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> equals002a: waiting for \"checked class dir\" info...");
+        log.display("**> equals002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class equals002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-             display
-                ("--> equals002a: checked class loaded:" + checked_class_name);
+             log.display("--> equals002a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> equals002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> equals002a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> equals002a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> equals002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> equals002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> equals002a: \"quit\" signal recieved!");
-            display("**> equals002a: completed!");
+            log.display("**> equals002a: \"quit\" signal recieved!");
+            log.display("**> equals002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class equals002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> equals002a: \"continue\" signal recieved!");
-        display("**> equals002a: enforce to unload checked class...");
+        log.display("**> equals002a: \"continue\" signal recieved!");
+        log.display("**> equals002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> equals002a: checked class may be NOT unloaded!");
+            log.display("**> equals002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> equals002a: checked class unloaded!");
+            log.display("**> equals002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> equals002a: waiting for \"quit\" signal...");
+        log.display("**> equals002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> equals002a: \"quit\" signal recieved!");
-            display("**> equals002a: completed!");
+            log.display("**> equals002a: \"quit\" signal recieved!");
+            log.display("**> equals002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> equals002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/equals/equals002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the equals002 JDI test.
  */
 
 public class equals002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.equals.";
     private final static String checked_class_name = package_prefix + "equals002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> equals002a: debugee started!");
+        display("**> equals002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> equals002a: waiting for \"checked class dir\" info...");
+        display("**> equals002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class equals002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-             print_log_on_verbose
+             display
                 ("--> equals002a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> equals002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> equals002a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> equals002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> equals002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> equals002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> equals002a: completed!");
+            display("**> equals002a: \"quit\" signal recieved!");
+            display("**> equals002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class equals002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> equals002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> equals002a: enforce to unload checked class...");
+        display("**> equals002a: \"continue\" signal recieved!");
+        display("**> equals002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> equals002a: checked class may be NOT unloaded!");
+            display("**> equals002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> equals002a: checked class unloaded!");
+            display("**> equals002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> equals002a: waiting for \"quit\" signal...");
+        display("**> equals002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> equals002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> equals002a: completed!");
+            display("**> equals002a: \"quit\" signal recieved!");
+            display("**> equals002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> equals002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedToInitialize001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedToInitialize001/TestDescription.java
@@ -43,7 +43,6 @@
  *        nsk.jdi.ReferenceType.failedToInitialize.failedToInitialize001a
  * @run driver
  *      nsk.jdi.ReferenceType.failedToInitialize.failedToInitialize001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedToInitialize001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedToInitialize001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class failedToInitialize001a {
 
+    private static Log log = new Log(System.err);
+
     failedToInitialize001 a001_0=new failedToInitialize001();
 
     // Interfaces must be loaded and linked, so classes that implement
@@ -40,13 +42,9 @@ public class failedToInitialize001a {
     interf_impl interf_impl_0 = new interf_impl();
     interf interf_0, interf_1[]={interf_0};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> failedToInitialize001a: debugee started!");
+        log.display("**> failedToInitialize001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -59,8 +57,7 @@ public class failedToInitialize001a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
         catch (ExceptionInInitializerError e) {
-            display
-                ("**> failedToInitialize001a: ExceptionInInitializerError caught (fail_init_class)!");
+            log.display("**> failedToInitialize001a: ExceptionInInitializerError caught (fail_init_class)!");
         }
 
         try {
@@ -71,16 +68,15 @@ public class failedToInitialize001a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
         catch (ExceptionInInitializerError e) {
-            display
-                ("**> failedToInitialize001a: ExceptionInInitializerError caught (fail_init_subcl)!");
+            log.display("**> failedToInitialize001a: ExceptionInInitializerError caught (fail_init_subcl)!");
         }
 
-        display("**> failedToInitialize001a: waiting for \"quit\" signal...");
+        log.display("**> failedToInitialize001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> failedToInitialize001a: \"quit\" signal recieved!");
-            display("**> failedToInitialize001a: completed succesfully!");
+            log.display("**> failedToInitialize001a: \"quit\" signal recieved!");
+            log.display("**> failedToInitialize001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> failedToInitialize001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedToInitialize001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedToInitialize001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the failedToInitialize001 JDI test.
  */
 
 public class failedToInitialize001a {
-
-    static boolean verbose_mode = false;
 
     failedToInitialize001 a001_0=new failedToInitialize001();
 
@@ -43,22 +40,13 @@ public class failedToInitialize001a {
     interf_impl interf_impl_0 = new interf_impl();
     interf interf_0, interf_1[]={interf_0};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> failedToInitialize001a: debugee started!");
+        display("**> failedToInitialize001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -71,7 +59,7 @@ public class failedToInitialize001a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
         catch (ExceptionInInitializerError e) {
-            print_log_on_verbose
+            display
                 ("**> failedToInitialize001a: ExceptionInInitializerError caught (fail_init_class)!");
         }
 
@@ -83,16 +71,16 @@ public class failedToInitialize001a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
         catch (ExceptionInInitializerError e) {
-            print_log_on_verbose
+            display
                 ("**> failedToInitialize001a: ExceptionInInitializerError caught (fail_init_subcl)!");
         }
 
-        print_log_on_verbose("**> failedToInitialize001a: waiting for \"quit\" signal...");
+        display("**> failedToInitialize001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> failedToInitialize001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> failedToInitialize001a: completed succesfully!");
+            display("**> failedToInitialize001a: \"quit\" signal recieved!");
+            display("**> failedToInitialize001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> failedToInitialize001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedtoinit002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedtoinit002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.failedToInitialize.failedtoinit002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedtoinit002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedtoinit002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class failedtoinit002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.failedToInitialize.";
     private final static String checked_class_name = package_prefix + "failedtoinit002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> failedtoinit002a: debugee started!");
+        log.display("**> failedtoinit002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> failedtoinit002a: waiting for \"checked class dir\" info...");
+        log.display("**> failedtoinit002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class failedtoinit002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> failedtoinit002a: checked class loaded: " + checked_class_name);
+            log.display("--> failedtoinit002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> failedtoinit002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> failedtoinit002a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> failedtoinit002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> failedtoinit002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> failedtoinit002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> failedtoinit002a: \"quit\" signal recieved!");
-            display("**> failedtoinit002a: completed!");
+            log.display("**> failedtoinit002a: \"quit\" signal recieved!");
+            log.display("**> failedtoinit002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class failedtoinit002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> failedtoinit002a: \"continue\" signal recieved!");
-        display("**> failedtoinit002a: enforce to unload checked class...");
+        log.display("**> failedtoinit002a: \"continue\" signal recieved!");
+        log.display("**> failedtoinit002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> failedtoinit002a: checked class may be NOT unloaded!");
+            log.display("**> failedtoinit002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> failedtoinit002a: checked class unloaded!");
+            log.display("**> failedtoinit002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> failedtoinit002a: waiting for \"quit\" signal...");
+        log.display("**> failedtoinit002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> failedtoinit002a: \"quit\" signal recieved!");
-            display("**> failedtoinit002a: completed!");
+            log.display("**> failedtoinit002a: \"quit\" signal recieved!");
+            log.display("**> failedtoinit002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> failedtoinit002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedtoinit002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/failedToInitialize/failedtoinit002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the failedtoinit002 JDI test.
  */
 
 public class failedtoinit002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.failedToInitialize.";
     private final static String checked_class_name = package_prefix + "failedtoinit002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> failedtoinit002a: debugee started!");
+        display("**> failedtoinit002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> failedtoinit002a: waiting for \"checked class dir\" info...");
+        display("**> failedtoinit002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class failedtoinit002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> failedtoinit002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> failedtoinit002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> failedtoinit002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> failedtoinit002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> failedtoinit002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> failedtoinit002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> failedtoinit002a: completed!");
+            display("**> failedtoinit002a: \"quit\" signal recieved!");
+            display("**> failedtoinit002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class failedtoinit002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> failedtoinit002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> failedtoinit002a: enforce to unload checked class...");
+        display("**> failedtoinit002a: \"continue\" signal recieved!");
+        display("**> failedtoinit002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> failedtoinit002a: checked class may be NOT unloaded!");
+            display("**> failedtoinit002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> failedtoinit002a: checked class unloaded!");
+            display("**> failedtoinit002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> failedtoinit002a: waiting for \"quit\" signal...");
+        display("**> failedtoinit002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> failedtoinit002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> failedtoinit002a: completed!");
+            display("**> failedtoinit002a: \"quit\" signal recieved!");
+            display("**> failedtoinit002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> failedtoinit002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname001/TestDescription.java
@@ -50,7 +50,6 @@
  *        nsk.jdi.ReferenceType.fieldByName.fieldbyname001a
  * @run driver
  *      nsk.jdi.ReferenceType.fieldByName.fieldbyname001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the fieldbyname001 JDI test.
  */
 
 public class fieldbyname001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> fieldbyname001a: debugee started!");
+        display("**> fieldbyname001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         fieldbyname001aClassForCheck class_for_check = new fieldbyname001aClassForCheck();
 
-        print_log_on_verbose("**> fieldbyname001a: waiting for \"quit\" signal...");
+        display("**> fieldbyname001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fieldbyname001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fieldbyname001a: completed succesfully!");
+            display("**> fieldbyname001a: \"quit\" signal recieved!");
+            display("**> fieldbyname001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fieldbyname001a: unexpected signal (no \"quit\") - " + instruction);
@@ -157,6 +143,5 @@ interface fieldbyname001aInterfaceForCheck {
 
     static final long    ambiguous_prim_field = 1;
     static final Object  ambiguous_ref_field = new Object();
-
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname001a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class fieldbyname001a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> fieldbyname001a: debugee started!");
+        log.display("**> fieldbyname001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         fieldbyname001aClassForCheck class_for_check = new fieldbyname001aClassForCheck();
 
-        display("**> fieldbyname001a: waiting for \"quit\" signal...");
+        log.display("**> fieldbyname001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fieldbyname001a: \"quit\" signal recieved!");
-            display("**> fieldbyname001a: completed succesfully!");
+            log.display("**> fieldbyname001a: \"quit\" signal recieved!");
+            log.display("**> fieldbyname001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fieldbyname001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002.java
@@ -103,11 +103,7 @@ public class fieldbyname002 extends Log {
 
         Debugee debugee;
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         print_log_on_verbose("==> nsk/jdi/ReferenceType/fieldByName/fieldbyname002 test LOG:");
         print_log_on_verbose("==> test checks fieldByName(...) method of ReferenceType interface ");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.fieldByName.fieldbyname002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002a.java
@@ -34,18 +34,16 @@ import java.io.*;
 
 public class fieldbyname002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.fieldByName.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "fieldbyname002aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> fieldbyname002a: debugee started!");
+        log.display("**> fieldbyname002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -54,19 +52,17 @@ public class fieldbyname002a {
         fieldbyname002aClassLoader customClassLoader = new fieldbyname002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> fieldbyname002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> fieldbyname002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> fieldbyname002a: checked class NOT loaded: " + e);
+            log.display("--> fieldbyname002a: checked class NOT loaded: " + e);
         }
 
-        display("**> fieldbyname002a: waiting for \"quit\" signal...");
+        log.display("**> fieldbyname002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fieldbyname002a: \"quit\" signal recieved!");
-            display("**> fieldbyname002a: completed succesfully!");
+            log.display("**> fieldbyname002a: \"quit\" signal recieved!");
+            log.display("**> fieldbyname002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fieldbyname002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,37 +28,24 @@ import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 import java.io.*;
 
-
 /**
  * This class is used as debugee application for the fieldbyname002 JDI test.
  */
 
 public class fieldbyname002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.fieldByName.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "fieldbyname002aClassForCheck";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> fieldbyname002a: debugee started!");
+        display("**> fieldbyname002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -67,19 +54,19 @@ public class fieldbyname002a {
         fieldbyname002aClassLoader customClassLoader = new fieldbyname002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> fieldbyname002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> fieldbyname002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> fieldbyname002a: waiting for \"quit\" signal...");
+        display("**> fieldbyname002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fieldbyname002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fieldbyname002a: completed succesfully!");
+            display("**> fieldbyname002a: \"quit\" signal recieved!");
+            display("**> fieldbyname002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fieldbyname002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname003/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.fieldByName.fieldbyname003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the fieldbyname003 JDI test.
  */
 
 public class fieldbyname003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     static String package_prefix = "nsk.jdi.ReferenceType.fieldByName.";
     static String checked_class_name = package_prefix + "fieldbyname003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> fieldbyname003a: debugee started!");
+        display("**> fieldbyname003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> fieldbyname003a: waiting for \"checked class dir\" info...");
+        display("**> fieldbyname003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
@@ -65,23 +58,23 @@ public class fieldbyname003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> fieldbyname003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> fieldbyname003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> fieldbyname003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> fieldbyname003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> fieldbyname003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fieldbyname003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fieldbyname003a: completed!");
+            display("**> fieldbyname003a: \"quit\" signal recieved!");
+            display("**> fieldbyname003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -91,24 +84,24 @@ public class fieldbyname003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> fieldbyname003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> fieldbyname003a: enforce to unload checked class...");
+        display("**> fieldbyname003a: \"continue\" signal recieved!");
+        display("**> fieldbyname003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> fieldbyname003a: checked class may be NOT unloaded!");
+            display("**> fieldbyname003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> fieldbyname003a: checked class unloaded!");
+            display("**> fieldbyname003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> fieldbyname003a: waiting for \"quit\" signal...");
+        display("**> fieldbyname003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fieldbyname003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fieldbyname003a: completed!");
+            display("**> fieldbyname003a: \"quit\" signal recieved!");
+            display("**> fieldbyname003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fieldbyname003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fieldByName/fieldbyname003a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class fieldbyname003a {
 
+    private static Log log = new Log(System.err);
+
     static String package_prefix = "nsk.jdi.ReferenceType.fieldByName.";
     static String checked_class_name = package_prefix + "fieldbyname003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> fieldbyname003a: debugee started!");
+        log.display("**> fieldbyname003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> fieldbyname003a: waiting for \"checked class dir\" info...");
+        log.display("**> fieldbyname003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
 
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
@@ -58,23 +56,21 @@ public class fieldbyname003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> fieldbyname003a: checked class loaded:" + checked_class_name);
+            log.display("--> fieldbyname003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> fieldbyname003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> fieldbyname003a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> fieldbyname003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> fieldbyname003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> fieldbyname003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fieldbyname003a: \"quit\" signal recieved!");
-            display("**> fieldbyname003a: completed!");
+            log.display("**> fieldbyname003a: \"quit\" signal recieved!");
+            log.display("**> fieldbyname003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -84,24 +80,24 @@ public class fieldbyname003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> fieldbyname003a: \"continue\" signal recieved!");
-        display("**> fieldbyname003a: enforce to unload checked class...");
+        log.display("**> fieldbyname003a: \"continue\" signal recieved!");
+        log.display("**> fieldbyname003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> fieldbyname003a: checked class may be NOT unloaded!");
+            log.display("**> fieldbyname003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> fieldbyname003a: checked class unloaded!");
+            log.display("**> fieldbyname003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> fieldbyname003a: waiting for \"quit\" signal...");
+        log.display("**> fieldbyname003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fieldbyname003a: \"quit\" signal recieved!");
-            display("**> fieldbyname003a: completed!");
+            log.display("**> fieldbyname003a: \"quit\" signal recieved!");
+            log.display("**> fieldbyname003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fieldbyname003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields001/TestDescription.java
@@ -48,7 +48,6 @@
  *        nsk.jdi.ReferenceType.fields.fields001a
  * @run driver
  *      nsk.jdi.ReferenceType.fields.fields001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the fields001 JDI test.
  */
 
 public class fields001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> fields001a: debugee started!");
+        display("**> fields001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         fields001aClassForCheck class_for_check = new fields001aClassForCheck();
 
-        print_log_on_verbose("**> fields001a: waiting for \"quit\" signal...");
+        display("**> fields001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fields001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fields001a: completed succesfully!");
+            display("**> fields001a: \"quit\" signal recieved!");
+            display("**> fields001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fields001a: unexpected signal (no \"quit\") - " + instruction);
@@ -157,6 +143,5 @@ interface fields001aInterfaceForCheck {
 
     static final long    ambiguous_prim_field = 1;
     static final Object  ambiguous_ref_field = new Object();
-
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields001a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class fields001a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> fields001a: debugee started!");
+        log.display("**> fields001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         fields001aClassForCheck class_for_check = new fields001aClassForCheck();
 
-        display("**> fields001a: waiting for \"quit\" signal...");
+        log.display("**> fields001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fields001a: \"quit\" signal recieved!");
-            display("**> fields001a: completed succesfully!");
+            log.display("**> fields001a: \"quit\" signal recieved!");
+            log.display("**> fields001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fields001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,6 @@ import java.io.*;
 public class fields002 {
     static ArgumentHandler argsHandler;
     static Log test_log_handler;
-    static boolean verbose_mode = false;  // test argument -verbose switches to true
-                                          // - for more easy failure evaluation
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -54,7 +52,6 @@ public class fields002 {
 
     private final static String classLoaderName = package_prefix + "fields002aClassLoader";
     private final static String classFieldName = "loadedClass";
-
 
     public static void main (String argv[]) {
         int result = run(argv,System.out);
@@ -102,13 +99,9 @@ public class fields002 {
         print_log_on_verbose("    of the com.sun.jdi package for not prepared class\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            debugee_launch_command = debugeeName + " -vbs";
-        }
 
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
-
 
         debugee.redirectStderr(out);
         print_log_on_verbose("--> fields002: fields002a debugee launched");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002.java
@@ -69,20 +69,12 @@ public class fields002 {
 
         int v_test_result = new fields002().runThis(argv,out);
         if ( v_test_result == 2/*STATUS_FAILED*/ ) {
-            print_log_anyway("\n==> nsk/jdi/ReferenceType/fields/fields002 test FAILED");
+            test_log_handler.complain("\n==> nsk/jdi/ReferenceType/fields/fields002 test FAILED");
         }
         else {
-            print_log_on_verbose("\n==> nsk/jdi/ReferenceType/fields/fields002 test PASSED");
+            test_log_handler.display("\n==> nsk/jdi/ReferenceType/fields/fields002 test PASSED");
         }
         return v_test_result;
-    }
-
-    private static void print_log_on_verbose(String message) {
-        test_log_handler.display(message);
-    }
-
-    private static void print_log_anyway(String message) {
-        test_log_handler.complain(message);
     }
 
     /**
@@ -94,9 +86,9 @@ public class fields002 {
         test_log_handler = new Log(out, argsHandler);
         Binder binder    = new Binder(argsHandler, test_log_handler);
 
-        print_log_on_verbose("==> nsk/jdi/ReferenceType/fields/fields002 test LOG:");
-        print_log_on_verbose("==> test checks fields() method of ReferenceType interface ");
-        print_log_on_verbose("    of the com.sun.jdi package for not prepared class\n");
+        test_log_handler.display("==> nsk/jdi/ReferenceType/fields/fields002 test LOG:");
+        test_log_handler.display("==> test checks fields() method of ReferenceType interface ");
+        test_log_handler.display("    of the com.sun.jdi package for not prepared class\n");
 
         String debugee_launch_command = debugeeName;
 
@@ -104,26 +96,23 @@ public class fields002 {
         IOPipe pipe = new IOPipe(debugee);
 
         debugee.redirectStderr(out);
-        print_log_on_verbose("--> fields002: fields002a debugee launched");
+        test_log_handler.display("--> fields002: fields002a debugee launched");
         debugee.resume();
 
         String line = pipe.readln();
         if (line == null) {
-            print_log_anyway
-                ("##> fields002: UNEXPECTED debugee's signal (not \"ready\") - " + line);
+            test_log_handler.complain("##> fields002: UNEXPECTED debugee's signal (not \"ready\") - " + line);
             return 2/*STATUS_FAILED*/;
         }
         if (!line.equals("ready")) {
-            print_log_anyway
-                ("##> fields002: UNEXPECTED debugee's signal (not \"ready\") - " + line);
+            test_log_handler.complain("##> fields002: UNEXPECTED debugee's signal (not \"ready\") - " + line);
             return 2/*STATUS_FAILED*/;
         }
         else {
-            print_log_on_verbose("--> fields002: debugee's \"ready\" signal recieved!");
+            test_log_handler.display("--> fields002: debugee's \"ready\" signal recieved!");
         }
 
-        print_log_on_verbose
-            ("--> fields002: check ReferenceType.fields() method for not prepared "
+        test_log_handler.display("--> fields002: check ReferenceType.fields() method for not prepared "
             + class_for_check + " class...");
         boolean class_not_found_error = false;
         boolean fields_method_error = false;
@@ -131,7 +120,7 @@ public class fields002 {
         while ( true ) {  // test body
             ReferenceType loaderRefType = debugee.classByName(classLoaderName);
             if (loaderRefType == null) {
-                print_log_anyway("##> Could NOT FIND custom class loader: " + classLoaderName);
+                test_log_handler.complain("##> Could NOT FIND custom class loader: " + classLoaderName);
                 class_not_found_error = true;
                 break;
             }
@@ -143,7 +132,7 @@ public class fields002 {
             try {
                 classObjRef = (ClassObjectReference)classValue;
             } catch (Exception e) {
-                print_log_anyway ("##> Unexpected exception while getting ClassObjectReference : " + e);
+                test_log_handler.complain("##> Unexpected exception while getting ClassObjectReference : " + e);
                 class_not_found_error = true;
                 break;
             }
@@ -151,34 +140,27 @@ public class fields002 {
             ReferenceType refType = classObjRef.reflectedType();
             boolean isPrep = refType.isPrepared();
             if (isPrep) {
-                print_log_anyway
-                        ("##> fields002: FAILED: isPrepared() returns for " + class_for_check + " : " + isPrep);
+                test_log_handler.complain("##> fields002: FAILED: isPrepared() returns for " + class_for_check + " : " + isPrep);
                 class_not_found_error = true;
                 break;
             } else {
-                print_log_on_verbose
-                    ("--> fields002: isPrepared() returns for " + class_for_check + " : " + isPrep);
+                test_log_handler.display("--> fields002: isPrepared() returns for " + class_for_check + " : " + isPrep);
             }
 
             List fields_list = null;
             try {
                 fields_list = refType.fields();
-                print_log_anyway
-                    ("##> fields002: FAILED: NO any Exception thrown!");
-                print_log_anyway
-                    ("##>            expected Exception - com.sun.jdi.ClassNotPreparedException");
+                test_log_handler.complain("##> fields002: FAILED: NO any Exception thrown!");
+                test_log_handler.complain("##>            expected Exception - com.sun.jdi.ClassNotPreparedException");
                 fields_method_error = true;
             }
             catch (Exception expt) {
                 if (expt instanceof com.sun.jdi.ClassNotPreparedException) {
-                    print_log_on_verbose
-                        ("--> fields002: PASSED: expected Exception thrown - " + expt.toString());
+                    test_log_handler.display("--> fields002: PASSED: expected Exception thrown - " + expt.toString());
                 }
                 else {
-                    print_log_anyway
-                        ("##> fields002: FAILED: unexpected Exception thrown - " + expt.toString());
-                    print_log_anyway
-                        ("##>            expected Exception - com.sun.jdi.ClassNotPreparedException");
+                    test_log_handler.complain("##> fields002: FAILED: unexpected Exception thrown - " + expt.toString());
+                    test_log_handler.complain("##>            expected Exception - com.sun.jdi.ClassNotPreparedException");
                     fields_method_error = true;
                 }
             }
@@ -189,19 +171,17 @@ public class fields002 {
             v_test_result = 2/*STATUS_FAILED*/;
         }
 
-        print_log_on_verbose("--> fields002: waiting for debugee finish...");
+        test_log_handler.display("--> fields002: waiting for debugee finish...");
         pipe.println("quit");
         debugee.waitFor();
 
         int status = debugee.getStatus();
         if (status != 0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/) {
-            print_log_anyway
-                ("##> fields002: UNEXPECTED Debugee's exit status (not 95) - " + status);
+            test_log_handler.complain("##> fields002: UNEXPECTED Debugee's exit status (not 95) - " + status);
             v_test_result = 2/*STATUS_FAILED*/;
         }
         else {
-            print_log_on_verbose
-                ("--> fields002: expected Debugee's exit status - " + status);
+            test_log_handler.display("--> fields002: expected Debugee's exit status - " + status);
         }
 
         return v_test_result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.fields.fields002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002a.java
@@ -34,18 +34,16 @@ import java.io.*;
 
 public class fields002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.fields.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "fields002aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> fields002a: debugee started!");
+        log.display("**> fields002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -54,19 +52,17 @@ public class fields002a {
         fields002aClassLoader customClassLoader = new fields002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> fields002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> fields002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> fields002a: checked class NOT loaded: " + e);
+            log.display("--> fields002a: checked class NOT loaded: " + e);
         }
 
-        display("**> fields002a: waiting for \"quit\" signal...");
+        log.display("**> fields002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fields002a: \"quit\" signal recieved!");
-            display("**> fields002a: completed succesfully!");
+            log.display("**> fields002a: \"quit\" signal recieved!");
+            log.display("**> fields002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fields002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,37 +28,24 @@ import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 import java.io.*;
 
-
 /**
  * This class is used as debugee application for the fields002 JDI test.
  */
 
 public class fields002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.fields.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "fields002aClassForCheck";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> fields002a: debugee started!");
+        display("**> fields002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -67,19 +54,19 @@ public class fields002a {
         fields002aClassLoader customClassLoader = new fields002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> fields002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> fields002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> fields002a: waiting for \"quit\" signal...");
+        display("**> fields002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fields002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fields002a: completed succesfully!");
+            display("**> fields002a: \"quit\" signal recieved!");
+            display("**> fields002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fields002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields003/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.fields.fields003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the fields003 JDI test.
  */
 
 public class fields003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private static final String package_prefix = "nsk.jdi.ReferenceType.fields.";
     private static final String checked_class_name = package_prefix + "fields003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> fields003a: debugee started!");
+        display("**> fields003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> fields003a: waiting for \"checked class dir\" info...");
+        display("**> fields003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class fields003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> fields003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> fields003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> fields003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> fields003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> fields003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fields003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fields003a: completed!");
+            display("**> fields003a: \"quit\" signal recieved!");
+            display("**> fields003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class fields003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> fields003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> fields003a: enforce to unload checked class...");
+        display("**> fields003a: \"continue\" signal recieved!");
+        display("**> fields003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> fields003a: checked class may be NOT unloaded!");
+            display("**> fields003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> fields003a: checked class unloaded!");
+            display("**> fields003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> fields003a: waiting for \"quit\" signal...");
+        display("**> fields003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fields003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fields003a: completed!");
+            display("**> fields003a: \"quit\" signal recieved!");
+            display("**> fields003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fields003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields003a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class fields003a {
 
+    private static Log log = new Log(System.err);
+
     private static final String package_prefix = "nsk.jdi.ReferenceType.fields.";
     private static final String checked_class_name = package_prefix + "fields003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> fields003a: debugee started!");
+        log.display("**> fields003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> fields003a: waiting for \"checked class dir\" info...");
+        log.display("**> fields003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class fields003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> fields003a: checked class loaded:" + checked_class_name);
+            log.display("--> fields003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> fields003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> fields003a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> fields003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> fields003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> fields003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fields003a: \"quit\" signal recieved!");
-            display("**> fields003a: completed!");
+            log.display("**> fields003a: \"quit\" signal recieved!");
+            log.display("**> fields003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class fields003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> fields003a: \"continue\" signal recieved!");
-        display("**> fields003a: enforce to unload checked class...");
+        log.display("**> fields003a: \"continue\" signal recieved!");
+        log.display("**> fields003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> fields003a: checked class may be NOT unloaded!");
+            log.display("**> fields003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> fields003a: checked class unloaded!");
+            log.display("**> fields003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> fields003a: waiting for \"quit\" signal...");
+        log.display("**> fields003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fields003a: \"quit\" signal recieved!");
-            display("**> fields003a: completed!");
+            log.display("**> fields003a: \"quit\" signal recieved!");
+            log.display("**> fields003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> fields003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields004/TestDescription.java
@@ -48,7 +48,6 @@
  *        nsk.jdi.ReferenceType.fields.fields004a
  * @run driver
  *      nsk.jdi.ReferenceType.fields.fields004
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the fields004 JDI test.
  */
 
 public class fields004a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> fields004a: debugee started!");
+        display("**> fields004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         fields004aClassForCheck class_for_check = new fields004aClassForCheck();
 
-        print_log_on_verbose("**> fields004a: waiting for \"quit\" signal...");
+        display("**> fields004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> fields004a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> fields004a: completed succesfully!");
+            display("**> fields004a: \"quit\" signal recieved!");
+            display("**> fields004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> fields004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/fields/fields004a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class fields004a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> fields004a: debugee started!");
+        log.display("**> fields004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         fields004aClassForCheck class_for_check = new fields004aClassForCheck();
 
-        display("**> fields004a: waiting for \"quit\" signal...");
+        log.display("**> fields004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> fields004a: \"quit\" signal recieved!");
-            display("**> fields004a: completed succesfully!");
+            log.display("**> fields004a: \"quit\" signal recieved!");
+            log.display("**> fields004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> fields004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001/TestDescription.java
@@ -47,7 +47,6 @@
  *        nsk.jdi.ReferenceType.hashCode.hashcode001a
  * @run driver
  *      nsk.jdi.ReferenceType.hashCode.hashcode001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,16 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the hashcode001 JDI test.
  */
 
 public class hashcode001a {
-
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
 
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
@@ -75,33 +70,24 @@ public class hashcode001a {
     InterfaceForCheck_impl interf_for_check_impl0 = new    InterfaceForCheck_impl();
     InterfaceForCheck interf_for_check0,interf_for_check1[]={interf_for_check0}, interf_for_check2[][]={interf_for_check1};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> hashcode001a: debugee started!");
+        display("**> hashcode001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         hashcode001a hashcode001a_obj = new hashcode001a();
 
-        print_log_on_verbose("**> hashcode001a: waiting for \"quit\" signal...");
+        display("**> hashcode001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> hashcode001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> hashcode001a: completed succesfully!");
+            display("**> hashcode001a: \"quit\" signal recieved!");
+            display("**> hashcode001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> hashcode001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class hashcode001a {
 
+    private static Log log = new Log(System.err);
+
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
     char    c0, c1[]={c0}, c2[][]={c1};
@@ -70,24 +72,20 @@ public class hashcode001a {
     InterfaceForCheck_impl interf_for_check_impl0 = new    InterfaceForCheck_impl();
     InterfaceForCheck interf_for_check0,interf_for_check1[]={interf_for_check0}, interf_for_check2[][]={interf_for_check1};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> hashcode001a: debugee started!");
+        log.display("**> hashcode001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         hashcode001a hashcode001a_obj = new hashcode001a();
 
-        display("**> hashcode001a: waiting for \"quit\" signal...");
+        log.display("**> hashcode001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> hashcode001a: \"quit\" signal recieved!");
-            display("**> hashcode001a: completed succesfully!");
+            log.display("**> hashcode001a: \"quit\" signal recieved!");
+            log.display("**> hashcode001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> hashcode001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.hashCode.hashcode002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class hashcode002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.hashCode.";
     private final static String checked_class_name = package_prefix + "hashcode002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> hashcode002a: debugee started!");
+        log.display("**> hashcode002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> hashcode002a: waiting for \"checked class dir\" info...");
+        log.display("**> hashcode002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class hashcode002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> hashcode002a: checked class loaded: " + checked_class_name);
+            log.display("--> hashcode002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> hashcode002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> hashcode002a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> hashcode002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> hashcode002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> hashcode002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> hashcode002a: \"quit\" signal recieved!");
-            display("**> hashcode002a: completed!");
+            log.display("**> hashcode002a: \"quit\" signal recieved!");
+            log.display("**> hashcode002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class hashcode002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> hashcode002a: \"continue\" signal recieved!");
-        display("**> hashcode002a: enforce to unload checked class...");
+        log.display("**> hashcode002a: \"continue\" signal recieved!");
+        log.display("**> hashcode002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> hashcode002a: checked class may be NOT unloaded!");
+            log.display("**> hashcode002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> hashcode002a: checked class unloaded!");
+            log.display("**> hashcode002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> hashcode002a: waiting for \"quit\" signal...");
+        log.display("**> hashcode002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> hashcode002a: \"quit\" signal recieved!");
-            display("**> hashcode002a: completed!");
+            log.display("**> hashcode002a: \"quit\" signal recieved!");
+            log.display("**> hashcode002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> hashcode002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/hashCode/hashcode002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the hashcode002 JDI test.
  */
 
 public class hashcode002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.hashCode.";
     private final static String checked_class_name = package_prefix + "hashcode002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> hashcode002a: debugee started!");
+        display("**> hashcode002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> hashcode002a: waiting for \"checked class dir\" info...");
+        display("**> hashcode002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class hashcode002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> hashcode002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> hashcode002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> hashcode002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> hashcode002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> hashcode002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> hashcode002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> hashcode002a: completed!");
+            display("**> hashcode002a: \"quit\" signal recieved!");
+            display("**> hashcode002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class hashcode002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> hashcode002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> hashcode002a: enforce to unload checked class...");
+        display("**> hashcode002a: \"continue\" signal recieved!");
+        display("**> hashcode002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> hashcode002a: checked class may be NOT unloaded!");
+            display("**> hashcode002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> hashcode002a: checked class unloaded!");
+            display("**> hashcode002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> hashcode002a: waiting for \"quit\" signal...");
+        display("**> hashcode002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> hashcode002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> hashcode002a: completed!");
+            display("**> hashcode002a: \"quit\" signal recieved!");
+            display("**> hashcode002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> hashcode002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isAbstract001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isAbstract001/TestDescription.java
@@ -43,7 +43,6 @@
  *        nsk.jdi.ReferenceType.isAbstract.isAbstract001a
  * @run driver
  *      nsk.jdi.ReferenceType.isAbstract.isAbstract001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isAbstract001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isAbstract001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class isAbstract001a {
 
+    private static Log log = new Log(System.err);
+
     // Abstract classes must be extended by a class and that class must be
     // initialized, so that abstract classes could be returnedin debugger
 
@@ -58,22 +60,18 @@ public class isAbstract001a {
     abstr_interf abstr_interf_0, abstr_interf_1[]={abstr_interf_0};
     abstr_interf_impl abstr_interf_impl_0= new abstr_interf_impl();
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> isAbstract001a: debugee started!");
+        log.display("**> isAbstract001a: debugee started!");
         isAbstract001a isAbstract001a_obj = new isAbstract001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        display("**> isAbstract001a: waiting for \"quit\" signal...");
+        log.display("**> isAbstract001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isAbstract001a: \"quit\" signal recieved!");
-            display("**> isAbstract001a: completed succesfully!");
+            log.display("**> isAbstract001a: \"quit\" signal recieved!");
+            log.display("**> isAbstract001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isAbstract001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isAbstract001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isAbstract001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isAbstract001 JDI test.
  */
 
 public class isAbstract001a {
-
-    static boolean verbose_mode = false;
 
     // Abstract classes must be extended by a class and that class must be
     // initialized, so that abstract classes could be returnedin debugger
@@ -61,31 +58,22 @@ public class isAbstract001a {
     abstr_interf abstr_interf_0, abstr_interf_1[]={abstr_interf_0};
     abstr_interf_impl abstr_interf_impl_0= new abstr_interf_impl();
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> isAbstract001a: debugee started!");
+        display("**> isAbstract001a: debugee started!");
         isAbstract001a isAbstract001a_obj = new isAbstract001a();
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
-        print_log_on_verbose("**> isAbstract001a: waiting for \"quit\" signal...");
+        display("**> isAbstract001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isAbstract001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isAbstract001a: completed succesfully!");
+            display("**> isAbstract001a: \"quit\" signal recieved!");
+            display("**> isAbstract001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isAbstract001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isabstract002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isabstract002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.isAbstract.isabstract002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isabstract002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isabstract002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isabstract002 JDI test.
  */
 
 public class isabstract002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.isAbstract.";
     static String checked_class_name = package_prefix + "isabstract002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> isabstract002a: debugee started!");
+        display("**> isabstract002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> isabstract002a: waiting for \"checked class dir\" info...");
+        display("**> isabstract002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class isabstract002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> isabstract002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> isabstract002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> isabstract002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> isabstract002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> isabstract002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isabstract002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isabstract002a: completed!");
+            display("**> isabstract002a: \"quit\" signal recieved!");
+            display("**> isabstract002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class isabstract002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> isabstract002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> isabstract002a: enforce to unload checked class...");
+        display("**> isabstract002a: \"continue\" signal recieved!");
+        display("**> isabstract002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> isabstract002a: checked class may be NOT unloaded!");
+            display("**> isabstract002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> isabstract002a: checked class unloaded!");
+            display("**> isabstract002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> isabstract002a: waiting for \"quit\" signal...");
+        display("**> isabstract002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isabstract002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isabstract002a: completed!");
+            display("**> isabstract002a: \"quit\" signal recieved!");
+            display("**> isabstract002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isabstract002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isabstract002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isAbstract/isabstract002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class isabstract002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.isAbstract.";
     static String checked_class_name = package_prefix + "isabstract002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> isabstract002a: debugee started!");
+        log.display("**> isabstract002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> isabstract002a: waiting for \"checked class dir\" info...");
+        log.display("**> isabstract002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class isabstract002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> isabstract002a: checked class loaded: " + checked_class_name);
+            log.display("--> isabstract002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> isabstract002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> isabstract002a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> isabstract002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> isabstract002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> isabstract002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isabstract002a: \"quit\" signal recieved!");
-            display("**> isabstract002a: completed!");
+            log.display("**> isabstract002a: \"quit\" signal recieved!");
+            log.display("**> isabstract002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class isabstract002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> isabstract002a: \"continue\" signal recieved!");
-        display("**> isabstract002a: enforce to unload checked class...");
+        log.display("**> isabstract002a: \"continue\" signal recieved!");
+        log.display("**> isabstract002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> isabstract002a: checked class may be NOT unloaded!");
+            log.display("**> isabstract002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> isabstract002a: checked class unloaded!");
+            log.display("**> isabstract002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> isabstract002a: waiting for \"quit\" signal...");
+        log.display("**> isabstract002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isabstract002a: \"quit\" signal recieved!");
-            display("**> isabstract002a: completed!");
+            log.display("**> isabstract002a: \"quit\" signal recieved!");
+            log.display("**> isabstract002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isabstract002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit001.java
@@ -64,7 +64,6 @@ public class isinit001 {
 
     };
 
-
     public static void main (String argv[]) {
         int result = run(argv,System.out);
         if (result != 0) {
@@ -111,13 +110,9 @@ public class isinit001 {
         print_log_on_verbose("    of the com.sun.jdi package for ClassType, InterfaceType\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            debugee_launch_command = debugeeName + " -vbs";
-        }
 
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
-
 
         debugee.redirectStderr(out);
         print_log_on_verbose("--> isinit001: isinit001a debugee launched");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit001/TestDescription.java
@@ -54,7 +54,6 @@
  *        nsk.jdi.ReferenceType.isInitialized.isinit001a
  * @run driver
  *      nsk.jdi.ReferenceType.isInitialized.isinit001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isinit001 JDI test.
  */
 
 public class isinit001a {
-
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
 
     NotInitializedClass not_initialized_class_0,
         not_initialized_class_1[] = {not_initialized_class_0};
@@ -47,33 +43,24 @@ public class isinit001a {
 
     int copy_super_class_int_var = SubClass.super_class_int_var;
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> isinit001a: debugee started!");
+        display("**> isinit001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         isinit001a isinit001a_obj = new isinit001a();
 
-        print_log_on_verbose("**> isinit001a: waiting for \"quit\" signal...");
+        display("**> isinit001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isinit001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isinit001a: completed succesfully!");
+            display("**> isinit001a: \"quit\" signal recieved!");
+            display("**> isinit001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isinit001a: unexpected signal (no \"quit\") - " + instruction);
@@ -87,7 +74,6 @@ class NotInitializedClass {}
 
 // not initialized interface
 interface NotInitializedInterface {}
-
 
 // initialized interface
 interface InitializedInterface {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class isinit001a {
 
+    private static Log log = new Log(System.err);
+
     NotInitializedClass not_initialized_class_0,
         not_initialized_class_1[] = {not_initialized_class_0};
 
@@ -43,24 +45,20 @@ public class isinit001a {
 
     int copy_super_class_int_var = SubClass.super_class_int_var;
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> isinit001a: debugee started!");
+        log.display("**> isinit001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         isinit001a isinit001a_obj = new isinit001a();
 
-        display("**> isinit001a: waiting for \"quit\" signal...");
+        log.display("**> isinit001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isinit001a: \"quit\" signal recieved!");
-            display("**> isinit001a: completed succesfully!");
+            log.display("**> isinit001a: \"quit\" signal recieved!");
+            log.display("**> isinit001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isinit001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.isInitialized.isinit002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class isinit002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.isInitialized.";
     private final static String checked_class_name = package_prefix + "isinit002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> isinit002a: debugee started!");
+        log.display("**> isinit002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> isinit002a: waiting for \"checked class dir\" info...");
+        log.display("**> isinit002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,20 @@ public class isinit002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> isinit002a: checked class loaded: " + checked_class_name);
+            log.display("--> isinit002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
-            display
-                ("**> isinit002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> isinit002a: checked class NOT loaded: " + checked_class_name);
+            log.display("**> isinit002a: load class: exception thrown = " + e.toString());
+            log.display("--> isinit002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> isinit002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> isinit002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isinit002a: \"quit\" signal recieved!");
-            display("**> isinit002a: completed!");
+            log.display("**> isinit002a: \"quit\" signal recieved!");
+            log.display("**> isinit002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +78,24 @@ public class isinit002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> isinit002a: \"continue\" signal recieved!");
-        display("**> isinit002a: enforce to unload checked class...");
+        log.display("**> isinit002a: \"continue\" signal recieved!");
+        log.display("**> isinit002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> isinit002a: checked class may be NOT unloaded!");
+            log.display("**> isinit002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> isinit002a: checked class unloaded!");
+            log.display("**> isinit002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> isinit002a: waiting for \"quit\" signal...");
+        log.display("**> isinit002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isinit002a: \"quit\" signal recieved!");
-            display("**> isinit002a: completed!");
+            log.display("**> isinit002a: \"quit\" signal recieved!");
+            log.display("**> isinit002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isinit002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isInitialized/isinit002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isinit002 JDI test.
  */
 
 public class isinit002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.isInitialized.";
     private final static String checked_class_name = package_prefix + "isinit002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> isinit002a: debugee started!");
+        display("**> isinit002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> isinit002a: waiting for \"checked class dir\" info...");
+        display("**> isinit002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class isinit002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> isinit002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("**> isinit002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> isinit002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> isinit002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> isinit002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isinit002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isinit002a: completed!");
+            display("**> isinit002a: \"quit\" signal recieved!");
+            display("**> isinit002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class isinit002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> isinit002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> isinit002a: enforce to unload checked class...");
+        display("**> isinit002a: \"continue\" signal recieved!");
+        display("**> isinit002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> isinit002a: checked class may be NOT unloaded!");
+            display("**> isinit002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> isinit002a: checked class unloaded!");
+            display("**> isinit002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> isinit002a: waiting for \"quit\" signal...");
+        display("**> isinit002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isinit002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isinit002a: completed!");
+            display("**> isinit002a: \"quit\" signal recieved!");
+            display("**> isinit002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isinit002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared001.java
@@ -63,7 +63,6 @@ public class isprepared001 {
 
     };
 
-
     public static void main (String argv[]) {
         int result = run(argv,System.out);
         if (result != 0) {
@@ -110,9 +109,6 @@ public class isprepared001 {
         print_log_on_verbose("    of the com.sun.jdi package for ClassType, InterfaceType\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            debugee_launch_command = debugeeName + " -vbs";
-        }
 
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared001/TestDescription.java
@@ -54,7 +54,6 @@
  *        nsk.jdi.ReferenceType.isPrepared.isprepared001a
  * @run driver
  *      nsk.jdi.ReferenceType.isPrepared.isprepared001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared001a.java
@@ -33,30 +33,28 @@ import nsk.share.jdi.*;
 
 public class isprepared001a {
 
+    private static Log log = new Log(System.err);
+
     NotPreparedClass not_prepared_class_0, not_prepared_class_1[] = {not_prepared_class_0};
 
     NotPreparedInterface not_prepared_interface_0, not_prepared_interface_1[] = {not_prepared_interface_0};
 
     PreparedClass  prepared_class_0 = new PreparedClass();
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> isprepared001a: debugee started!");
+        log.display("**> isprepared001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         isprepared001a isprepared001a_obj = new isprepared001a();
 
-        display("**> isprepared001a: waiting for \"quit\" signal...");
+        log.display("**> isprepared001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isprepared001a: \"quit\" signal recieved!");
-            display("**> isprepared001a: completed succesfully!");
+            log.display("**> isprepared001a: \"quit\" signal recieved!");
+            log.display("**> isprepared001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isprepared001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isprepared001 JDI test.
  */
 
 public class isprepared001a {
-
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
 
     NotPreparedClass not_prepared_class_0, not_prepared_class_1[] = {not_prepared_class_0};
 
@@ -43,33 +39,24 @@ public class isprepared001a {
 
     PreparedClass  prepared_class_0 = new PreparedClass();
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> isprepared001a: debugee started!");
+        display("**> isprepared001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         isprepared001a isprepared001a_obj = new isprepared001a();
 
-        print_log_on_verbose("**> isprepared001a: waiting for \"quit\" signal...");
+        display("**> isprepared001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isprepared001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isprepared001a: completed succesfully!");
+            display("**> isprepared001a: \"quit\" signal recieved!");
+            display("**> isprepared001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isprepared001a: unexpected signal (no \"quit\") - " + instruction);
@@ -83,7 +70,6 @@ class NotPreparedClass {}
 
 // not prepared interface
 interface NotPreparedInterface {}
-
 
 // prepared interface
 interface PreparedInterface {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.isPrepared.isprepared002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isprepared002 JDI test.
  */
 
 public class isprepared002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.isPrepared.";
     private final static String checked_class_name = package_prefix + "isprepared002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> isprepared002a: debugee started!");
+        display("**> isprepared002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> isprepared002a: waiting for \"checked class dir\" info...");
+        display("**> isprepared002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class isprepared002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> isprepared002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> isprepared002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> isprepared002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> isprepared002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> isprepared002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isprepared002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isprepared002a: completed!");
+            display("**> isprepared002a: \"quit\" signal recieved!");
+            display("**> isprepared002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class isprepared002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> isprepared002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> isprepared002a: enforce to unload checked class...");
+        display("**> isprepared002a: \"continue\" signal recieved!");
+        display("**> isprepared002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> isprepared002a: checked class may be NOT unloaded!");
+            display("**> isprepared002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> isprepared002a: checked class unloaded!");
+            display("**> isprepared002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> isprepared002a: waiting for \"quit\" signal...");
+        display("**> isprepared002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isprepared002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isprepared002a: completed!");
+            display("**> isprepared002a: \"quit\" signal recieved!");
+            display("**> isprepared002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isprepared002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isPrepared/isprepared002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class isprepared002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.isPrepared.";
     private final static String checked_class_name = package_prefix + "isprepared002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> isprepared002a: debugee started!");
+        log.display("**> isprepared002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> isprepared002a: waiting for \"checked class dir\" info...");
+        log.display("**> isprepared002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class isprepared002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> isprepared002a: checked class loaded: " + checked_class_name);
+            log.display("--> isprepared002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> isprepared002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> isprepared002a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> isprepared002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> isprepared002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> isprepared002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isprepared002a: \"quit\" signal recieved!");
-            display("**> isprepared002a: completed!");
+            log.display("**> isprepared002a: \"quit\" signal recieved!");
+            log.display("**> isprepared002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class isprepared002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> isprepared002a: \"continue\" signal recieved!");
-        display("**> isprepared002a: enforce to unload checked class...");
+        log.display("**> isprepared002a: \"continue\" signal recieved!");
+        log.display("**> isprepared002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> isprepared002a: checked class may be NOT unloaded!");
+            log.display("**> isprepared002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> isprepared002a: checked class unloaded!");
+            log.display("**> isprepared002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> isprepared002a: waiting for \"quit\" signal...");
+        log.display("**> isprepared002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isprepared002a: \"quit\" signal recieved!");
-            display("**> isprepared002a: completed!");
+            log.display("**> isprepared002a: \"quit\" signal recieved!");
+            log.display("**> isprepared002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isprepared002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001.java
@@ -48,7 +48,6 @@ public class isVerified001 extends Log {
         thisClassName = package_prefix + "isVerified001",
         debugeeName   = thisClassName + "a";
 
-
     static ArgumentHandler      argsHandler;
     private static Log  logHandler;
 
@@ -69,7 +68,6 @@ public class isVerified001 extends Log {
         {package_prefix + "verif_subcl", "verified", "class"}
 
     };
-
 
     public static void main (String argv[]) {
         int result = run(argv,System.out);
@@ -114,13 +112,9 @@ public class isVerified001 extends Log {
         print_log_on_verbose("    of the com.sun.jdi package for ClassType, InterfaceType\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            debugee_launch_command = debugeeName + " -vbs";
-        }
 
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
-
 
         debugee.redirectStderr(out);
         print_log_on_verbose("--> isVerified001: isVerified001a debugee launched");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001/TestDescription.java
@@ -49,7 +49,6 @@
  *        nsk.jdi.ReferenceType.isVerified.isVerified001a
  * @run driver
  *      nsk.jdi.ReferenceType.isVerified.isVerified001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class isVerified001a {
 
+    private static Log log = new Log(System.err);
+
     isVerified001 a001_0 = new isVerified001();
 
     not_verif_cls not_verif_cls_0, not_verif_cls_1[] = {not_verif_cls_0};
@@ -43,24 +45,20 @@ public class isVerified001a {
 
     verif_subcl  verif_subcl_0 = new verif_subcl();
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> isVerified001a: debugee started!");
+        log.display("**> isVerified001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         isVerified001a isVerified001a_obj = new isVerified001a();
 
-        display("**> isVerified001a: waiting for \"quit\" signal...");
+        log.display("**> isVerified001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isVerified001a: \"quit\" signal recieved!");
-            display("**> isVerified001a: completed succesfully!");
+            log.display("**> isVerified001a: \"quit\" signal recieved!");
+            log.display("**> isVerified001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isVerified001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isVerified001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isVerified001 JDI test.
  */
 
 public class isVerified001a {
-
-    static boolean verbose_mode = false;
 
     isVerified001 a001_0 = new isVerified001();
 
@@ -46,33 +43,24 @@ public class isVerified001a {
 
     verif_subcl  verif_subcl_0 = new verif_subcl();
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> isVerified001a: debugee started!");
+        display("**> isVerified001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         isVerified001a isVerified001a_obj = new isVerified001a();
 
-        print_log_on_verbose("**> isVerified001a: waiting for \"quit\" signal...");
+        display("**> isVerified001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isVerified001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isVerified001a: completed succesfully!");
+            display("**> isVerified001a: \"quit\" signal recieved!");
+            display("**> isVerified001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isVerified001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isverified002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isverified002/TestDescription.java
@@ -64,7 +64,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.isVerified.isverified002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isverified002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isverified002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class isverified002a {
 
+    private static Log log = new Log(System.err);
+
     static String package_prefix = "nsk.jdi.ReferenceType.isVerified.";
     static String checked_class_name = package_prefix + "isverified002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> isverified002a: debugee started!");
+        log.display("**> isverified002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> isverified002a: waiting for \"checked class dir\" info...");
+        log.display("**> isverified002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class isverified002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> isverified002a: checked class loaded: " + checked_class_name);
+            log.display("--> isverified002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> isverified002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> isverified002a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> isverified002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> isverified002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> isverified002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isverified002a: \"quit\" signal recieved!");
-            display("**> isverified002a: completed!");
+            log.display("**> isverified002a: \"quit\" signal recieved!");
+            log.display("**> isverified002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class isverified002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> isverified002a: \"continue\" signal recieved!");
-        display("**> isverified002a: enforce to unload checked class...");
+        log.display("**> isverified002a: \"continue\" signal recieved!");
+        log.display("**> isverified002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> isverified002a: checked class may be NOT unloaded!");
+            log.display("**> isverified002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> isverified002a: checked class unloaded!");
+            log.display("**> isverified002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> isverified002a: waiting for \"quit\" signal...");
+        log.display("**> isverified002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> isverified002a: \"quit\" signal recieved!");
-            display("**> isverified002a: completed!");
+            log.display("**> isverified002a: \"quit\" signal recieved!");
+            log.display("**> isverified002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isverified002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isverified002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/isVerified/isverified002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,59 +29,51 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the isverified002 JDI test.
  */
 
 public class isverified002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     static String package_prefix = "nsk.jdi.ReferenceType.isVerified.";
     static String checked_class_name = package_prefix + "isverified002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> isverified002a: debugee started!");
+        display("**> isverified002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> isverified002a: waiting for \"checked class dir\" info...");
+        display("**> isverified002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
-
 
         ClassUnloader classUnloader = new ClassUnloader();
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> isverified002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> isverified002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> isverified002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> isverified002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> isverified002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isverified002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isverified002a: completed!");
+            display("**> isverified002a: \"quit\" signal recieved!");
+            display("**> isverified002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -91,24 +83,24 @@ public class isverified002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> isverified002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> isverified002a: enforce to unload checked class...");
+        display("**> isverified002a: \"continue\" signal recieved!");
+        display("**> isverified002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> isverified002a: checked class may be NOT unloaded!");
+            display("**> isverified002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> isverified002a: checked class unloaded!");
+            display("**> isverified002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> isverified002a: waiting for \"quit\" signal...");
+        display("**> isverified002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> isverified002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> isverified002a: completed!");
+            display("**> isverified002a: \"quit\" signal recieved!");
+            display("**> isverified002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> isverified002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods001/TestDescription.java
@@ -47,7 +47,6 @@
  *        nsk.jdi.ReferenceType.methods.methods001a
  * @run driver
  *      nsk.jdi.ReferenceType.methods.methods001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,37 +27,24 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the methods001 JDI test.
  */
 
 public class methods001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methods001aClassForCheck";
 
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> methods001a: debugee started!");
+        display("**> methods001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -65,23 +52,23 @@ public class methods001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, methods001a.class.getClassLoader());
-            print_log_on_verbose
+            display
                 ("--> methods001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> methods001a: load class: Throwable thrown = " + thrown.toString());
-            print_log_on_verbose
+            display
                 ("--> methods001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> methods001a: waiting for \"quit\" signal...");
+        display("**> methods001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methods001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methods001a: completed succesfully!");
+            display("**> methods001a: \"quit\" signal recieved!");
+            display("**> methods001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methods001a: unexpected signal (no \"quit\") - " + instruction);
@@ -196,7 +183,6 @@ abstract class methods001aClassForCheck extends methods001aSuperClassForCheck
 
     // static initializer
     static {}
-
 
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods001a.java
@@ -33,18 +33,16 @@ import nsk.share.jdi.*;
 
 public class methods001a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methods001aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> methods001a: debugee started!");
+        log.display("**> methods001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -52,23 +50,21 @@ public class methods001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, methods001a.class.getClassLoader());
-            display
-                ("--> methods001a: checked class loaded:" + checked_class_name);
+            log.display("--> methods001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> methods001a: load class: Throwable thrown = " + thrown.toString());
-            display
-                ("--> methods001a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> methods001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> methods001a: waiting for \"quit\" signal...");
+        log.display("**> methods001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methods001a: \"quit\" signal recieved!");
-            display("**> methods001a: completed succesfully!");
+            log.display("**> methods001a: \"quit\" signal recieved!");
+            log.display("**> methods001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methods001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002.java
@@ -69,20 +69,12 @@ public class methods002 {
 
         int v_test_result = new methods002().runThis(argv,out);
         if ( v_test_result == 2/*STATUS_FAILED*/ ) {
-            print_log_anyway("\n==> nsk/jdi/ReferenceType/methods/methods002 test FAILED");
+            test_log_handler.complain("\n==> nsk/jdi/ReferenceType/methods/methods002 test FAILED");
         }
         else {
-            print_log_on_verbose("\n==> nsk/jdi/ReferenceType/methods/methods002 test PASSED");
+            test_log_handler.display("\n==> nsk/jdi/ReferenceType/methods/methods002 test PASSED");
         }
         return v_test_result;
-    }
-
-    private static void print_log_on_verbose(String message) {
-        test_log_handler.display(message);
-    }
-
-    private static void print_log_anyway(String message) {
-        test_log_handler.complain(message);
     }
 
     /**
@@ -94,9 +86,9 @@ public class methods002 {
         test_log_handler = new Log(out, argsHandler);
         Binder binder    = new Binder(argsHandler, test_log_handler);
 
-        print_log_on_verbose("==> nsk/jdi/ReferenceType/methods/methods002 test LOG:");
-        print_log_on_verbose("==> test checks methods() method of ReferenceType interface ");
-        print_log_on_verbose("    of the com.sun.jdi package for not prepared class\n");
+        test_log_handler.display("==> nsk/jdi/ReferenceType/methods/methods002 test LOG:");
+        test_log_handler.display("==> test checks methods() method of ReferenceType interface ");
+        test_log_handler.display("    of the com.sun.jdi package for not prepared class\n");
 
         String debugee_launch_command = debugeeName;
 
@@ -104,26 +96,23 @@ public class methods002 {
         IOPipe pipe = new IOPipe(debugee);
 
         debugee.redirectStderr(out);
-        print_log_on_verbose("--> methods002: methods002a debugee launched");
+        test_log_handler.display("--> methods002: methods002a debugee launched");
         debugee.resume();
 
         String line = pipe.readln();
         if (line == null) {
-            print_log_anyway
-                ("##> methods002: UNEXPECTED debugee's signal (not \"ready\") - " + line);
+            test_log_handler.complain("##> methods002: UNEXPECTED debugee's signal (not \"ready\") - " + line);
             return 2/*STATUS_FAILED*/;
         }
         if (!line.equals("ready")) {
-            print_log_anyway
-                ("##> methods002: UNEXPECTED debugee's signal (not \"ready\") - " + line);
+            test_log_handler.complain("##> methods002: UNEXPECTED debugee's signal (not \"ready\") - " + line);
             return 2/*STATUS_FAILED*/;
         }
         else {
-            print_log_on_verbose("--> methods002: debugee's \"ready\" signal recieved!");
+            test_log_handler.display("--> methods002: debugee's \"ready\" signal recieved!");
         }
 
-        print_log_on_verbose
-            ("--> methods002: check ReferenceType.methods() method for not prepared "
+        test_log_handler.display("--> methods002: check ReferenceType.methods() method for not prepared "
             + class_for_check + " class...");
         boolean class_not_found_error = false;
         boolean methods_method_error = false;
@@ -131,7 +120,7 @@ public class methods002 {
         while ( true ) {  // test body
             ReferenceType loaderRefType = debugee.classByName(classLoaderName);
             if (loaderRefType == null) {
-                print_log_anyway("##> Could NOT FIND custom class loader: " + classLoaderName);
+                test_log_handler.complain("##> Could NOT FIND custom class loader: " + classLoaderName);
                 class_not_found_error = true;
                 break;
             }
@@ -143,7 +132,7 @@ public class methods002 {
             try {
                 classObjRef = (ClassObjectReference)classValue;
             } catch (Exception e) {
-                print_log_anyway ("##> Unexpected exception while getting ClassObjectReference : " + e);
+                test_log_handler.complain("##> Unexpected exception while getting ClassObjectReference : " + e);
                 class_not_found_error = true;
                 break;
             }
@@ -151,34 +140,27 @@ public class methods002 {
             ReferenceType refType = classObjRef.reflectedType();
             boolean isPrep = refType.isPrepared();
             if (isPrep) {
-                print_log_anyway
-                        ("##> methods002: FAILED: isPrepared() returns for " + class_for_check + " : " + isPrep);
+                test_log_handler.complain("##> methods002: FAILED: isPrepared() returns for " + class_for_check + " : " + isPrep);
                 class_not_found_error = true;
                 break;
             } else {
-                print_log_on_verbose
-                    ("--> methods002: isPrepared() returns for " + class_for_check + " : " + isPrep);
+                test_log_handler.display("--> methods002: isPrepared() returns for " + class_for_check + " : " + isPrep);
             }
 
             List methods_list = null;
             try {
                 methods_list = refType.methods();
-                print_log_anyway
-                    ("##> methods002: FAILED: NO any Exception thrown!");
-                print_log_anyway
-                    ("##>             expected Exception - com.sun.jdi.ClassNotPreparedException");
+                test_log_handler.complain("##> methods002: FAILED: NO any Exception thrown!");
+                test_log_handler.complain("##>             expected Exception - com.sun.jdi.ClassNotPreparedException");
                 methods_method_error = true;
             }
             catch (Exception expt) {
                 if (expt instanceof com.sun.jdi.ClassNotPreparedException) {
-                    print_log_on_verbose
-                        ("--> methods002: PASSED: expected Exception thrown - " + expt.toString());
+                    test_log_handler.display("--> methods002: PASSED: expected Exception thrown - " + expt.toString());
                 }
                 else {
-                    print_log_anyway
-                        ("##> methods002: FAILED: unexpected Exception thrown - " + expt.toString());
-                    print_log_anyway
-                        ("##>             expected Exception - com.sun.jdi.ClassNotPreparedException");
+                    test_log_handler.complain("##> methods002: FAILED: unexpected Exception thrown - " + expt.toString());
+                    test_log_handler.complain("##>             expected Exception - com.sun.jdi.ClassNotPreparedException");
                     methods_method_error = true;
                 }
             }
@@ -189,19 +171,17 @@ public class methods002 {
             v_test_result = 2/*STATUS_FAILED*/;
         }
 
-        print_log_on_verbose("--> methods002: waiting for debugee finish...");
+        test_log_handler.display("--> methods002: waiting for debugee finish...");
         pipe.println("quit");
         debugee.waitFor();
 
         int status = debugee.getStatus();
         if (status != 0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/) {
-            print_log_anyway
-                ("##> methods002: UNEXPECTED Debugee's exit status (not 95) - " + status);
+            test_log_handler.complain("##> methods002: UNEXPECTED Debugee's exit status (not 95) - " + status);
             v_test_result = 2/*STATUS_FAILED*/;
         }
         else {
-            print_log_on_verbose
-                ("--> methods002: expected Debugee's exit status - " + status);
+            test_log_handler.display("--> methods002: expected Debugee's exit status - " + status);
         }
 
         return v_test_result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,6 @@ import java.io.*;
 public class methods002 {
     static ArgumentHandler argsHandler;
     static Log test_log_handler;
-    static boolean verbose_mode = false;  // test argument -verbose switches to true
-                                          // - for more easy failure evaluation
 
     /** The main class names of the debugger & debugee applications. */
     private final static String
@@ -54,7 +52,6 @@ public class methods002 {
 
     private final static String classLoaderName = package_prefix + "methods002aClassLoader";
     private final static String classFieldName = "loadedClass";
-
 
     public static void main (String argv[]) {
         int result = run(argv,System.out);
@@ -102,13 +99,9 @@ public class methods002 {
         print_log_on_verbose("    of the com.sun.jdi package for not prepared class\n");
 
         String debugee_launch_command = debugeeName;
-        if (verbose_mode) {
-            debugee_launch_command = debugeeName + " -vbs";
-        }
 
         Debugee debugee = binder.bindToDebugee(debugee_launch_command);
         IOPipe pipe = new IOPipe(debugee);
-
 
         debugee.redirectStderr(out);
         print_log_on_verbose("--> methods002: methods002a debugee launched");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.methods.methods002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002a.java
@@ -34,18 +34,16 @@ import java.io.*;
 
 public class methods002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methods002aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> methods002a: debugee started!");
+        log.display("**> methods002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -54,19 +52,17 @@ public class methods002a {
         methods002aClassLoader customClassLoader = new methods002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> methods002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> methods002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> methods002a: checked class NOT loaded: " + e);
+            log.display("--> methods002a: checked class NOT loaded: " + e);
         }
 
-        display("**> methods002a: waiting for \"quit\" signal...");
+        log.display("**> methods002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methods002a: \"quit\" signal recieved!");
-            display("**> methods002a: completed succesfully!");
+            log.display("**> methods002a: \"quit\" signal recieved!");
+            log.display("**> methods002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methods002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,30 +34,18 @@ import java.io.*;
 
 public class methods002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methods002aClassForCheck";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> methods002a: debugee started!");
+        display("**> methods002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -66,19 +54,19 @@ public class methods002a {
         methods002aClassLoader customClassLoader = new methods002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> methods002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> methods002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> methods002a: waiting for \"quit\" signal...");
+        display("**> methods002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methods002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methods002a: completed succesfully!");
+            display("**> methods002a: \"quit\" signal recieved!");
+            display("**> methods002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methods002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods003/TestDescription.java
@@ -61,7 +61,6 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run driver
  *      nsk.jdi.ReferenceType.methods.methods003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the methods003 JDI test.
  */
 
 public class methods003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.methods.";
     private final static String checked_class_name = package_prefix + "methods003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> methods003a: debugee started!");
+        display("**> methods003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> methods003a: waiting for \"checked class dir\" info...");
+        display("**> methods003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class methods003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> methods003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> methods003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> methods003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> methods003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> methods003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methods003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methods003a: completed!");
+            display("**> methods003a: \"quit\" signal recieved!");
+            display("**> methods003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class methods003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> methods003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> methods003a: enforce to unload checked class...");
+        display("**> methods003a: \"continue\" signal recieved!");
+        display("**> methods003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> methods003a: checked class may be NOT unloaded!");
+            display("**> methods003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> methods003a: checked class unloaded!");
+            display("**> methods003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> methods003a: waiting for \"quit\" signal...");
+        display("**> methods003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methods003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methods003a: completed!");
+            display("**> methods003a: \"quit\" signal recieved!");
+            display("**> methods003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methods003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods003a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class methods003a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.methods.";
     private final static String checked_class_name = package_prefix + "methods003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> methods003a: debugee started!");
+        log.display("**> methods003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> methods003a: waiting for \"checked class dir\" info...");
+        log.display("**> methods003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class methods003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> methods003a: checked class loaded:" + checked_class_name);
+            log.display("--> methods003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> methods003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> methods003a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> methods003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> methods003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> methods003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methods003a: \"quit\" signal recieved!");
-            display("**> methods003a: completed!");
+            log.display("**> methods003a: \"quit\" signal recieved!");
+            log.display("**> methods003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class methods003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> methods003a: \"continue\" signal recieved!");
-        display("**> methods003a: enforce to unload checked class...");
+        log.display("**> methods003a: \"continue\" signal recieved!");
+        log.display("**> methods003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> methods003a: checked class may be NOT unloaded!");
+            log.display("**> methods003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> methods003a: checked class unloaded!");
+            log.display("**> methods003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> methods003a: waiting for \"quit\" signal...");
+        log.display("**> methods003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methods003a: \"quit\" signal recieved!");
-            display("**> methods003a: completed!");
+            log.display("**> methods003a: \"quit\" signal recieved!");
+            log.display("**> methods003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methods003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods004/TestDescription.java
@@ -46,7 +46,6 @@
  *        nsk.jdi.ReferenceType.methods.methods004a
  * @run driver
  *      nsk.jdi.ReferenceType.methods.methods004
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the methods004 JDI test.
  */
 
 public class methods004a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> methods004a: debugee started!");
+        display("**> methods004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         methods004aClassForCheck class_for_check = new methods004aClassForCheck();
 
-        print_log_on_verbose("**> methods004a: waiting for \"quit\" signal...");
+        display("**> methods004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methods004a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methods004a: completed succesfully!");
+            display("**> methods004a: \"quit\" signal recieved!");
+            display("**> methods004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> methods004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methods/methods004a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class methods004a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> methods004a: debugee started!");
+        log.display("**> methods004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         methods004aClassForCheck class_for_check = new methods004aClassForCheck();
 
-        display("**> methods004a: waiting for \"quit\" signal...");
+        log.display("**> methods004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methods004a: \"quit\" signal recieved!");
-            display("**> methods004a: completed succesfully!");
+            log.display("**> methods004a: \"quit\" signal recieved!");
+            log.display("**> methods004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> methods004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s001/TestDescription.java
@@ -46,7 +46,6 @@
  *        nsk.jdi.ReferenceType.methodsByName_s.methbyname_s001a
  * @run driver
  *      nsk.jdi.ReferenceType.methodsByName_s.methbyname_s001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,37 +27,24 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the methbyname_s001 JDI test.
  */
 
 public class methbyname_s001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_s.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_s001aClassForCheck";
 
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> methbyname_s001a: debugee started!");
+        display("**> methbyname_s001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -65,23 +52,23 @@ public class methbyname_s001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, methbyname_s001a.class.getClassLoader());
-            print_log_on_verbose
+            display
                 ("--> methbyname_s001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> methbyname_s001a: load class: Throwable thrown = " + thrown.toString());
-            print_log_on_verbose
+            display
                 ("--> methbyname_s001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> methbyname_s001a: waiting for \"quit\" signal...");
+        display("**> methbyname_s001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_s001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_s001a: completed succesfully!");
+            display("**> methbyname_s001a: \"quit\" signal recieved!");
+            display("**> methbyname_s001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_s001a: unexpected signal (no \"quit\") - " + instruction);
@@ -193,10 +180,8 @@ abstract class methbyname_s001aClassForCheck extends methbyname_s001aSuperClassF
     protected Object  i_protected_method(Object obj) {return new Object();}
     public Object  i_public_method(Object obj) {return new Object();}
 
-
     // static initializer
     static {}
-
 
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s001a.java
@@ -33,18 +33,16 @@ import nsk.share.jdi.*;
 
 public class methbyname_s001a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_s.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_s001aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> methbyname_s001a: debugee started!");
+        log.display("**> methbyname_s001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -52,23 +50,21 @@ public class methbyname_s001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, methbyname_s001a.class.getClassLoader());
-            display
-                ("--> methbyname_s001a: checked class loaded:" + checked_class_name);
+            log.display("--> methbyname_s001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> methbyname_s001a: load class: Throwable thrown = " + thrown.toString());
-            display
-                ("--> methbyname_s001a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> methbyname_s001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> methbyname_s001a: waiting for \"quit\" signal...");
+        log.display("**> methbyname_s001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_s001a: \"quit\" signal recieved!");
-            display("**> methbyname_s001a: completed succesfully!");
+            log.display("**> methbyname_s001a: \"quit\" signal recieved!");
+            log.display("**> methbyname_s001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_s001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002.java
@@ -57,8 +57,6 @@ public class methbyname_s002 extends Log {
     static ArgumentHandler      argsHandler;
     private static Log  logHandler;
 
-
-
     public static void main (String argv[]) {
         int result = run(argv,System.out);
         if (result != 0) {
@@ -97,18 +95,13 @@ public class methbyname_s002 extends Log {
      */
     private int runThis (String argv[], PrintStream out) {
 
-
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
 
         Debugee debugee;
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         print_log_on_verbose("==> nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002 test LOG:");
         print_log_on_verbose("==> test checks methodsByName(String name) method of ReferenceType interface ");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.methodsByName_s.methbyname_s002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,37 +28,24 @@ import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 import java.io.*;
 
-
 /**
  * This class is used as debugee application for the methbyname_s002 JDI test.
  */
 
 public class methbyname_s002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_s.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_s002aClassForCheck";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> methbyname_s002a: debugee started!");
+        display("**> methbyname_s002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -67,19 +54,19 @@ public class methbyname_s002a {
         methbyname_s002aClassLoader customClassLoader = new methbyname_s002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> methbyname_s002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> methbyname_s002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> methbyname_s002a: waiting for \"quit\" signal...");
+        display("**> methbyname_s002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_s002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_s002a: completed succesfully!");
+            display("**> methbyname_s002a: \"quit\" signal recieved!");
+            display("**> methbyname_s002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_s002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s002a.java
@@ -34,18 +34,16 @@ import java.io.*;
 
 public class methbyname_s002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_s.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_s002aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> methbyname_s002a: debugee started!");
+        log.display("**> methbyname_s002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -54,19 +52,17 @@ public class methbyname_s002a {
         methbyname_s002aClassLoader customClassLoader = new methbyname_s002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> methbyname_s002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> methbyname_s002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> methbyname_s002a: checked class NOT loaded: " + e);
+            log.display("--> methbyname_s002a: checked class NOT loaded: " + e);
         }
 
-        display("**> methbyname_s002a: waiting for \"quit\" signal...");
+        log.display("**> methbyname_s002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_s002a: \"quit\" signal recieved!");
-            display("**> methbyname_s002a: completed succesfully!");
+            log.display("**> methbyname_s002a: \"quit\" signal recieved!");
+            log.display("**> methbyname_s002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_s002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s003/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.methodsByName_s.methbyname_s003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s003a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class methbyname_s003a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.methodsByName_s.";
     private final static String checked_class_name = package_prefix + "methbyname_s003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> methbyname_s003a: debugee started!");
+        log.display("**> methbyname_s003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> methbyname_s003a: waiting for \"checked class dir\" info...");
+        log.display("**> methbyname_s003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class methbyname_s003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> methbyname_s003a: checked class loaded:" + checked_class_name);
+            log.display("--> methbyname_s003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> methbyname_s003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> methbyname_s003a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> methbyname_s003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> methbyname_s003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> methbyname_s003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_s003a: \"quit\" signal recieved!");
-            display("**> methbyname_s003a: completed!");
+            log.display("**> methbyname_s003a: \"quit\" signal recieved!");
+            log.display("**> methbyname_s003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class methbyname_s003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> methbyname_s003a: \"continue\" signal recieved!");
-        display("**> methbyname_s003a: enforce to unload checked class...");
+        log.display("**> methbyname_s003a: \"continue\" signal recieved!");
+        log.display("**> methbyname_s003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> methbyname_s003a: checked class may be NOT unloaded!");
+            log.display("**> methbyname_s003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> methbyname_s003a: checked class unloaded!");
+            log.display("**> methbyname_s003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> methbyname_s003a: waiting for \"quit\" signal...");
+        log.display("**> methbyname_s003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_s003a: \"quit\" signal recieved!");
-            display("**> methbyname_s003a: completed!");
+            log.display("**> methbyname_s003a: \"quit\" signal recieved!");
+            log.display("**> methbyname_s003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_s003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the methbyname_s003 JDI test.
  */
 
 public class methbyname_s003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.methodsByName_s.";
     private final static String checked_class_name = package_prefix + "methbyname_s003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> methbyname_s003a: debugee started!");
+        display("**> methbyname_s003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> methbyname_s003a: waiting for \"checked class dir\" info...");
+        display("**> methbyname_s003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class methbyname_s003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> methbyname_s003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> methbyname_s003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> methbyname_s003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> methbyname_s003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> methbyname_s003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_s003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_s003a: completed!");
+            display("**> methbyname_s003a: \"quit\" signal recieved!");
+            display("**> methbyname_s003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class methbyname_s003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> methbyname_s003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> methbyname_s003a: enforce to unload checked class...");
+        display("**> methbyname_s003a: \"continue\" signal recieved!");
+        display("**> methbyname_s003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> methbyname_s003a: checked class may be NOT unloaded!");
+            display("**> methbyname_s003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> methbyname_s003a: checked class unloaded!");
+            display("**> methbyname_s003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> methbyname_s003a: waiting for \"quit\" signal...");
+        display("**> methbyname_s003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_s003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_s003a: completed!");
+            display("**> methbyname_s003a: \"quit\" signal recieved!");
+            display("**> methbyname_s003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_s003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s004/TestDescription.java
@@ -46,7 +46,6 @@
  *        nsk.jdi.ReferenceType.methodsByName_s.methbyname_s004a
  * @run driver
  *      nsk.jdi.ReferenceType.methodsByName_s.methbyname_s004
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s004a.java
@@ -33,18 +33,16 @@ import nsk.share.jdi.*;
 
 public class methbyname_s004a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_s.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_s004aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> methbyname_s004a: debugee started!");
+        log.display("**> methbyname_s004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -52,23 +50,21 @@ public class methbyname_s004a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, methbyname_s004a.class.getClassLoader());
-            display
-                ("--> methbyname_s004a: checked class loaded:" + checked_class_name);
+            log.display("--> methbyname_s004a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> methbyname_s004a: load class: Throwable thrown = " + thrown.toString());
-            display
-                ("--> methbyname_s004a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> methbyname_s004a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> methbyname_s004a: waiting for \"quit\" signal...");
+        log.display("**> methbyname_s004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_s004a: \"quit\" signal recieved!");
-            display("**> methbyname_s004a: completed succesfully!");
+            log.display("**> methbyname_s004a: \"quit\" signal recieved!");
+            log.display("**> methbyname_s004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_s004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_s/methbyname_s004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,37 +27,24 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the methbyname_s004 JDI test.
  */
 
 public class methbyname_s004a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_s.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_s004aClassForCheck";
 
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> methbyname_s004a: debugee started!");
+        display("**> methbyname_s004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -65,23 +52,23 @@ public class methbyname_s004a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, methbyname_s004a.class.getClassLoader());
-            print_log_on_verbose
+            display
                 ("--> methbyname_s004a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> methbyname_s004a: load class: Throwable thrown = " + thrown.toString());
-            print_log_on_verbose
+            display
                 ("--> methbyname_s004a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> methbyname_s004a: waiting for \"quit\" signal...");
+        display("**> methbyname_s004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_s004a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_s004a: completed succesfully!");
+            display("**> methbyname_s004a: \"quit\" signal recieved!");
+            display("**> methbyname_s004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_s004a: unexpected signal (no \"quit\") - " + instruction);
@@ -91,7 +78,6 @@ public class methbyname_s004a {
 }
 
 abstract class methbyname_s004aClassForCheck extends methbyname_s004aSuperClassForCheck implements methbyname_s004aInterfaceForCheck {
-
 
     // overloaded static methods
     static void  s_overloaded_method() {}
@@ -109,7 +95,6 @@ abstract class methbyname_s004aClassForCheck extends methbyname_s004aSuperClassF
 
     Object  i_super_overloaded_method(long l, String s) {return new Object();}
     Object  i_interf_overloaded_method(long l, String s) {return new Object();}
-
 
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss001/TestDescription.java
@@ -46,7 +46,6 @@
  *        nsk.jdi.ReferenceType.methodsByName_ss.methbyname_ss001a
  * @run driver
  *      nsk.jdi.ReferenceType.methodsByName_ss.methbyname_ss001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,37 +27,24 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the methbyname_ss001 JDI test.
  */
 
 public class methbyname_ss001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_ss.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_ss001aClassForCheck";
 
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> methbyname_ss001a: debugee started!");
+        display("**> methbyname_ss001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -65,23 +52,23 @@ public class methbyname_ss001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, methbyname_ss001a.class.getClassLoader());
-            print_log_on_verbose
+            display
                 ("--> methbyname_ss001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> methbyname_ss001a: load class: Throwable thrown = " + thrown.toString());
-            print_log_on_verbose
+            display
                 ("--> methbyname_ss001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> methbyname_ss001a: waiting for \"quit\" signal...");
+        display("**> methbyname_ss001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_ss001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_ss001a: completed succesfully!");
+            display("**> methbyname_ss001a: \"quit\" signal recieved!");
+            display("**> methbyname_ss001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_ss001a: unexpected signal (no \"quit\") - " + instruction);
@@ -194,7 +181,6 @@ abstract class methbyname_ss001aClassForCheck extends methbyname_ss001aSuperClas
     protected Object  i_protected_method(Object obj) {return new Object();}
     public Object  i_public_method(Object obj) {return new Object();}
 
-
     // static initializer
     static {}
 
@@ -214,7 +200,6 @@ abstract class methbyname_ss001aClassForCheck extends methbyname_ss001aSuperClas
 
     Object  i_super_overloaded_method(long l, String s) {return new Object();}
     Object  i_interf_overloaded_method(long l, String s) {return new Object();}
-
 
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss001a.java
@@ -33,18 +33,16 @@ import nsk.share.jdi.*;
 
 public class methbyname_ss001a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_ss.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_ss001aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> methbyname_ss001a: debugee started!");
+        log.display("**> methbyname_ss001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -52,23 +50,21 @@ public class methbyname_ss001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, methbyname_ss001a.class.getClassLoader());
-            display
-                ("--> methbyname_ss001a: checked class loaded:" + checked_class_name);
+            log.display("--> methbyname_ss001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> methbyname_ss001a: load class: Throwable thrown = " + thrown.toString());
-            display
-                ("--> methbyname_ss001a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> methbyname_ss001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> methbyname_ss001a: waiting for \"quit\" signal...");
+        log.display("**> methbyname_ss001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_ss001a: \"quit\" signal recieved!");
-            display("**> methbyname_ss001a: completed succesfully!");
+            log.display("**> methbyname_ss001a: \"quit\" signal recieved!");
+            log.display("**> methbyname_ss001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_ss001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002.java
@@ -57,8 +57,6 @@ public class methbyname_ss002 extends Log {
     static ArgumentHandler      argsHandler;
     private static Log  logHandler;
 
-
-
     public static void main (String argv[]) {
         int result = run(argv,System.out);
         if (result != 0) {
@@ -103,11 +101,7 @@ public class methbyname_ss002 extends Log {
 
         Debugee debugee;
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         print_log_on_verbose("==> nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002 test LOG:");
         print_log_on_verbose("==> test checks methodsByName(String name, String signature) method of ReferenceType ");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.methodsByName_ss.methbyname_ss002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002a.java
@@ -34,18 +34,16 @@ import java.io.*;
 
 public class methbyname_ss002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_ss.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_ss002aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> methbyname_ss002a: debugee started!");
+        log.display("**> methbyname_ss002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -54,19 +52,17 @@ public class methbyname_ss002a {
         methbyname_ss002aClassLoader customClassLoader = new methbyname_ss002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> methbyname_ss002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> methbyname_ss002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> methbyname_ss002a: checked class NOT loaded: " + e);
+            log.display("--> methbyname_ss002a: checked class NOT loaded: " + e);
         }
 
-        display("**> methbyname_ss002a: waiting for \"quit\" signal...");
+        log.display("**> methbyname_ss002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_ss002a: \"quit\" signal recieved!");
-            display("**> methbyname_ss002a: completed succesfully!");
+            log.display("**> methbyname_ss002a: \"quit\" signal recieved!");
+            log.display("**> methbyname_ss002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_ss002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,37 +28,24 @@ import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 import java.io.*;
 
-
 /**
  * This class is used as debugee application for the methbyname_ss002 JDI test.
  */
 
 public class methbyname_ss002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.methodsByName_ss.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "methbyname_ss002aClassForCheck";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> methbyname_ss002a: debugee started!");
+        display("**> methbyname_ss002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -67,19 +54,19 @@ public class methbyname_ss002a {
         methbyname_ss002aClassLoader customClassLoader = new methbyname_ss002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> methbyname_ss002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> methbyname_ss002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> methbyname_ss002a: waiting for \"quit\" signal...");
+        display("**> methbyname_ss002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_ss002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_ss002a: completed succesfully!");
+            display("**> methbyname_ss002a: \"quit\" signal recieved!");
+            display("**> methbyname_ss002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_ss002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss003/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.methodsByName_ss.methbyname_ss003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss003a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class methbyname_ss003a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.methodsByName_ss.";
     private final static String checked_class_name = package_prefix + "methbyname_ss003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> methbyname_ss003a: debugee started!");
+        log.display("**> methbyname_ss003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> methbyname_ss003a: waiting for \"checked class dir\" info...");
+        log.display("**> methbyname_ss003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class methbyname_ss003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> methbyname_ss003a: checked class loaded:" + checked_class_name);
+            log.display("--> methbyname_ss003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> methbyname_ss003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> methbyname_ss003a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> methbyname_ss003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> methbyname_ss003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> methbyname_ss003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_ss003a: \"quit\" signal recieved!");
-            display("**> methbyname_ss003a: completed!");
+            log.display("**> methbyname_ss003a: \"quit\" signal recieved!");
+            log.display("**> methbyname_ss003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class methbyname_ss003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> methbyname_ss003a: \"continue\" signal recieved!");
-        display("**> methbyname_ss003a: enforce to unload checked class...");
+        log.display("**> methbyname_ss003a: \"continue\" signal recieved!");
+        log.display("**> methbyname_ss003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> methbyname_ss003a: checked class may be NOT unloaded!");
+            log.display("**> methbyname_ss003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> methbyname_ss003a: checked class unloaded!");
+            log.display("**> methbyname_ss003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> methbyname_ss003a: waiting for \"quit\" signal...");
+        log.display("**> methbyname_ss003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> methbyname_ss003a: \"quit\" signal recieved!");
-            display("**> methbyname_ss003a: completed!");
+            log.display("**> methbyname_ss003a: \"quit\" signal recieved!");
+            log.display("**> methbyname_ss003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_ss003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/methodsByName_ss/methbyname_ss003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the methbyname_ss003 JDI test.
  */
 
 public class methbyname_ss003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.methodsByName_ss.";
     private final static String checked_class_name = package_prefix + "methbyname_ss003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> methbyname_ss003a: debugee started!");
+        display("**> methbyname_ss003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> methbyname_ss003a: waiting for \"checked class dir\" info...");
+        display("**> methbyname_ss003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class methbyname_ss003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> methbyname_ss003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> methbyname_ss003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> methbyname_ss003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> methbyname_ss003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> methbyname_ss003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_ss003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_ss003a: completed!");
+            display("**> methbyname_ss003a: \"quit\" signal recieved!");
+            display("**> methbyname_ss003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class methbyname_ss003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> methbyname_ss003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> methbyname_ss003a: enforce to unload checked class...");
+        display("**> methbyname_ss003a: \"continue\" signal recieved!");
+        display("**> methbyname_ss003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> methbyname_ss003a: checked class may be NOT unloaded!");
+            display("**> methbyname_ss003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> methbyname_ss003a: checked class unloaded!");
+            display("**> methbyname_ss003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> methbyname_ss003a: waiting for \"quit\" signal...");
+        display("**> methbyname_ss003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> methbyname_ss003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> methbyname_ss003a: completed!");
+            display("**> methbyname_ss003a: \"quit\" signal recieved!");
+            display("**> methbyname_ss003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> methbyname_ss003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name001/TestDescription.java
@@ -48,7 +48,6 @@
  *        nsk.jdi.ReferenceType.name.name001a
  * @run driver
  *      nsk.jdi.ReferenceType.name.name001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class name001a {
 
+    private static Log log = new Log(System.err);
+
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
     char    c0, c1[]={c0}, c2[][]={c1};
@@ -72,24 +74,20 @@ public class name001a {
                       interf_for_check1[]={interf_for_check0},
                       interf_for_check2[][]={interf_for_check1};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> name001a: debugee started!");
+        log.display("**> name001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         name001a name001a_obj = new name001a();
 
-        display("**> name001a: waiting for \"quit\" signal...");
+        log.display("**> name001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> name001a: \"quit\" signal recieved!");
-            display("**> name001a: completed succesfully!");
+            log.display("**> name001a: \"quit\" signal recieved!");
+            log.display("**> name001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> name001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,16 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the name001 JDI test.
  */
 
 public class name001a {
-
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
 
     boolean z0, z1[]={z0}, z2[][]={z1};
     byte    b0, b1[]={b0}, b2[][]={b1};
@@ -77,33 +72,24 @@ public class name001a {
                       interf_for_check1[]={interf_for_check0},
                       interf_for_check2[][]={interf_for_check1};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> name001a: debugee started!");
+        display("**> name001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         name001a name001a_obj = new name001a();
 
-        print_log_on_verbose("**> name001a: waiting for \"quit\" signal...");
+        display("**> name001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> name001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> name001a: completed succesfully!");
+            display("**> name001a: \"quit\" signal recieved!");
+            display("**> name001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> name001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.name.name002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the name002 JDI test.
  */
 
 public class name002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.name.";
     private final static String checked_class_name = package_prefix + "name002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> name002a: debugee started!");
+        display("**> name002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> name002a: waiting for \"checked class dir\" info...");
+        display("**> name002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class name002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> name002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> name002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> name002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> name002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> name002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> name002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> name002a: completed!");
+            display("**> name002a: \"quit\" signal recieved!");
+            display("**> name002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class name002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> name002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> name002a: enforce to unload checked class...");
+        display("**> name002a: \"continue\" signal recieved!");
+        display("**> name002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> name002a: checked class may be NOT unloaded!");
+            display("**> name002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> name002a: checked class unloaded!");
+            display("**> name002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> name002a: waiting for \"quit\" signal...");
+        display("**> name002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> name002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> name002a: completed!");
+            display("**> name002a: \"quit\" signal recieved!");
+            display("**> name002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> name002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/name/name002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class name002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.name.";
     private final static String checked_class_name = package_prefix + "name002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> name002a: debugee started!");
+        log.display("**> name002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> name002a: waiting for \"checked class dir\" info...");
+        log.display("**> name002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class name002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> name002a: checked class loaded: " + checked_class_name);
+            log.display("--> name002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> name002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> name002a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> name002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> name002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> name002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> name002a: \"quit\" signal recieved!");
-            display("**> name002a: completed!");
+            log.display("**> name002a: \"quit\" signal recieved!");
+            log.display("**> name002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class name002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> name002a: \"continue\" signal recieved!");
-        display("**> name002a: enforce to unload checked class...");
+        log.display("**> name002a: \"continue\" signal recieved!");
+        log.display("**> name002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> name002a: checked class may be NOT unloaded!");
+            log.display("**> name002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> name002a: checked class unloaded!");
+            log.display("**> name002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> name002a: waiting for \"quit\" signal...");
+        log.display("**> name002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> name002a: \"quit\" signal recieved!");
-            display("**> name002a: completed!");
+            log.display("**> name002a: \"quit\" signal recieved!");
+            log.display("**> name002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> name002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename001/TestDescription.java
@@ -48,7 +48,6 @@
  *        nsk.jdi.ReferenceType.sourceName.sourcename001a
  * @run driver
  *      nsk.jdi.ReferenceType.sourceName.sourcename001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class sourcename001a {
 
+    private static Log log = new Log(System.err);
+
     // Classes must be loaded and linked, so all fields must be
     // initialized
     static class  s_class {}
@@ -54,24 +56,20 @@ public class sourcename001a {
     sourcename001 sourcename001_0 = new sourcename001(),
                   sourcename001_1[]={sourcename001_0};
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> sourcename001a: debugee started!");
+        log.display("**> sourcename001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         sourcename001a sourcename001a_obj = new sourcename001a();
 
-        display("**> sourcename001a: waiting for \"quit\" signal...");
+        log.display("**> sourcename001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> sourcename001a: \"quit\" signal recieved!");
-            display("**> sourcename001a: completed succesfully!");
+            log.display("**> sourcename001a: \"quit\" signal recieved!");
+            log.display("**> sourcename001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> sourcename001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,11 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the sourcename001 JDI test.
  */
 
 public class sourcename001a {
-
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
 
     // Classes must be loaded and linked, so all fields must be
     // initialized
@@ -58,33 +54,24 @@ public class sourcename001a {
     sourcename001 sourcename001_0 = new sourcename001(),
                   sourcename001_1[]={sourcename001_0};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> sourcename001a: debugee started!");
+        display("**> sourcename001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         sourcename001a sourcename001a_obj = new sourcename001a();
 
-        print_log_on_verbose("**> sourcename001a: waiting for \"quit\" signal...");
+        display("**> sourcename001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> sourcename001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> sourcename001a: completed succesfully!");
+            display("**> sourcename001a: \"quit\" signal recieved!");
+            display("**> sourcename001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> sourcename001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename002/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.sourceName.sourcename002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the sourcename002 JDI test.
  */
 
 public class sourcename002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.sourceName.";
     private final static String checked_class_name = package_prefix + "sourcename002b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> sourcename002a: debugee started!");
+        display("**> sourcename002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> sourcename002a: waiting for \"checked class dir\" info...");
+        display("**> sourcename002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class sourcename002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> sourcename002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("**> sourcename002a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> sourcename002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> sourcename002a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> sourcename002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> sourcename002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> sourcename002a: completed!");
+            display("**> sourcename002a: \"quit\" signal recieved!");
+            display("**> sourcename002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class sourcename002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> sourcename002a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> sourcename002a: enforce to unload checked class...");
+        display("**> sourcename002a: \"continue\" signal recieved!");
+        display("**> sourcename002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> sourcename002a: checked class may be NOT unloaded!");
+            display("**> sourcename002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> sourcename002a: checked class unloaded!");
+            display("**> sourcename002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> sourcename002a: waiting for \"quit\" signal...");
+        display("**> sourcename002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> sourcename002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> sourcename002a: completed!");
+            display("**> sourcename002a: \"quit\" signal recieved!");
+            display("**> sourcename002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> sourcename002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename002a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class sourcename002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.sourceName.";
     private final static String checked_class_name = package_prefix + "sourcename002b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> sourcename002a: debugee started!");
+        log.display("**> sourcename002a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> sourcename002a: waiting for \"checked class dir\" info...");
+        log.display("**> sourcename002a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,20 @@ public class sourcename002a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> sourcename002a: checked class loaded: " + checked_class_name);
+            log.display("--> sourcename002a: checked class loaded: " + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
-            display
-                ("**> sourcename002a: load class: exception thrown = " + e.toString());
-            display
-                ("--> sourcename002a: checked class NOT loaded: " + checked_class_name);
+            log.display("**> sourcename002a: load class: exception thrown = " + e.toString());
+            log.display("--> sourcename002a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> sourcename002a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> sourcename002a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> sourcename002a: \"quit\" signal recieved!");
-            display("**> sourcename002a: completed!");
+            log.display("**> sourcename002a: \"quit\" signal recieved!");
+            log.display("**> sourcename002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +78,24 @@ public class sourcename002a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> sourcename002a: \"continue\" signal recieved!");
-        display("**> sourcename002a: enforce to unload checked class...");
+        log.display("**> sourcename002a: \"continue\" signal recieved!");
+        log.display("**> sourcename002a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> sourcename002a: checked class may be NOT unloaded!");
+            log.display("**> sourcename002a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> sourcename002a: checked class unloaded!");
+            log.display("**> sourcename002a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> sourcename002a: waiting for \"quit\" signal...");
+        log.display("**> sourcename002a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> sourcename002a: \"quit\" signal recieved!");
-            display("**> sourcename002a: completed!");
+            log.display("**> sourcename002a: \"quit\" signal recieved!");
+            log.display("**> sourcename002a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> sourcename002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename003/TestDescription.java
@@ -46,7 +46,6 @@
  *        nsk.jdi.ReferenceType.sourceName.sourcename003a
  * @run driver
  *      nsk.jdi.ReferenceType.sourceName.sourcename003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,45 +27,32 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the sourcename003 JDI test.
  */
 
 public class sourcename003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     sourcename003 sourcename003_0, sourcename003_1[]={sourcename003_0};
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> sourcename003a: debugee started!");
+        display("**> sourcename003a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         sourcename003a sourcename003a_obj = new sourcename003a();
 
-        print_log_on_verbose("**> sourcename003a: waiting for \"quit\" signal...");
+        display("**> sourcename003a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> sourcename003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> sourcename003a: completed succesfully!");
+            display("**> sourcename003a: \"quit\" signal recieved!");
+            display("**> sourcename003a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> sourcename003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/sourceName/sourcename003a.java
@@ -33,26 +33,24 @@ import nsk.share.jdi.*;
 
 public class sourcename003a {
 
-    sourcename003 sourcename003_0, sourcename003_1[]={sourcename003_0};
+    private static Log log = new Log(System.err);
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    sourcename003 sourcename003_0, sourcename003_1[]={sourcename003_0};
 
     public static void main (String argv[]) {
 
-        display("**> sourcename003a: debugee started!");
+        log.display("**> sourcename003a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         sourcename003a sourcename003a_obj = new sourcename003a();
 
-        display("**> sourcename003a: waiting for \"quit\" signal...");
+        log.display("**> sourcename003a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> sourcename003a: \"quit\" signal recieved!");
-            display("**> sourcename003a: completed succesfully!");
+            log.display("**> sourcename003a: \"quit\" signal recieved!");
+            log.display("**> sourcename003a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> sourcename003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield001/TestDescription.java
@@ -48,7 +48,6 @@
  *        nsk.jdi.ReferenceType.visibleFields.visibfield001a
  * @run driver
  *      nsk.jdi.ReferenceType.visibleFields.visibfield001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield001a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class visibfield001a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> visibfield001a: debugee started!");
+        log.display("**> visibfield001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         visibfield001aClassForCheck class_for_check = new visibfield001aClassForCheck();
 
-        display("**> visibfield001a: waiting for \"quit\" signal...");
+        log.display("**> visibfield001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibfield001a: \"quit\" signal recieved!");
-            display("**> visibfield001a: completed succesfully!");
+            log.display("**> visibfield001a: \"quit\" signal recieved!");
+            log.display("**> visibfield001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibfield001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the visibfield001 JDI test.
  */
 
 public class visibfield001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> visibfield001a: debugee started!");
+        display("**> visibfield001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         visibfield001aClassForCheck class_for_check = new visibfield001aClassForCheck();
 
-        print_log_on_verbose("**> visibfield001a: waiting for \"quit\" signal...");
+        display("**> visibfield001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibfield001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibfield001a: completed succesfully!");
+            display("**> visibfield001a: \"quit\" signal recieved!");
+            display("**> visibfield001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibfield001a: unexpected signal (no \"quit\") - " + instruction);
@@ -158,6 +144,5 @@ interface visibfield001aInterfaceForCheck {
 
     static final long    ambiguous_prim_field = 1;
     static final Object  ambiguous_ref_field = new Object();
-
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002.java
@@ -57,8 +57,6 @@ public class visibfield002 extends Log {
     static ArgumentHandler      argsHandler;
     private static Log  logHandler;
 
-
-
     public static void main (String argv[]) {
         int result = run(argv,System.out);
         if (result != 0) {
@@ -103,11 +101,7 @@ public class visibfield002 extends Log {
 
         Debugee debugee;
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         print_log_on_verbose("==> nsk/jdi/ReferenceType/visibleFields/visibfield002 test LOG:");
         print_log_on_verbose("==> test checks visibleFields() method of ReferenceType interface ");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.visibleFields.visibfield002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002a.java
@@ -34,18 +34,16 @@ import java.io.*;
 
 public class visibfield002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.visibleFields.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "visibfield002aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> visibfield002a: debugee started!");
+        log.display("**> visibfield002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -54,19 +52,17 @@ public class visibfield002a {
         visibfield002aClassLoader customClassLoader = new visibfield002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> visibfield002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> visibfield002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> visibfield002a: checked class NOT loaded: " + e);
+            log.display("--> visibfield002a: checked class NOT loaded: " + e);
         }
 
-        display("**> visibfield002a: waiting for \"quit\" signal...");
+        log.display("**> visibfield002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibfield002a: \"quit\" signal recieved!");
-            display("**> visibfield002a: completed succesfully!");
+            log.display("**> visibfield002a: \"quit\" signal recieved!");
+            log.display("**> visibfield002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibfield002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,37 +28,24 @@ import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 import java.io.*;
 
-
 /**
  * This class is used as debugee application for the visibfield002 JDI test.
  */
 
 public class visibfield002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.visibleFields.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "visibfield002aClassForCheck";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> visibfield002a: debugee started!");
+        display("**> visibfield002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -67,19 +54,19 @@ public class visibfield002a {
         visibfield002aClassLoader customClassLoader = new visibfield002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> visibfield002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> visibfield002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> visibfield002a: waiting for \"quit\" signal...");
+        display("**> visibfield002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibfield002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibfield002a: completed succesfully!");
+            display("**> visibfield002a: \"quit\" signal recieved!");
+            display("**> visibfield002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibfield002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield003/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.visibleFields.visibfield003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the visibfield003 JDI test.
  */
 
 public class visibfield003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.visibleFields.";
     private final static String checked_class_name = package_prefix + "visibfield003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> visibfield003a: debugee started!");
+        display("**> visibfield003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> visibfield003a: waiting for \"checked class dir\" info...");
+        display("**> visibfield003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class visibfield003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> visibfield003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> visibfield003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> visibfield003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> visibfield003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> visibfield003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibfield003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibfield003a: completed!");
+            display("**> visibfield003a: \"quit\" signal recieved!");
+            display("**> visibfield003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class visibfield003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> visibfield003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> visibfield003a: enforce to unload checked class...");
+        display("**> visibfield003a: \"continue\" signal recieved!");
+        display("**> visibfield003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> visibfield003a: checked class may be NOT unloaded!");
+            display("**> visibfield003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> visibfield003a: checked class unloaded!");
+            display("**> visibfield003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> visibfield003a: waiting for \"quit\" signal...");
+        display("**> visibfield003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibfield003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibfield003a: completed!");
+            display("**> visibfield003a: \"quit\" signal recieved!");
+            display("**> visibfield003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibfield003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield003a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class visibfield003a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.visibleFields.";
     private final static String checked_class_name = package_prefix + "visibfield003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> visibfield003a: debugee started!");
+        log.display("**> visibfield003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> visibfield003a: waiting for \"checked class dir\" info...");
+        log.display("**> visibfield003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class visibfield003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> visibfield003a: checked class loaded:" + checked_class_name);
+            log.display("--> visibfield003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> visibfield003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> visibfield003a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> visibfield003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> visibfield003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> visibfield003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibfield003a: \"quit\" signal recieved!");
-            display("**> visibfield003a: completed!");
+            log.display("**> visibfield003a: \"quit\" signal recieved!");
+            log.display("**> visibfield003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class visibfield003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> visibfield003a: \"continue\" signal recieved!");
-        display("**> visibfield003a: enforce to unload checked class...");
+        log.display("**> visibfield003a: \"continue\" signal recieved!");
+        log.display("**> visibfield003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> visibfield003a: checked class may be NOT unloaded!");
+            log.display("**> visibfield003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> visibfield003a: checked class unloaded!");
+            log.display("**> visibfield003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> visibfield003a: waiting for \"quit\" signal...");
+        log.display("**> visibfield003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibfield003a: \"quit\" signal recieved!");
-            display("**> visibfield003a: completed!");
+            log.display("**> visibfield003a: \"quit\" signal recieved!");
+            log.display("**> visibfield003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibfield003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield004/TestDescription.java
@@ -47,7 +47,6 @@
  *        nsk.jdi.ReferenceType.visibleFields.visibfield004a
  * @run driver
  *      nsk.jdi.ReferenceType.visibleFields.visibfield004
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the visibfield004 JDI test.
  */
 
 public class visibfield004a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> visibfield004a: debugee started!");
+        display("**> visibfield004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         visibfield004aClassForCheck class_for_check = new visibfield004aClassForCheck();
 
-        print_log_on_verbose("**> visibfield004a: waiting for \"quit\" signal...");
+        display("**> visibfield004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibfield004a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibfield004a: completed succesfully!");
+            display("**> visibfield004a: \"quit\" signal recieved!");
+            display("**> visibfield004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> visibfield004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleFields/visibfield004a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class visibfield004a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> visibfield004a: debugee started!");
+        log.display("**> visibfield004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         visibfield004aClassForCheck class_for_check = new visibfield004aClassForCheck();
 
-        display("**> visibfield004a: waiting for \"quit\" signal...");
+        log.display("**> visibfield004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibfield004a: \"quit\" signal recieved!");
-            display("**> visibfield004a: completed succesfully!");
+            log.display("**> visibfield004a: \"quit\" signal recieved!");
+            log.display("**> visibfield004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> visibfield004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod001/TestDescription.java
@@ -47,7 +47,6 @@
  *        nsk.jdi.ReferenceType.visibleMethods.visibmethod001a
  * @run driver
  *      nsk.jdi.ReferenceType.visibleMethods.visibmethod001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,37 +27,24 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the visibmethod001 JDI test.
  */
 
 public class visibmethod001a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.visibleMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "visibmethod001aClassForCheck";
 
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> visibmethod001a: debugee started!");
+        display("**> visibmethod001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -65,23 +52,23 @@ public class visibmethod001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, visibmethod001a.class.getClassLoader());
-            print_log_on_verbose
+            display
                 ("--> visibmethod001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> visibmethod001a: load class: Throwable thrown = " + thrown.toString());
-            print_log_on_verbose
+            display
                 ("--> visibmethod001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> visibmethod001a: waiting for \"quit\" signal...");
+        display("**> visibmethod001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibmethod001a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibmethod001a: completed succesfully!");
+            display("**> visibmethod001a: \"quit\" signal recieved!");
+            display("**> visibmethod001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibmethod001a: unexpected signal (no \"quit\") - " + instruction);
@@ -196,7 +183,6 @@ abstract class visibmethod001aClassForCheck extends visibmethod001aSuperClassFor
 
     // static initializer
     static {}
-
 
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod001a.java
@@ -33,18 +33,16 @@ import nsk.share.jdi.*;
 
 public class visibmethod001a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.visibleMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "visibmethod001aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> visibmethod001a: debugee started!");
+        log.display("**> visibmethod001a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -52,23 +50,21 @@ public class visibmethod001a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, visibmethod001a.class.getClassLoader());
-            display
-                ("--> visibmethod001a: checked class loaded:" + checked_class_name);
+            log.display("--> visibmethod001a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> visibmethod001a: load class: Throwable thrown = " + thrown.toString());
-            display
-                ("--> visibmethod001a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> visibmethod001a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> visibmethod001a: waiting for \"quit\" signal...");
+        log.display("**> visibmethod001a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibmethod001a: \"quit\" signal recieved!");
-            display("**> visibmethod001a: completed succesfully!");
+            log.display("**> visibmethod001a: \"quit\" signal recieved!");
+            log.display("**> visibmethod001a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibmethod001a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002.java
@@ -57,8 +57,6 @@ public class visibmethod002 extends Log {
     static ArgumentHandler      argsHandler;
     private static Log  logHandler;
 
-
-
     public static void main (String argv[]) {
         int result = run(argv,System.out);
         if (result != 0) {
@@ -103,11 +101,7 @@ public class visibmethod002 extends Log {
 
         Debugee debugee;
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         print_log_on_verbose("==> nsk/jdi/ReferenceType/visibleMethods/visibmethod002 test LOG:");
         print_log_on_verbose("==> test checks visibleMethods() method of ReferenceType interface ");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002/TestDescription.java
@@ -56,7 +56,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.visibleMethods.visibmethod002
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,37 +28,24 @@ import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 import java.io.*;
 
-
 /**
  * This class is used as debugee application for the visibmethod002 JDI test.
  */
 
 public class visibmethod002a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.visibleMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "visibmethod002aClassForCheck";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> visibmethod002a: debugee started!");
+        display("**> visibmethod002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -67,19 +54,19 @@ public class visibmethod002a {
         visibmethod002aClassLoader customClassLoader = new visibmethod002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            print_log_on_verbose
+            display
                 ("--> visibmethod002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            print_log_on_verbose
+            display
                 ("--> visibmethod002a: checked class NOT loaded: " + e);
         }
 
-        print_log_on_verbose("**> visibmethod002a: waiting for \"quit\" signal...");
+        display("**> visibmethod002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibmethod002a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibmethod002a: completed succesfully!");
+            display("**> visibmethod002a: \"quit\" signal recieved!");
+            display("**> visibmethod002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibmethod002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod002a.java
@@ -34,18 +34,16 @@ import java.io.*;
 
 public class visibmethod002a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.visibleMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "visibmethod002aClassForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> visibmethod002a: debugee started!");
+        log.display("**> visibmethod002a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -54,19 +52,17 @@ public class visibmethod002a {
         visibmethod002aClassLoader customClassLoader = new visibmethod002aClassLoader(checked_class_dir, checked_class_name);
         try {
             customClassLoader.preloadClass(checked_class_name);
-            display
-                ("--> visibmethod002a: checked class loaded but not prepared: " + checked_class_name);
+            log.display("--> visibmethod002a: checked class loaded but not prepared: " + checked_class_name);
         } catch (Throwable e) {  // ClassNotFoundException
-            display
-                ("--> visibmethod002a: checked class NOT loaded: " + e);
+            log.display("--> visibmethod002a: checked class NOT loaded: " + e);
         }
 
-        display("**> visibmethod002a: waiting for \"quit\" signal...");
+        log.display("**> visibmethod002a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibmethod002a: \"quit\" signal recieved!");
-            display("**> visibmethod002a: completed succesfully!");
+            log.display("**> visibmethod002a: \"quit\" signal recieved!");
+            log.display("**> visibmethod002a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibmethod002a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod003/TestDescription.java
@@ -62,7 +62,6 @@
  *
  * @run driver
  *      nsk.jdi.ReferenceType.visibleMethods.visibmethod003
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod003a.java
@@ -35,21 +35,19 @@ import nsk.share.jdi.*;
 
 public class visibmethod003a {
 
+    private static Log log = new Log(System.err);
+
     private final static String package_prefix = "nsk.jdi.ReferenceType.visibleMethods.";
     private final static String checked_class_name = package_prefix + "visibmethod003b";
-
-    private static void display(String message) {
-        System.err.println(message);
-    }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
-        display("**> visibmethod003a: debugee started!");
+        log.display("**> visibmethod003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        display("**> visibmethod003a: waiting for \"checked class dir\" info...");
+        log.display("**> visibmethod003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -57,23 +55,21 @@ public class visibmethod003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            display
-                ("--> visibmethod003a: checked class loaded:" + checked_class_name);
+            log.display("--> visibmethod003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> visibmethod003a: load class: exception thrown = " + e.toString());
-            display
-                ("--> visibmethod003a: checked class NOT loaded:" + checked_class_name);
+            log.display("--> visibmethod003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> visibmethod003a: waiting for \"continue\" or \"quit\" signal...");
+        log.display("**> visibmethod003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibmethod003a: \"quit\" signal recieved!");
-            display("**> visibmethod003a: completed!");
+            log.display("**> visibmethod003a: \"quit\" signal recieved!");
+            log.display("**> visibmethod003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -83,24 +79,24 @@ public class visibmethod003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        display("**> visibmethod003a: \"continue\" signal recieved!");
-        display("**> visibmethod003a: enforce to unload checked class...");
+        log.display("**> visibmethod003a: \"continue\" signal recieved!");
+        log.display("**> visibmethod003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            display("**> visibmethod003a: checked class may be NOT unloaded!");
+            log.display("**> visibmethod003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            display("**> visibmethod003a: checked class unloaded!");
+            log.display("**> visibmethod003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        display("**> visibmethod003a: waiting for \"quit\" signal...");
+        log.display("**> visibmethod003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibmethod003a: \"quit\" signal recieved!");
-            display("**> visibmethod003a: completed!");
+            log.display("**> visibmethod003a: \"quit\" signal recieved!");
+            log.display("**> visibmethod003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibmethod003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,34 +29,27 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the visibmethod003 JDI test.
  */
 
 public class visibmethod003a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
     private final static String package_prefix = "nsk.jdi.ReferenceType.visibleMethods.";
     private final static String checked_class_name = package_prefix + "visibmethod003b";
 
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
         ArgumentHandler argHandler = new ArgumentHandler(argv);
-        verbose_mode = argHandler.verbose();
 
-        print_log_on_verbose("**> visibmethod003a: debugee started!");
+        display("**> visibmethod003a: debugee started!");
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
-        print_log_on_verbose("**> visibmethod003a: waiting for \"checked class dir\" info...");
+        display("**> visibmethod003a: waiting for \"checked class dir\" info...");
         pipe.println("ready0");
         String checked_class_dir = (argHandler.getArguments())[0] + File.separator + "loadclass";
 
@@ -64,23 +57,23 @@ public class visibmethod003a {
 
         try {
             classUnloader.loadClass(checked_class_name, checked_class_dir);
-            print_log_on_verbose
+            display
                 ("--> visibmethod003a: checked class loaded:" + checked_class_name);
         }
         catch ( Exception e ) {  // ClassNotFoundException
             System.err.println
                 ("**> visibmethod003a: load class: exception thrown = " + e.toString());
-            print_log_on_verbose
+            display
                 ("--> visibmethod003a: checked class NOT loaded:" + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> visibmethod003a: waiting for \"continue\" or \"quit\" signal...");
+        display("**> visibmethod003a: waiting for \"continue\" or \"quit\" signal...");
         pipe.println("ready1");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibmethod003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibmethod003a: completed!");
+            display("**> visibmethod003a: \"quit\" signal recieved!");
+            display("**> visibmethod003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         if ( ! instruction.equals("continue")) {
@@ -90,24 +83,24 @@ public class visibmethod003a {
             System.exit(2/*STATUS_FAILED*/ + 95/*STATUS_TEMP*/);
         }
 
-        print_log_on_verbose("**> visibmethod003a: \"continue\" signal recieved!");
-        print_log_on_verbose("**> visibmethod003a: enforce to unload checked class...");
+        display("**> visibmethod003a: \"continue\" signal recieved!");
+        display("**> visibmethod003a: enforce to unload checked class...");
 
         boolean test_class_loader_finalized = classUnloader.unloadClass();
 
         if ( ! test_class_loader_finalized ) {
-            print_log_on_verbose("**> visibmethod003a: checked class may be NOT unloaded!");
+            display("**> visibmethod003a: checked class may be NOT unloaded!");
             pipe.println("not_unloaded");
         }
         else {
-            print_log_on_verbose("**> visibmethod003a: checked class unloaded!");
+            display("**> visibmethod003a: checked class unloaded!");
             pipe.println("ready2");
         }
-        print_log_on_verbose("**> visibmethod003a: waiting for \"quit\" signal...");
+        display("**> visibmethod003a: waiting for \"quit\" signal...");
         instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibmethod003a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibmethod003a: completed!");
+            display("**> visibmethod003a: \"quit\" signal recieved!");
+            display("**> visibmethod003a: completed!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibmethod003a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod004/TestDescription.java
@@ -45,7 +45,6 @@
  *        nsk.jdi.ReferenceType.visibleMethods.visibmethod004a
  * @run driver
  *      nsk.jdi.ReferenceType.visibleMethods.visibmethod004
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod004a.java
@@ -33,24 +33,22 @@ import nsk.share.jdi.*;
 
 public class visibmethod004a {
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
+    private static Log log = new Log(System.err);
 
     public static void main (String argv[]) {
 
-        display("**> visibmethod004a: debugee started!");
+        log.display("**> visibmethod004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         visibmethod004aClassForCheck class_for_check = new visibmethod004aClassForCheck();
 
-        display("**> visibmethod004a: waiting for \"quit\" signal...");
+        log.display("**> visibmethod004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibmethod004a: \"quit\" signal recieved!");
-            display("**> visibmethod004a: completed succesfully!");
+            log.display("**> visibmethod004a: \"quit\" signal recieved!");
+            log.display("**> visibmethod004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> visibmethod004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,44 +27,30 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the visibmethod004 JDI test.
  */
 
 public class visibmethod004a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
-
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> visibmethod004a: debugee started!");
+        display("**> visibmethod004a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
         visibmethod004aClassForCheck class_for_check = new visibmethod004aClassForCheck();
 
-        print_log_on_verbose("**> visibmethod004a: waiting for \"quit\" signal...");
+        display("**> visibmethod004a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibmethod004a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibmethod004a: completed succesfully!");
+            display("**> visibmethod004a: \"quit\" signal recieved!");
+            display("**> visibmethod004a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("##> visibmethod004a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod005/TestDescription.java
@@ -47,7 +47,6 @@
  *        nsk.jdi.ReferenceType.visibleMethods.visibmethod005a
  * @run driver
  *      nsk.jdi.ReferenceType.visibleMethods.visibmethod005
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod005a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,37 +27,24 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the visibmethod005 JDI test.
  */
 
 public class visibmethod005a {
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-                                          // - for more easy failure evaluation
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.visibleMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "visibmethod005aInterfaceForCheck";
 
-
-    private static void print_log_on_verbose(String message) {
-        if ( verbose_mode ) {
-            System.err.println(message);
-        }
+    private static void display(String message) {
+        System.err.println(message);
     }
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
-
-        print_log_on_verbose("**> visibmethod005a: debugee started!");
+        display("**> visibmethod005a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -65,23 +52,23 @@ public class visibmethod005a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, visibmethod005a.class.getClassLoader());
-            print_log_on_verbose
+            display
                 ("--> visibmethod005a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> visibmethod005a: load class: Throwable thrown = " + thrown.toString());
-            print_log_on_verbose
+            display
                 ("--> visibmethod005a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        print_log_on_verbose("**> visibmethod005a: waiting for \"quit\" signal...");
+        display("**> visibmethod005a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            print_log_on_verbose("**> visibmethod005a: \"quit\" signal recieved!");
-            print_log_on_verbose("**> visibmethod005a: completed succesfully!");
+            display("**> visibmethod005a: \"quit\" signal recieved!");
+            display("**> visibmethod005a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibmethod005a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/visibleMethods/visibmethod005a.java
@@ -33,18 +33,16 @@ import nsk.share.jdi.*;
 
 public class visibmethod005a {
 
+    private static Log log = new Log(System.err);
+
     private final static String
         package_prefix = "nsk.jdi.ReferenceType.visibleMethods.";
 //        package_prefix = "";    //  for DEBUG without package
     static String checked_class_name = package_prefix + "visibmethod005aInterfaceForCheck";
 
-    private static void display(String message) {
-        System.err.println(message);
-    }
-
     public static void main (String argv[]) {
 
-        display("**> visibmethod005a: debugee started!");
+        log.display("**> visibmethod005a: debugee started!");
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
 
@@ -52,23 +50,21 @@ public class visibmethod005a {
         try {
             checked_class_classobj =
                 Class.forName(checked_class_name, true, visibmethod005a.class.getClassLoader());
-            display
-                ("--> visibmethod005a: checked class loaded:" + checked_class_name);
+            log.display("--> visibmethod005a: checked class loaded:" + checked_class_name);
         }
         catch ( Throwable thrown ) {  // ClassNotFoundException
 //            System.err.println
 //                ("**> visibmethod005a: load class: Throwable thrown = " + thrown.toString());
-            display
-                ("--> visibmethod005a: checked class NOT loaded: " + checked_class_name);
+            log.display("--> visibmethod005a: checked class NOT loaded: " + checked_class_name);
             // Debuuger finds this fact itself
         }
 
-        display("**> visibmethod005a: waiting for \"quit\" signal...");
+        log.display("**> visibmethod005a: waiting for \"quit\" signal...");
         pipe.println("ready");
         String instruction = pipe.readln();
         if (instruction.equals("quit")) {
-            display("**> visibmethod005a: \"quit\" signal recieved!");
-            display("**> visibmethod005a: completed succesfully!");
+            log.display("**> visibmethod005a: \"quit\" signal recieved!");
+            log.display("**> visibmethod005a: completed succesfully!");
             System.exit(0/*STATUS_PASSED*/ + 95/*STATUS_TEMP*/);
         }
         System.err.println("!!**> visibmethod005a: unexpected signal (no \"quit\") - " + instruction);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/classesByName/classesbyname001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/classesByName/classesbyname001.java
@@ -119,11 +119,7 @@ public class classesbyname001 {
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
 
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");  // *** tp
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);            // *** tp
-        }
+        debugee = binder.bindToDebugee(debugeeName);
 
         IOPipe pipe     = new IOPipe(debugee);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/classesByName/classesbyname001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/classesByName/classesbyname001/TestDescription.java
@@ -63,7 +63,6 @@
  *        nsk.jdi.VirtualMachine.classesByName.classesbyname001a
  * @run driver
  *      nsk.jdi.VirtualMachine.classesByName.classesbyname001
- *      -verbose
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/classesByName/classesbyname001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/classesByName/classesbyname001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 
-
 /**
  * This class is used as debugee application for the classesbyname001 JDI test.
  */
@@ -40,19 +39,14 @@ public class classesbyname001a {
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
 
-
      //--------------------------------------------------   log procedures
 
-    static boolean verbose_mode = false;  // debugger may switch to true
-
     private static void log1(String message) {
-        if (verbose_mode)
-            System.err.println("**> classesbyname001a: " + message);
+        System.err.println("**> classesbyname001a: " + message);
     }
 
     private static void logErr(String message) {
-        if (verbose_mode)
-            System.err.println("!!**> classesbyname001a: " + message);
+        System.err.println("!!**> classesbyname001a: " + message);
     }
 
     //====================================================== test program
@@ -63,19 +57,12 @@ public class classesbyname001a {
 
     public static void main (String argv[]) {
 
-        for (int i=0; i<argv.length; i++) {
-            if ( argv[i].equals("-vbs") || argv[i].equals("-verbose") ) {
-                verbose_mode = true;
-                break;
-            }
-        }
         log1("debugee started!");
 
         // informing debuger of readyness
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         IOPipe pipe = argHandler.createDebugeeIOPipe();
         pipe.println("ready");
-
 
         int exitCode = PASSED;
         for (int i = 0; ; i++) {
@@ -122,14 +109,11 @@ public class classesbyname001a {
                                 pipe.println("checkready");
                                 break ;
 
-
                 // not a fully qualified name
 
                 case 7:
                                 pipe.println("checkready");
                                 break ;
-
-
 
     //-------------------------------------------------    standard end section
 
@@ -149,7 +133,6 @@ public class classesbyname001a {
         System.exit(exitCode + PASS_BASE);
     }
 }
-
 
 class Class1ForCheck {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/classesByName/classesbyname001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/classesByName/classesbyname001a.java
@@ -33,6 +33,8 @@ import nsk.share.jdi.*;
 
 public class classesbyname001a {
 
+    private static Log log = new Log(System.err);
+
     //----------------------------------------------------- template section
 
     static final int PASSED = 0;
@@ -40,14 +42,6 @@ public class classesbyname001a {
     static final int PASS_BASE = 95;
 
      //--------------------------------------------------   log procedures
-
-    private static void log1(String message) {
-        System.err.println("**> classesbyname001a: " + message);
-    }
-
-    private static void logErr(String message) {
-        System.err.println("!!**> classesbyname001a: " + message);
-    }
 
     //====================================================== test program
 
@@ -57,7 +51,7 @@ public class classesbyname001a {
 
     public static void main (String argv[]) {
 
-        log1("debugee started!");
+        log.display("**> classesbyname001a: debugee started!");
 
         // informing debuger of readyness
         ArgumentHandler argHandler = new ArgumentHandler(argv);
@@ -68,10 +62,10 @@ public class classesbyname001a {
         for (int i = 0; ; i++) {
             String instruction;
 
-            log1("waiting for an instruction from the debuger ...");
+            log.display("**> classesbyname001a: waiting for an instruction from the debuger ...");
             instruction = pipe.readln();
             if (instruction.equals("quit")) {
-                log1("'quit' recieved");
+                log.display("**> classesbyname001a: 'quit' recieved");
                 break ;
             }
 
@@ -123,8 +117,8 @@ public class classesbyname001a {
                 }
 
             } else {
-                logErr("unexpected instruction: " + instruction);
-                logErr("FAILED!");
+                log.complain("classesbyname001a: unexpected instruction: " + instruction);
+                log.complain("classesbyname001a: FAILED!");
                 exitCode = 2;
                 break ;
             }


### PR DESCRIPTION
Old jdi debugee classes keep their own verbose flag and only print their trace when the debugger passes -vbs. logs you cannot see until a rerun are useless for failures that do not reproduce, so the gating goes and the messages always print. 65 files here, the flag and its -vbs parsing are deleted and the little print helper becomes an unconditional display on stderr. two debugger classes carried a flag that nothing ever set, that dead code is just removed. the remaining files with the same pattern overlap open reviews and follow separately. output volume is a handful of lines per debugee.

PS: Checked log size against a full nsk/jdi in CI run and  none of the changed tests hit the jtreg output limit. Largest .jtr was about 100 KB, and this change adds only around a dozen short protocol lines per debuggee. The tests that do trip the overflow marker are the monitor and stress event tests. which aren’t modified here and were already doing so before this change.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390350](https://bugs.openjdk.org/browse/JDK-8390350): Remove test-local verbose mode from vmTestbase nsk tests (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32375/head:pull/32375` \
`$ git checkout pull/32375`

Update a local copy of the PR: \
`$ git checkout pull/32375` \
`$ git pull https://git.openjdk.org/jdk.git pull/32375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32375`

View PR using the GUI difftool: \
`$ git pr show -t 32375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32375.diff">https://git.openjdk.org/jdk/pull/32375.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32375#issuecomment-5331345707)
</details>
