### PR TITLE
8387798: VectorAPI: VectorOperators.DIV javadoc incorrectly says "Floating only"

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorOperators.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorOperators.java
@@ -533,7 +533,7 @@ public final class VectorOperators {
     public static final Binary SUB = binary("SUB", "-", VectorSupport.VECTOR_OP_SUB, VO_ALL);
     /** Produce {@code a*b}. */
     public static final Associative MUL = assoc("MUL", "*", VectorSupport.VECTOR_OP_MUL, VO_ALL+VO_ASSOC);
-    /** Produce {@code a/b}. Floating only. */
+    /** Produce {@code a/b}. */
     public static final Binary DIV = binary("DIV", "/", VectorSupport.VECTOR_OP_DIV, VO_ALL| VO_SPECIAL);
     /** Produce {@code min(a,b)}. */
     public static final Associative MIN = assoc("MIN", "min", VectorSupport.VECTOR_OP_MIN, VO_ALL+VO_ASSOC);


### PR DESCRIPTION

VectorOperators.DIV is documented as “Floating only,” but the operator is supported/implemented for all numeric vector lane types: byte, short, int, long, Float16, float, and double, including masked operations.

1) DIV is declared with VO_ALL, meaning all supported lane types.
2) Byte, short, int, and long vectors all implement signed division fallbacks.
3) Named Vector.div(...) methods document integral divide-by-zero behavior.
4) Masked division only checks selected lanes for zero and suppresses inactive-lane division.
5) Existing generated tests cover integral masked and unmasked division.
6) C2 maps integral DIV to integer division IR nodes (VectorDivTest.java/line 110?).

This is a doc-only change to remove the incorrect “Floating only” qualification. No implementation or behavioral change is introduced.
Existing generated Vector API tests cover masked and unmasked division across all lane types and vector species, including integral divide-by-zero behavior.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change requires CSR request [JDK-8390492](https://bugs.openjdk.org/browse/JDK-8390492) to be approved
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8387798](https://bugs.openjdk.org/browse/JDK-8387798): VectorAPI: VectorOperators.DIV javadoc incorrectly says "Floating only" (**Bug** - P4)
 * [JDK-8390492](https://bugs.openjdk.org/browse/JDK-8390492): VectorAPI: VectorOperators.DIV javadoc incorrectly says "Floating only" (**CSR**)


### Reviewers
 * [Eric Fang](https://openjdk.org/census#erfang) (@erifan - Author)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32409/head:pull/32409` \
`$ git checkout pull/32409`

Update a local copy of the PR: \
`$ git checkout pull/32409` \
`$ git pull https://git.openjdk.org/jdk.git pull/32409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32409`

View PR using the GUI difftool: \
`$ git pr show -t 32409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32409.diff">https://git.openjdk.org/jdk/pull/32409.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32409#issuecomment-5322761086)
</details>
