### PR TITLE
8390484: Problem list appcds/aotCache/ tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,6 +92,12 @@ gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#default 8386964
 
 # :hotspot_runtime
 
+runtime/cds/appcds/aotCache/aotClassLinking/AOTClassLinkingVMOptions.java
+runtime/cds/appcds/aotCache/aotClassLinking/AddExports.java
+runtime/cds/appcds/aotCache/aotClassLinking/AddOpens.java
+runtime/cds/appcds/aotCache/aotClassLinking/AddReads.java
+runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java
+runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java
 runtime/jni/terminatedThread/TestTerminatedThread.java 8317789 aix-ppc64
 runtime/Monitor/SyncOnValueBasedClassTest.java 8340995 linux-s390x
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,12 +92,12 @@ gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#default 8386964
 
 # :hotspot_runtime
 
-runtime/cds/appcds/aotCache/aotClassLinking/AOTClassLinkingVMOptions.java
-runtime/cds/appcds/aotCache/aotClassLinking/AddExports.java
-runtime/cds/appcds/aotCache/aotClassLinking/AddOpens.java
-runtime/cds/appcds/aotCache/aotClassLinking/AddReads.java
-runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java
-runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java
+runtime/cds/appcds/aotCache/aotClassLinking/AOTClassLinkingVMOptions.java 8390485 generic-all
+runtime/cds/appcds/aotCache/aotClassLinking/AddExports.java 8390485 generic-all
+runtime/cds/appcds/aotCache/aotClassLinking/AddOpens.java 8390485 generic-all
+runtime/cds/appcds/aotCache/aotClassLinking/AddReads.java 8390485 generic-all
+runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java 8390485 generic-all
+runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java 8390485 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8317789 aix-ppc64
 runtime/Monitor/SyncOnValueBasedClassTest.java 8340995 linux-s390x
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64


### PR DESCRIPTION
Problem list a few aotClassLinkingTests because they did not properly migrate to AOT workflow in [JDK-8368350](https://bugs.openjdk.org/browse/JDK-8368350)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390484](https://bugs.openjdk.org/browse/JDK-8390484): Problem list appcds/aotCache/ tests (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32404/head:pull/32404` \
`$ git checkout pull/32404`

Update a local copy of the PR: \
`$ git checkout pull/32404` \
`$ git pull https://git.openjdk.org/jdk.git pull/32404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32404`

View PR using the GUI difftool: \
`$ git pr show -t 32404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32404.diff">https://git.openjdk.org/jdk/pull/32404.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32404#issuecomment-5321097249)
</details>
