### PR TITLE
8389939: RISC-V: OrderAccess can be simplified by UseZtso

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
@@ -41,12 +41,25 @@ inline void OrderAccess::storeload()  { fence(); }
 #define READ_MEM_BARRIER  __atomic_thread_fence(__ATOMIC_ACQUIRE);
 #define WRITE_MEM_BARRIER __atomic_thread_fence(__ATOMIC_RELEASE);
 
+// A compiler barrier, forcing the C++ compiler to invalidate all memory assumptions
+static inline void compiler_barrier() {
+  __asm__ volatile ("" : : : "memory");
+}
+
 inline void OrderAccess::acquire() {
-  READ_MEM_BARRIER;
+  if (UseZtso) {
+    compiler_barrier();
+  } else {
+    READ_MEM_BARRIER;
+  }
 }
 
 inline void OrderAccess::release() {
-  WRITE_MEM_BARRIER;
+  if (UseZtso) {
+    compiler_barrier();
+  } else {
+    WRITE_MEM_BARRIER;
+  }
 }
 
 inline void OrderAccess::fence() {


### PR DESCRIPTION

When enable ztso extension, some barrier functions in orderAccess_linux_riscv.hpp can be simplified.
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389939](https://bugs.openjdk.org/browse/JDK-8389939): RISC-V: OrderAccess can be simplified by UseZtso (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32391/head:pull/32391` \
`$ git checkout pull/32391`

Update a local copy of the PR: \
`$ git checkout pull/32391` \
`$ git pull https://git.openjdk.org/jdk.git pull/32391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32391`

View PR using the GUI difftool: \
`$ git pr show -t 32391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32391.diff">https://git.openjdk.org/jdk/pull/32391.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32391#issuecomment-5313841442)
</details>
