### PR TITLE
8390481: stop002 test should no longer call Thread.interrupted() to work around JDK-8306324

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,8 +119,6 @@ public class stop002t {
                 return Consts.TEST_FAILED;
             }
         } catch (Throwable t) {
-            // Call Thread.interrupted(). Workaround for JDK-8306324
-            log.display("TEST #3: interrupted = " + Thread.interrupted());
             // We don't expect the exception to be thrown when in vthread mode.
             if (!vthreadMode && t instanceof MyThrowable) {
                 log.display("TEST #3: Caught expected exception while in loop: " + t);


### PR DESCRIPTION
The following still exists in vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java

            // Call Thread.interrupted(). Workaround for JDK-8306324
            log.display("TEST #2: interrupted = " + Thread.interrupted());

[JDK-8306324](https://bugs.openjdk.org/browse/JDK-8306324) has been fixed, so this code should be removed.

Tested by running test 100 times on all supported platforms in both virtual thread mode and platform thread mode.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390481](https://bugs.openjdk.org/browse/JDK-8390481): stop002 test should no longer call Thread.interrupted() to work around JDK-8306324 (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32411/head:pull/32411` \
`$ git checkout pull/32411`

Update a local copy of the PR: \
`$ git checkout pull/32411` \
`$ git pull https://git.openjdk.org/jdk.git pull/32411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32411`

View PR using the GUI difftool: \
`$ git pr show -t 32411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32411.diff">https://git.openjdk.org/jdk/pull/32411.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32411#issuecomment-5322890506)
</details>
