### PR TITLE
8390467: C2: _map != nullptr assert failure in LibraryCallKit::inline_Class_cast()

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4631,7 +4631,7 @@ bool LibraryCallKit::inline_Class_cast() {
   }
 
   // Not-subtype or the mirror's klass ptr is nullptr (in case it is a primitive).
-  enum { _bad_type_path = 1, _prim_path = 2, _npe_path = 3, PATH_LIMIT };
+  enum { _bad_type_path = 1, _prim_path = 2, PATH_LIMIT };
   RegionNode* region = new RegionNode(PATH_LIMIT);
   record_for_igvn(region);
 
@@ -4653,8 +4653,7 @@ bool LibraryCallKit::inline_Class_cast() {
     region->init_req(_bad_type_path, bad_type_ctrl);
   }
   if (region->in(_prim_path) != top() ||
-      region->in(_bad_type_path) != top() ||
-      region->in(_npe_path) != top()) {
+      region->in(_bad_type_path) != top()) {
     // Let Interpreter throw ClassCastException.
     PreserveJVMState pjvms(this);
     if (new_cast_failure_map != nullptr) {

--- a/test/hotspot/jtreg/compiler/intrinsics/TestClassCastDeadPath.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestClassCastDeadPath.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390467
+ * @summary C2: _map != nullptr assert failure in LibraryCallKit::inline_Class_cast()
+ * @run main/othervm  -XX:CompileOnly=${test.main.class}::test1 -Xcomp ${test.main.class}
+ */
+
+package compiler.intrinsics;
+
+public class TestClassCastDeadPath {
+    public static void main(String[] args) {
+        B b = new B();
+        C c = new C();
+        A.class.cast(b);
+        try {
+            test1(c);
+        } catch (ClassCastException cce) {
+        }
+    }
+
+    private static void test1(Object o) {
+        if (!(o instanceof I)) {
+            throw new RuntimeException("never taken");
+        }
+        A.class.cast(o);
+    }
+
+    static abstract class A {
+
+    }
+
+    static class B extends A {
+
+    }
+
+    interface I {
+
+    }
+
+    static class C implements I {
+
+    }
+
+}


### PR DESCRIPTION
`LibraryCallKit::inline_Class_cast()`, `region` for the slow path has
3 inputs. 2 of them are `top`. The third one is `nullptr`. The slow
path is dead and there's logic to test for that:

```
   if (region->in(_prim_path) != top() ||
       region->in(_bad_type_path) != top() ||
       region->in(_npe_path) != top()) {
```

but because the third input (`_npe_path`) is `nullptr`, it fails to
detect it. `_npe_path` was brought with valhalla and appears to be
unused. Simply removing it fixes the crash.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390467](https://bugs.openjdk.org/browse/JDK-8390467): C2: _map != nullptr assert failure in LibraryCallKit::inline_Class_cast() (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32397/head:pull/32397` \
`$ git checkout pull/32397`

Update a local copy of the PR: \
`$ git checkout pull/32397` \
`$ git pull https://git.openjdk.org/jdk.git pull/32397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32397`

View PR using the GUI difftool: \
`$ git pr show -t 32397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32397.diff">https://git.openjdk.org/jdk/pull/32397.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32397#issuecomment-5320363524)
</details>
