### PR TITLE
8390202: Typos in the javadoc of various classes in jdk.sctp module

### DIFF
--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/MessageInfo.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/MessageInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,7 +142,7 @@ public abstract class MessageInfo {
      * otherwise the preferred destination of the message to be sent.
      *
      * @return  The socket address, or {@code null} if this instance is to be
-     *          used for sending a message and has been construced without
+     *          used for sending a message and has been constructed without
      *          specifying a preferred destination address
      *
      */
@@ -154,7 +154,7 @@ public abstract class MessageInfo {
      * sent on.
      *
      * @return The association, or {@code null} if this instance is to be
-     *         used for sending a message and has been construced using the
+     *         used for sending a message and has been constructed using the
      *         the {@link #createOutgoing(SocketAddress,int)
      *         createOutgoing(SocketAddress,int)} static factory method
      */
@@ -163,7 +163,7 @@ public abstract class MessageInfo {
     /**
      * Returns the number of bytes read for the received message.
      *
-     * <P> This method is only appicable for received messages, it has no
+     * <P> This method is only applicable for received messages, it has no
      * meaning for messages being sent.
      *
      * @return  The number of bytes read, {@code -1} if the channel is an {@link

--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/SctpChannel.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/SctpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -438,7 +438,7 @@ public abstract class SctpChannel
     /**
      * Connects this channel's socket.
      *
-     * <P> This is a convience method and is equivalent to evaluating the
+     * <P> This is a convenience method and is equivalent to evaluating the
      * following expression:
      * <blockquote><pre>
      * setOption(SctpStandardSocketOptions.SCTP_INIT_MAXSTREAMS, SctpStandardSocketOption.InitMaxStreams.create(maxInStreams, maxOutStreams))
@@ -723,7 +723,7 @@ public abstract class SctpChannel
      * does not contain the complete message, then an invocation of {@link
      * MessageInfo#isComplete isComplete} on the returned {@code
      * MessageInfo} will return {@code false}, and more invocations of this
-     * method will be necessary to completely consume the messgae. Only
+     * method will be necessary to completely consume the message. Only
      * one message at a time will be partially delivered in any stream. The
      * socket option {@link SctpStandardSocketOptions#SCTP_FRAGMENT_INTERLEAVE
      * SCTP_FRAGMENT_INTERLEAVE} controls various aspects of what interlacing of
@@ -829,7 +829,7 @@ public abstract class SctpChannel
      *          output buffer
      *
      * @throws  InvalidStreamException
-     *          If {@code streamNumner} is negative or greater than or equal to
+     *          If {@code streamNumber} is negative or greater than or equal to
      *          the maximum number of outgoing streams
      *
      * @throws  java.nio.channels.ClosedChannelException

--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/SctpMultiChannel.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/SctpMultiChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -544,7 +544,7 @@ public abstract class SctpMultiChannel
      * contain the complete message, then an invocation of {@link
      * MessageInfo#isComplete isComplete} on the returned {@code
      * MessageInfo} will return {@code false}, and more invocations of this
-     * method will be necessary to completely consume the messgae. Only
+     * method will be necessary to completely consume the message. Only
      * one message at a time will be partially delivered in any stream. The
      * socket option {@link SctpStandardSocketOptions#SCTP_FRAGMENT_INTERLEAVE
      * SCTP_FRAGMENT_INTERLEAVE} controls various aspects of what interlacing of


### PR DESCRIPTION
Can I please get a review of this trivial change which fixes some typos in the `jdk.sctp` module that are noted in https://bugs.openjdk.org/browse/JDK-8390202? 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390202](https://bugs.openjdk.org/browse/JDK-8390202): Typos in the javadoc of various classes in jdk.sctp module (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32395/head:pull/32395` \
`$ git checkout pull/32395`

Update a local copy of the PR: \
`$ git checkout pull/32395` \
`$ git pull https://git.openjdk.org/jdk.git pull/32395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32395`

View PR using the GUI difftool: \
`$ git pr show -t 32395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32395.diff">https://git.openjdk.org/jdk/pull/32395.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32395#issuecomment-5315877209)
</details>
