### PR TITLE
8390442: Heap dump generated by SA cannot be parsed on MAT

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -220,6 +220,7 @@
   nonstatic_field(InstanceKlass,               _method_ordering,                              Array<int>*)                           \
   nonstatic_field(InstanceKlass,               _default_vtable_indices,                       Array<int>*)                           \
   nonstatic_field(InstanceKlass,               _access_flags,                                 AccessFlags)                           \
+  nonstatic_field(Klass,                       _kind,                                         const Klass::KlassKind)                \
   nonstatic_field(Klass,                       _super_check_offset,                           juint)                                 \
   nonstatic_field(Klass,                       _secondary_super_cache,                        Klass*)                                \
   nonstatic_field(Klass,                       _secondary_supers,                             Array<Klass*>*)                        \
@@ -1190,6 +1191,7 @@
    declare_integer_type(AOTCompressedPointers::narrowPtr)                 \
    declare_integer_type(Bytecodes::Code)                                  \
    declare_integer_type(InstanceKlass::ClassState)                        \
+   declare_integer_type(Klass::KlassKind)                                 \
    declare_integer_type(JavaThreadState)                                  \
    declare_integer_type(ThreadState)                                      \
    declare_integer_type(Location::Type)                                   \
@@ -1485,6 +1487,22 @@
   declare_constant(InstanceKlass::being_initialized)                      \
   declare_constant(InstanceKlass::fully_initialized)                      \
   declare_constant(InstanceKlass::initialization_error)                   \
