### PR TITLE
8390521: RISC-V: Clean up vector register dispatch in MachSpillCopyNode::implementation

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1559,11 +1559,11 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
     int last_dst_offset = dst_offset;
     if (bottom_type()->isa_vect() != nullptr) {
       if (!bottom_type()->isa_pvectmask()) {
-        assert(ideal_reg() == Op_VecA, "Must be");
+        assert(ideal_reg() == Op_VecA, "Must be Op_VecA");
         int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
         last_dst_offset += vector_reg_size_in_bytes - 8;
       } else {
-        assert(ideal_reg() == Op_RegVectMask, "Must be");
+        assert(ideal_reg() == Op_RegVectMask, "Must be Op_RegVectMask");
         int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
         last_dst_offset += vmask_size_in_bytes - 4;
       }
@@ -1580,7 +1580,7 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
 
   if (bottom_type()->isa_vect() != nullptr && masm != nullptr) {
     if (!bottom_type()->isa_pvectmask()) {
-      assert(ideal_reg() == Op_VecA, "Must be");
+      assert(ideal_reg() == Op_VecA, "Must be Op_VecA");
       int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
       if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
         // stack to stack
@@ -1600,7 +1600,7 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
         ShouldNotReachHere();
       }
     } else {
-      assert(ideal_reg() == Op_RegVectMask, "Must be");
+      assert(ideal_reg() == Op_RegVectMask, "Must be Op_RegVectMask");
       int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
       if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
         // stack to stack
@@ -1703,11 +1703,11 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
       st->print("%s", Matcher::regName[dst_lo]);
     }
     if (bottom_type()->isa_vect() && !bottom_type()->isa_pvectmask()) {
-      assert(ideal_reg() == Op_VecA, "Must be");
+      assert(ideal_reg() == Op_VecA, "Must be Op_VecA");
       int vsize = Matcher::scalable_vector_reg_size(T_BYTE) * 8;
       st->print("\t# vector spill size = %d", vsize);
     } else if (bottom_type()->isa_pvectmask()) {
-      assert(ideal_reg() == Op_RegVectMask, "Must be");
+      assert(ideal_reg() == Op_RegVectMask, "Must be Op_RegVectMask");
       assert(Matcher::supports_scalable_vector(), "bad register type for spill");
       int vsize = Matcher::scalable_predicate_reg_slots() * 32;
       st->print("\t# vmask spill size = %d", vsize);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1557,12 +1557,16 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
   // address also needs t0 to materialize an offset outside the 12-bit range.
   if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
     int last_dst_offset = dst_offset;
-    if (bottom_type()->isa_pvectmask()) {
-      int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
-      last_dst_offset += vmask_size_in_bytes - 4;
-    } else if (ideal_reg() == Op_VecA) {
-      int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
-      last_dst_offset += vector_reg_size_in_bytes - 8;
+    if (bottom_type()->isa_vect() != nullptr) {
+      if (!bottom_type()->isa_pvectmask()) {
+        assert(ideal_reg() == Op_VecA, "Must be");
+        int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
+        last_dst_offset += vector_reg_size_in_bytes - 8;
+      } else {
+        assert(ideal_reg() == Op_RegVectMask, "Must be");
+        int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
+        last_dst_offset += vmask_size_in_bytes - 4;
+      }
     }
 
     if (masm != nullptr && !Assembler::is_simm12(last_dst_offset)) {
@@ -1574,9 +1578,9 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
     }
   }
 
-  if (bottom_type()->isa_vect() != nullptr) {
-    uint ireg = ideal_reg();
-    if (ireg == Op_VecA && masm) {
+  if (bottom_type()->isa_vect() != nullptr && masm != nullptr) {
+    if (!bottom_type()->isa_pvectmask()) {
+      assert(ideal_reg() == Op_VecA, "Must be");
       int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
       if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
         // stack to stack
@@ -1595,7 +1599,8 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
       } else {
         ShouldNotReachHere();
       }
-    } else if (bottom_type()->isa_pvectmask() && masm) {
+    } else {
+      assert(ideal_reg() == Op_RegVectMask, "Must be");
       int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
       if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
         // stack to stack
@@ -1698,14 +1703,11 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
       st->print("%s", Matcher::regName[dst_lo]);
     }
     if (bottom_type()->isa_vect() && !bottom_type()->isa_pvectmask()) {
-      int vsize = 0;
-      if (ideal_reg() == Op_VecA) {
-        vsize = Matcher::scalable_vector_reg_size(T_BYTE) * 8;
-      } else {
-        ShouldNotReachHere();
-      }
+      assert(ideal_reg() == Op_VecA, "Must be");
+      int vsize = Matcher::scalable_vector_reg_size(T_BYTE) * 8;
       st->print("\t# vector spill size = %d", vsize);
-    } else if (ideal_reg() == Op_RegVectMask) {
+    } else if (bottom_type()->isa_pvectmask()) {
+      assert(ideal_reg() == Op_RegVectMask, "Must be");
       assert(Matcher::supports_scalable_vector(), "bad register type for spill");
       int vsize = Matcher::scalable_predicate_reg_slots() * 32;
       st->print("\t# vmask spill size = %d", vsize);


### PR DESCRIPTION
Hi, please consider.

MachSpillCopyNode::implementation() in riscv.ad uses ideal_reg() to tell vector
registers from vector mask registers. That is needed on AArch64, where the NEON
and SVE register families coexist, but RVV has a single vector register family
(Matcher::vector_ideal_reg() only returns Op_VecA), so testing bottom_type() for
isa_pvectmask() is sufficient.

Dispatch on bottom_type(), keep ideal_reg() in asserts only, and drop the dead
ShouldNotReachHere() branch in the format() part. No functional change.

### Test
-  fastdebug hotspot_vector_1/2 and jdk_vector on SG2044

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390521](https://bugs.openjdk.org/browse/JDK-8390521): RISC-V: Clean up vector register dispatch in MachSpillCopyNode::implementation (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32416/head:pull/32416` \
`$ git checkout pull/32416`

Update a local copy of the PR: \
`$ git checkout pull/32416` \
`$ git pull https://git.openjdk.org/jdk.git pull/32416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32416`

View PR using the GUI difftool: \
`$ git pr show -t 32416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32416.diff">https://git.openjdk.org/jdk/pull/32416.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32416#issuecomment-5332826825)
</details>
