### PR TITLE
8390493: Remove vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java from the ProblemList

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -210,8 +210,6 @@ compiler/vectorapi/TestVectorReassociations.java 8388927 generic-all
 
 serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp-disable-tiered-compilation 8386674 linux-aarch64
 
-vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java 8384882 linux-all
-
 # The following test failure(s) DID NOT reproduce during Tier[1-8] testing
 # done for 8377828. Further analysis was done with 8376235 and just one
 # sub-test needed to remain on the ProblemList via 8361089.


### PR DESCRIPTION
The issue this test was PL'd for was fixed in mainline but the PL entry was brought across from the valhalla repo with the JEP-401 integration.

Thanks

/reviewers 1

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390493](https://bugs.openjdk.org/browse/JDK-8390493): Remove vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java from the ProblemList (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32408/head:pull/32408` \
`$ git checkout pull/32408`

Update a local copy of the PR: \
`$ git checkout pull/32408` \
`$ git pull https://git.openjdk.org/jdk.git pull/32408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32408`

View PR using the GUI difftool: \
`$ git pr show -t 32408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32408.diff">https://git.openjdk.org/jdk/pull/32408.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32408#issuecomment-5322064967)
</details>
