### PR TITLE
8390390: Shenandoah: ShenandoahAdaptiveInitialConfidence accepts negative values

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -275,6 +275,7 @@
           "margin of error for the average cycle time and average "         \
           "allocation rate. Increasing this value will cause the "          \
           "heuristic to initiate more concurrent cycles." )                 \
+          range(0.0,100.0)                                                  \
                                                                             \
   product(uintx, ShenandoahGuaranteedGCInterval, 5*60*1000, EXPERIMENTAL,   \
           "Many heuristics would guarantee a concurrent GC cycle at "       \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -275,7 +275,7 @@
           "margin of error for the average cycle time and average "         \
           "allocation rate. Increasing this value will cause the "          \
           "heuristic to initiate more concurrent cycles." )                 \
-          range(0.0,100.0)                                                  \
+          range(0.319,3.291)                                                \
                                                                             \
   product(uintx, ShenandoahGuaranteedGCInterval, 5*60*1000, EXPERIMENTAL,   \
           "Many heuristics would guarantee a concurrent GC cycle at "       \

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestArgumentRanges.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestArgumentRanges.java
@@ -40,6 +40,7 @@ public class TestArgumentRanges {
         testRange("ShenandoahGarbageThreshold", 0, 100);
         testRange("ShenandoahMinFreeThreshold", 0, 100);
         testRange("ShenandoahAllocationThreshold", 0, 100);
+        testRange("ShenandoahAdaptiveInitialConfidence", 0, 100);
         testHeuristics();
     }
 

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestArgumentRanges.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestArgumentRanges.java
@@ -40,7 +40,6 @@ public class TestArgumentRanges {
         testRange("ShenandoahGarbageThreshold", 0, 100);
         testRange("ShenandoahMinFreeThreshold", 0, 100);
         testRange("ShenandoahAllocationThreshold", 0, 100);
-        testRange("ShenandoahAdaptiveInitialConfidence", 0, 100);
         testHeuristics();
     }
 


### PR DESCRIPTION
Add a range constraint for ShenandoahAdaptiveInitialConfidence to prevent using negative numbers. We already bound this in adaptive heuristics when adjusting the [margin of error](https://github.com/pf0n/jdk/blob/master/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp#L421) to [these numbers](https://github.com/pf0n/jdk/blob/master/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp#L56-L57), but we don't bound during initialization.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390390](https://bugs.openjdk.org/browse/JDK-8390390): Shenandoah: ShenandoahAdaptiveInitialConfidence accepts negative values (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [725f04de](https://git.openjdk.org/jdk/pull/32380/files/725f04debc9af4002d5be57126695a67afdf6ccb)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Committer) Review applies to [725f04de](https://git.openjdk.org/jdk/pull/32380/files/725f04debc9af4002d5be57126695a67afdf6ccb)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Committer)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32380/head:pull/32380` \
`$ git checkout pull/32380`

Update a local copy of the PR: \
`$ git checkout pull/32380` \
`$ git pull https://git.openjdk.org/jdk.git pull/32380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32380`

View PR using the GUI difftool: \
`$ git pr show -t 32380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32380.diff">https://git.openjdk.org/jdk/pull/32380.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32380#issuecomment-5298000736)
</details>
