### PR TITLE
8390501: Several JMH benchmarks fail with java.lang.UnsupportedClassVersionError

### DIFF
--- a/test/micro/org/openjdk/bench/valhalla/array/read/HoistArrayChecks.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/HoistArrayChecks.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(3)
+@Fork(value = 3, jvmArgsAppend = {"--add-opens", "java.base/jdk.internal.value=ALL-UNNAMED", "--enable-preview"})
 public class HoistArrayChecks {
     private static final int SIZE = 1_000_000;
 

--- a/test/micro/org/openjdk/bench/valhalla/array/read/HoistArrayChecks.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/HoistArrayChecks.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsAppend = {"--add-opens", "java.base/jdk.internal.value=ALL-UNNAMED", "--enable-preview"})
+@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED", "--enable-preview"})
 public class HoistArrayChecks {
     private static final int SIZE = 1_000_000;
 

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayListCursorTest.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayListCursorTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
-@Fork(1)
+@Fork(value = 1, jvmArgsAppend = {"--enable-preview"})
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 3)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapBench.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapBench.java
@@ -55,7 +55,7 @@ import static java.util.stream.Collectors.toMap;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(1)
+@Fork(value = 1, jvmArgsAppend = {"--enable-preview"})
 @State(Scope.Thread)
 public class HashMapBench {
     private IntFunction<Map<Integer, Integer>> mapSupplier;


### PR DESCRIPTION
Hi all,

This patch adds `--enable-preview` (and `--add-opens`) to several JMH benchmarks to avoid the error `java.lang.UnsupportedClassVersionError`.

Best Regards,
-- Guoxiong

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390501](https://bugs.openjdk.org/browse/JDK-8390501): Several JMH benchmarks fail with java.lang.UnsupportedClassVersionError (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32413/head:pull/32413` \
`$ git checkout pull/32413`

Update a local copy of the PR: \
`$ git checkout pull/32413` \
`$ git pull https://git.openjdk.org/jdk.git pull/32413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32413`

View PR using the GUI difftool: \
`$ git pr show -t 32413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32413.diff">https://git.openjdk.org/jdk/pull/32413.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32413#issuecomment-5325055422)
</details>
