### PR TITLE
8381505: C2: Extended time-to-safepoint due to range check elimination

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1942,25 +1942,7 @@ void Compile::remove_from_post_loop_opts_igvn(Node* n) {
   _for_post_loop_igvn.remove(n);
 }
 
-// Keep a uniform side-loop structure through loop opts, then remove the strip-mined shells that RCE did not require.
-static void remove_redundant_outer_strip_mined_loops(Compile* compile, PhaseIterGVN& igvn) {
-  bool removed = false;
-  for (int i = compile->macro_count(); i > 0; i--) {
-    Node* node = compile->macro_node(i - 1);
-    if (node->is_OuterStripMinedLoop() && node->as_OuterStripMinedLoop()->is_redundant()) {
-      node->as_OuterStripMinedLoop()->remove_outer_loop_and_safepoint(&igvn);
-      removed = true;
-    }
-  }
-  if (removed) {
-    igvn.optimize();
-  }
-}
-
 void Compile::process_for_post_loop_opts_igvn(PhaseIterGVN& igvn) {
-  remove_redundant_outer_strip_mined_loops(this, igvn);
-  if (failing()) return;
-
   // Verify that all previous optimizations produced a valid graph
   // at least to this point, even if no loop optimizations were done.
   PhaseIdealLoop::verify(igvn);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1942,7 +1942,25 @@ void Compile::remove_from_post_loop_opts_igvn(Node* n) {
   _for_post_loop_igvn.remove(n);
 }
 
+// Keep a uniform side-loop structure through loop opts, then remove the strip-mined shells that RCE did not require.
+static void remove_redundant_outer_strip_mined_loops(Compile* compile, PhaseIterGVN& igvn) {
+  bool removed = false;
+  for (int i = compile->macro_count(); i > 0; i--) {
+    Node* node = compile->macro_node(i - 1);
+    if (node->is_OuterStripMinedLoop() && node->as_OuterStripMinedLoop()->is_redundant()) {
+      node->as_OuterStripMinedLoop()->remove_outer_loop_and_safepoint(&igvn);
+      removed = true;
+    }
+  }
+  if (removed) {
+    igvn.optimize();
+  }
+}
+
 void Compile::process_for_post_loop_opts_igvn(PhaseIterGVN& igvn) {
+  remove_redundant_outer_strip_mined_loops(this, igvn);
+  if (failing()) return;
+
   // Verify that all previous optimizations produced a valid graph
   // at least to this point, even if no loop optimizations were done.
   PhaseIdealLoop::verify(igvn);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1449,7 +1449,8 @@ void PhaseIdealLoop::ensure_zero_trip_guard_proj(Node* node, bool is_main_loop) 
 // Insert pre and post loops.  If peel_only is set, the pre-loop can not have
 // more iterations added.  It acts as a 'peel' only, no lower-bound RCE, no
 // alignment.  Useful to unroll loops that do no array accesses.
-void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree *loop, Node_List &old_new, bool peel_only) {
+void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_new, bool peel_only,
+                                           bool keep_side_loop_safepoints) {
 
 #ifndef PRODUCT
   if (TraceLoopOpts) {
@@ -1494,7 +1495,8 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree *loop, Node_List &old_n
   // Add the post loop
   CountedLoopNode *post_head = nullptr;
   Node* post_incr = incr;
-  Node* main_exit = insert_post_loop(loop, old_new, main_head, main_end, post_incr, limit, post_head);
+  Node* main_exit = insert_post_loop(loop, old_new, main_head, main_end, post_incr, limit, post_head,
+                                    keep_side_loop_safepoints);
   C->print_method(PHASE_AFTER_POST_LOOP, 4, post_head);
 
   //------------------------------
@@ -1513,7 +1515,9 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree *loop, Node_List &old_n
 
   const uint first_node_index_in_pre_loop_body = Compile::current()->unique();
   uint dd_main_head = dom_depth(outer_main_head);
-  clone_loop(loop, old_new, dd_main_head, ControlAroundStripMined);
+  const CloneLoopMode clone_mode = keep_side_loop_safepoints && main_head->is_strip_mined() ?
+                                   CloneIncludesStripMined : ControlAroundStripMined;
+  clone_loop(loop, old_new, dd_main_head, clone_mode);
   CountedLoopNode*    pre_head = old_new[main_head->_idx]->as_CountedLoop();
   CountedLoopEndNode* pre_end  = old_new[main_end ->_idx]->as_CountedLoopEnd();
   pre_head->set_pre_loop(main_head);
@@ -1523,10 +1527,14 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree *loop, Node_List &old_n
   pre_end->_prob = PROB_FAIR;
 
   // Find the pre-loop normal exit.
-  IfFalseNode* pre_exit = pre_end->false_proj();
-  IfFalseNode* new_pre_exit = new IfFalseNode(pre_end);
+  IfNode* outer_pre_end = pre_end;
+  if (pre_head->is_strip_mined()) {
+    outer_pre_end = pre_head->outer_loop_end();
+  }
+  IfFalseNode* pre_exit = outer_pre_end->false_proj();
+  IfFalseNode* new_pre_exit = new IfFalseNode(outer_pre_end);
   _igvn.register_new_node_with_optimizer(new_pre_exit);
-  set_idom(new_pre_exit, pre_end, dd_main_head);
+  set_idom(new_pre_exit, outer_pre_end, dd_main_head);
   set_loop(new_pre_exit, outer_loop->_parent);
 
   // Step B2: Build a zero-trip guard for the main-loop.  After leaving the
@@ -1560,7 +1568,8 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree *loop, Node_List &old_n
   _igvn.hash_delete(outer_main_head);
   outer_main_head->set_req(LoopNode::EntryControl, min_taken);
   set_idom(outer_main_head, min_taken, dd_main_head);
-  assert(post_head->in(1)->is_IfProj(), "must be zero-trip guard If node projection of the post loop");
+  assert(post_head->skip_strip_mined()->in(1)->is_IfProj(),
+         "must be zero-trip guard If node projection of the post loop");
 
   VectorSet visited;
   Node_Stack clones(main_head->back_control()->outcnt());
@@ -1711,7 +1720,7 @@ void PhaseIdealLoop::insert_vector_post_loop(IdealLoopTree *loop, Node_List &old
   // In this case we throw away the result as we are not using it to connect anything else.
   C->print_method(PHASE_BEFORE_POST_LOOP, 4, main_head);
   CountedLoopNode *post_head = nullptr;
-  insert_post_loop(loop, old_new, main_head, main_end, incr, limit, post_head);
+  insert_post_loop(loop, old_new, main_head, main_end, incr, limit, post_head, false);
   C->print_method(PHASE_AFTER_POST_LOOP, 4, post_head);
 
   // It's difficult to be precise about the trip-counts
@@ -1753,7 +1762,8 @@ Node* PhaseIdealLoop::find_last_store_in_outer_loop(Node* store, const IdealLoop
 // Insert post loops.  Add a post loop to the given loop passed.
 Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
                                        CountedLoopNode* main_head, CountedLoopEndNode* main_end,
-                                       Node* incr, Node* limit, CountedLoopNode*& post_head) {
+                                       Node* incr, Node* limit, CountedLoopNode*& post_head,
+                                       bool keep_side_loop_safepoints) {
   IfNode* outer_main_end = main_end;
   IdealLoopTree* outer_loop = loop;
   if (main_head->is_strip_mined()) {
@@ -1771,7 +1781,9 @@ Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
   // Step A1: Clone the loop body of main. The clone becomes the post-loop.
   // The main loop pre-header illegally has 2 control users (old & new loops).
   const uint first_node_index_in_cloned_loop_body = C->unique();
-  clone_loop(loop, old_new, dd_main_exit, ControlAroundStripMined);
+  const CloneLoopMode clone_mode = keep_side_loop_safepoints && main_head->is_strip_mined() ?
+                                   CloneIncludesStripMined : ControlAroundStripMined;
+  clone_loop(loop, old_new, dd_main_exit, clone_mode);
   assert(old_new[main_end->_idx]->Opcode() == Op_CountedLoopEnd, "");
   post_head = old_new[main_head->_idx]->as_CountedLoop();
   post_head->set_normal_loop();
@@ -1818,9 +1830,10 @@ Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
   set_idom(zer_taken, zer_iff, dd_main_exit);
   set_loop(zer_taken, outer_loop->_parent);
   // Plug in the true path
-  _igvn.hash_delete(post_head);
-  post_head->set_req(LoopNode::EntryControl, zer_taken);
-  set_idom(post_head, zer_taken, dd_main_exit);
+  LoopNode* outer_post_head = post_head->skip_strip_mined();
+  _igvn.hash_delete(outer_post_head);
+  outer_post_head->set_req(LoopNode::EntryControl, zer_taken);
+  set_idom(outer_post_head, zer_taken, dd_main_exit);
 
   VectorSet visited;
   Node_Stack clones(main_head->back_control()->outcnt());
@@ -1832,7 +1845,7 @@ Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
       Node* post_phi = old_new[main_phi->_idx];
       Node* loopback_input = main_phi->in(LoopNode::LoopBackControl);
       Node* fallnew = clone_up_backedge_goo(main_head->back_control(),
-                                            post_head->init_control(),
+                                            outer_post_head->in(LoopNode::EntryControl),
                                             loopback_input,
                                             visited, clones);
       // Technically, the entry value of post_phi must be the loop back input of the corresponding
@@ -1885,7 +1898,7 @@ Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
     }
   }
 
-  DEBUG_ONLY(ensure_zero_trip_guard_proj(post_head->in(LoopNode::EntryControl), false);)
+  DEBUG_ONLY(ensure_zero_trip_guard_proj(post_head->skip_strip_mined()->in(LoopNode::EntryControl), false);)
   initialize_assertion_predicates_for_post_loop(main_head, post_head, first_node_index_in_cloned_loop_body);
   cast_incr_before_loop(zer_opaq->in(1), zer_taken, post_head);
   return new_main_exit;
@@ -2749,12 +2762,10 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 
   // Find the pre-loop limit; we will expand its iterations to
   // not ever trip low tests.
-  Node* pre_loop_exit_proj = zero_trip_guard->in(0);
-  // pre loop may have been optimized out
-  if (!pre_loop_exit_proj->is_IfFalse()) {
+  CountedLoopEndNode* pre_end = cl->find_pre_loop_end();
+  if (pre_end == nullptr) {
     return;
   }
-  CountedLoopEndNode* pre_end = pre_loop_exit_proj->in(0)->as_CountedLoopEnd();
   assert(pre_end->loopnode()->is_pre_loop(), "not a pre loop");
   Node* pre_loop_limit = pre_end->limit();
   // Occasionally it's possible for a pre-loop Opaque1 node to be
@@ -2768,7 +2779,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
   Node* pre_limit_ctrl = get_ctrl(pre_limit);
 
   // Where do we put new limit calculations
-  Node* pre_ctrl = pre_end->loopnode()->in(LoopNode::EntryControl);
+  Node* pre_ctrl = pre_end->loopnode()->skip_strip_mined()->in(LoopNode::EntryControl);
   // Range check elimination optimizes out conditions whose parameters are loop invariant in the main loop. They usually
   // have control above the pre loop, but there's no guarantee that they do. There's no guarantee either that the pre
   // loop limit has control that's out of loop (a previous round of range check elimination could have set a limit that's
@@ -2851,7 +2862,9 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
         continue;  // Don't rce this check but continue looking for other candidates.
       }
 
-      assert(is_dominator(compute_early_ctrl(limit, limit_ctrl), pre_end), "node pinned on loop exit test?");
+      if (!is_dominator(compute_early_ctrl(limit, limit_ctrl), pre_end)) {
+        continue;
+      }
 
       // Check for scaled induction variable plus an offset
       Node *offset = nullptr;
@@ -2870,6 +2883,10 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       // zero trip test.
       if (is_dominator(zero_trip_guard_success_proj, offset_ctrl)) {
         continue; // Don't rce this check but continue looking for other candidates.
+      }
+
+      if (!is_dominator(compute_early_ctrl(offset, offset_ctrl), pre_end)) {
+        continue;
       }
 
       // offset and limit can have control set below the pre loop when they are not loop invariant in the pre loop.
@@ -3183,19 +3200,9 @@ void IdealLoopTree::adjust_loop_exit_prob(PhaseIdealLoop *phase) {
 
 static CountedLoopNode* locate_pre_from_main(CountedLoopNode* main_loop) {
   assert(!main_loop->is_main_no_pre_loop(), "Does not have a pre loop");
-  Node* ctrl = main_loop->skip_assertion_predicates_with_halt();
-  assert(ctrl->Opcode() == Op_IfTrue || ctrl->Opcode() == Op_IfFalse, "");
-  Node* iffm = ctrl->in(0);
-  assert(iffm->Opcode() == Op_If, "%s", iffm->Name());
-  Node* p_f = iffm->in(0);
-  // Skip ReachabilityFences hoisted out of pre-loop.
-  while (p_f->is_ReachabilityFence()) {
-    p_f = p_f->in(0);
-  }
-  assert(p_f->Opcode() == Op_IfFalse, "%s", p_f->Name());
-  CountedLoopNode* pre_loop = p_f->in(0)->as_CountedLoopEnd()->loopnode();
-  assert(pre_loop->is_pre_loop(), "No pre loop found");
-  return pre_loop;
+  CountedLoopEndNode* pre_end = main_loop->find_pre_loop_end();
+  assert(pre_end != nullptr, "No pre loop found");
+  return pre_end->loopnode();
 }
 
 // Remove the main and post loops and make the pre loop execute all
@@ -3210,11 +3217,15 @@ void IdealLoopTree::remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *
   }
 
   // Can we find the main loop?
-  if (_next == nullptr) {
+  IdealLoopTree* pre_loop = skip_strip_mined();
+  if (pre_loop->_next == nullptr) {
     return;
   }
 
-  Node* next_head = _next->_head;
+  Node* next_head = pre_loop->_next->_head;
+  if (next_head->is_OuterStripMinedLoop()) {
+    next_head = next_head->as_OuterStripMinedLoop()->inner_counted_loop();
+  }
   if (!next_head->is_CountedLoop()) {
     return;
   }
@@ -3685,7 +3696,10 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
         phase->maybe_multiversion_for_auto_vectorization_runtime_checks(this, old_new);
       }
 
-      phase->insert_pre_post_loops(this, old_new, peel_only);
+      // Reassociation and split-if can expose an RCE candidate after iteration splitting.
+      const bool keep_side_loop_safepoints = should_rce ||
+                                             (RangeCheckElimination && policy_range_check(phase, true, T_INT));
+      phase->insert_pre_post_loops(this, old_new, peel_only, keep_side_loop_safepoints);
     }
     // Adjust the pre- and main-loop limits to let the pre and  post loops run
     // with full checks, but the main-loop with no checks.  Remove said checks

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1449,7 +1449,7 @@ void PhaseIdealLoop::ensure_zero_trip_guard_proj(Node* node, bool is_main_loop) 
 // Insert pre and post loops.  If peel_only is set, the pre-loop can not have
 // more iterations added.  It acts as a 'peel' only, no lower-bound RCE, no
 // alignment.  Useful to unroll loops that do no array accesses.
-void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_new, bool peel_only) {
+void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree *loop, Node_List &old_new, bool peel_only) {
 
 #ifndef PRODUCT
   if (TraceLoopOpts) {
@@ -1518,9 +1518,6 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_n
   CountedLoopNode*    pre_head = old_new[main_head->_idx]->as_CountedLoop();
   CountedLoopEndNode* pre_end  = old_new[main_end ->_idx]->as_CountedLoopEnd();
   pre_head->set_pre_loop(main_head);
-  if (pre_head->is_strip_mined()) {
-    pre_head->outer_loop()->mark_redundant();
-  }
   Node *pre_incr = old_new[incr->_idx];
 
   // Reduce the pre-loop trip count.
@@ -1666,6 +1663,16 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_n
   peeled_dom_test_elim(loop,old_new);
   loop->record_for_igvn();
 
+  if (pre_head->is_strip_mined()) {
+    SafePointNode* safepoint = pre_head->outer_safepoint();
+    pre_head->outer_loop()->transform_to_counted_loop(&_igvn, this);
+    C->record_for_post_loop_opts_igvn(safepoint);
+
+    safepoint = post_head->outer_safepoint();
+    post_head->outer_loop()->transform_to_counted_loop(&_igvn, this);
+    C->record_for_post_loop_opts_igvn(safepoint);
+  }
+
   C->print_method(PHASE_AFTER_PRE_MAIN_POST, 4, main_head);
 }
 
@@ -1732,6 +1739,12 @@ void PhaseIdealLoop::insert_vector_post_loop(IdealLoopTree *loop, Node_List &old
   // finds some, but we _know_ they are all useless.
   peeled_dom_test_elim(loop, old_new);
   loop->record_for_igvn();
+
+  if (post_head->is_strip_mined()) {
+    SafePointNode* safepoint = post_head->outer_safepoint();
+    post_head->outer_loop()->transform_to_counted_loop(&_igvn, this);
+    replace_node_and_forward_ctrl(safepoint, safepoint->in(TypeFunc::Control));
+  }
 }
 
 Node* PhaseIdealLoop::find_last_store_in_outer_loop(Node* store, const IdealLoopTree* outer_loop) {
@@ -1786,9 +1799,6 @@ Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
   post_head = old_new[main_head->_idx]->as_CountedLoop();
   post_head->set_normal_loop();
   post_head->set_post_loop(main_head);
-  if (post_head->is_strip_mined()) {
-    post_head->outer_loop()->mark_redundant();
-  }
 
   // clone_loop() above changes the exit projection
   main_exit = outer_main_end->false_proj();
@@ -2723,20 +2733,51 @@ bool PhaseIdealLoop::is_scaled_iv_plus_extra_offset(Node* exp1, Node* offset3, N
   return false;
 }
 
+static SafePointNode* find_rce_side_loop_safepoint(PhaseIdealLoop* phase, CountedLoopEndNode* loop_end) {
+  if (loop_end == nullptr) {
+    return nullptr;
+  }
+  Node_List* safepoints = phase->get_loop(loop_end->loopnode())->_safepts;
+  if (safepoints == nullptr) {
+    return nullptr;
+  }
+  for (uint i = 0; i < safepoints->size(); i++) {
+    Node* safepoint = safepoints->at(i);
+    if (safepoint->for_post_loop_opts_igvn()) {
+      assert(safepoint->is_SafePoint(), "unexpected node");
+      return safepoint->as_SafePoint();
+    }
+  }
+  return nullptr;
+}
+
+static void preserve_rce_side_loop_safepoint(PhaseIdealLoop* phase, CountedLoopEndNode* loop_end) {
+  SafePointNode* safepoint = find_rce_side_loop_safepoint(phase, loop_end);
+  if (safepoint != nullptr) {
+    phase->C->remove_from_post_loop_opts_igvn(safepoint);
+  }
+}
+
+static void remove_unneeded_rce_side_loop_safepoint(PhaseIdealLoop* phase, CountedLoopEndNode* loop_end) {
+  SafePointNode* safepoint = find_rce_side_loop_safepoint(phase, loop_end);
+  if (safepoint != nullptr) {
+    phase->C->remove_from_post_loop_opts_igvn(safepoint);
+    phase->replace_node_and_forward_ctrl(safepoint, safepoint->in(TypeFunc::Control));
+  }
+}
+
+static void remove_unneeded_rce_side_loop_safepoints(IdealLoopTree* main_loop) {
+  PhaseIdealLoop* phase = main_loop->_phase;
+  CountedLoopNode* main_loop_head = main_loop->_head->as_CountedLoop();
+  remove_unneeded_rce_side_loop_safepoint(phase, main_loop_head->find_pre_loop_end());
+  remove_unneeded_rce_side_loop_safepoint(phase, main_loop_head->find_post_loop_end());
+}
+
 static void preserve_rce_side_loop_safepoints(IdealLoopTree* main_loop, CountedLoopEndNode* pre_loop_end,
                                                CountedLoopEndNode* post_loop_end) {
-  CountedLoopNode* main_loop_head = main_loop->_head->as_CountedLoop();
-  if (!main_loop_head->is_strip_mined()) {
-    return;
-  }
-
-  CountedLoopNode* pre_loop = pre_loop_end->loopnode();
-  assert(pre_loop->is_strip_mined(), "pre-loop must be strip mined");
-  pre_loop->outer_loop()->clear_redundant();
-
-  CountedLoopNode* post_loop = post_loop_end->loopnode();
-  assert(post_loop->is_strip_mined(), "post-loop must be strip mined");
-  post_loop->outer_loop()->clear_redundant();
+  PhaseIdealLoop* phase = main_loop->_phase;
+  preserve_rce_side_loop_safepoint(phase, pre_loop_end);
+  preserve_rce_side_loop_safepoint(phase, post_loop_end);
 }
 
 //------------------------------do_range_check---------------------------------
@@ -2779,15 +2820,14 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 
   // Find the pre-loop limit; we will expand its iterations to
   // not ever trip low tests.
-  CountedLoopEndNode* pre_end = cl->find_pre_loop_end();
-  if (pre_end == nullptr) {
+  Node* pre_loop_exit_proj = zero_trip_guard->in(0);
+  // pre loop may have been optimized out
+  if (!pre_loop_exit_proj->is_IfFalse()) {
     return;
   }
+  CountedLoopEndNode* pre_end = pre_loop_exit_proj->in(0)->as_CountedLoopEnd();
   // The post-loop executes iterations excluded by the adjusted main-loop limit.
   CountedLoopEndNode* post_end = cl->find_post_loop_end();
-  if (post_end == nullptr) {
-    return;
-  }
   assert(pre_end->loopnode()->is_pre_loop(), "not a pre loop");
   Node* pre_loop_limit = pre_end->limit();
   // Occasionally it's possible for a pre-loop Opaque1 node to be
@@ -2801,7 +2841,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
   Node* pre_limit_ctrl = get_ctrl(pre_limit);
 
   // Where do we put new limit calculations
-  Node* pre_ctrl = pre_end->loopnode()->skip_strip_mined()->in(LoopNode::EntryControl);
+  Node* pre_ctrl = pre_end->loopnode()->in(LoopNode::EntryControl);
   // Range check elimination optimizes out conditions whose parameters are loop invariant in the main loop. They usually
   // have control above the pre loop, but there's no guarantee that they do. There's no guarantee either that the pre
   // loop limit has control that's out of loop (a previous round of range check elimination could have set a limit that's
@@ -2886,9 +2926,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
         continue;  // Don't rce this check but continue looking for other candidates.
       }
 
-      if (!is_dominator(compute_early_ctrl(limit, limit_ctrl), pre_end)) {
-        continue;
-      }
+      assert(is_dominator(compute_early_ctrl(limit, limit_ctrl), pre_end), "node pinned on loop exit test?");
 
       // Check for scaled induction variable plus an offset
       Node *offset = nullptr;
@@ -2907,10 +2945,6 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
       // zero trip test.
       if (is_dominator(zero_trip_guard_success_proj, offset_ctrl)) {
         continue; // Don't rce this check but continue looking for other candidates.
-      }
-
-      if (!is_dominator(compute_early_ctrl(offset, offset_ctrl), pre_end)) {
-        continue;
       }
 
       // offset and limit can have control set below the pre loop when they are not loop invariant in the pre loop.
@@ -3228,9 +3262,19 @@ void IdealLoopTree::adjust_loop_exit_prob(PhaseIdealLoop *phase) {
 
 static CountedLoopNode* locate_pre_from_main(CountedLoopNode* main_loop) {
   assert(!main_loop->is_main_no_pre_loop(), "Does not have a pre loop");
-  CountedLoopEndNode* pre_end = main_loop->find_pre_loop_end();
-  assert(pre_end != nullptr, "No pre loop found");
-  return pre_end->loopnode();
+  Node* ctrl = main_loop->skip_assertion_predicates_with_halt();
+  assert(ctrl->Opcode() == Op_IfTrue || ctrl->Opcode() == Op_IfFalse, "");
+  Node* iffm = ctrl->in(0);
+  assert(iffm->Opcode() == Op_If, "%s", iffm->Name());
+  Node* p_f = iffm->in(0);
+  // Skip ReachabilityFences hoisted out of pre-loop.
+  while (p_f->is_ReachabilityFence()) {
+    p_f = p_f->in(0);
+  }
+  assert(p_f->Opcode() == Op_IfFalse, "%s", p_f->Name());
+  CountedLoopNode* pre_loop = p_f->in(0)->as_CountedLoopEnd()->loopnode();
+  assert(pre_loop->is_pre_loop(), "No pre loop found");
+  return pre_loop;
 }
 
 // Remove the main and post loops and make the pre loop execute all
@@ -3245,15 +3289,11 @@ void IdealLoopTree::remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *
   }
 
   // Can we find the main loop?
-  IdealLoopTree* pre_loop = skip_strip_mined();
-  if (pre_loop->_next == nullptr) {
+  if (_next == nullptr) {
     return;
   }
 
-  Node* next_head = pre_loop->_next->_head;
-  if (next_head->is_OuterStripMinedLoop()) {
-    next_head = next_head->as_OuterStripMinedLoop()->inner_counted_loop();
-  }
+  Node* next_head = _next->_head;
   if (!next_head->is_CountedLoop()) {
     return;
   }
@@ -3272,9 +3312,7 @@ void IdealLoopTree::remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *
 
   // Remove the Opaque1Node of the pre loop and make it execute all iterations
   phase->_igvn.replace_input_of(pre_cmp, 2, pre_cmp->in(2)->in(2));
-  if (cl->is_strip_mined()) {
-    cl->outer_loop()->clear_redundant();
-  }
+  preserve_rce_side_loop_safepoint(phase, pre_end);
   // Remove the OpaqueZeroTripGuardNode of the main loop so it can be optimized out
   Node* main_cmp = main_iff->in(1)->in(1);
   assert(main_cmp->in(2)->Opcode() == Op_OpaqueZeroTripGuard, "main loop has no opaque node?");
@@ -3735,6 +3773,7 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
     if (should_rce) {
       phase->do_range_check(this);
     }
+    remove_unneeded_rce_side_loop_safepoints(this);
 
     // Double loop body for unrolling.  Adjust the minimum-trip test (will do
     // twice as many iterations as before) and the main body limit (only do

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1449,8 +1449,7 @@ void PhaseIdealLoop::ensure_zero_trip_guard_proj(Node* node, bool is_main_loop) 
 // Insert pre and post loops.  If peel_only is set, the pre-loop can not have
 // more iterations added.  It acts as a 'peel' only, no lower-bound RCE, no
 // alignment.  Useful to unroll loops that do no array accesses.
-void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_new, bool peel_only,
-                                           bool keep_side_loop_safepoints) {
+void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_new, bool peel_only) {
 
 #ifndef PRODUCT
   if (TraceLoopOpts) {
@@ -1495,8 +1494,7 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_n
   // Add the post loop
   CountedLoopNode *post_head = nullptr;
   Node* post_incr = incr;
-  Node* main_exit = insert_post_loop(loop, old_new, main_head, main_end, post_incr, limit, post_head,
-                                    keep_side_loop_safepoints);
+  Node* main_exit = insert_post_loop(loop, old_new, main_head, main_end, post_incr, limit, post_head);
   C->print_method(PHASE_AFTER_POST_LOOP, 4, post_head);
 
   //------------------------------
@@ -1515,12 +1513,14 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_n
 
   const uint first_node_index_in_pre_loop_body = Compile::current()->unique();
   uint dd_main_head = dom_depth(outer_main_head);
-  const CloneLoopMode clone_mode = keep_side_loop_safepoints && main_head->is_strip_mined() ?
-                                   CloneIncludesStripMined : ControlAroundStripMined;
+  const CloneLoopMode clone_mode = main_head->is_strip_mined() ? CloneIncludesStripMined : ControlAroundStripMined;
   clone_loop(loop, old_new, dd_main_head, clone_mode);
   CountedLoopNode*    pre_head = old_new[main_head->_idx]->as_CountedLoop();
   CountedLoopEndNode* pre_end  = old_new[main_end ->_idx]->as_CountedLoopEnd();
   pre_head->set_pre_loop(main_head);
+  if (pre_head->is_strip_mined()) {
+    pre_head->outer_loop()->mark_redundant();
+  }
   Node *pre_incr = old_new[incr->_idx];
 
   // Reduce the pre-loop trip count.
@@ -1720,7 +1720,7 @@ void PhaseIdealLoop::insert_vector_post_loop(IdealLoopTree *loop, Node_List &old
   // In this case we throw away the result as we are not using it to connect anything else.
   C->print_method(PHASE_BEFORE_POST_LOOP, 4, main_head);
   CountedLoopNode *post_head = nullptr;
-  insert_post_loop(loop, old_new, main_head, main_end, incr, limit, post_head, false);
+  insert_post_loop(loop, old_new, main_head, main_end, incr, limit, post_head);
   C->print_method(PHASE_AFTER_POST_LOOP, 4, post_head);
 
   // It's difficult to be precise about the trip-counts
@@ -1762,8 +1762,7 @@ Node* PhaseIdealLoop::find_last_store_in_outer_loop(Node* store, const IdealLoop
 // Insert post loops.  Add a post loop to the given loop passed.
 Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
                                        CountedLoopNode* main_head, CountedLoopEndNode* main_end,
-                                       Node* incr, Node* limit, CountedLoopNode*& post_head,
-                                       bool keep_side_loop_safepoints) {
+                                       Node* incr, Node* limit, CountedLoopNode*& post_head) {
   IfNode* outer_main_end = main_end;
   IdealLoopTree* outer_loop = loop;
   if (main_head->is_strip_mined()) {
@@ -1781,13 +1780,15 @@ Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
   // Step A1: Clone the loop body of main. The clone becomes the post-loop.
   // The main loop pre-header illegally has 2 control users (old & new loops).
   const uint first_node_index_in_cloned_loop_body = C->unique();
-  const CloneLoopMode clone_mode = keep_side_loop_safepoints && main_head->is_strip_mined() ?
-                                   CloneIncludesStripMined : ControlAroundStripMined;
+  const CloneLoopMode clone_mode = main_head->is_strip_mined() ? CloneIncludesStripMined : ControlAroundStripMined;
   clone_loop(loop, old_new, dd_main_exit, clone_mode);
   assert(old_new[main_end->_idx]->Opcode() == Op_CountedLoopEnd, "");
   post_head = old_new[main_head->_idx]->as_CountedLoop();
   post_head->set_normal_loop();
   post_head->set_post_loop(main_head);
+  if (post_head->is_strip_mined()) {
+    post_head->outer_loop()->mark_redundant();
+  }
 
   // clone_loop() above changes the exit projection
   main_exit = outer_main_end->false_proj();
@@ -2722,6 +2723,22 @@ bool PhaseIdealLoop::is_scaled_iv_plus_extra_offset(Node* exp1, Node* offset3, N
   return false;
 }
 
+static void preserve_rce_side_loop_safepoints(IdealLoopTree* main_loop, CountedLoopEndNode* pre_loop_end,
+                                               CountedLoopEndNode* post_loop_end) {
+  CountedLoopNode* main_loop_head = main_loop->_head->as_CountedLoop();
+  if (!main_loop_head->is_strip_mined()) {
+    return;
+  }
+
+  CountedLoopNode* pre_loop = pre_loop_end->loopnode();
+  assert(pre_loop->is_strip_mined(), "pre-loop must be strip mined");
+  pre_loop->outer_loop()->clear_redundant();
+
+  CountedLoopNode* post_loop = post_loop_end->loopnode();
+  assert(post_loop->is_strip_mined(), "post-loop must be strip mined");
+  post_loop->outer_loop()->clear_redundant();
+}
+
 //------------------------------do_range_check---------------------------------
 // Eliminate range-checks and other trip-counter vs loop-invariant tests.
 void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
@@ -2764,6 +2781,11 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
   // not ever trip low tests.
   CountedLoopEndNode* pre_end = cl->find_pre_loop_end();
   if (pre_end == nullptr) {
+    return;
+  }
+  // The post-loop executes iterations excluded by the adjusted main-loop limit.
+  CountedLoopEndNode* post_end = cl->find_post_loop_end();
+  if (post_end == nullptr) {
     return;
   }
   assert(pre_end->loopnode()->is_pre_loop(), "not a pre loop");
@@ -2813,6 +2835,8 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
     _igvn.set_type(final_iv_placeholder, TypeInt::INT);
     final_iv_placeholder->init_req(0, loop_entry);
   }
+
+  bool range_check_eliminated = false;
 
   // Check loop body for tests of trip-counter plus loop-invariant vs loop-variant.
   for (uint i = 0; i < loop->_body.size(); i++) {
@@ -3009,6 +3033,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 
       // Kill the eliminated test
       C->set_major_progress();
+      range_check_eliminated = true;
       Node* kill_con = intcon(1-flip);
       _igvn.replace_input_of(iff, 1, kill_con);
       // Find surviving projection
@@ -3026,6 +3051,9 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
         }
       }
     } // End of is IF
+  }
+  if (range_check_eliminated) {
+    preserve_rce_side_loop_safepoints(loop, pre_end, post_end);
   }
   if (loop_entry != cl->skip_strip_mined()->in(LoopNode::EntryControl)) {
     _igvn.replace_input_of(cl->skip_strip_mined(), LoopNode::EntryControl, loop_entry);
@@ -3244,6 +3272,9 @@ void IdealLoopTree::remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *
 
   // Remove the Opaque1Node of the pre loop and make it execute all iterations
   phase->_igvn.replace_input_of(pre_cmp, 2, pre_cmp->in(2)->in(2));
+  if (cl->is_strip_mined()) {
+    cl->outer_loop()->clear_redundant();
+  }
   // Remove the OpaqueZeroTripGuardNode of the main loop so it can be optimized out
   Node* main_cmp = main_iff->in(1)->in(1);
   assert(main_cmp->in(2)->Opcode() == Op_OpaqueZeroTripGuard, "main loop has no opaque node?");
@@ -3696,10 +3727,7 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
         phase->maybe_multiversion_for_auto_vectorization_runtime_checks(this, old_new);
       }
 
-      // Reassociation and split-if can expose an RCE candidate after iteration splitting.
-      const bool keep_side_loop_safepoints = should_rce ||
-                                             (RangeCheckElimination && policy_range_check(phase, true, T_INT));
-      phase->insert_pre_post_loops(this, old_new, peel_only, keep_side_loop_safepoints);
+      phase->insert_pre_post_loops(this, old_new, peel_only);
     }
     // Adjust the pre- and main-loop limits to let the pre and  post loops run
     // with full checks, but the main-loop with no checks.  Remove said checks

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3199,7 +3199,7 @@ IfNode* CountedLoopNode::find_multiversion_if_from_multiversion_fast_main_loop()
   assert(is_main_loop() && is_multiversion_fast_loop(), "must be multiversion fast main loop");
   CountedLoopEndNode* pre_end = find_pre_loop_end();
   if (pre_end == nullptr) { return nullptr; }
-  Node* pre_entry = pre_end->loopnode()->in(LoopNode::EntryControl);
+  Node* pre_entry = pre_end->loopnode()->skip_strip_mined()->in(LoopNode::EntryControl);
   const Predicates predicates(pre_entry);
   IfTrueNode* before_predicates = predicates.entry()->isa_IfTrue();
   if (before_predicates != nullptr &&
@@ -3309,10 +3309,8 @@ Node* CountedLoopNode::skip_assertion_predicates_with_halt() {
     // Dying loop.
     return nullptr;
   }
-  if (is_main_loop()) {
-    ctrl = skip_strip_mined()->in(LoopNode::EntryControl);
-  }
   if (is_main_loop() || is_post_loop()) {
+    ctrl = skip_strip_mined()->in(LoopNode::EntryControl);
     AssertionPredicates assertion_predicates(ctrl);
     return assertion_predicates.entry();
   }
@@ -3791,6 +3789,10 @@ Node* OuterStripMinedLoopNode::register_control(Node* node, Node* loop, Node* id
   }
   iloop->register_control(node, iloop->get_loop(loop), idom);
   return node;
+}
+
+CountedLoopEndNode* OuterStripMinedLoopEndNode::inner_counted_loop_end() const {
+  return in(0)->as_SafePoint()->in(0)->as_IfFalse()->in(0)->as_CountedLoopEnd();
 }
 
 const Type* OuterStripMinedLoopEndNode::Value(PhaseGVN* phase) const {
@@ -6708,10 +6710,20 @@ CountedLoopEndNode* CountedLoopNode::find_pre_loop_end() {
   }
 
   Node* p_f = skip_assertion_predicates_with_halt()->in(0)->in(0);
-  if (!p_f->is_IfFalse() || !p_f->in(0)->is_CountedLoopEnd()) {
+  while (p_f->is_ReachabilityFence()) {
+    p_f = p_f->in(0);
+  }
+  if (!p_f->is_IfFalse()) {
     return nullptr;
   }
-  CountedLoopEndNode* pre_end = p_f->in(0)->as_CountedLoopEnd();
+  Node* pre_exit_test = p_f->in(0);
+  CountedLoopEndNode* pre_end = pre_exit_test->isa_CountedLoopEnd();
+  if (pre_exit_test->is_OuterStripMinedLoopEnd()) {
+    pre_end = pre_exit_test->as_OuterStripMinedLoopEnd()->inner_counted_loop_end();
+  }
+  if (pre_end == nullptr) {
+    return nullptr;
+  }
   CountedLoopNode* loop_node = pre_end->loopnode();
   if (loop_node == nullptr || !loop_node->is_pre_loop()) {
     return nullptr;

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3199,7 +3199,7 @@ IfNode* CountedLoopNode::find_multiversion_if_from_multiversion_fast_main_loop()
   assert(is_main_loop() && is_multiversion_fast_loop(), "must be multiversion fast main loop");
   CountedLoopEndNode* pre_end = find_pre_loop_end();
   if (pre_end == nullptr) { return nullptr; }
-  Node* pre_entry = pre_end->loopnode()->skip_strip_mined()->in(LoopNode::EntryControl);
+  Node* pre_entry = pre_end->loopnode()->in(LoopNode::EntryControl);
   const Predicates predicates(pre_entry);
   IfTrueNode* before_predicates = predicates.entry()->isa_IfTrue();
   if (before_predicates != nullptr &&
@@ -3309,8 +3309,10 @@ Node* CountedLoopNode::skip_assertion_predicates_with_halt() {
     // Dying loop.
     return nullptr;
   }
-  if (is_main_loop() || is_post_loop()) {
+  if (is_main_loop()) {
     ctrl = skip_strip_mined()->in(LoopNode::EntryControl);
+  }
+  if (is_main_loop() || is_post_loop()) {
     AssertionPredicates assertion_predicates(ctrl);
     return assertion_predicates.entry();
   }
@@ -3754,8 +3756,9 @@ void OuterStripMinedLoopNode::transform_to_counted_loop(PhaseIterGVN* igvn, Phas
         }
         wq.push(in);
       }
-      assert(!loop->_body.contains(n), "Shouldn't append node to body twice");
-      loop->_body.push(n);
+      if (!loop->_body.contains(n)) {
+        loop->_body.push(n);
+      }
     }
     iloop->set_loop(safepoint, loop);
     loop->_body.push(safepoint);
@@ -3789,10 +3792,6 @@ Node* OuterStripMinedLoopNode::register_control(Node* node, Node* loop, Node* id
   }
   iloop->register_control(node, iloop->get_loop(loop), idom);
   return node;
-}
-
-CountedLoopEndNode* OuterStripMinedLoopEndNode::inner_counted_loop_end() const {
-  return in(0)->as_SafePoint()->in(0)->as_IfFalse()->in(0)->as_CountedLoopEnd();
 }
 
 const Type* OuterStripMinedLoopEndNode::Value(PhaseGVN* phase) const {
@@ -6710,20 +6709,10 @@ CountedLoopEndNode* CountedLoopNode::find_pre_loop_end() {
   }
 
   Node* p_f = skip_assertion_predicates_with_halt()->in(0)->in(0);
-  while (p_f->is_ReachabilityFence()) {
-    p_f = p_f->in(0);
-  }
-  if (!p_f->is_IfFalse()) {
+  if (!p_f->is_IfFalse() || !p_f->in(0)->is_CountedLoopEnd()) {
     return nullptr;
   }
-  Node* pre_exit_test = p_f->in(0);
-  CountedLoopEndNode* pre_end = pre_exit_test->isa_CountedLoopEnd();
-  if (pre_exit_test->is_OuterStripMinedLoopEnd()) {
-    pre_end = pre_exit_test->as_OuterStripMinedLoopEnd()->inner_counted_loop_end();
-  }
-  if (pre_end == nullptr) {
-    return nullptr;
-  }
+  CountedLoopEndNode* pre_end = p_f->in(0)->as_CountedLoopEnd();
   CountedLoopNode* loop_node = pre_end->loopnode();
   if (loop_node == nullptr || !loop_node->is_pre_loop()) {
     return nullptr;
@@ -6742,7 +6731,7 @@ static CountedLoopNode* find_immediate_post_loop(CountedLoopNode* loop) {
   }
 
   Node* control = loop_exit->unique_ctrl_out_or_null();
-  while (control != nullptr && control->is_Region()) {
+  if (control != nullptr && control->is_Region()) {
     control = control->unique_ctrl_out_or_null();
   }
   IfNode* zero_trip_guard = control != nullptr ? control->isa_If() : nullptr;
@@ -6757,8 +6746,7 @@ static CountedLoopNode* find_immediate_post_loop(CountedLoopNode* loop) {
       CountedLoopNode* post_loop = post_loop_head->is_OuterStripMinedLoop() ?
           post_loop_head->as_OuterStripMinedLoop()->inner_counted_loop() : post_loop_head->isa_CountedLoop();
       if (post_loop == nullptr || !post_loop->is_post_loop() ||
-          post_loop_head->in(LoopNode::EntryControl) != post_entry ||
-          post_loop->is_canonical_loop_entry() == nullptr) {
+          post_loop_head->in(LoopNode::EntryControl) != post_entry) {
         return nullptr;
       }
       return post_loop;

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -6731,6 +6731,54 @@ CountedLoopEndNode* CountedLoopNode::find_pre_loop_end() {
   return pre_end;
 }
 
+static CountedLoopNode* find_immediate_post_loop(CountedLoopNode* loop) {
+  CountedLoopEndNode* loop_end = loop->loopexit_or_null();
+  IfFalseNode* loop_exit = loop_end != nullptr ? loop_end->false_proj_or_null() : nullptr;
+  if (loop->is_strip_mined()) {
+    loop_exit = loop->outer_loop_exit();
+  }
+  if (loop_exit == nullptr) {
+    return nullptr;
+  }
+
+  Node* control = loop_exit->unique_ctrl_out_or_null();
+  while (control != nullptr && control->is_Region()) {
+    control = control->unique_ctrl_out_or_null();
+  }
+  IfNode* zero_trip_guard = control != nullptr ? control->isa_If() : nullptr;
+  Node* post_entry = zero_trip_guard != nullptr ? zero_trip_guard->true_proj_or_null() : nullptr;
+  while (post_entry != nullptr) {
+    Node* next = post_entry->unique_ctrl_out_or_null();
+    if (next == nullptr) {
+      return nullptr;
+    }
+    if (next->is_Loop()) {
+      LoopNode* post_loop_head = next->as_Loop();
+      CountedLoopNode* post_loop = post_loop_head->is_OuterStripMinedLoop() ?
+          post_loop_head->as_OuterStripMinedLoop()->inner_counted_loop() : post_loop_head->isa_CountedLoop();
+      if (post_loop == nullptr || !post_loop->is_post_loop() ||
+          post_loop_head->in(LoopNode::EntryControl) != post_entry ||
+          post_loop->is_canonical_loop_entry() == nullptr) {
+        return nullptr;
+      }
+      return post_loop;
+    }
+    IfNode* predicate = next->isa_If();
+    post_entry = predicate != nullptr ? predicate->true_proj_or_null() : nullptr;
+  }
+  return nullptr;
+}
+
+// Find the scalar post-loop end from the main loop. Returns nullptr if none.
+CountedLoopEndNode* CountedLoopNode::find_post_loop_end() {
+  assert(is_main_loop(), "Can only find post-loop from main-loop");
+  CountedLoopNode* post_loop = find_immediate_post_loop(this);
+  if (post_loop != nullptr && post_loop->is_vectorized_loop()) {
+    post_loop = find_immediate_post_loop(post_loop);
+  }
+  return post_loop != nullptr ? post_loop->loopexit_or_null() : nullptr;
+}
+
 Node* CountedLoopNode::uncasted_init_trip(bool uncast) {
   Node* init = init_trip();
   if (uncast && init->is_CastII()) {

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -87,7 +87,8 @@ protected:
          MultiversionSlowLoop         = 2<<17, // 1<<18
          MultiversionDelayedSlowLoop  = 3<<17,
          MultiversionFlagsMask        = 3<<17,
-         FlatArrays            = 1<<19};
+         FlatArrays                    = 1<<19,
+         RedundantOuterStripMinedLoop  = 1<<20};
   char _unswitch_count;
   enum { _unswitch_max=3 };
 
@@ -373,6 +374,7 @@ public:
 
   Node* is_canonical_loop_entry();
   CountedLoopEndNode* find_pre_loop_end();
+  CountedLoopEndNode* find_post_loop_end();
 
   Node* uncasted_init_trip(bool uncasted);
 
@@ -618,6 +620,10 @@ public:
 
   Node* register_control(Node* node, Node* loop, Node* idom, PhaseIterGVN* igvn,
                          PhaseIdealLoop* iloop);
+
+  bool is_redundant() const { return (_loop_flags & RedundantOuterStripMinedLoop) != 0; }
+  void mark_redundant() { _loop_flags |= RedundantOuterStripMinedLoop; }
+  void clear_redundant() { _loop_flags &= ~RedundantOuterStripMinedLoop; }
 };
 
 class OuterStripMinedLoopEndNode : public IfNode {
@@ -1538,8 +1544,7 @@ public:
 
   // Add pre and post loops around the given loop.  These loops are used
   // during RCE, unrolling and aligning loops.
-  void insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_new, bool peel_only,
-                             bool keep_side_loop_safepoints);
+  void insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_new, bool peel_only);
 
   // Find the last store in the body of an OuterStripMinedLoop when following memory uses
   Node *find_last_store_in_outer_loop(Node* store, const IdealLoopTree* outer_loop);
@@ -1547,8 +1552,7 @@ public:
   // Add post loop after the given loop.
   Node *insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
                          CountedLoopNode* main_head, CountedLoopEndNode* main_end,
-                         Node* incr, Node* limit, CountedLoopNode*& post_head,
-                         bool keep_side_loop_safepoints);
+                         Node* incr, Node* limit, CountedLoopNode*& post_head);
 
   // Add a vector post loop between a vector main loop and the current post loop
   void insert_vector_post_loop(IdealLoopTree *loop, Node_List &old_new);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -632,6 +632,7 @@ public:
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
 
+  CountedLoopEndNode* inner_counted_loop_end() const;
   bool is_expanded(PhaseGVN *phase) const;
 };
 
@@ -1537,7 +1538,8 @@ public:
 
   // Add pre and post loops around the given loop.  These loops are used
   // during RCE, unrolling and aligning loops.
-  void insert_pre_post_loops( IdealLoopTree *loop, Node_List &old_new, bool peel_only );
+  void insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_new, bool peel_only,
+                             bool keep_side_loop_safepoints);
 
   // Find the last store in the body of an OuterStripMinedLoop when following memory uses
   Node *find_last_store_in_outer_loop(Node* store, const IdealLoopTree* outer_loop);
@@ -1545,7 +1547,8 @@ public:
   // Add post loop after the given loop.
   Node *insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
                          CountedLoopNode* main_head, CountedLoopEndNode* main_end,
-                         Node* incr, Node* limit, CountedLoopNode*& post_head);
+                         Node* incr, Node* limit, CountedLoopNode*& post_head,
+                         bool keep_side_loop_safepoints);
 
   // Add a vector post loop between a vector main loop and the current post loop
   void insert_vector_post_loop(IdealLoopTree *loop, Node_List &old_new);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -87,8 +87,7 @@ protected:
          MultiversionSlowLoop         = 2<<17, // 1<<18
          MultiversionDelayedSlowLoop  = 3<<17,
          MultiversionFlagsMask        = 3<<17,
-         FlatArrays                    = 1<<19,
-         RedundantOuterStripMinedLoop  = 1<<20};
+         FlatArrays            = 1<<19};
   char _unswitch_count;
   enum { _unswitch_max=3 };
 
@@ -620,10 +619,6 @@ public:
 
   Node* register_control(Node* node, Node* loop, Node* idom, PhaseIterGVN* igvn,
                          PhaseIdealLoop* iloop);
-
-  bool is_redundant() const { return (_loop_flags & RedundantOuterStripMinedLoop) != 0; }
-  void mark_redundant() { _loop_flags |= RedundantOuterStripMinedLoop; }
-  void clear_redundant() { _loop_flags &= ~RedundantOuterStripMinedLoop; }
 };
 
 class OuterStripMinedLoopEndNode : public IfNode {
@@ -638,7 +633,6 @@ public:
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
 
-  CountedLoopEndNode* inner_counted_loop_end() const;
   bool is_expanded(PhaseGVN *phase) const;
 };
 
