### PR TITLE
8368597: make should support selection by status for JTREG tests

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1054,11 +1054,11 @@ define SetupRunJtregTestBody
   $1_JTREG_BASIC_OPTIONS += -timeoutFactor:$$(JTREG_TIMEOUT_FACTOR)
 
   clean-outputdirs-$1:
-    ifeq ($(JTREG_STATUS),)
-	$$(call LogWarn, Clean up dirs for $1)
-	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
-	$$(RM) -r $$($1_TEST_RESULTS_DIR)
-    endif
+        ifeq ($(JTREG_STATUS),)
+	  $$(call LogWarn, Clean up dirs for $1)
+	  $$(RM) -r $$($1_TEST_SUPPORT_DIR)
+	  $$(RM) -r $$($1_TEST_RESULTS_DIR)
+        endif
 
   $1_COMMAND_LINE := \
       $$(JTREG_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1054,9 +1054,11 @@ define SetupRunJtregTestBody
   $1_JTREG_BASIC_OPTIONS += -timeoutFactor:$$(JTREG_TIMEOUT_FACTOR)
 
   clean-outputdirs-$1:
+    ifeq ($(JTREG_STATUS),)
 	$$(call LogWarn, Clean up dirs for $1)
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
 	$$(RM) -r $$($1_TEST_RESULTS_DIR)
+    endif
 
   $1_COMMAND_LINE := \
       $$(JTREG_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \


### PR DESCRIPTION
Tests results should not be deleted if current run do selection by status.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8368597: make should support selection by status for JTREG tests`

### Issue
 * [JDK-8368597](https://bugs.openjdk.org/browse/JDK-8368597): make should support selection by status for JTREG tests (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32377/head:pull/32377` \
`$ git checkout pull/32377`

Update a local copy of the PR: \
`$ git checkout pull/32377` \
`$ git pull https://git.openjdk.org/jdk.git pull/32377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32377`

View PR using the GUI difftool: \
`$ git pr show -t 32377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32377.diff">https://git.openjdk.org/jdk/pull/32377.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32377#issuecomment-5296691395)
</details>
