### PR TITLE
8390159: [ARM32] Native ARM32 build hangs in COMPILE_CREATE_SYMBOLS

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -829,11 +829,18 @@ AC_DEFUN([JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE_NOCOOPS],
 
 AC_DEFUN([JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE_PREVIEW],
 [
-  # Value objects need object header bits that only exist on 64-bit
   UTIL_ARG_ENABLE(NAME: cds-archive-preview, DEFAULT: auto, RESULT: BUILD_CDS_ARCHIVE_PREVIEW,
-      AVAILABLE: $(test "x$OPENJDK_TARGET_CPU_BITS" = "x64" && echo true || echo false),
       DESC: [enable generation of preview CDS archives (requires --enable-cds-archive)],
-      CHECKING_MSG: [if default CDS archives for preview should be generated])
+      CHECKING_MSG: [if default CDS archives for preview should be generated],
+      CHECK_AVAILABLE: [
+        AC_MSG_CHECKING([if value objects are supported])
+        if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
+          AC_MSG_RESULT([yes])
+        else
+          AC_MSG_RESULT([no (64-bit only)])
+          AVAILABLE=false
+        fi
+      ])
   AC_SUBST(BUILD_CDS_ARCHIVE_PREVIEW)
 ])
 

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -829,7 +829,9 @@ AC_DEFUN([JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE_NOCOOPS],
 
 AC_DEFUN([JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE_PREVIEW],
 [
-  UTIL_ARG_ENABLE(NAME: cds-archive-preview, DEFAULT: true, RESULT: BUILD_CDS_ARCHIVE_PREVIEW,
+  # Value objects need object header bits that only exist on 64-bit
+  UTIL_ARG_ENABLE(NAME: cds-archive-preview, DEFAULT: auto, RESULT: BUILD_CDS_ARCHIVE_PREVIEW,
+      AVAILABLE: $(test "x$OPENJDK_TARGET_CPU_BITS" = "x64" && echo true || echo false),
       DESC: [enable generation of preview CDS archives (requires --enable-cds-archive)],
       CHECKING_MSG: [if default CDS archives for preview should be generated])
   AC_SUBST(BUILD_CDS_ARCHIVE_PREVIEW)

--- a/src/hotspot/cpu/arm/jniFastGetField_arm.cpp
+++ b/src/hotspot/cpu/arm/jniFastGetField_arm.cpp
@@ -26,9 +26,11 @@
 #include "asm/macroAssembler.hpp"
 #include "code/codeBlob.hpp"
 #include "memory/resourceArea.hpp"
+#include "oops/instanceKlass.hpp"
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"
 #include "prims/jvmtiExport.hpp"
+#include "runtime/jfieldIDWorkaround.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/safepoint.hpp"
 
@@ -138,10 +140,10 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
 #endif // !__ABI_HARD__
       ) {
     // Only ldr and ldrb support embedded shift, other loads do not
-    __ add(Robj, Robj, AsmOperand(R2, lsr, 2));
+    __ add(Robj, Robj, AsmOperand(R2, lsr, jfieldIDWorkaround::offset_shift));
     field_addr = Address(Robj);
   } else {
-    field_addr = Address(Robj, R2, lsr, 2);
+    field_addr = Address(Robj, R2, lsr, jfieldIDWorkaround::offset_shift);
   }
   assert(count < LIST_CAPACITY, "LIST_CAPACITY too small");
   speculative_load_pclist[count] = __ pc();

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -258,7 +258,7 @@ class Compilation: public StackObj {
   }
   bool profile_array_accesses() {
     return env()->comp_level() == CompLevel_full_profile &&
-      C1UpdateMethodData;
+      C1UpdateMethodData && MethodData::profile_array_accesses();
   }
 
   // will compilation make optimistic assumptions that might lead to

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -260,6 +260,9 @@ class Compilation: public StackObj {
     return env()->comp_level() == CompLevel_full_profile &&
       C1UpdateMethodData && MethodData::profile_array_accesses();
   }
+  bool profile_acmp() {
+    return is_profiling() && profile_branches() && MethodData::profile_acmp();
+  }
 
   // will compilation make optimistic assumptions that might lead to
   // deoptimization and that the runtime will account for?

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1390,7 +1390,7 @@ void GraphBuilder::if_node(Value x, If::Condition cond, Value y, ValueStack* sta
     }
   }
   if ((stream()->cur_bc() == Bytecodes::_if_acmpeq || stream()->cur_bc() == Bytecodes::_if_acmpne) &&
-      is_profiling() && profile_branches() && MethodData::profile_acmp()) {
+      profile_acmp()) {
     compilation()->set_would_profile(true);
     append(new ProfileACmpTypes(method(), bci(), x, y));
   }

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1390,7 +1390,7 @@ void GraphBuilder::if_node(Value x, If::Condition cond, Value y, ValueStack* sta
     }
   }
   if ((stream()->cur_bc() == Bytecodes::_if_acmpeq || stream()->cur_bc() == Bytecodes::_if_acmpne) &&
-      is_profiling() && profile_branches()) {
+      is_profiling() && profile_branches() && MethodData::profile_acmp()) {
     compilation()->set_would_profile(true);
     append(new ProfileACmpTypes(method(), bci(), x, y));
   }

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -430,6 +430,7 @@ class GraphBuilder {
   bool profile_arguments()     { return _compilation->profile_arguments();     }
   bool profile_return()        { return _compilation->profile_return();        }
   bool profile_array_accesses(){ return _compilation->profile_array_accesses();}
+  bool profile_acmp()          { return _compilation->profile_acmp();          }
 
   Values* args_list_for_profiling(ciMethod* target, int& start, bool may_have_receiver);
   Values* collect_args_for_profiling(Values* args, ciMethod* target, bool may_have_receiver);

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -389,8 +389,11 @@ char* DumpRegion::allocate_metaspace_obj(size_t num_bytes, address src, Metaspac
     assert(read_only == false, "only gaps in RW region are reusable");
     char* gap_bottom = top();
     char* gap_top = align_up(gap_bottom + RuntimeClassInfoPtrSize, alignment) - RuntimeClassInfoPtrSize;
-    size_t gap_bytes = _gap_tree.add_gap(gap_bottom, gap_top);
-    allocate(gap_bytes);
+    // A gap smaller than an allocation unit can never be reused
+    if (pointer_delta(gap_top, gap_bottom, 1) >= SharedSpaceObjectAlignment) {
+      size_t gap_bytes = _gap_tree.add_gap(gap_bottom, gap_top);
+      allocate(gap_bytes);
+    }
   }
 
   char* oldtop = top();

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -389,11 +389,12 @@ char* DumpRegion::allocate_metaspace_obj(size_t num_bytes, address src, Metaspac
     assert(read_only == false, "only gaps in RW region are reusable");
     char* gap_bottom = top();
     char* gap_top = align_up(gap_bottom + RuntimeClassInfoPtrSize, alignment) - RuntimeClassInfoPtrSize;
+    size_t gap_bytes = pointer_delta(gap_top, gap_bottom, 1);
     // A gap smaller than an allocation unit can never be reused
-    if (pointer_delta(gap_top, gap_bottom, 1) >= SharedSpaceObjectAlignment) {
-      size_t gap_bytes = _gap_tree.add_gap(gap_bottom, gap_top);
-      allocate(gap_bytes);
+    if (gap_bytes >= SharedSpaceObjectAlignment) {
+      _gap_tree.add_gap(gap_bottom, gap_top);
     }
+    allocate(gap_bytes);
   }
 
   char* oldtop = top();

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1703,6 +1703,14 @@ bool MethodData::profile_parameters_jsr292_only() {
   return profile_parameters_flag() == type_profile_jsr292;
 }
 
+bool MethodData::profile_array_accesses() {
+  return COMPILER2_PRESENT(UseArrayLoadStoreProfile ||) TypeProfileLevel > 0;
+}
+
+bool MethodData::profile_acmp() {
+  return COMPILER2_PRESENT(UseACmpProfile ||) TypeProfileLevel > 0;
+}
+
 bool MethodData::profile_all_parameters() {
   return profile_parameters_flag() == type_profile_all;
 }

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -2724,6 +2724,8 @@ public:
   static bool profile_arguments_jsr292_only();
   static bool profile_return();
   static bool profile_parameters();
+  static bool profile_array_accesses();
+  static bool profile_acmp();
   static bool profile_return_jsr292_only();
 
   void clean_method_data(bool always_clean);

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -101,7 +101,8 @@ class ClassLoaderData;
 #define PERM_REFCOUNT 0xffff
 #endif
 
-class Symbol : public MetaspaceObj {
+// VerificationType::TypeMask == 0x7 demands 8-byte aligned Symbol*
+class alignas(8) Symbol : public MetaspaceObj {
   friend class VMStructs;
   friend class SymbolTable;
   friend class vmSymbols;


### PR DESCRIPTION
These fixes address a series of failures reproducible when building arm32 natively on an arm32 platform (not cross-compilation), in both release and fastdebug modes.

1. jniFastGetField_arm.cpp: use offset_shift

After JEP 401 was integrated, jfieldIDWorkaround's offset_shift changed from 2 to 3. ARM32 is the only port where the shift was hardcoded as the literal 2 in JNI_FastGetField::generate_fast_get_int_field0. Other architectures take this value from the jfieldIDWorkaround::offset_shift constant and picked up the change automatically. This caused java.io.FileDescriptor's int fd field to be read incorrectly in the native fdval() function (IOUtil.c, libnio.so), which made the JVM hang during module loading at the COMPILE_CREATE_SYMBOLS step of the JDK build (fd was incorrectly decoded as 0 -- a blocking read from stdin). Fix: use the jfieldIDWorkaround::offset_shift constant instead of the hardcoded literal.

2. oops/symbol.hpp: class alignas(8) Symbol

JEP 401 widened VerificationType::TypeMask from 0x3 to 0x7, reserving a third bit for inline types. As a result is_reference() now requires a Symbol* to be 8-byte aligned. On 32-bit a Symbol sits at offset 4 inside a SymbolTable node, so is_reference() is always false and verification of any class fails with VerifyError. This only happens in release builds: in debug builds the node carries an extra DEBUG_ONLY field, which pushes the Symbol to offset 8. Fix: alignas(8) makes Symbol 8-byte aligned. On 64-bit the layout is unchanged.

3. make/autoconf/jdk-options.m4: disable cds-archive-preview for 32-bit systems

The build unconditionally generates a preview CDS archive, but value objects are not supported on 32-bit: InlineKlass::InlineKlass hits assert "Should not be called in 32 bit mode" (markWord.hpp), and the jdk-image step fails while dumping classes_preview.jsa. Fix: make the cds-archive-preview option unavailable on non-64-bit platforms.

4. cds/archiveUtils.cpp: additional check for minimal gap size

This fixes a fastdebug build failure at the generate-link-opt-data step: assert(is_aligned(gap_bytes(), SharedSpaceObjectAlignment)) failed. It is related to ee90f00b3b3 (8376822, UseCompactObjectHeaders: fill Klass alignment gaps), not to JEP 401. That change started inserting an alignment gap in front of a buffered Klass and recording it for later reuse. On arm32 the gap is always 4 bytes -- nothing can ever fit into it, and AllocGap fails its precondition. Fix: only record a gap that is at least SharedSpaceObjectAlignment. On 64-bit the gap is always a multiple of 8, so behaviour is unchanged.

5. c1: emit array access and acmp type profiles only when such profiling is enabled

C1 created these profiles without looking at UseArrayLoadStoreProfile, UseACmpProfile or TypeProfileLevel. On arm32 that is fatal, because LIR_Assembler::emit_profile_type() is not implemented there. On arm32 that is fatal, because LIR_Assembler::emit_profile_type() is not implemented there. Fix: add MethodData::profile_array_accesses() and MethodData::profile_acmp(), and consult them in C1.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390159](https://bugs.openjdk.org/browse/JDK-8390159): [ARM32] Native ARM32 build hangs in COMPILE_CREATE_SYMBOLS (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [f73ef6b7](https://git.openjdk.org/jdk/pull/32402/files/f73ef6b7af1c1baa761de0d24a29f525b875cc98)
 * [Sergey Nazarkin](https://openjdk.org/census#snazarki) (@snazarkin - no project role)
 * [Marc R. Hoffmann](https://openjdk.org/census#marchof) (@marchof - Author) Review applies to [f73ef6b7](https://git.openjdk.org/jdk/pull/32402/files/f73ef6b7af1c1baa761de0d24a29f525b875cc98)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32402/head:pull/32402` \
`$ git checkout pull/32402`

Update a local copy of the PR: \
`$ git checkout pull/32402` \
`$ git pull https://git.openjdk.org/jdk.git pull/32402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32402`

View PR using the GUI difftool: \
`$ git pr show -t 32402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32402.diff">https://git.openjdk.org/jdk/pull/32402.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32402#issuecomment-5320023355)
</details>
