### PR TITLE
8390184: Some typos in the jdk.jdi module

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/InconsistentDebugInfoException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/InconsistentDebugInfoException.java
@@ -26,7 +26,7 @@
 package com.sun.jdi;
 
 /**
- * Thrown to indicate that there is an inconistency in the debug
+ * Thrown to indicate that there is an inconsistency in the debug
  * information provided by the target VM. For example, this exception
  * is thrown if there is a type mismatch between a retrieved value's
  * runtime type and its declared type as reported by the target VM.

--- a/src/jdk.jdi/share/classes/com/sun/jdi/InconsistentDebugInfoException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/InconsistentDebugInfoException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/LaunchingConnector.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/LaunchingConnector.java
@@ -54,7 +54,7 @@ public interface LaunchingConnector extends Connector {
      * received.
      * <p>
      * <b>Important note:</b> If a target VM is launched through this
-     * funcctions, its output and error streams must be read as it
+     * function, its output and error streams must be read as it
      * executes. These streams are available through the
      * {@link java.lang.Process Process} object returned by
      * {@link VirtualMachine#process}. If the streams are not periodically

--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/LaunchingConnector.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/LaunchingConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/spi/Connection.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/spi/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/spi/Connection.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/spi/Connection.java
@@ -100,7 +100,7 @@ public abstract class Connection {
      *          the connection while the readPacket is in progress.
      *
      * @throws  java.io.IOException
-     *          If the length of the packet (as indictaed by the first
+     *          If the length of the packet (as indicated by the first
      *          4 bytes) is less than 11 bytes, or an I/O error occurs.
      *
      *

--- a/src/jdk.jdi/share/classes/com/sun/jdi/request/ClassPrepareRequest.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/request/ClassPrepareRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/jdi/request/ClassPrepareRequest.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/request/ClassPrepareRequest.java
@@ -105,7 +105,7 @@ public interface ClassPrepareRequest extends EventRequest {
      *     refType.availableStrata();
      *
      * such that a name on the list returned by
-     *     refType.sourceNames(someStratam)
+     *     refType.sourceNames(someStratum)
      *
      * matches 'sourceNamePattern'.
      * Regular expressions are limited

--- a/src/jdk.jdi/share/classes/com/sun/jdi/request/MonitorContendedEnterRequest.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/request/MonitorContendedEnterRequest.java
@@ -36,7 +36,7 @@ import com.sun.jdi.event.MonitorContendedEnterEvent;
 /**
  * Request for notification of a thread in the target VM
  * attempting to enter a monitor already acquired by another thread.
- * When an enabled MonitorContededEnterRequest is satisfied, an
+ * When an enabled MonitorContendedEnterRequest is satisfied, an
  * {@link EventSet event set} containing a
  * {@link MonitorContendedEnterEvent MonitorContendedEnterEvent}
  * will be placed on the {@link EventQueue EventQueue}.

--- a/src/jdk.jdi/share/classes/com/sun/jdi/request/MonitorContendedEnteredRequest.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/request/MonitorContendedEnteredRequest.java
@@ -36,7 +36,7 @@ import com.sun.jdi.event.MonitorContendedEnteredEvent;
 /**
  * Request for notification of a thread in the target VM entering a monitor
  * after waiting for it to be released by another thread.
- * When an enabled MonitorContededEnteredRequest is satisfied, an
+ * When an enabled MonitorContendedEnteredRequest is satisfied, an
  * {@link EventSet event set} containing a
  * {@link MonitorContendedEnteredEvent MonitorContendedEnteredEvent}
  * will be placed on the {@link EventQueue EventQueue}.


### PR DESCRIPTION
Can I please get a review of this trivial change which fixes some typos in the core-svc area. 
Listed in https://bugs.openjdk.org/browse/JDK-8390184



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390184](https://bugs.openjdk.org/browse/JDK-8390184): Some typos in the jdk.jdi module (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32400/head:pull/32400` \
`$ git checkout pull/32400`

Update a local copy of the PR: \
`$ git checkout pull/32400` \
`$ git pull https://git.openjdk.org/jdk.git pull/32400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32400`

View PR using the GUI difftool: \
`$ git pr show -t 32400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32400.diff">https://git.openjdk.org/jdk/pull/32400.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32400#issuecomment-5318467139)
</details>
