### PR TITLE
8388873: C2: AddHF is wrongly reassociated using AddNode::Ideal

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -747,6 +747,12 @@ const Type* AddHFNode::add_ring(const Type* t0, const Type* t1) const {
   return TypeH::make(t0->getf() + t1->getf());
 }
 
+//------------------------------Ideal------------------------------------------
+Node* AddHFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  // Floating point additions are not associative because of boundary conditions (infinity)
+  return commute(phase, this) ? this : nullptr;
+}
+
 //=============================================================================
 //------------------------------add_of_identity--------------------------------
 // Check for addition of the identity

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -749,7 +749,7 @@ const Type* AddHFNode::add_ring(const Type* t0, const Type* t1) const {
 
 //------------------------------Ideal------------------------------------------
 Node* AddHFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  // Floating point additions are not associative because of boundary conditions (infinity)
+  // Float16 addition is commutative but not associative.
   return commute(phase, this) ? this : nullptr;
 }
 

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -698,6 +698,13 @@ const Type *AddLNode::add_ring( const Type *t0, const Type *t1 ) const {
 
 
 //=============================================================================
+//------------------------------Ideal------------------------------------------
+Node* AddFPNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  // Floating-point addition is commutative but not associative.
+  return commute(phase, this) ? this : nullptr;
+}
+
+//=============================================================================
 //------------------------------add_of_identity--------------------------------
 // Check for addition of the identity
 const Type *AddFNode::add_of_identity( const Type *t1, const Type *t2 ) const {
@@ -724,12 +731,6 @@ const Type *AddFNode::add_ring( const Type *t0, const Type *t1 ) const {
   return TypeF::make( t0->getf() + t1->getf() );
 }
 
-//------------------------------Ideal------------------------------------------
-Node *AddFNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  // Floating point additions are not associative because of boundary conditions (infinity)
-  return commute(phase, this) ? this : nullptr;
-}
-
 //=============================================================================
 //------------------------------add_of_identity--------------------------------
 // Check for addition of the identity
@@ -745,12 +746,6 @@ const Type* AddHFNode::add_ring(const Type* t0, const Type* t1) const {
     return bottom_type();
   }
   return TypeH::make(t0->getf() + t1->getf());
-}
-
-//------------------------------Ideal------------------------------------------
-Node* AddHFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  // Float16 addition is commutative but not associative.
-  return commute(phase, this) ? this : nullptr;
 }
 
 //=============================================================================
@@ -777,12 +772,6 @@ const Type *AddDNode::add_ring( const Type *t0, const Type *t1 ) const {
     return bottom_type();
   }
   return TypeD::make( t0->getd() + t1->getd() );
-}
-
-//------------------------------Ideal------------------------------------------
-Node *AddDNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  // Floating point additions are not associative because of boundary conditions (infinity)
-  return commute(phase, this) ? this : nullptr;
 }
 
 

--- a/src/hotspot/share/opto/addnode.hpp
+++ b/src/hotspot/share/opto/addnode.hpp
@@ -166,54 +166,58 @@ public:
   virtual uint ideal_reg() const { return Op_RegL; }
 };
 
+//------------------------------AddFPNode--------------------------------------
+// Add 2 floats, doubles, or half-precision floats
+class AddFPNode : public AddNode {
+protected:
+  AddFPNode(Node* in1, Node* in2) : AddNode(in1, in2) {}
+public:
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
+  virtual Node* Identity(PhaseGVN* phase) { return this; }
+};
+
 //------------------------------AddFNode---------------------------------------
 // Add 2 floats
