### PR TITLE
8383567: VM.class_print_layout should use external class names

### DIFF
--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -597,13 +597,15 @@ void ClassPrintLayout::class_print_layout(outputStream* st, char* class_name) {
     return;
   }
 
-  for (char* p = class_name; *p != '\0'; p++) {
+  ResourceMark rm;
+  char* normalized_name = ResourceArea::strdup(class_name);
+  for (char* p = normalized_name; *p != '\0'; p++) {
     if (*p == JVM_SIGNATURE_DOT) {
       *p = JVM_SIGNATURE_SLASH;
     }
   }
 
-  Symbol* classname = SymbolTable::probe(class_name, (int)strlen(class_name));
+  Symbol* classname = SymbolTable::probe(normalized_name, (int)strlen(normalized_name));
 
   GrowableArray<Klass*>* klasses = new (mtServiceability) GrowableArray<Klass*>(100, mtServiceability);
 

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -597,6 +597,12 @@ void ClassPrintLayout::class_print_layout(outputStream* st, char* class_name) {
     return;
   }
 
+  for (char* p = class_name; *p != '\0'; p++) {
+    if (*p == JVM_SIGNATURE_DOT) {
+      *p = JVM_SIGNATURE_SLASH;
+    }
+  }
+
   Symbol* classname = SymbolTable::probe(class_name, (int)strlen(class_name));
 
   GrowableArray<Klass*>* klasses = new (mtServiceability) GrowableArray<Klass*>(100, mtServiceability);
@@ -608,9 +614,9 @@ void ClassPrintLayout::class_print_layout(outputStream* st, char* class_name) {
     Klass* klass = klasses->at(i);
     if (!klass->is_instance_klass()) continue;  // Skip
     InstanceKlass* ik = InstanceKlass::cast(klass);
-    st->print_cr("Class %s [@%s]:", klass->name()->as_C_string(),
-        klass->class_loader_data()->loader_name());
     ResourceMark rm;
+    st->print_cr("Class %s [@%s]:", klass->external_name(),
+                 klass->class_loader_data()->loader_name());
     GrowableArray<FieldDesc>* fields = new (mtServiceability) GrowableArray<FieldDesc>(100, mtServiceability);
     for (AllFieldStream fd(ik); !fd.done(); fd.next()) {
       if (!fd.access_flags().is_static()) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd.java
@@ -81,10 +81,10 @@ public value class ClassPrintLayoutDcmd {
     }
 
     public static void main(String args[]) throws Exception {
-        testCmd("foo/bar", 0, "");
+        testCmd("foo.bar", 0, "");
         testCmd("", 1, "IllegalArgumentException", "mandatory");
-        testCmd("java/lang/Object", 0, "java/lang/Object", "@bootstrap");
-        testCmd("java/lang/Class", 0, "java/lang/Class", "@bootstrap");
-        testCmd("runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd$Line", 0, "@app", "p1", "p2");
+        testCmd("java.lang.Object", 0, "java.lang.Object", "@bootstrap");
+        testCmd("java.lang.Class", 0, "java.lang.Class", "@bootstrap");
+        testCmd("runtime.valhalla.inlinetypes.ClassPrintLayoutDcmd$Line", 0, "@app", "p1", "p2");
     }
 }


### PR DESCRIPTION
Hi everyone, `ClassPrintLayout::class_print_layout` expects internal class names as its argument, but is called externally by users through `jcmd`. This leads to inconsistencies with other commands. For example:

```
jcmd <pid> VM.class_hierarchy java.lang.String
jcmd <pid> VM.class_print_layout java/lang/String
```

In addition, the command's output is also in the internal format. This should be changed to also use the external dotted class name instead. To resolve this, I added a conversion step that replaces external dotted names with internal slashed names in-place before we start searching for classes. That way we avoid extra allocations and string comparisons. As a side effect, this now works on both internal and external names, as slashes are left untouched.

This was a previously approved PR in https://github.com/openjdk/valhalla/pull/2375, but did not get integrated in time.

Testing:

- Tier 1
- Manual inspection with jcmd

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383567](https://bugs.openjdk.org/browse/JDK-8383567): VM.class_print_layout should use external class names (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32396/head:pull/32396` \
`$ git checkout pull/32396`

Update a local copy of the PR: \
`$ git checkout pull/32396` \
`$ git pull https://git.openjdk.org/jdk.git pull/32396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32396`

View PR using the GUI difftool: \
`$ git pr show -t 32396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32396.diff">https://git.openjdk.org/jdk/pull/32396.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32396#issuecomment-5316157529)
</details>
