### PR TITLE
8390357: AOTMapTest.java fails --vmoptions:--enable-preview

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTMapTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTMapTest.java
@@ -66,13 +66,12 @@
  *                 AOTMapTestValhallaHelper$Wrapper
  *                 AOTMapTestValhallaHelper$WrapperWrapper
  *                 AOTMapTestValhallaHelper$ArchivedData
- * @run main/othervm/timeout=240 AOTMapTest AOT --two-step-training
+ * @run main/othervm/timeout=240 AOTMapTest AOT --two-step-training Valhalla
  */
 
 import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
-import jdk.internal.misc.PreviewFeatures;
 import java.util.ArrayList;
 import jdk.test.lib.cds.CDSAppTester;
 import jdk.test.lib.helpers.ClassFileInstaller;
@@ -82,12 +81,9 @@ public class AOTMapTest {
     static final String appJar = ClassFileInstaller.getJarPath("app.jar");
     static final String mainClass = "AOTMapTestApp";
     static final String classLoadLogFile = "production.class.load.log";
-
+    static boolean testValhalla;
     public static void main(String[] args) throws Exception {
-        doTest(args);
-    }
-
-    public static void doTest(String[] args) throws Exception {
+        testValhalla = args.length >= 3 && args[2].equals("Valhalla");
         Tester tester = new Tester();
         tester.run(args);
 
@@ -137,7 +133,7 @@ public class AOTMapTest {
             vmArgs.add("--add-exports");
             vmArgs.add("java.base/jdk.internal.misc=ALL-UNNAMED");
 
-            if (PreviewFeatures.isEnabled()) {
+            if (testValhalla) {
                 vmArgs.add("--enable-preview");
                 vmArgs.add("--add-exports");
                 vmArgs.add("java.base/jdk.internal.value=ALL-UNNAMED");
@@ -165,6 +161,7 @@ public class AOTMapTest {
         public String[] appCommandLine(RunMode runMode) {
             return new String[] {
                 mainClass,
+                testValhalla ? "Valhalla" : "none"
             };
         }
     }
@@ -176,9 +173,10 @@ class AOTMapTestApp {
         System.out.println("Hello AOTMapTestApp");
         testCustomLoader();
 
-        if (PreviewFeatures.isEnabled()) {
+        if (args[0].equals("Valhalla")) {
             Class<?> c = Class.forName("AOTMapTestValhallaHelper");
-            c.newInstance();
+            Object o = c.newInstance();
+            System.out.println(o);
         }
     }
 


### PR DESCRIPTION
This test has 3 `@test` blocks. The `AOTMapTestValhallaHelper` class is built in only one of them.

The bug was using `PreviewFeatures.isEnabled()` to check if the class exists. This is unreliable, as the returned value can be influenced by passing `--vmoptions:--enable-preview` to jtreg.

The fix is to pass the condition explicitly as an argument to `AOTMapTest.main()` with the `@run` tag.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390357](https://bugs.openjdk.org/browse/JDK-8390357): AOTMapTest.java fails --vmoptions:--enable-preview (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32389/head:pull/32389` \
`$ git checkout pull/32389`

Update a local copy of the PR: \
`$ git checkout pull/32389` \
`$ git pull https://git.openjdk.org/jdk.git pull/32389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32389`

View PR using the GUI difftool: \
`$ git pr show -t 32389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32389.diff">https://git.openjdk.org/jdk/pull/32389.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32389#issuecomment-5311522895)
</details>
