### PR TITLE
8390452: RISC-V: gc/shenandoah/TestSieveObjects.java fails with "assert(UseZba) failed: must be"

### DIFF
--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -854,7 +854,7 @@ void ShenandoahBarrierStubC2::lrb(MacroAssembler& masm) {
     // Save the result where needed. Narrow entries return narrowOop (32 bits)
     // we need to zero the upper 32 bits of x10.
     if (_narrow) {
-      __ zext_w(_obj, x10);
+      __ zext(_obj, x10, 32);
     } else {
       __ mv(_obj, x10);
     }


### PR DESCRIPTION
Hi, please consider.
 
This PR fixes a crash on RISC-V CPUs without Zba when Shenandoah's C2 load-reference-barrier
slow path is taken.
 
`ShenandoahBarrierStubC2::lrb()` zero-extends the narrowOop returned by the LRB runtime call with
`MacroAssembler::zext_w()`, which is a Zba pseudo instruction that leaves the `UseZba` check to its
caller. Without Zba, a fastdebug build asserts while emitting the stub and a product build emits
`add.uw` unconditionally and crashes with SIGILL. This patch uses `MacroAssembler::zext()` instead,
which falls back to `slli + srli` when Zba is unavailable.
 
Testing: gc/shenandoah/TestSieveObjects.java on sg2042(fastdebug)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390452](https://bugs.openjdk.org/browse/JDK-8390452): RISC-V: gc/shenandoah/TestSieveObjects.java fails with "assert(UseZba) failed: must be" (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32392/head:pull/32392` \
`$ git checkout pull/32392`

Update a local copy of the PR: \
`$ git checkout pull/32392` \
`$ git pull https://git.openjdk.org/jdk.git pull/32392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32392`

View PR using the GUI difftool: \
`$ git pr show -t 32392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32392.diff">https://git.openjdk.org/jdk/pull/32392.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32392#issuecomment-5314077816)
</details>
