### PR TITLE
8389487: Test vmTestbase/nsk/jdi/ThreadReference/stop/stop002/TestDescription.java failed: unexpected com.sun.jdi.OpaqueFrameException

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -66,9 +66,11 @@ public class stop002 {
     // debuggee fields used to indicate to exit infinite loops
     static final String DEBUGGEE_STOP_LOOP1_FIELD = "stopLooping1";
     static final String DEBUGGEE_STOP_LOOP2_FIELD = "stopLooping2";
+    // debuggee field used to indicate that debugger got OpaqueFrameException
+    static final String DEBUGGEE_GOT_OPE_FIELD = "gotOpaqueFrameException";
 
     // debuggee source line where it should be stopped
-    static final int DEBUGGEE_STOPATLINE = 90;
+    static final int DEBUGGEE_STOPATLINE = 91;
 
     static final int DELAY = 500; // in milliseconds
 
@@ -118,6 +120,7 @@ public class stop002 {
 
         Field stopLoop1 = null;
         Field stopLoop2 = null;
+        Field gotOpaqueFrameException = null;
         ObjectReference objRef = null;
         ObjectReference throwableRef = null;
 
@@ -142,6 +145,11 @@ public class stop002 {
             stopLoop2 = mainClass.fieldByName(DEBUGGEE_STOP_LOOP2_FIELD);
             if (stopLoop1 == null || stopLoop2 == null) {
                 throw new RuntimeException("Failed to find a \"stop loop\" field");
+            }
+
+            gotOpaqueFrameException = mainClass.fieldByName(DEBUGGEE_GOT_OPE_FIELD);
+            if (gotOpaqueFrameException == null) {
+                throw new RuntimeException("Failed to find a \"gotOpaqueFrameException\" field");
             }
 
             log.display("non-throwable object: \"" + objRef + "\"");
@@ -223,6 +231,7 @@ public class stop002 {
                 log.display("TEST #4: thread is suspended.");
                 thrRef.stop(throwableRef);
                 log.display("TEST #4 PASSED: stop() call succeeded.");
+                objRef.setValue(gotOpaqueFrameException, vm.mirrorOf(false));
             } catch (OpaqueFrameException ofe) {
                 if (vthreadMode) {
                     log.display("TEST #4 PASSED: stop() call resulted in OpaqueFrameException.");
@@ -231,10 +240,12 @@ public class stop002 {
                     log.complain("TEST #4 FAILED: caught unexpected " + ofe);
                     tot_res = Consts.TEST_FAILED;
                 }
+                objRef.setValue(gotOpaqueFrameException, vm.mirrorOf(true));
             } catch (Throwable ue) {
                 ue.printStackTrace();
                 log.complain("TEST #4 FAILED: caught unexpected " + ue);
                 tot_res = Consts.TEST_FAILED;
+                objRef.setValue(gotOpaqueFrameException, vm.mirrorOf(false));
             } finally {
                 log.display("TEST #4: resuming thread.");
                 thrRef.resume();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -67,7 +67,7 @@ public class stop002 {
     static final String DEBUGGEE_STOP_LOOP1_FIELD = "stopLooping1";
     static final String DEBUGGEE_STOP_LOOP2_FIELD = "stopLooping2";
     // debuggee field used to indicate that debugger got OpaqueFrameException
-    static final String DEBUGGEE_GOT_OPE_FIELD = "gotOpaqueFrameException";
+    static final String DEBUGGEE_GOT_OFE_FIELD = "gotOpaqueFrameException";
 
     // debuggee source line where it should be stopped
     static final int DEBUGGEE_STOPATLINE = 91;
@@ -147,7 +147,7 @@ public class stop002 {
                 throw new RuntimeException("Failed to find a \"stop loop\" field");
             }
 
-            gotOpaqueFrameException = mainClass.fieldByName(DEBUGGEE_GOT_OPE_FIELD);
+            gotOpaqueFrameException = mainClass.fieldByName(DEBUGGEE_GOT_OFE_FIELD);
             if (gotOpaqueFrameException == null) {
                 throw new RuntimeException("Failed to find a \"gotOpaqueFrameException\" field");
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,15 +38,16 @@ import nsk.share.jdi.*;
  * The test checks that the JDI method:<br><code>com.sun.jdi.ThreadReference.stop()</code><br>
  * behaves properly in various situations. It consists of 5 subtests.
  *
- * TEST #1: Tests that stop() properly throws <i>InvalidTypeException</i> if
- * specified throwable is not an instance of java.lang.Throwable in the target VM.<p>
+ * TEST #1: Tests that stop() properly throws InvalidTypeException if
+ * specified throwable is not an instance of java.lang.Throwable in the target VM.
  *
  * TEST #2: Verify that stop() works when suspended at a breakpoint.
  *
  * TEST #3: Verify that stop() works when not suspended in a loop. For virtual threads
  * we expect an IncompatibleThreadStateException.
  *
- * TEST #4: Verify that stop() works when suspended in a loop.
+ * TEST #4: Verify that stop() works when suspended in a loop. For Virtual threads
+ * we may get OpaqueFrameException.
  *
  * TEST #5: Verify that stop() works when suspended in Thread.sleep(). For virtual
  * threads we expect an OpaqueFrameException.
@@ -222,6 +223,14 @@ public class stop002 {
                 log.display("TEST #4: thread is suspended.");
                 thrRef.stop(throwableRef);
                 log.display("TEST #4 PASSED: stop() call succeeded.");
+            } catch (OpaqueFrameException ofe) {
+                if (vthreadMode) {
+                    log.display("TEST #4 PASSED: stop() call resulted in OpaqueFrameException.");
+                } else {
+                    ofe.printStackTrace();
+                    log.complain("TEST #4 FAILED: caught unexpected " + ofe);
+                    tot_res = Consts.TEST_FAILED;
+                }
             } catch (Throwable ue) {
                 ue.printStackTrace();
                 log.complain("TEST #4 FAILED: caught unexpected " + ue);
@@ -229,8 +238,7 @@ public class stop002 {
             } finally {
                 log.display("TEST #4: resuming thread.");
                 thrRef.resume();
-                // Force the debuggee out of the loop. Not really needed if the stop() call
-                // successfully threw the async exception, but it's easier to just always do this.
+                // Force the debuggee out of the loop.
                 log.display("TEST #4: clearing loop flag.");
                 objRef.setValue(stopLoop2, vm.mirrorOf(true));
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -214,8 +214,7 @@ public class stop002 {
                     tot_res = Consts.TEST_FAILED;
                 }
             } finally {
-                // Force the debuggee out of the loop. Not really needed if the stop() call
-                // successfully threw the async exception, but it's easier to just always do this.
+                // Make sure the debuggee exits the loop even if the async exception was not thrown.
                 log.display("TEST #3: clearing loop flag.");
                 objRef.setValue(stopLoop1, vm.mirrorOf(true));
             }
@@ -249,7 +248,7 @@ public class stop002 {
             } finally {
                 log.display("TEST #4: resuming thread.");
                 thrRef.resume();
-                // Force the debuggee out of the loop.
+                // Make sure the debuggee exits the loop even if the async exception was not thrown.
                 log.display("TEST #4: clearing loop flag.");
                 objRef.setValue(stopLoop2, vm.mirrorOf(true));
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -233,7 +233,7 @@ public class stop002 {
                 objRef.setValue(gotOpaqueFrameException, vm.mirrorOf(false));
             } catch (OpaqueFrameException ofe) {
                 if (vthreadMode) {
-                    log.display("TEST #4 PASSED: stop() call resulted in OpaqueFrameException.");
+                    log.display("TEST #4 PASSED: stop() call resulted in OpaqueFrameException while in vthread mode.");
                 } else {
                     ofe.printStackTrace();
                     log.complain("TEST #4 FAILED: caught unexpected " + ofe);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,8 +141,13 @@ public class stop002t {
                 testNumReady = 4; // signal debugger side of test that we are ready
                 stopMeHere++; stopMeHere--;
             }
-            log.complain("TEST #4: Failed to throw expected exception");
-            return Consts.TEST_FAILED;
+            if (vthreadMode) {
+                // Exception not required when in vthread mode
+                log.display("TEST #4: did not throw exception while in vthread mode");
+            } else {
+                log.complain("TEST #4: Failed to throw expected exception");
+                return Consts.TEST_FAILED;
+            }
         } catch (Throwable t) {
             // Call Thread.interrupted(). Workaround for JDK-8306324
             log.display("TEST #4: interrupted = " + Thread.interrupted());

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
@@ -37,6 +37,7 @@ public class stop002t {
     private IOPipe pipe;
     volatile boolean stopLooping1 = false;
     volatile boolean stopLooping2 = false;
+    volatile boolean gotOpaqueFrameException = false;
     volatile static int testNumReady = 0;
     static final boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
     static Thread testThread = null;
@@ -142,8 +143,13 @@ public class stop002t {
                 stopMeHere++; stopMeHere--;
             }
             if (vthreadMode) {
-                // Exception not required when in vthread mode
-                log.display("TEST #4: did not throw exception while in vthread mode");
+                if (gotOpaqueFrameException) {
+                    // Exception not required when in vthread mode if OpaqueFrameException thrown
+                    log.display("TEST #4: threw OpaqueFrameException while in vthread mode");
+                } else {
+                    log.complain("TEST #4: Failed to throw expected exception and " +
+                                 "failed to throw debugger side OpaqueFrameException");
+                }
             } else {
                 log.complain("TEST #4: Failed to throw expected exception");
                 return Consts.TEST_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
@@ -149,6 +149,7 @@ public class stop002t {
                 } else {
                     log.complain("TEST #4: Failed to throw expected exception and " +
                                  "failed to throw debugger side OpaqueFrameException");
+                    return Consts.TEST_FAILED;
                 }
             } else {
                 log.complain("TEST #4: Failed to throw expected exception");


### PR DESCRIPTION
Allow OpaqueFrameException for vthreads when suspended in a loop (not at an event). This became necessary after [JDK-8386116](https://bugs.openjdk.org/browse/JDK-8386116). The ThreadReference.stop() spec allows for this:

`This method may be used to send an asynchronous exception to a virtual thread when it is suspended at an event. An implementation may support sending an asynchronous exception to a suspended virtual thread in other cases.`

and

`OpaqueFrameException - if the thread is a suspended virtual thread and the implementation was unable to throw an asynchronous exception from the thread's current frame`

I also field [JDK-8390483](https://bugs.openjdk.org/browse/JDK-8390483) to investigate if JVMTI should remove all vthread support for StopThread when not at an event rather than having work just some of the time.

The failure used to happen about 1 out of 50 runs. Tested with both platform threads and with virtual threads about 200 times each with no issues.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389487](https://bugs.openjdk.org/browse/JDK-8389487): Test vmTestbase/nsk/jdi/ThreadReference/stop/stop002/TestDescription.java failed: unexpected com.sun.jdi.OpaqueFrameException (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) Review applies to [6f73bc8e](https://git.openjdk.org/jdk/pull/32403/files/6f73bc8e5471833223e77fdadd45c4af60df16dc)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32403/head:pull/32403` \
`$ git checkout pull/32403`

Update a local copy of the PR: \
`$ git checkout pull/32403` \
`$ git pull https://git.openjdk.org/jdk.git pull/32403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32403`

View PR using the GUI difftool: \
`$ git pr show -t 32403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32403.diff">https://git.openjdk.org/jdk/pull/32403.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32403#issuecomment-5320703560)
</details>