@@ -1544,7 +1538,7 @@ public:
 
   // Add pre and post loops around the given loop.  These loops are used
   // during RCE, unrolling and aligning loops.
-  void insert_pre_post_loops(IdealLoopTree* loop, Node_List& old_new, bool peel_only);
+  void insert_pre_post_loops( IdealLoopTree *loop, Node_List &old_new, bool peel_only );
 
   // Find the last store in the body of an OuterStripMinedLoop when following memory uses
   Node *find_last_store_in_outer_loop(Node* store, const IdealLoopTree* outer_loop);

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2136,7 +2136,11 @@ bool PhaseIdealLoop::ctrl_of_all_uses_out_of_loop(const Node* n, Node* n_ctrl, I
 bool PhaseIdealLoop::would_sink_below_pre_loop_exit(IdealLoopTree* n_loop, Node* ctrl) {
   if (n_loop->_head->is_CountedLoop() && n_loop->_head->as_CountedLoop()->is_pre_loop()) {
     CountedLoopNode* pre_loop = n_loop->_head->as_CountedLoop();
-    if (is_dominator(pre_loop->loopexit(), ctrl)) {
+    IfNode* pre_loop_end = pre_loop->loopexit();
+    if (pre_loop->is_strip_mined()) {
+      pre_loop_end = pre_loop->outer_loop_end();
+    }
+    if (is_dominator(pre_loop_end, ctrl)) {
       return true;
     }
   }

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2136,11 +2136,7 @@ bool PhaseIdealLoop::ctrl_of_all_uses_out_of_loop(const Node* n, Node* n_ctrl, I
 bool PhaseIdealLoop::would_sink_below_pre_loop_exit(IdealLoopTree* n_loop, Node* ctrl) {
   if (n_loop->_head->is_CountedLoop() && n_loop->_head->as_CountedLoop()->is_pre_loop()) {
     CountedLoopNode* pre_loop = n_loop->_head->as_CountedLoop();
-    IfNode* pre_loop_end = pre_loop->loopexit();
-    if (pre_loop->is_strip_mined()) {
-      pre_loop_end = pre_loop->outer_loop_end();
-    }
-    if (is_dominator(pre_loop_end, ctrl)) {
+    if (is_dominator(pre_loop->loopexit(), ctrl)) {
       return true;
     }
   }

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2784,7 +2784,7 @@ void VTransform::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   Node* old_limit = pre_opaq->in(1);
 
   // Where we put new limit calculations.
-  Node* pre_ctrl = _vloop.pre_loop_head()->in(LoopNode::EntryControl);
+  Node* pre_ctrl = _vloop.pre_loop_entry();
 
   // Ensure the original loop limit is available from the pre-loop Opaque1 node.
   Node* orig_limit = pre_opaq->original_loop_limit();

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2784,7 +2784,7 @@ void VTransform::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   Node* old_limit = pre_opaq->in(1);
 
   // Where we put new limit calculations.
-  Node* pre_ctrl = _vloop.pre_loop_entry();
+  Node* pre_ctrl = _vloop.pre_loop_head()->in(LoopNode::EntryControl);
 
   // Ensure the original loop limit is available from the pre-loop Opaque1 node.
   Node* orig_limit = pre_opaq->original_loop_limit();

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -113,7 +113,7 @@ VStatus VLoop::check_preconditions_helper() {
 
     // See if we find the infrastructure for speculative runtime-checks.
     //  (1) Auto Vectorization Parse Predicate
-    Node* pre_ctrl = pre_loop_head()->in(LoopNode::EntryControl);
+    Node* pre_ctrl = pre_loop_entry();
     const Predicates predicates(pre_ctrl);
     const PredicateBlock* predicate_block = predicates.auto_vectorization_check_block();
     if (predicate_block->has_parse_predicate()) {

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -113,7 +113,7 @@ VStatus VLoop::check_preconditions_helper() {
 
     // See if we find the infrastructure for speculative runtime-checks.
     //  (1) Auto Vectorization Parse Predicate
-    Node* pre_ctrl = pre_loop_entry();
+    Node* pre_ctrl = pre_loop_head()->in(LoopNode::EntryControl);
     const Predicates predicates(pre_ctrl);
     const PredicateBlock* predicate_block = predicates.auto_vectorization_check_block();
     if (predicate_block->has_parse_predicate()) {

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -149,10 +149,6 @@ public:
     return head;
   };
 
-  Node* pre_loop_entry() const {
-    return pre_loop_head()->skip_strip_mined()->in(LoopNode::EntryControl);
-  }
-
   ParsePredicateSuccessProj* auto_vectorization_parse_predicate_proj() const {
     return _auto_vectorization_parse_predicate_proj;
   }

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -149,6 +149,10 @@ public:
     return head;
   };
 
+  Node* pre_loop_entry() const {
+    return pre_loop_head()->skip_strip_mined()->in(LoopNode::EntryControl);
+  }
+
   ParsePredicateSuccessProj* auto_vectorization_parse_predicate_proj() const {
     return _auto_vectorization_parse_predicate_proj;
   }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestRCESideLoopSafepointNodes.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestRCESideLoopSafepointNodes.java
@@ -32,7 +32,7 @@ import compiler.lib.ir_framework.TestFramework;
 /*
  * @test
  * @bug 8381505
- * @summary Range check elimination must keep safepoints in pre- and post-loops
+ * @summary Keep only the pre- and post-loop safepoints required by range check elimination
  * @library /test/lib /
  * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestRCESideLoopSafepointNodes
@@ -69,8 +69,31 @@ public class TestRCESideLoopSafepointNodes {
         }
     }
 
+    @Test
+    @IR(counts = {IRNode.COUNTED_LOOP, "3"})
+    @IR(applyIf = {"LoopStripMiningIter", "1"},
+        counts = {IRNode.SAFEPOINT, "1"},
+        failOn = {IRNode.OUTER_STRIP_MINED_LOOP})
+    @IR(applyIf = {"LoopStripMiningIter", "> 1"},
+        counts = {IRNode.OUTER_STRIP_MINED_LOOP, "1",
+                  IRNode.SAFEPOINT, "1"})
+    private static void testRejectedRCE(int start, int limit, int bound) {
+        for (int i = start; i < limit; i++) {
+            Thread.onSpinWait();
+            java.lang.invoke.VarHandle.fullFence();
+            if (Integer.compareUnsigned(i * 2, bound) > 0) {
+                break;
+            }
+        }
+    }
+
     @Run(test = "test")
     private static void testRunner() {
         test(Integer.MIN_VALUE, Integer.MIN_VALUE + 10_000, Integer.MAX_VALUE);
+    }
+
+    @Run(test = "testRejectedRCE")
+    private static void testRejectedRCERunner() {
+        testRejectedRCE(0, 10_000, -1);
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestRCESideLoopSafepointNodes.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestRCESideLoopSafepointNodes.java
@@ -57,7 +57,7 @@ public class TestRCESideLoopSafepointNodes {
         counts = {IRNode.SAFEPOINT, "3"},
         failOn = {IRNode.OUTER_STRIP_MINED_LOOP})
     @IR(applyIf = {"LoopStripMiningIter", "> 1"},
-        counts = {IRNode.OUTER_STRIP_MINED_LOOP, "3",
+        counts = {IRNode.OUTER_STRIP_MINED_LOOP, "1",
                   IRNode.SAFEPOINT, "3"})
     private static void test(int start, int limit, int bound) {
         for (int i = start; i < limit; i++) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestRCESideLoopSafepointNodes.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestRCESideLoopSafepointNodes.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.IRNode;
+import compiler.lib.ir_framework.Run;
+import compiler.lib.ir_framework.Test;
+import compiler.lib.ir_framework.TestFramework;
+
+/*
+ * @test
+ * @bug 8381505
+ * @summary Range check elimination must keep safepoints in pre- and post-loops
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.irTests.TestRCESideLoopSafepointNodes
+ */
+
+public class TestRCESideLoopSafepointNodes {
+    public static void main(String[] args) {
+        runWithStripMiningIter(1);
+        runWithStripMiningIter(1000);
+    }
+
+    private static void runWithStripMiningIter(int iterations) {
+        TestFramework.runWithFlags("-XX:-TieredCompilation",
+                                   "-XX:+UseCountedLoopSafepoints",
+                                   "-XX:LoopStripMiningIter=" + iterations,
+                                   "-XX:LoopUnrollLimit=0");
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNTED_LOOP, "3"})
+    @IR(applyIf = {"LoopStripMiningIter", "1"},
+        counts = {IRNode.SAFEPOINT, "3"},
+        failOn = {IRNode.OUTER_STRIP_MINED_LOOP})
+    @IR(applyIf = {"LoopStripMiningIter", "> 1"},
+        counts = {IRNode.OUTER_STRIP_MINED_LOOP, "3",
+                  IRNode.SAFEPOINT, "3"})
+    private static void test(int start, int limit, int bound) {
+        for (int i = start; i < limit; i++) {
+            Thread.onSpinWait();
+            java.lang.invoke.VarHandle.fullFence();
+            if (i * 2 > bound) {
+                break;
+            }
+        }
+    }
+
+    @Run(test = "test")
+    private static void testRunner() {
+        test(Integer.MIN_VALUE, Integer.MIN_VALUE + 10_000, Integer.MAX_VALUE);
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestRCESideLoopSafepoints.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestRCESideLoopSafepoints.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8381505
+ * @summary Range check elimination must preserve safepoints in long-running pre- and post-loops
+ * @requires vm.compiler2.enabled
+ * @library /test/lib
+ * @run driver/timeout=240 compiler.loopstripmining.TestRCESideLoopSafepoints
+ */
+
+package compiler.loopstripmining;
+
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestRCESideLoopSafepoints {
+    public static void main(String[] args) throws Exception {
+        ProcessTools.executeTestJava(
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+SafepointTimeout",
+                "-XX:+SafepointALot",
+                "-XX:SafepointTimeoutDelay=" + Utils.adjustTimeout(100),
+                "-XX:GuaranteedSafepointInterval=" + Utils.adjustTimeout(10),
+                "-XX:-TieredCompilation",
+                "-XX:-UseOnStackReplacement",
+                "-XX:+UseCountedLoopSafepoints",
+                "-XX:LoopStripMiningIter=1000",
+                "-XX:LoopUnrollLimit=0",
+                "-XX:CompileCommand=compileonly," + TestCase.class.getName() + "::test",
+                "-Xcomp",
+                TestCase.class.getName())
+            .shouldHaveExitValue(0)
+            .shouldNotContain("Timed out while spinning to reach a safepoint");
+    }
+
+    public static class TestCase {
+        public static void main(String[] args) {
+            test(Integer.MIN_VALUE, Integer.MIN_VALUE + 10_000, Integer.MAX_VALUE);
+            test(Integer.MIN_VALUE, 0, Integer.MAX_VALUE);
+            test(0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        }
+
+        private static void test(int start, int limit, int bound) {
+            for (int i = start; i < limit; i++) {
+                Thread.onSpinWait();
+                java.lang.invoke.VarHandle.fullFence();
+                if (i * 2 > bound) {
+                    System.out.println(0);
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Preserve safepoints in pre- and post-loops when range check elimination can increase their trip counts. Teach loop consumers to handle strip-mined side loops, and add runtime and IR coverage.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381505](https://bugs.openjdk.org/browse/JDK-8381505): C2: Extended time-to-safepoint due to range check elimination (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32384/head:pull/32384` \
`$ git checkout pull/32384`

Update a local copy of the PR: \
`$ git checkout pull/32384` \
`$ git pull https://git.openjdk.org/jdk.git pull/32384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32384`

View PR using the GUI difftool: \
`$ git pr show -t 32384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32384.diff">https://git.openjdk.org/jdk/pull/32384.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32384#issuecomment-5307820201)
</details>
