### PR TITLE
8388138: Emit runtime warning for the RSA/ECB/PKCS1Padding Cipher

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -829,7 +829,7 @@ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
 #   jdk.crypto.disabledAlgorithms=Cipher.RSA/ECB/PKCS1Padding, MessageDigest.MD2
 #   jdk.crypto.legacyAlgorithms=Cipher.RSA/ECB/PKCS1Padding, MessageDigest.MD2
 #
-#jdk.crypto.legacyAlgorithms=
+jdk.crypto.legacyAlgorithms=Cipher.RSA/ECB/PKCS1Padding
 #jdk.crypto.disabledAlgorithms=
 
 #

--- a/test/jdk/jdk/security/JavaDotSecurity/TestLegacyAlgorithms.java
+++ b/test/jdk/jdk/security/JavaDotSecurity/TestLegacyAlgorithms.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.Security;
+
+/**
+ * @test
+ * @bug 8388138
+ * @summary Test the default setting of the jdk.crypto.legacyAlgorithms security property
+ * @comment This property has a default value of "Cipher.RSA/ECB/PKCS1Padding"
+ *          This test assures the default is not changed.
+ * @run main TestLegacyAlgorithms
+ */
+public class TestLegacyAlgorithms {
+
+    public static void main(String args[]) throws Exception {
+        String value = Security.getProperty("jdk.crypto.legacyAlgorithms");
+        if (value == null || !value.equals("Cipher.RSA/ECB/PKCS1Padding")) {
+            throw new RuntimeException("Test failed: jdk.crypto.legacyAlgorithms " +
+                "security property does not have default value of Cipher.RSA/ECB/PKCS1Padding");
+        }
+    }
+}

--- a/test/jdk/jdk/security/JavaDotSecurity/TestLegacyCryptoAlgorithms.java
+++ b/test/jdk/jdk/security/JavaDotSecurity/TestLegacyCryptoAlgorithms.java
@@ -29,9 +29,9 @@ import java.security.Security;
  * @summary Test the default setting of the jdk.crypto.legacyAlgorithms security property
  * @comment This property has a default value of "Cipher.RSA/ECB/PKCS1Padding"
  *          This test assures the default is not changed.
- * @run main TestLegacyAlgorithms
+ * @run main TestLegacyCryptoAlgorithms
  */
-public class TestLegacyAlgorithms {
+public class TestLegacyCryptoAlgorithms {
 
     public static void main(String args[]) throws Exception {
         String value = Security.getProperty("jdk.crypto.legacyAlgorithms");


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8388138

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8390138](https://bugs.openjdk.org/browse/JDK-8390138) to be approved

### Issues
 * [JDK-8388138](https://bugs.openjdk.org/browse/JDK-8388138): Emit runtime warning for the RSA/ECB/PKCS1Padding Cipher (**Enhancement** - P3)
 * [JDK-8390138](https://bugs.openjdk.org/browse/JDK-8390138): Emit runtime warning for the RSA/ECB/PKCS1Padding Cipher (**CSR**)


### Reviewers
 * [Mikhail Yankelevich](https://openjdk.org/census#myankelevich) (@myankelev - Committer) Review applies to [d5ecfbd1](https://git.openjdk.org/jdk/pull/32382/files/d5ecfbd1498efc1216d0bc604ddf95faa33565f3)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - **Reviewer**) Review applies to [d5ecfbd1](https://git.openjdk.org/jdk/pull/32382/files/d5ecfbd1498efc1216d0bc604ddf95faa33565f3)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32382/head:pull/32382` \
`$ git checkout pull/32382`

Update a local copy of the PR: \
`$ git checkout pull/32382` \
`$ git pull https://git.openjdk.org/jdk.git pull/32382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32382`

View PR using the GUI difftool: \
`$ git pr show -t 32382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32382.diff">https://git.openjdk.org/jdk/pull/32382.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32382#issuecomment-5417064465)
</details>
