### PR TITLE
8390499: Clean up suspicious bailout in ciMethod::find_monomorphic_target

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -820,17 +820,7 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
   if (target() == root_m->get_Method()) {
     return root_m;
   }
-  if (!root_m->is_public() &&
-      !root_m->is_protected()) {
-    // If we are going to reason about inheritance, it's easiest
-    // if the method in question is public, protected, or private.
-    // If the answer is not root_m, it is conservatively correct
-    // to return null, even if the CHA encountered irrelevant
-    // methods in other packages.
-    // %%% TO DO: Work out logic for package-private methods
-    // with the same name but different vtable indexes.
-    return nullptr;
-  }
+
   return CURRENT_THREAD_ENV->get_method(target());
 }
 

--- a/test/hotspot/jtreg/compiler/cha/packagePrivate/NonOverridenParent.java
+++ b/test/hotspot/jtreg/compiler/cha/packagePrivate/NonOverridenParent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.cha.packagePrivate;
+
+/**
+ * An abstract class such that all of its concrete subclasses have a single implementation of
+ * {@link #call}. The subclasses lie in a different package so they cannot override {@link #call}.
+ */
+public abstract class NonOverridenParent {
+    int call() {
+        return 0;
+    }
+}

--- a/test/hotspot/jtreg/compiler/cha/packagePrivate/OverridenParent.java
+++ b/test/hotspot/jtreg/compiler/cha/packagePrivate/OverridenParent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.cha.packagePrivate;
+
+/**
+ * An abstract class such that all of its concrete subclasses have a single implementation of
+ * {@link #call} that is defined in a subclass of this class.
+ */
+public abstract class OverridenParent {
+    int call() {
+        return 0;
+    }
+}

--- a/test/hotspot/jtreg/compiler/cha/packagePrivate/OverridingChild.java
+++ b/test/hotspot/jtreg/compiler/cha/packagePrivate/OverridingChild.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.cha.packagePrivate;
+
+/**
+ * This class provides the unique implementation for {@link OverridenParent#call}, it is abstract
+ * so that {@code ciInstanceKlass::unique_concrete_subklass} does not find it.
+ */
+public abstract class OverridingChild extends OverridenParent {
+    // 3 concrete implementations to defeat the bimorphic inlining heuristic
+    public static class GrandChild1 extends OverridingChild {}
+    public static class GrandChild2 extends OverridingChild {}
+    public static class GrandChild3 extends OverridingChild {}
+
+    @Override
+    int call() {
+        return 1;
+    }
+}

