### PR TITLE
8390455: Fix more typos in java.desktop module

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
@@ -1359,7 +1359,7 @@ public class LWWindowPeer
             if (focusLog.isLoggable(PlatformLogger.Level.FINE)) {
                 focusLog.fine("ungrabbing on " + grabbingWindow);
             }
-            // ungrab a simple window if its owner looses activation.
+            // ungrab a simple window if its owner loses activation.
             grabbingWindow.ungrab();
         }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,8 +101,8 @@ struct _ImageSDOps
     CGDataProviderRef        dataProvider;
 
     // Pointer in memory that is used for create the CGBitmapContext and the CGDataProvider (used for imgRef). This is a native
-    // copy of the pixels for the Image. There is a spearate copy of the pixels that lives in Java heap. There are two main
-    // reasons why we keep those pixels spearate: 1) CG doesn't support all the Java pixel formats 2) The Garbage collector can
+    // copy of the pixels for the Image. There is a separate copy of the pixels that lives in Java heap. There are two main
+    // reasons why we keep those pixels separate: 1) CG doesn't support all the Java pixel formats 2) The Garbage collector can
     // move the java pixels at any time. There are possible workarounds for both problems. Number 2) seems to be a more serious issue, since
     // we can solve 1) by only supporting certain image types.
     void *                    nativePixels;

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1810,7 +1810,7 @@ public class PNGMetadata extends IIOMetadata implements Cloneable {
      * Latin-1 [ISO-8859-1] characters and spaces; that is, only
      * character codes 32-126 and 161-255 decimal are allowed.
      * For Latin-1 value fields the 0x10 (linefeed) control
-     * character is aloowed too.
+     * character is allowed too.
      *
      * See: http://www.w3.org/TR/PNG/#11keywords
      */

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFDecompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFDecompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,7 @@ public abstract class TIFFDecompressor {
     /**
      * The width of the source region that will actually be copied
      * into the destination image, taking into account all
-     * susbampling, offsetting, and clipping.
+     * subsampling, offsetting, and clipping.
      *
      * <p> The active source width will always be equal to
      * {@code (dstWidth - 1)*subsampleX + 1}.

--- a/src/java.desktop/share/classes/com/sun/media/sound/DLSModulator.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DLSModulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 package com.sun.media.sound;
 
 /**
- * This class is used to store modulator/artiuclation data.
+ * This class is used to store modulator/articulation data.
  * A modulator connects one synthesizer source to
  * a destination. For example a note on velocity
  * can be mapped to the gain of the synthesized voice.

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1221,7 +1221,7 @@ public final class SoftSynthesizer implements AudioSynthesizer,
                 // Always create external_channels array
                 // with 16 or more channels
                 // so getChannels works correctly
-                // when the synhtesizer is closed.
+                // when the synthesizer is closed.
                 if (channels.length < 16)
                     external_channels = new SoftChannelProxy[16];
                 else

--- a/src/java.desktop/share/classes/com/sun/media/sound/WaveFileReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/WaveFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public final class WaveFileReader extends SunFileReader {
     StandardFileFormat getAudioFileFormatImpl(final InputStream stream)
             throws UnsupportedAudioFileException, IOException {
 
-        // assumes sream is rewound
+        // assumes stream is rewound
 
         int nread = 0;
         int fmt;

--- a/src/java.desktop/share/classes/java/awt/Dialog.java
+++ b/src/java.desktop/share/classes/java/awt/Dialog.java
@@ -908,7 +908,7 @@ public class Dialog extends Window {
                 }
 
                 // This call is required as the show() method of the Dialog class
-                // does not invoke the super.show(). So wried... :(
+                // does not invoke the super.show(). So weird... :(
                 mixOnShowing();
 
                 peer.setVisible(true); // now guaranteed never to block

--- a/src/java.desktop/share/classes/javax/swing/AbstractButton.java
+++ b/src/java.desktop/share/classes/javax/swing/AbstractButton.java
@@ -417,7 +417,7 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
      * the label.
      *
      * @return an <code>Insets</code> object specifying the margin
-     *          between the botton's border and the label
+     *          between the button's border and the label
      * @see #setMargin
      */
     public Insets getMargin() {

--- a/src/java.desktop/share/classes/javax/swing/ProgressMonitor.java
+++ b/src/java.desktop/share/classes/javax/swing/ProgressMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -534,7 +534,7 @@ public class ProgressMonitor implements Accessible
          *       AccessibleJLabel
          *       AccessibleJProgressBar
          *
-         * The abstraction presented to assitive technologies by
+         * The abstraction presented to assistive technologies by
          * the AccessibleProgressMonitor is that a dialog contains a
          * progress monitor with three children: a message, a note
          * label and a progress bar.

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxUI.java
@@ -532,7 +532,7 @@ public class BasicComboBoxUI extends ComboBoxUI {
     }
 
     /**
-     * Creates the default renderer that will be used in a non-editiable combo
+     * Creates the default renderer that will be used in a non-editable combo
      * box. A default renderer will used only if a renderer has not been
      * explicitly set with <code>setRenderer</code>.
      *

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicListUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicListUI.java
@@ -747,7 +747,7 @@ public class BasicListUI extends ListUI
     /**
      * Unregisters keyboard actions installed from
      * <code>installKeyboardActions</code>.
-     * This method is called at uninstallUI() time - subclassess should
+     * This method is called at uninstallUI() time - subclasses should
      * ensure that all of the keyboard actions registered at installUI
      * time are removed here.
      *

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthComboBoxUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthComboBoxUI.java
@@ -105,7 +105,7 @@ public class SynthComboBoxUI extends BasicComboBoxUI implements
     private ButtonHandler buttonHandler;
 
     /**
-     * Handler for repainting combo when editor component gains/looses focus
+     * Handler for repainting combo when editor component gains/loses focus
      */
     private EditorFocusHandler editorFocusHandler;
 
@@ -766,7 +766,7 @@ public class SynthComboBoxUI extends BasicComboBoxUI implements
     }
 
     /**
-     * Handler for repainting combo when editor component gains/looses focus
+     * Handler for repainting combo when editor component gains/loses focus
      */
     private static class EditorFocusHandler implements FocusListener,
             PropertyChangeListener {

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3164,7 +3164,7 @@ public class StyleSheet extends StyleContext {
 
 
     /**
-     * SelectorMapping contains a specifitiy, as an integer, and an associated
+     * SelectorMapping contains a specificity, as an integer, and an associated
      * Style. It can also reference children <code>SelectorMapping</code>s,
      * so that it behaves like a tree.
      * <p>

--- a/src/java.desktop/share/classes/sun/awt/UngrabEvent.java
+++ b/src/java.desktop/share/classes/sun/awt/UngrabEvent.java
@@ -30,7 +30,7 @@ import java.awt.Component;
 
 /**
  * Sent when one of the following events occur on the grabbed window: <ul>
- * <li> it looses focus, but not to one of the owned windows
+ * <li> it loses focus, but not to one of the owned windows
  * <li> mouse click on the outside area happens (except for one of the owned windows)
  * <li> switch to another application or desktop happens
  * <li> click in the non-client area of the owning window or this window happens

--- a/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
@@ -68,7 +68,7 @@ import sun.java2d.DisposerRecord;
  * The FontDesignMetrics class expresses font metrics in terms of arbitrary
  * <i>typographic units</i> (not points) chosen by the font supplier
  * and used in the underlying platform font representations.  These units are
- * defined by dividing the em-square into a grid.  The em-sqaure is the
+ * defined by dividing the em-square into a grid.  The em-square is the
  * theoretical square whose dimensions are the full body height of the
  * font.  A typographic unit is the smallest measurable unit in the
  * em-square.  The number of units-per-em is determined by the font

--- a/src/java.desktop/share/classes/sun/font/FontManagerNativeLibrary.java
+++ b/src/java.desktop/share/classes/sun/font/FontManagerNativeLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class FontManagerNativeLibrary {
               top of freetype library (that is used in binary form).
 
               This wrapper is compiled into fontmanager and this make
-              fontmanger library depending on freetype library.
+              font manager library depending on freetype library.
 
               On Windows DLL's in the JRE's BIN directory cannot be
               found by windows DLL loading as that directory is not

--- a/src/java.desktop/share/classes/sun/font/SunFontManager.java
+++ b/src/java.desktop/share/classes/sun/font/SunFontManager.java
@@ -2617,7 +2617,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
          * - family name is not the same as the full name of an installed font
          * - full name is not the same as the family name of an installed font
          * The last two of these may initially look odd but the reason is
-         * that (unfortunately) Font constructors do not distinuguish these.
+         * that (unfortunately) Font constructors do not distinguish these.
          * An extreme example of such a problem would be a font which has
          * family name "Dialog.Plain" and full name of "Dialog".
          * The one arguably overly stringent restriction here is that if an

--- a/src/java.desktop/share/classes/sun/swing/plaf/DesktopProperty.java
+++ b/src/java.desktop/share/classes/sun/swing/plaf/DesktopProperty.java
@@ -75,7 +75,7 @@ public class DesktopProperty implements UIDefaults.ActiveValue {
 
 
     /**
-     * Cleans up any lingering state held by unrefeernced
+     * Cleans up any lingering state held by unreferenced
      * DesktopProperties.
      */
     public static void flushUnreferencedProperties() {

--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -519,7 +519,7 @@ static int GET_ARRAYS(JNIEnv *env, imageIODataPtr data, const JOCTET **next_byte
 /*
  * Set up error handling to use setjmp/longjmp.  This is the third such
  * setup, as both the AWT jpeg decoder and the com.sun... JPEG classes
- * setup thier own.  Ultimately these should be integrated, as they all
+ * setup their own.  Ultimately these should be integrated, as they all
  * do pretty much the same thing.
  */
 
@@ -2358,7 +2358,7 @@ imageio_term_destination (j_compress_ptr cinfo)
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(the_jvm, JNI_VERSION_1_2);
 
     /* find out how much needs to be written */
-    /* this conversion from size_t to jint is safe, because the lenght of the buffer is limited by jint */
+    /* this conversion from size_t to jint is safe, because the length of the buffer is limited by jint */
     jint datacount = (jint)(sb->bufferLength - dest->free_in_buffer);
 
     if (datacount != 0) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XAtom.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XAtom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,10 @@ package sun.awt.X11;
  * Standard X Atom are defined by X11 and these atoms are defined in this class
  * for convenience. Common X Atoms like {@code XA_WM_NAME} are used to communicate with the
  * Window manager to let it know the Window name. The use and protocol for these
- * atoms are defined in the Inter client communications converntions manual.
+ * atoms are defined in the Inter client communications conventions manual.
  * User specified XAtoms are defined by specifying a name that gets Interned
  * by the XServer and an {@code XAtom} object is returned. An {@code XAtom} can also be created
- * by using a pre-exisiting atom like {@code XA_WM_CLASS}. A {@code display} has to be specified
+ * by using a pre-existing atom like {@code XA_WM_CLASS}. A {@code display} has to be specified
  * in order to create an {@code XAtom}. <p> <p>
  *
  * Once an {@code XAtom} instance is created, you can call get and set property methods to


### PR DESCRIPTION
There are few typos in java.desktop module that are fixed

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390455](https://bugs.openjdk.org/browse/JDK-8390455): Fix more typos in java.desktop module (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32393/head:pull/32393` \
`$ git checkout pull/32393`

Update a local copy of the PR: \
`$ git checkout pull/32393` \
`$ git pull https://git.openjdk.org/jdk.git pull/32393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32393`

View PR using the GUI difftool: \
`$ git pr show -t 32393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32393.diff">https://git.openjdk.org/jdk/pull/32393.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32393#issuecomment-5314515178)
</details>
