### PR TITLE
8390339: Test  vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java timed out due to missing prompt with virtual threads

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -136,7 +136,7 @@ public class interrupt001 extends JdbTest {
         // every thread except for the main thread.
         reply = jdb.receiveReplyFor(JdbCommand.suspend + mainThread);
         reply = jdb.receiveReplyFor(JdbCommand.resume, false); // don't expect a compound prompt
-        reply = jdb.receiveReplyFor(JdbCommand.thread + mainThread); // get compund prompt back
+        reply = jdb.receiveReplyFor(JdbCommand.thread + mainThread); // get compound prompt back
 
         for (int i = 0; i < threads.length; i++) {
             reply = jdb.receiveReplyFor(JdbCommand.interrupt + threads[i]);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -105,6 +105,8 @@ public class interrupt001 extends JdbTest {
         Paragrep grep;
         String found;
         String[] threads;
+        String[] mainThreads;
+        String mainThread;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         waitForTestedThreadStarts(THREAD_STARTED_BREAK, numThreads);
@@ -118,6 +120,23 @@ public class interrupt001 extends JdbTest {
         }
 
         pauseTillAllThreadsWaiting(threads);
+
+        mainThreads = jdb.getThreadIdsByName("main");
+        if (mainThreads.length != 1) {
+            log.complain("Failed to properly find one main thread: " + mainThreads.length);
+            success = false;
+        }
+        mainThread = mainThreads[0];
+
+        // Right now all threads are suspended. Before doing the interrupts we need to
+        // resume all threads except for the main thread. Otherwise, in the case of
+        // virtual threads, we can get a deadlock. To accomplish this we issue a
+        // "suspend" on the main thread so its suspend count is one higher than all
+        // the other threads, and then we "resume" on all threads, which should resume
+        // every thread except for the main thread.
+        reply = jdb.receiveReplyFor(JdbCommand.suspend + mainThread);
+        reply = jdb.receiveReplyFor(JdbCommand.resume, false); // don't expect a compound prompt
+        reply = jdb.receiveReplyFor(JdbCommand.thread + mainThread); // get compund prompt back
 
         for (int i = 0; i < threads.length; i++) {
             reply = jdb.receiveReplyFor(JdbCommand.interrupt + threads[i]);


### PR DESCRIPTION
The test tries to do interrupts while all threads are suspended. With virtual threads this can cause a deadlock because some threads may need to make progress in order for JVMTI InterruptThread to work. Solution is to resume all but the main thread before issuing the interrupts.

The failure was very hard to reproduce. It took about 2700 runs. During testing of this fix I ran it about 5000 times and didn't see any issues.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390339](https://bugs.openjdk.org/browse/JDK-8390339): Test  vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java timed out due to missing prompt with virtual threads (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) Review applies to [fc51985e](https://git.openjdk.org/jdk/pull/32399/files/fc51985ef2aa4ac4ad6b3f54bac638d849dc374d)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32399/head:pull/32399` \
`$ git checkout pull/32399`

Update a local copy of the PR: \
`$ git checkout pull/32399` \
`$ git pull https://git.openjdk.org/jdk.git pull/32399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32399`

View PR using the GUI difftool: \
`$ git pr show -t 32399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32399.diff">https://git.openjdk.org/jdk/pull/32399.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32399#issuecomment-5317671383)
</details>