--- a/test/hotspot/jtreg/compiler/cha/packagePrivate/TestDevirtualizePackageMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/packagePrivate/TestDevirtualizePackageMethod.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.cha.packagePrivate;
+
+import compiler.cha.packagePrivate.differentPackage.NonOverridingChild;
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8390499
+ * @summary Verify that C2 correctly devirtualizes package-private methods.
+ * @library /test/lib /
+ * @run driver ${test.main.class}
+ */
+public class TestDevirtualizePackageMethod {
+    public static void main(String[] args) {
+        var framework = new TestFramework();
+        framework.setDefaultWarmup(1);
+        framework.addFlags("-XX:CompileCommand=dontinline,*::call");
+        framework.start();
+    }
+
+    @Run(test = {"testOverriding1", "testOverriding2"})
+    public void runOverriding() {
+        var v1 = new OverridingChild.GrandChild1();
+        var v2 = new OverridingChild.GrandChild2();
+        var v3 = new OverridingChild.GrandChild3();
+        Asserts.assertEQ(1, testOverriding1(v1));
+        Asserts.assertEQ(1, testOverriding1(v2));
+        Asserts.assertEQ(1, testOverriding1(v3));
+        Asserts.assertEQ(1, testOverriding2(v1));
+        Asserts.assertEQ(1, testOverriding2(v2));
+        Asserts.assertEQ(1, testOverriding2(v3));
+    }
+
+    @Test
+    @IR(failOn = {IRNode.DYNAMIC_CALL_OF_METHOD, "OverridenParent::call", IRNode.DYNAMIC_CALL_OF_METHOD, "OverridingChild::call"})
+    @IR(counts = {IRNode.STATIC_CALL_OF_METHOD, "OverridingChild::call", "1"})
+    private static int testOverriding1(OverridenParent v) {
+        return v.call();
+    }
+
+    @Test
+    @IR(failOn = {IRNode.DYNAMIC_CALL_OF_METHOD, "OverridenParent::call", IRNode.DYNAMIC_CALL_OF_METHOD, "OverridingChild::call"})
+    @IR(counts = {IRNode.STATIC_CALL_OF_METHOD, "OverridingChild::call", "1"})
+    private static int testOverriding2(OverridingChild v) {
+        return v.call();
+    }
+
+    @Run(test = {"testNonOverriding1", "testNonOverriding2"})
+    public void runNonOverriding() {
+        var v1 = new NonOverridingChild.GrandChild1();
+        var v2 = new NonOverridingChild.GrandChild2();
+        var v3 = new NonOverridingChild.GrandChild3();
+        Asserts.assertEQ(0, testNonOverriding1(v1));
+        Asserts.assertEQ(0, testNonOverriding1(v2));
+        Asserts.assertEQ(0, testNonOverriding1(v3));
+        Asserts.assertEQ(1, testNonOverriding2(v1));
+        Asserts.assertEQ(1, testNonOverriding2(v2));
+        Asserts.assertEQ(1, testNonOverriding2(v3));
+    }
+
+    @Test
+    @IR(failOn = {IRNode.DYNAMIC_CALL_OF_METHOD, "NonOverridenParent::call", IRNode.DYNAMIC_CALL_OF_METHOD, "NonOverridingChild::call"})
+    @IR(counts = {IRNode.STATIC_CALL_OF_METHOD, "NonOverridenParent::call", "1"})
+    private static int testNonOverriding1(NonOverridenParent v) {
+        return v.call();
+    }
+
+    @Test
+    @IR(failOn = {IRNode.DYNAMIC_CALL_OF_METHOD, "NonOverridenParent::call", IRNode.DYNAMIC_CALL_OF_METHOD, "NonOverridingChild::call"})
+    @IR(counts = {IRNode.STATIC_CALL_OF_METHOD, "NonOverridingChild::call", "1"})
+    private static int testNonOverriding2(NonOverridingChild v) {
+        return v.call();
+    }
+}

--- a/test/hotspot/jtreg/compiler/cha/packagePrivate/differentPackage/NonOverridingChild.java
+++ b/test/hotspot/jtreg/compiler/cha/packagePrivate/differentPackage/NonOverridingChild.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.cha.packagePrivate.differentPackage;
+
+import compiler.cha.packagePrivate.NonOverridenParent;
+
+/**
+ * Although this class also has {@link #call}, it does not override
+ * {@link NonOverridenParent#call}.
+ */
+public abstract class NonOverridingChild extends NonOverridenParent {
+    // 3 subclasses to defeat the bimorphic inlining heuristic
+    public static class GrandChild1 extends NonOverridingChild {}
+    public static class GrandChild2 extends NonOverridingChild {}
+    public static class GrandChild3 extends NonOverridingChild {}
+
+    public int call() {
+        return 1;
+    }
+}


### PR DESCRIPTION
Hi,

This PR removes a suspicious place where we bail out of devirtualization. It is suspicious because it is either unnecessary, or it is too late as we have returned `root_m` in various places. Looking at `Dependencies::find_unique_concrete_method`, it is also clear that the implementation does not look at the name or the signature, but the `vtable` or `itable` index of the method to decide that it is the correct target.

Testing:

- [x] tier1-4,hs-comp-stress

Please take a look and let me know what you think, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390499](https://bugs.openjdk.org/browse/JDK-8390499): Clean up suspicious bailout in ciMethod::find_monomorphic_target (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32412/head:pull/32412` \
`$ git checkout pull/32412`

Update a local copy of the PR: \
`$ git checkout pull/32412` \
`$ git pull https://git.openjdk.org/jdk.git pull/32412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32412`

View PR using the GUI difftool: \
`$ git pr show -t 32412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32412.diff">https://git.openjdk.org/jdk/pull/32412.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32412#issuecomment-5324445198)
</details>
