### PR TITLE
8390432: Zero i386 build broken after JDK-8389219

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -198,6 +198,7 @@ void ShenandoahArguments::initialize() {
         ShenandoahAllocRateSampleWindow));
   }
 
+#ifdef _LP64
   if (Arguments::is_valhalla_enabled()) {
     // Flat atomic payloads may contain embedded oops. Current Valhalla code does not handle
     // it well, missing the GC barriers. As the temporary kludge, disable compressed oops:
@@ -206,6 +207,7 @@ void ShenandoahArguments::initialize() {
     log_warning(gc)("Shenandoah disables compressed oops to avoid breaking with Valhalla");
     FLAG_SET_ERGO(UseCompressedOops, false);
   }
+#endif
 
   FullGCForwarding::initialize_flags(MaxHeapSize);
 }


### PR DESCRIPTION
This PR adds `#ifdef` statements around ` FLAG_SET_ERGO(UseCompressedOops, false);`. `UseCompressedOps` is a boolean constant in 32 bit build.

```
bash configure --disable-warnings-as-errors --with-jvm-variants=zero --disable-precompiled-headers

...
A new configuration has been successfully created in
/home/vladimirp/work/git/jdk/build/linux-x86-zero-release
using configure arguments '--disable-warnings-as-errors --with-jvm-variants=zero'.


Configuration summary:
* Name:           linux-x86-zero-release
* Debug level:    release
* HS debug level: product
* JVM variants:   zero
* JVM features:   zero: 'cds dtrace epsilongc g1gc jni-check jvmti management parallelgc serialgc services shenandoahgc vm-structs zero' 
* OpenJDK target: OS: linux, CPU architecture: x86, address length: 32
* Version string: 28-internal-adhoc.vladimirp.jdk (28-internal)
* Source date:    1787005914 (2026-08-17T22:31:54Z)

Tools summary:
* Boot JDK:       openjdk version "27-ea" 2026-09-15 OpenJDK Runtime Environment (build 27-ea+34-1-Debian) OpenJDK Zero VM (build 27-ea+34-1-Debian, interpreted mode, sharing) (at /usr/lib/jvm/java-27-openjdk-i386)
* Toolchain:      gcc (GNU Compiler Collection)
* C Compiler:     Version 16.2.0 (at /usr/bin/gcc)
* C++ Compiler:   Version 16.2.0 (at /usr/bin/g++)

Build performance summary:
* Build jobs:     32
* Memory limit:   62150 MB

...
make images CONF=linux-x86-zero-release
Building target 'images' in configuration 'linux-x86-zero-release'
....
Creating jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/jpackageapplauncher from 3 file(s)
Creating jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources/libjpackageapplauncheraux.so from 19 file(s)
Error: Unable to load main class com.sun.tools.javac.Main in module jdk.compiler
Caused by: java.lang.VerifyError
gmake[3]: *** [modules/jdk.compiler/Gendata.gmk:60: /home/vladimirp/work/git/jdk/build/linux-x86-zero-release/buildtools/create_symbols_javac/_the.COMPILE_CREATE_SYMBOLS_batch] Error 1
gmake[2]: *** [make/Main.gmk:136: jdk.compiler-gendata] Error 2

ERROR: Build failed for target 'images' in configuration 'linux-x86-zero-release' (exit code 2)
Stopping javac server

=== Output from failing command(s) repeated here ===
* For target buildtools_create_symbols_javac__the.COMPILE_CREATE_SYMBOLS_batch:
Error: Unable to load main class com.sun.tools.javac.Main in module jdk.compiler
Caused by: java.lang.VerifyError

* All command lines available in /home/vladimirp/work/git/jdk/build/linux-x86-zero-release/make-support/failure-logs.
=== End of repeated output ===

No indication of failed target found.
HELP: Try searching the build log for '] Error'.
HELP: Run 'make doctor' to diagnose build problems.

make[1]: *** [/home/vladimirp/work/git/jdk/make/Init.gmk:151: main] Error 2
make: *** [/home/vladimirp/work/git/jdk/make/PreInit.gmk:160: images] Error 2
```

The build fails due to https://bugs.openjdk.org/browse/JDK-8390159. 

After applying the patch for https://bugs.openjdk.org/browse/JDK-8390159

```
Creating CDS archive for jdk image for zero
Finished building target 'images' in configuration 'linux-x86-zero-release'
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390432](https://bugs.openjdk.org/browse/JDK-8390432): Zero i386 build broken after JDK-8389219 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32405/head:pull/32405` \
`$ git checkout pull/32405`

Update a local copy of the PR: \
`$ git checkout pull/32405` \
`$ git pull https://git.openjdk.org/jdk.git pull/32405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32405`

View PR using the GUI difftool: \
`$ git pr show -t 32405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32405.diff">https://git.openjdk.org/jdk/pull/32405.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32405#issuecomment-5322312291)
</details>
