### PR TITLE
8389755: VectorAPI Vector Javadoc Implementation notes incorrect

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
@@ -1886,27 +1886,23 @@ import java.util.Arrays;
  * <ul>
  *
  * <li> Intel x64 platforms supporting at least AVX2 up to AVX-512.
- * Masking using mask registers and mask accepting hardware
- * instructions on AVX-512 are not currently supported.
  *
- * <li> ARM AArch64 platforms supporting NEON.  Although the API has
- * been designed to ensure ARM SVE instructions can be supported
- * (vector sizes between 128 and 2048 bits) there is currently no
- * implementation of such instructions and the general masking
- * capability.
- *
+ * <li> Arm AArch64 platforms supporting Neon, SVE or SVE2.
  * </ul>
- * The implementation currently supports masked lane-wise operations
- * in a cross-platform manner by composing the unmasked lane-wise
- * operation with {@link #blend(Vector, VectorMask) blend} as in
+ *
+ * In the absence of hardware support, the implementation supports
+ * masked lane-wise operations by composing the unmasked lane-wise
+ * operations with {@link #blend(Vector, VectorMask) blend} as in
  * the expression {@code a.blend(a.lanewise(op, b), m)}, where
  * {@code a} and {@code b} are vectors, {@code op} is the vector
  * operation, and {@code m} is the mask.
  *
- * <p> The implementation does not currently support optimal
- * vectorized instructions for floating point transcendental
- * functions (such as operators {@link VectorOperators#SIN SIN}
- * and {@link VectorOperators#LOG LOG}).
+ * <p> The implementation includes optimal vectorized routines for
+ * transcendental and trigonometric lanewise operations on floating-point
+ * vectors (such as operators {@link VectorOperators#SIN SIN} and
+ * {@link VectorOperators#LOG LOG}).
+ * These are implemented for x64 platforms on Windows and Linux,
+ * and for AArch64 platforms on Linux and MacOS, and for RISC-V on Linux.
  *
  * <h2>No boxing of primitives</h2>
  *


### PR DESCRIPTION
The jdk.incubator.vector javadoc for jdk.incubator.vector.Vector has some stale information.

Under "Implementation Note: Hardware platform dependencies and limitations" there is the following text:

>  The Vector API is to accelerate computations in style of Single Instruction Multiple Data (SIMD), using available hardware resources such as vector hardware registers and vector hardware instructions. The API is designed to make effective use of multiple SIMD hardware platforms.
> 
>  This API will also work correctly even on Java platforms which do not include specialized hardware support for SIMD computations. The Vector API is not likely to provide any special performance benefit on such platforms.
> 
>  Currently the implementation is optimized to work best on:
> 
>  Intel x64 platforms supporting at least AVX2 up to AVX-512. Masking using mask registers and mask accepting hardware instructions on AVX-512 are not currently supported.
>  ARM AArch64 platforms supporting NEON. Although the API has been designed to ensure ARM SVE instructions can be supported (vector sizes between 128 and 2048 bits) there is currently no implementation of such instructions and the general masking capability.
> 
>  The implementation currently supports masked lane-wise operations in a cross-platform manner by composing the unmasked lane-wise operation with blend as in the expression a.blend(a.lanewise(op, b), m), where a and b are vectors, op is the vector operation, and m is the mask.
> 
>  The implementation does not currently support optimal vectorized instructions for floating point transcendental functions (such as operators SIN and LOG).
> 

As I understand it:

1. The AVX-512 support now includes support for masks.
2. The Arm AArch64 platform support now include SVE/SVE2 support and masking (predicate register support).
3. As well as the fall-back for masked lane-wise operations using blend, there is support for masks where the hardware allows.
4. There is now support for transcendental functions thanks to the SVML and SLEEF libraries.

Also, "ARM" is styled as "Arm", and "NEON" as "Neon".

This should be updated to reflect the implementation as it exists. 

---------
- [x ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8389755](https://bugs.openjdk.org/browse/JDK-8389755): VectorAPI Vector Javadoc Implementation notes incorrect (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32414/head:pull/32414` \
`$ git checkout pull/32414`

Update a local copy of the PR: \
`$ git checkout pull/32414` \
`$ git pull https://git.openjdk.org/jdk.git pull/32414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32414`

View PR using the GUI difftool: \
`$ git pr show -t 32414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32414.diff">https://git.openjdk.org/jdk/pull/32414.diff</a>

</details>
