### PR TITLE
8390480: Remove unnecessary check in ThawBase::patch

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2633,14 +2633,14 @@ inline void ThawBase::patch(frame& f, const frame& caller, bool bottom) {
   if (bottom) {
     ContinuationHelper::Frame::patch_pc(caller, _cont.is_empty() ? caller.pc()
                                                                  : StubRoutines::cont_returnBarrier());
-  } else if (_should_patch_caller_pc || caller.is_compiled_frame()) {
+  } else if (_should_patch_caller_pc) {
     // Caller was deoptimized during thaw but we've overwritten the return address when copying f from the heap.
     // Also, on some platforms, if the caller is interpreted but the callee not we also need to patch.
 
 #if defined(PPC64) || defined(S390)
-    assert(!_should_patch_caller_pc || caller.is_deoptimized_frame() || caller.is_interpreted_frame(), "");
+    assert(caller.is_deoptimized_frame() || caller.is_interpreted_frame(), "");
 #else
-    assert(!_should_patch_caller_pc || caller.is_deoptimized_frame(), "");
+    assert(caller.is_deoptimized_frame(), "");
 #endif
 
     ContinuationHelper::Frame::patch_pc(caller, caller.raw_pc());


### PR DESCRIPTION
The extra condition in the `else if` branch was incorrectly added in the merge of [JDK-8377715](https://bugs.openjdk.org/browse/JDK-8377715) into the `lworld` branch during `Valhalla` development and carried over in the JEP 401 integration, which I missed spotting. It is benign after the changes in [JDK-8377715](https://bugs.openjdk.org/browse/JDK-8377715) but it adds an unnecessary extra case to patch the pc when it is not needed.

Thanks,
Patricio

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390480](https://bugs.openjdk.org/browse/JDK-8390480): Remove unnecessary check in ThawBase::patch (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32406/head:pull/32406` \
`$ git checkout pull/32406`

Update a local copy of the PR: \
`$ git checkout pull/32406` \
`$ git pull https://git.openjdk.org/jdk.git pull/32406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32406`

View PR using the GUI difftool: \
`$ git pr show -t 32406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32406.diff">https://git.openjdk.org/jdk/pull/32406.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32406#issuecomment-5321567786)
</details>