-class AddFNode : public AddNode {
+class AddFNode : public AddFPNode {
 public:
-  AddFNode( Node *in1, Node *in2 ) : AddNode(in1,in2) {}
+  AddFNode( Node *in1, Node *in2 ) : AddFPNode(in1,in2) {}
   virtual int Opcode() const;
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type *add_of_identity( const Type *t1, const Type *t2 ) const;
   virtual const Type *add_ring( const Type *, const Type * ) const;
   virtual const Type *add_id() const { return TypeF::ZERO; }
   virtual const Type *bottom_type() const { return Type::FLOAT; }
   int max_opcode() const { return Op_MaxF; }
   int min_opcode() const { return Op_MinF; }
-  virtual Node* Identity(PhaseGVN* phase) { return this; }
   virtual uint ideal_reg() const { return Op_RegF; }
 };
 
 //------------------------------AddDNode---------------------------------------
 // Add 2 doubles
-class AddDNode : public AddNode {
+class AddDNode : public AddFPNode {
 public:
-  AddDNode( Node *in1, Node *in2 ) : AddNode(in1,in2) {}
+  AddDNode( Node *in1, Node *in2 ) : AddFPNode(in1,in2) {}
   virtual int Opcode() const;
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type *add_of_identity( const Type *t1, const Type *t2 ) const;
   virtual const Type *add_ring( const Type *, const Type * ) const;
   virtual const Type *add_id() const { return TypeD::ZERO; }
   virtual const Type *bottom_type() const { return Type::DOUBLE; }
   int max_opcode() const { return Op_MaxD; }
   int min_opcode() const { return Op_MinD; }
-  virtual Node* Identity(PhaseGVN* phase) { return this; }
   virtual uint ideal_reg() const { return Op_RegD; }
 };
 
 //------------------------------AddHFNode---------------------------------------
 // Add 2 half-precision floats
-class AddHFNode : public AddNode {
+class AddHFNode : public AddFPNode {
 public:
-  AddHFNode(Node* in1, Node* in2) : AddNode(in1,in2) {}
+  AddHFNode(Node* in1, Node* in2) : AddFPNode(in1, in2) {}
   virtual int Opcode() const;
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual const Type* add_of_identity(const Type* t1, const Type* t2) const;
   virtual const Type* add_ring(const Type*, const Type*) const;
   virtual const Type* add_id() const { return TypeH::ZERO; }
   virtual const Type* bottom_type() const { return Type::HALF_FLOAT; }
   int max_opcode() const { return Op_MaxHF; }
   int min_opcode() const { return Op_MinHF; }
-  virtual Node* Identity(PhaseGVN* phase) { return this; }
   virtual uint ideal_reg() const { return Op_RegF; }
 };
 

--- a/src/hotspot/share/opto/addnode.hpp
+++ b/src/hotspot/share/opto/addnode.hpp
@@ -206,6 +206,7 @@ class AddHFNode : public AddNode {
 public:
   AddHFNode(Node* in1, Node* in2) : AddNode(in1,in2) {}
   virtual int Opcode() const;
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual const Type* add_of_identity(const Type* t1, const Type* t2) const;
   virtual const Type* add_ring(const Type*, const Type*) const;
   virtual const Type* add_id() const { return TypeH::ZERO; }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1423,7 +1423,7 @@ void PhaseIterGVN::verify_Ideal_for(Node* n, bool can_reshape, bool deep_revisit
     //   }
     //   break; // keep verifying
 
-    // AddFNode::Ideal calls "commute", which can reorder the inputs for this:
+    // AddFPNode::Ideal calls "commute", which can reorder the inputs for this:
     //   Check for tight loop increments: Loop-phi of Add of loop-phi
     // It wants to take the phi into in(1):
     //    471  Phi  === 435 38 390

--- a/test/hotspot/jtreg/compiler/c2/irTests/AddHFNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/AddHFNodeIdealizationTests.java
@@ -25,7 +25,7 @@ package compiler.c2.irTests;
 import compiler.lib.ir_framework.*;
 import compiler.lib.verify.Verify;
 import jdk.incubator.vector.Float16;
-import static jdk.incubator.vector.Float16.*;
+import static jdk.incubator.vector.Float16.valueOf;
 
 /*
  * @test
@@ -55,6 +55,13 @@ public class AddHFNodeIdealizationTests {
 
     public static void main(String[] args) {
         TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+
+    // Same semantics as Float16.add, but force-inlined so the ConvF2HF idealization
+    // can pattern-match ConvF2HF(AddF(ConvHF2F(x), ConvHF2F(y))) into AddHF.
+    @ForceInline
+    private static Float16 add(Float16 x, Float16 y) {
+        return valueOf(x.floatValue() + y.floatValue());
     }
 
     @DontCompile

--- a/test/hotspot/jtreg/compiler/c2/irTests/AddHFNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/AddHFNodeIdealizationTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.verify.Verify;
+import jdk.incubator.vector.Float16;
+import static jdk.incubator.vector.Float16.*;
+
+/*
+ * @test
+ * @bug 8388873
+ * @summary Test that AddHFNode is not reassociated.
+ * @modules jdk.incubator.vector
+ * @library /test/lib /
+ * @run driver ${test.main.class}
+ */
+public class AddHFNodeIdealizationTests {
+
+    private static final Float16 SMALL = valueOf(3.0e-4f);
+    private static final Float16 HALF  = valueOf(0.5f);
+    private static final Float16 ONE   = valueOf(1.0f);
+
+    private Float16 a1    = valueOf(1.0f);
+    private Float16 a1024 = valueOf(1024.0f);
+    private Float16 a2048 = valueOf(2048.0f);
+    private Float16 b     = valueOf(1.0f);
+    private Float16 bHalf = valueOf(0.5f);
+
+    private Float16 dst1;
+    private Float16 dst2;
+    private Float16 dst3;
+    private Float16 dst4;
+    private Float16 dst5;
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+
+    @DontCompile
+    private static Float16 addHF(Float16 x, Float16 y) {
+        // Single, rounded Float16 addition: (x + y).
+        return valueOf(x.floatValue() + y.floatValue());
+    }
+
+    @DontCompile
+    private static Float16 goldLeft(Float16 x, Float16 y, Float16 z) {
+        // ((x + y) + z)
+        return addHF(addHF(x, y), z);
+    }
+
+    @DontCompile
+    private static Float16 goldRight(Float16 x, Float16 y, Float16 z) {
+        // (x + (y + z))
+        return addHF(x, addHF(y, z));
+    }
+
+    @DontCompile
+    private static Float16 goldChain(Float16 x, Float16 c1, Float16 c2, Float16 c3) {
+        // (((x + c1) + c2) + c3)
+        return addHF(addHF(addHF(x, c1), c2), c3);
+    }
+
+    // Pattern 1: "(x + c1) + c2" -> "x + (c1 + c2)" (combine constants).
+
+    @Test
+    @IR(counts = {IRNode.ADD_HF, "2"},
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})
+    @IR(counts = {IRNode.ADD_HF, "2"},
+        applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
+    public void test1() {
+        dst1 = add(add(a1, SMALL), SMALL);
+    }
+
+    @Check(test = "test1")
+    public void check1() {
+        Verify.checkEQ(dst1, goldLeft(a1, SMALL, SMALL));
+    }
+
+    // Pattern 1 with a large operand, where the rounding difference is
+    // large and easy to observe: (1024 + 0.5) + 0.5.
+
+    @Test
+    @IR(counts = {IRNode.ADD_HF, "2"},
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})
+    @IR(counts = {IRNode.ADD_HF, "2"},
+        applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
+    public void test2() {
+        dst2 = add(add(a1024, HALF), HALF);
+    }
+
+    @Check(test = "test2")
+    public void check2() {
+        Verify.checkEQ(dst2, goldLeft(a1024, HALF, HALF));
+    }
+
+    // Pattern 1, longer chain: "((x + c1) + c2) + c3". Without the fix the
+    // three constants collapse into one, leaving a single AddHF; with the
+    // fix all three additions survive.
+
+    @Test
+    @IR(counts = {IRNode.ADD_HF, "3"},
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})
+    @IR(counts = {IRNode.ADD_HF, "3"},
+        applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
+    public void test3() {
+        dst3 = add(add(add(a2048, ONE), ONE), ONE);
+    }
+
+    @Check(test = "test3")
+    public void check3() {
+        Verify.checkEQ(dst3, goldChain(a2048, ONE, ONE, ONE));
+    }
+
+    // Pattern 2: "(x + c) + y" -> "(x + y) + c" (push constant down).
+    // The node count stays at two, so only the numeric result exposes the bug.
+
+    @Test
+    public void test4() {
+        dst4 = add(add(a1024, HALF), b);
+    }
+
+    @Check(test = "test4")
+    public void check4() {
+        Verify.checkEQ(dst4, goldLeft(a1024, HALF, b));
+    }
+
+    // Pattern 3: "x + (y + c)" -> "(x + y) + c" (push constant down).
+
+    @Test
+    public void test5() {
+        dst5 = add(a1024, add(bHalf, HALF));
+    }
+
+    @Check(test = "test5")
+    public void check5() {
+        Verify.checkEQ(dst5, goldRight(a1024, bHalf, HALF));
+    }
+}


### PR DESCRIPTION
Hi all,

Currently AddHFNode inherits its Ideal routine from the parent AddNode::Ideal, which performs transformations/re-associations that are unsafe for floating-point inputs (floating-point addition is commutative but not associative). This patch specializes the Ideal routine for AddHFNode, along the lines of AddFNode and AddDNode, to permit only commutation and prevent the unsafe re-associations.

Kindly review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388873](https://bugs.openjdk.org/browse/JDK-8388873): C2: AddHF is wrongly reassociated using AddNode::Ideal (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32390/head:pull/32390` \
`$ git checkout pull/32390`

Update a local copy of the PR: \
`$ git checkout pull/32390` \
`$ git pull https://git.openjdk.org/jdk.git pull/32390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32390`

View PR using the GUI difftool: \
`$ git pr show -t 32390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32390.diff">https://git.openjdk.org/jdk/pull/32390.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32390#issuecomment-5312381695)
</details>