+                                                                          \
+  /************************/                                              \
+  /* Klass KlassKind enum */                                              \
+  /************************/                                              \
+                                                                          \
+  declare_constant(Klass::KlassKind::InstanceKlassKind)                   \
+  declare_constant(Klass::KlassKind::InlineKlassKind)                     \
+  declare_constant(Klass::KlassKind::InstanceRefKlassKind)                \
+  declare_constant(Klass::KlassKind::InstanceMirrorKlassKind)             \
+  declare_constant(Klass::KlassKind::InstanceClassLoaderKlassKind)        \
+  declare_constant(Klass::KlassKind::InstanceStackChunkKlassKind)         \
+  declare_constant(Klass::KlassKind::TypeArrayKlassKind)                  \
+  declare_constant(Klass::KlassKind::ObjArrayKlassKind)                   \
+  declare_constant(Klass::KlassKind::RefArrayKlassKind)                   \
+  declare_constant(Klass::KlassKind::FlatArrayKlassKind)                  \
+  declare_constant(Klass::KlassKind::UnknownKlassKind)                    \
                                                                           \
   /*********************************/                                     \
   /* Symbol* - symbol max length */                                       \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Klass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Klass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,84 @@ import sun.jvm.hotspot.utilities.Observable;
 import sun.jvm.hotspot.utilities.Observer;
 
 public class Klass extends Metadata implements ClassConstants {
+
+  public static class KlassKind {
+
+    public static KlassKind InstanceKlassKind;
+    public static KlassKind InlineKlassKind;
+    public static KlassKind InstanceRefKlassKind;
+    public static KlassKind InstanceMirrorKlassKind;
+    public static KlassKind InstanceClassLoaderKlassKind;
+    public static KlassKind InstanceStackChunkKlassKind;
+    public static KlassKind TypeArrayKlassKind;
+    public static KlassKind ObjArrayKlassKind;
+    public static KlassKind RefArrayKlassKind;
+    public static KlassKind FlatArrayKlassKind;
+    public static KlassKind UnknownKlassKind;
+
+    private final int value;
+
+    static {
+      VM.registerVMInitializedObserver((_, _) -> initialize(VM.getVM().getTypeDataBase()));
+    }
+
+    private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
+      Type type = db.lookupType("Klass::KlassKind");
+
+      InstanceKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::InstanceKlassKind").intValue());
+      InlineKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::InlineKlassKind").intValue());
+      InstanceRefKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::InstanceRefKlassKind").intValue());
+      InstanceMirrorKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::InstanceMirrorKlassKind").intValue());
+      InstanceClassLoaderKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::InstanceClassLoaderKlassKind").intValue());
+      InstanceStackChunkKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::InstanceStackChunkKlassKind").intValue());
+      TypeArrayKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::TypeArrayKlassKind").intValue());
+      ObjArrayKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::ObjArrayKlassKind").intValue());
+      RefArrayKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::RefArrayKlassKind").intValue());
+      FlatArrayKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::FlatArrayKlassKind").intValue());
+      UnknownKlassKind = new KlassKind(db.lookupIntConstant("Klass::KlassKind::UnknownKlassKind").intValue());
+    }
+
+    private KlassKind(int value) {
+      this.value = value;
+    }
+
+    public static KlassKind valueOf(int rawValue) {
+      if (rawValue == InstanceKlassKind.value) {
+        return InstanceKlassKind;
+      } else if (rawValue == InlineKlassKind.value) {
+        return InlineKlassKind;
+      } else if (rawValue == InstanceRefKlassKind.value) {
+        return InstanceRefKlassKind;
+      } else if (rawValue == InstanceMirrorKlassKind.value) {
+        return InstanceMirrorKlassKind;
+      } else if (rawValue == InstanceClassLoaderKlassKind.value) {
+        return InstanceClassLoaderKlassKind;
+      } else if (rawValue == InstanceStackChunkKlassKind.value) {
+        return InstanceStackChunkKlassKind;
+      } else if (rawValue == TypeArrayKlassKind.value) {
+        return TypeArrayKlassKind;
+      } else if (rawValue == ObjArrayKlassKind.value) {
+        return ObjArrayKlassKind;
+      } else if (rawValue == RefArrayKlassKind.value) {
+        return RefArrayKlassKind;
+      } else if (rawValue == FlatArrayKlassKind.value) {
+        return FlatArrayKlassKind;
+      } else if (rawValue == UnknownKlassKind.value) {
+        return UnknownKlassKind;
+      } else {
+        throw new IllegalArgumentException("Out of range");
+      }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if ((obj != null) && (obj instanceof KlassKind k)) {
+          return k.value == this.value;
+      }
+      return false;
+    }
+  }
+
   static {
     VM.registerVMInitializedObserver(new Observer() {
         public void update(Observable o, Object data) {
@@ -54,6 +132,7 @@ public class Klass extends Metadata implements ClassConstants {
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type    = db.lookupType("Klass");
     javaMirrorFieldOffset = type.getField("_java_mirror").getOffset();
+    kindField    = new CIntField(type.getCIntegerField("_kind"), 0);
     superField   = new MetadataField(type.getAddressField("_super"), 0);
     layoutHelper = new IntField(type.getJIntField("_layout_helper"), 0);
     name         = type.getAddressField("_name");
@@ -90,6 +169,7 @@ public class Klass extends Metadata implements ClassConstants {
 
   // Fields
   private static long javaMirrorFieldOffset;
+  private static CIntField kindField;
   private static MetadataField  superField;
   private static IntField layoutHelper;
   private static AddressField  name;
@@ -110,6 +190,7 @@ public class Klass extends Metadata implements ClassConstants {
     VMOopHandle vmOopHandle = VMObjectFactory.newObject(VMOopHandle.class, addr);
     return vmOopHandle.resolve();
   }
+  public KlassKind getKind()            { return KlassKind.valueOf((int)kindField.getValue(this)); }
   public Klass    getSuper()            { return (Klass)    superField.getValue(this);   }
   public Klass    getJavaSuper()        { return null;  }
   public int      getLayoutHelper()     { return            layoutHelper.getValue(this); }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -706,11 +706,19 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
         return (int) length;
     }
 
+    private boolean filterOutKlass(Klass k) {
+        return (k instanceof ObjArrayKlass) &&
+               !k.getKind().equals(Klass.KlassKind.ObjArrayKlassKind);
+    }
+
     private void writeClassDumpRecords() throws IOException {
         ClassLoaderDataGraph cldGraph = VM.getVM().getClassLoaderDataGraph();
         try {
              cldGraph.classesDo(new ClassLoaderDataGraph.ClassVisitor() {
                             public void visit(Klass k) {
+                                if (filterOutKlass(k)) {
+                                    return;
+                                }
                                 try {
                                     writeHeapRecordPrologue(calculateClassDumpRecordSize(k));
                                     writeClassDumpRecord(k);
@@ -1285,6 +1293,9 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
         try {
             cldGraph.classesDo(new ClassLoaderDataGraph.ClassVisitor() {
                 public void visit(Klass k) {
+                    if (filterOutKlass(k)) {
+                        return;
+                    }
                     try {
                         Instance clazz = k.getJavaMirror();
                         writeHeader(HPROF_LOAD_CLASS, 2 * (OBJ_ID_SIZE + 4));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -706,6 +706,9 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
         return (int) length;
     }
 
+    // Direct instances of ObjArrayKlass represent the Java types that Java code can see.
+    // RefArrayKlass/FlatArrayKlass describe different implementations of the arrays,
+    // filter them out to avoid duplicates.
     private boolean filterOutKlass(Klass k) {
         return (k instanceof ObjArrayKlass) &&
                !k.getKind().equals(Klass.KlassKind.ObjArrayKlassKind);

--- a/test/lib/jdk/test/lib/hprof/model/Snapshot.java
+++ b/test/lib/jdk/test/lib/hprof/model/Snapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -593,13 +593,17 @@ public class Snapshot implements AutoCloseable {
 
     private void putInClassesMap(JavaClass c) {
         String name = c.getName();
-        if (classes.containsKey(name)) {
+        JavaClass originClass = classes.get(name);
+        if (originClass != null) {
+            if (originClass.getId() == c.getId()) {
+                throw new IllegalStateException(String.format("%s (id=0x%x) already exists", c.getName(), c.getId()));
+            }
             // more than one class can have the same name
             // if so, create a unique name by appending
             // - and id string to it.
             name += "-" + c.getIdString();
         }
-        classes.put(c.getName(), c);
+        classes.put(name, c);
     }
 
     private void addFakeClass(JavaClass c) {


### PR DESCRIPTION
I tried to parse the heap dump generated by `jhsdb jmap`, but it couldn't with following error on MAT. This exception happens since JDK 28. It does not happen on JDK 27 EA and 26 at least.

```
java.lang.NullPointerException
        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:483)
        at java.base/java.util.concurrent.ForkJoinTask.getException(ForkJoinTask.java:564)
        at java.base/java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:580)
        at java.base/java.util.concurrent.ForkJoinTask.get(ForkJoinTask.java:1022)
        at org.eclipse.mat.parser.internal.GarbageCleaner.createHistogramOfUnreachableObjects(GarbageCleaner.java:592)
        at org.eclipse.mat.parser.internal.GarbageCleaner.clean(GarbageCleaner.java:170)
        at org.eclipse.mat.parser.internal.SnapshotFactoryImpl.parse(SnapshotFactoryImpl.java:505)
        at org.eclipse.mat.parser.internal.SnapshotFactoryImpl.openSnapshot(SnapshotFactoryImpl.java:244)
        at org.eclipse.mat.snapshot.SnapshotFactory.openSnapshot(SnapshotFactory.java:149)
        at org.eclipse.mat.ui.snapshot.ParseHeapDumpJob.run(ParseHeapDumpJob.java:99)
        at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
Caused by: java.lang.NullPointerException: Cannot invoke "org.eclipse.mat.parser.model.ClassImpl.getName()" because "r.clazz" is null
        at org.eclipse.mat.parser.internal.GarbageCleaner$CreateHistogramOfUnreachableObjectsChunk.call(GarbageCleaner.java:683)
        at org.eclipse.mat.parser.internal.GarbageCleaner$CreateHistogramOfUnreachableObjectsChunk.call(GarbageCleaner.java:1)
        at java.base/java.util.concurrent.ForkJoinTask$AdaptedInterruptibleCallable.compute(ForkJoinTask.java:1718)
        at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(ForkJoinTask.java:1662)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
```

[JDK-8389219](https://bugs.openjdk.org/browse/JDK-8389219) introduced following code in heapDumper.cpp in HotSpot. The error has been gone when I imported it into SA.

```cpp
  // Direct instances of ObjArrayKlass represent the Java types that Java code can see.
  // RefArrayKlass/FlatArrayKlass describe different implementations of the arrays, filter them out to avoid duplicates.
  static bool filter_out_klass(Klass* k) {
    if (k->is_objArray_klass() && k->kind() != Klass::KlassKind::ObjArrayKlassKind) {
      return true;
    }
    return false;
  }
```

This PR introduces that code in SA, and tests class ID duplication.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390442](https://bugs.openjdk.org/browse/JDK-8390442): Heap dump generated by SA cannot be parsed on MAT (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32386/head:pull/32386` \
`$ git checkout pull/32386`

Update a local copy of the PR: \
`$ git checkout pull/32386` \
`$ git pull https://git.openjdk.org/jdk.git pull/32386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32386`

View PR using the GUI difftool: \
`$ git pr show -t 32386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32386.diff">https://git.openjdk.org/jdk/pull/32386.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32386#issuecomment-5307958054)
</details>
