### PR TITLE
8390441: RISC-V: Fix C2 stack-to-stack spill copies with large offsets

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -178,9 +178,10 @@
 
   void spill_copy_vector_stack_to_stack(int src_offset, int dst_offset, uint vector_length_in_bytes) {
     assert(vector_length_in_bytes % 16 == 0, "unexpected vector reg size");
+    // spill() may use t0 to materialize a large stack offset.
     for (int i = 0; i < (int)vector_length_in_bytes / 8; i++) {
-      unspill(t0, true, src_offset + (i * 8));
-      spill(t0, true, dst_offset + (i * 8));
+      unspill(ra, true, src_offset + (i * 8));
+      spill(ra, true, dst_offset + (i * 8));
     }
   }
 
@@ -284,9 +285,10 @@
 
   void spill_copy_vmask_stack_to_stack(int src_offset, int dst_offset, uint vector_length_in_bytes) {
     assert(vector_length_in_bytes % 4 == 0, "unexpected vector mask reg size");
+    // spill() may use t0 to materialize a large stack offset.
     for (int i = 0; i < (int)vector_length_in_bytes / 4; i++) {
-      unspill(t0, false, src_offset + (i * 4));
-      spill(t0, false, dst_offset + (i * 4));
+      unspill(ra, false, src_offset + (i * 4));
+      spill(ra, false, dst_offset + (i * 4));
     }
   }
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -178,10 +178,9 @@
 
   void spill_copy_vector_stack_to_stack(int src_offset, int dst_offset, uint vector_length_in_bytes) {
     assert(vector_length_in_bytes % 16 == 0, "unexpected vector reg size");
-    // spill() may use t0 to materialize a large stack offset.
     for (int i = 0; i < (int)vector_length_in_bytes / 8; i++) {
-      unspill(ra, true, src_offset + (i * 8));
-      spill(ra, true, dst_offset + (i * 8));
+      unspill(t0, true, src_offset + (i * 8));
+      spill(t0, true, dst_offset + (i * 8));
     }
   }
 
@@ -285,10 +284,9 @@
 
   void spill_copy_vmask_stack_to_stack(int src_offset, int dst_offset, uint vector_length_in_bytes) {
     assert(vector_length_in_bytes % 4 == 0, "unexpected vector mask reg size");
-    // spill() may use t0 to materialize a large stack offset.
     for (int i = 0; i < (int)vector_length_in_bytes / 4; i++) {
-      unspill(ra, false, src_offset + (i * 4));
-      spill(ra, false, dst_offset + (i * 4));
+      unspill(t0, false, src_offset + (i * 4));
+      spill(t0, false, dst_offset + (i * 4));
     }
   }
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1651,12 +1651,13 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
                      is64, src_offset);
         } else {                    // stack --> stack copy
           assert(dst_lo_rc == rc_stack, "spill to bad register class");
+          // spill() may use t0 to materialize a large stack offset.
           if (this->ideal_reg() == Op_RegI) {
-            __ unspill(t0, is64, src_offset);
+            __ unspill(ra, is64, src_offset);
           } else { // zero extended for narrow oop or klass
-            __ unspillu(t0, is64, src_offset);
+            __ unspillu(ra, is64, src_offset);
           }
-          __ spill(t0, is64, dst_offset);
+          __ spill(ra, is64, dst_offset);
         }
         break;
       default:

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1553,6 +1553,27 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
   int src_offset = ra_->reg2offset(src_lo);
   int dst_offset = ra_->reg2offset(dst_lo);
 
+  // Stack-to-stack copies use t0 for the value. Bail out if a destination
+  // address also needs t0 to materialize an offset outside the 12-bit range.
+  if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
+    int last_dst_offset = dst_offset;
+    if (bottom_type()->isa_pvectmask()) {
+      int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
+      last_dst_offset += vmask_size_in_bytes - 4;
+    } else if (ideal_reg() == Op_VecA) {
+      int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
+      last_dst_offset += vector_reg_size_in_bytes - 8;
+    }
+
+    if (masm != nullptr && !Assembler::is_simm12(last_dst_offset)) {
+      // size() emits into a scratch buffer where recording a failure is not allowed.
+      if (!C->output()->in_scratch_emit_size()) {
+        C->record_method_not_compilable("unsupported large stack-to-stack spill copy");
+      }
+      return 0;
+    }
+  }
+
   if (bottom_type()->isa_vect() != nullptr) {
     uint ireg = ideal_reg();
     if (ireg == Op_VecA && masm) {
@@ -1651,13 +1672,12 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
                      is64, src_offset);
         } else {                    // stack --> stack copy
           assert(dst_lo_rc == rc_stack, "spill to bad register class");
-          // spill() may use t0 to materialize a large stack offset.
           if (this->ideal_reg() == Op_RegI) {
-            __ unspill(ra, is64, src_offset);
+            __ unspill(t0, is64, src_offset);
           } else { // zero extended for narrow oop or klass
-            __ unspillu(ra, is64, src_offset);
+            __ unspillu(t0, is64, src_offset);
           }
-          __ spill(ra, is64, dst_offset);
+          __ spill(t0, is64, dst_offset);
         }
         break;
       default:


### PR DESCRIPTION
Hi, while running HotSpot tier1 on SpacemiT Key Stone K3, TestAlignVectorFuzzer crashed with a SIGSEGV in the C2-compiled testDUBCFH method.
C2 stack-to-stack spill copies used `t0` to hold the copied value. For large stack offsets, `spill()` also uses `t0` to materialize the destination address, clobbering the value and potentially causing a crash.

We ran thousands of tier1 test cases and only encountered this one test with this issue, so I believe this is a rare case. It would be somewhat wasteful to reserve a dedicated register in C2 just to handle this scenario. I think the simplest approach is to simply disable C2 compilation for such methods.

This change detects unsupported large stack-to-stack copies, including scalar, RVV vector, and vector mask copies, and marks the method as not compilable by C2. Scratch-buffer size calculation is excluded from recording the compilation failure.


### Testing
- [x] Run tier1-tier3 test with release on SpacemiT Key Stone K3
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390441](https://bugs.openjdk.org/browse/JDK-8390441): RISC-V: Fix C2 stack-to-stack spill copies with large offsets (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32387/head:pull/32387` \
`$ git checkout pull/32387`

Update a local copy of the PR: \
`$ git checkout pull/32387` \
`$ git pull https://git.openjdk.org/jdk.git pull/32387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32387`

View PR using the GUI difftool: \
`$ git pr show -t 32387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32387.diff">https://git.openjdk.org/jdk/pull/32387.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32387#issuecomment-5312225861)
</details>
