### PR TITLE
8388265: early_larval StackMapTable frames not rejected for non-preview class files

### DIFF
--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -271,6 +271,13 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
   VerificationType* locals = nullptr;
   u1 frame_type = _stream->get_u1(CHECK_NULL);
   if (frame_type == EARLY_LARVAL) {
+    // early_larval frames are only supported in classes that support strict fields (preview classes)
+    if (!Verifier::supports_strict_fields(_verifier->current_class())) {
+       // reserved frame types when preview classes are disabled
+      _stream->stackmap_format_error(
+         "reserved frame type", CHECK_VERIFY_(_verifier, nullptr));
+    }
+
     u2 num_unset_fields = _stream->get_u2(CHECK_NULL);
     StackMapFrame::AssertUnsetFieldTable* new_fields = new StackMapFrame::AssertUnsetFieldTable();
 

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -636,7 +636,7 @@ TypeOrigin ClassVerifier::ref_ctx(const char* sig) {
   return TypeOrigin::implicit(vt);
 }
 
-static bool supports_strict_fields(InstanceKlass* klass) {
+bool Verifier::supports_strict_fields(InstanceKlass* klass) {
   int ver = klass->major_version();
   return ver > Verifier::VALUE_TYPES_MAJOR_VERSION ||
          (ver == Verifier::VALUE_TYPES_MAJOR_VERSION && klass->minor_version() == Verifier::JAVA_PREVIEW_MINOR_VERSION);
@@ -2428,7 +2428,7 @@ void ClassVerifier::verify_field_instructions(RawBytecodeStream* bcs,
             }
           }
         }
-      } else if (supports_strict_fields(_klass)) {
+      } else if (Verifier::supports_strict_fields(_klass)) {
         // `strict` fields are not writable, but only local fields produce verification errors
         if (is_local_field && fd.access_flags().is_strict() && fd.access_flags().is_final()) {
           verify_error(ErrorContext::bad_code(bci),

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -638,8 +638,7 @@ TypeOrigin ClassVerifier::ref_ctx(const char* sig) {
 
 bool Verifier::supports_strict_fields(InstanceKlass* klass) {
   int ver = klass->major_version();
-  return ver > Verifier::VALUE_TYPES_MAJOR_VERSION ||
-         (ver == Verifier::VALUE_TYPES_MAJOR_VERSION && klass->minor_version() == Verifier::JAVA_PREVIEW_MINOR_VERSION);
+  return (ver >= Verifier::VALUE_TYPES_MAJOR_VERSION && klass->minor_version() == Verifier::JAVA_PREVIEW_MINOR_VERSION);
 }
 
 void ClassVerifier::verify_class(TRAPS) {

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -69,6 +69,8 @@ class Verifier : AllStatic {
   // Print output for class+resolve
   static void trace_class_resolution(Klass* resolve_class, InstanceKlass* verify_class);
 
+  static bool supports_strict_fields(InstanceKlass* klass);
+
  private:
   static Symbol* inference_verify(
     InstanceKlass* klass, char* msg, size_t msg_len, TRAPS);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewApp.jasm
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewApp.jasm
@@ -1,4 +1,27 @@
-final identity class EarlyLarvalNonPreviewApp extends java/lang/Record version 70:0
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+final identity class EarlyLarvalNonPreviewApp extends java/lang/Record version 72:0
 {
   public final Field x:I;
   public final Field y:I;
@@ -28,84 +51,4 @@ final identity class EarlyLarvalNonPreviewApp extends java/lang/Record version 7
          putfield          Field y:"I";
          return;
   }
-
-  public final Method toString:"()Ljava/lang/String;"
-    stack 1  locals 1
-  {
-         aload_0;
-         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
-                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
-                           toString:"(LEarlyLarvalNonPreviewApp;)Ljava/lang/String;" {
-                             class EarlyLarvalNonPreviewApp,
-                             String "x;y",
-                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.x:"I",
-                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.y:"I"
-                           };
-         areturn;
-  }
-
-  public final Method hashCode:"()I"
-    stack 1  locals 1
-  {
-         aload_0;
-         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
-                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
-                           hashCode:"(LEarlyLarvalNonPreviewApp;)I" {
-                             class EarlyLarvalNonPreviewApp,
-                             String "x;y",
-                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.x:"I",
-                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.y:"I"
-                           };
-         ireturn;
-  }
-
-  public final Method equals:"(Ljava/lang/Object;)Z"
-    stack 2  locals 2
-  {
-         aload_0;
-         aload_1;
-         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
-                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
-                           equals:"(LEarlyLarvalNonPreviewApp;Ljava/lang/Object;)Z" {
-                             class EarlyLarvalNonPreviewApp,
-                             String "x;y",
-                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.x:"I",
-                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.y:"I"
-                           };
-         ireturn;
-  }
-
-  public Method x:"()I"
-    stack 1  locals 1
-  {
-         aload_0;
-         getfield          Field x:"I";
-         ireturn;
-  }
-
-  public Method y:"()I"
-    stack 1  locals 1
-  {
-         aload_0;
-         getfield          Field y:"I";
-         ireturn;
-  }
-
-  SourceFile               "EarlyLarvalNonPreviewApp.java";
-
-  Record {
-    Component              x:I;
-    Component              y:I;
-  }
-
-  InnerClass               public static final Lookup = class java/lang/invoke/MethodHandles$Lookup of class java/lang/invoke/MethodHandles;
-
-  BootstrapMethod          REF_invokeStatic:java/lang/runtime/ObjectMethods.bootstrap:
-                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;";
-                           {
-                             class EarlyLarvalNonPreviewApp,
-                             String "x;y",
-                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.x:"I",
-                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.y:"I"
-                           }
-} // end Class EarlyLarvalNonPreviewApp compiled from "EarlyLarvalNonPreviewApp.java"
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewApp.jasm
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewApp.jasm
@@ -1,0 +1,111 @@
+final identity class EarlyLarvalNonPreviewApp extends java/lang/Record version 70:0
+{
+  public final Field x:I;
+  public final Field y:I;
+
+  public Method "<init>":"(II)V"
+    stack 2  locals 3
+     0:  #{ x }
+     1:  #{ y }
+  {
+         aload_0;
+         invokespecial     Method java/lang/Record."<init>":"()V";
+         aload_0;
+         iload_1;
+         putfield          Field x:"I";
+         iload_1;
+         ifge              L16;
+         iload_2;
+         ineg;
+         istore_2;
+  L16:   stack_frame_type early_larval;
+          unset_fields;
+          frame_type full;
+              locals_map      class EarlyLarvalNonPreviewApp, int, int;
+              stack_map;
+         aload_0;
+         iload_2;
+         putfield          Field y:"I";
+         return;
+  }
+
+  public final Method toString:"()Ljava/lang/String;"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           toString:"(LEarlyLarvalNonPreviewApp;)Ljava/lang/String;" {
+                             class EarlyLarvalNonPreviewApp,
+                             String "x;y",
+                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.x:"I",
+                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.y:"I"
+                           };
+         areturn;
+  }
+
+  public final Method hashCode:"()I"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           hashCode:"(LEarlyLarvalNonPreviewApp;)I" {
+                             class EarlyLarvalNonPreviewApp,
+                             String "x;y",
+                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.x:"I",
+                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.y:"I"
+                           };
+         ireturn;
+  }
+
+  public final Method equals:"(Ljava/lang/Object;)Z"
+    stack 2  locals 2
+  {
+         aload_0;
+         aload_1;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           equals:"(LEarlyLarvalNonPreviewApp;Ljava/lang/Object;)Z" {
+                             class EarlyLarvalNonPreviewApp,
+                             String "x;y",
+                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.x:"I",
+                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.y:"I"
+                           };
+         ireturn;
+  }
+
+  public Method x:"()I"
+    stack 1  locals 1
+  {
+         aload_0;
+         getfield          Field x:"I";
+         ireturn;
+  }
+
+  public Method y:"()I"
+    stack 1  locals 1
+  {
+         aload_0;
+         getfield          Field y:"I";
+         ireturn;
+  }
+
+  SourceFile               "EarlyLarvalNonPreviewApp.java";
+
+  Record {
+    Component              x:I;
+    Component              y:I;
+  }
+
+  InnerClass               public static final Lookup = class java/lang/invoke/MethodHandles$Lookup of class java/lang/invoke/MethodHandles;
+
+  BootstrapMethod          REF_invokeStatic:java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;";
+                           {
+                             class EarlyLarvalNonPreviewApp,
+                             String "x;y",
+                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.x:"I",
+                             MethodHandle REF_getField:EarlyLarvalNonPreviewApp.y:"I"
+                           }
+} // end Class EarlyLarvalNonPreviewApp compiled from "EarlyLarvalNonPreviewApp.java"

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @library /test/lib
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ * @compile EarlyLarvalNonPreviewApp.jasm
+ * @run driver EarlyLarvalNonPreviewTest
+ */
+
+public class EarlyLarvalNonPreviewTest {
+    public static void main(String[] args) {
+        try {
+            var value = new EarlyLarvalNonPreviewApp(-1, -2);
+            throw new RuntimeException("Expected ClassFormatError");
+        } catch (java.lang.ClassFormatError c) {
+            System.out.println("Test passed");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewTest.java
@@ -28,7 +28,7 @@
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.value
  * @compile EarlyLarvalNonPreviewApp.jasm
- * @run driver EarlyLarvalNonPreviewTest
+ * @run main EarlyLarvalNonPreviewTest
  */
 
 public class EarlyLarvalNonPreviewTest {
@@ -37,10 +37,10 @@ public class EarlyLarvalNonPreviewTest {
             var value = new EarlyLarvalNonPreviewApp(-1, -2);
             throw new RuntimeException("Expected ClassFormatError");
         } catch (ClassFormatError c) {
-            System.out.println("Test passed");
             if (!c.getMessage().equals("StackMapTable format error: reserved frame type")) {
                 throw new RuntimeException("Unexpected ClassFormatError " + c.getMessage());
             }
+            System.out.println("Test passed");
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewTest.java
@@ -36,8 +36,11 @@ public class EarlyLarvalNonPreviewTest {
         try {
             var value = new EarlyLarvalNonPreviewApp(-1, -2);
             throw new RuntimeException("Expected ClassFormatError");
-        } catch (java.lang.ClassFormatError c) {
+        } catch (ClassFormatError c) {
             System.out.println("Test passed");
+            if (!c.getMessage().equals("StackMapTable format error: reserved frame type")) {
+                throw new RuntimeException("Unexpected ClassFormatError " + c.getMessage());
+            }
         }
     }
 }


### PR DESCRIPTION
Although javac no longer emits early_larval frames for non-preview classes, a classfile that has these frames while not being in preview mode is not currently rejected by the verifier. This change adds the necessary ClassFormatError when an early_larval frame is seen. Verified with tier 1-5 tests and new regression test.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388265](https://bugs.openjdk.org/browse/JDK-8388265): early_larval StackMapTable frames not rejected for non-preview class files (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) Review applies to [e02d64bd](https://git.openjdk.org/jdk/pull/32381/files/e02d64bd3dba649bb87f0c5f3fd1682185b4e2c4)

### Contributors
 * Dan Heidinga `<heidinga@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32381/head:pull/32381` \
`$ git checkout pull/32381`

Update a local copy of the PR: \
`$ git checkout pull/32381` \
`$ git pull https://git.openjdk.org/jdk.git pull/32381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32381`

View PR using the GUI difftool: \
`$ git pr show -t 32381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32381.diff">https://git.openjdk.org/jdk/pull/32381.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32381#issuecomment-5298024445)
</details>
