### PR TITLE
8378896: A make target "clean-microbenchmark", for micro development

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1420,6 +1420,9 @@ clean: $(CLEAN_DIR_TARGETS)
 clean-docs:
 	$(call CleanDocs)
 
+clean-microbenchmark:
+	$(call CleanMicrobenchmark)
+
 clean-compile-commands:
 	$(call CleanMakeSupportDir,compile-commands)
 
@@ -1468,7 +1471,8 @@ dist-clean: clean
 	)
 	$(ECHO) Cleaned everything, you will have to re-run configure.
 
-ALL_TARGETS += clean clean-docs clean-compile-commands dist-clean $(CLEAN_DIR_TARGETS) \
+ALL_TARGETS += clean clean-docs clean-microbenchmark clean-compile-commands \
+    dist-clean $(CLEAN_DIR_TARGETS) \
     $(CLEAN_SUPPORT_DIR_TARGETS) $(CLEAN_TEST_TARGETS) $(CLEAN_PHASE_TARGETS) \
     $(CLEAN_MODULE_TARGETS) $(CLEAN_MODULE_PHASE_TARGETS)
 

--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -65,6 +65,14 @@ define CleanDocs
 	@$(ECHO) " done"
 endef
 
+define CleanMicrobenchmark
+        @$(PRINTF) "Cleaning microbenchmark build artifacts ..."
+        @$(ECHO) "" $(LOG_DEBUG)
+        $(RM) -r $(SUPPORT_OUTPUTDIR)/test/micro
+        $(RM) -r $(TEST_IMAGE_DIR)/micro
+        @$(ECHO) " done"
+endef
+
 # Cleans the dir given as $1
 define CleanDir
 	@$(PRINTF) "Cleaning %s build artifacts ..." "$(strip $1)"

--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -66,11 +66,11 @@ define CleanDocs
 endef
 
 define CleanMicrobenchmark
-        @$(PRINTF) "Cleaning microbenchmark build artifacts ..."
-        @$(ECHO) "" $(LOG_DEBUG)
-        $(RM) -r $(SUPPORT_OUTPUTDIR)/test/micro
-        $(RM) -r $(TEST_IMAGE_DIR)/micro
-        @$(ECHO) " done"
+	@$(PRINTF) "Cleaning microbenchmark build artifacts ..."
+	@$(ECHO) "" $(LOG_DEBUG)
+	$(RM) -r $(SUPPORT_OUTPUTDIR)/test/micro
+	$(RM) -r $(TEST_IMAGE_DIR)/micro
+	@$(ECHO) " done"
 endef
 
 # Cleans the dir given as $1


### PR DESCRIPTION
This addresses JDK-8378896.

This adds a `clean-microbenchmark` make target for microbenchmark development.
The target removes the following directories from the build output:

- `support/test/micro`
- `images/test/micro`

I did not add a dedicated test for this build-system cleanup target. Instead, I
validated it with the existing Make tests and a clean/rebuild cycle.

Testing:

- `make test-make`
- `make build-microbenchmark`
- Verified that `support/test/micro` and `images/test/micro` were created.
- `make clean-microbenchmark`
- Verified that both microbenchmark output directories were removed.
- Re-ran `clean-microbenchmark` successfully with the output directories absent.
- Rebuilt the microbenchmarks successfully after cleaning and verified that
  `images/test/micro/benchmarks.jar` was generated.

```shell
$ make clean-microbenchmark

Building target 'clean-microbenchmark' in configuration 'linux-aarch64-server-release-jmh'
Cleaning microbenchmark build artifacts ... done
Finished building target 'clean-microbenchmark' in configuration 'linux-aarch64-server-release-jmh'
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8378896](https://bugs.openjdk.org/browse/JDK-8378896): A make target "clean-microbenchmark", for micro development (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32383/head:pull/32383` \
`$ git checkout pull/32383`

Update a local copy of the PR: \
`$ git checkout pull/32383` \
`$ git pull https://git.openjdk.org/jdk.git pull/32383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32383`

View PR using the GUI difftool: \
`$ git pr show -t 32383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32383.diff">https://git.openjdk.org/jdk/pull/32383.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32383#issuecomment-5307411403)
</details>
