### PR TITLE
8390522: RISC-V: Avoid clobbering ra in the nmethod entry barrier

### DIFF
--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -300,8 +300,10 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
           // Because processors will not start the second load until the first comes back.
           // This means you can't overlap the two loads,
           // which is stronger than needed for ordering (stronger than TSO).
-          __ srli(ra, t0, 32);
-          __ orr(t1, t1, ra);
+          // XOR the guard into the epoch address twice. This preserves the
+          // address while making it dependent on the guard load.
+          __ xorr(t1, t1, t0);
+          __ xorr(t1, t1, t0);
         }
         // Read the global epoch value.
         __ lwu(t1, t1);


### PR DESCRIPTION
Hi, please consider.
The RISC-V concurrent nmethod entry barrier currently uses ra as a temporary register when constructing a synthetic dependency between the guard load and the patching epoch load.
Although the real return address has already been saved on the stack, the fast path leaves ra set to zero. An asynchronous profiler or external unwinder sampling the generated method can therefore observe an invalid return address.

This patch use the existing self-cancelling XOR dependency pattern instead. This preserves the required RVWMO ordering and the epoch address without clobbering ra or another allocatable register. The generated instruction count remains unchanged.

- [x] Run tier1 test with release on SG2044

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390522](https://bugs.openjdk.org/browse/JDK-8390522): RISC-V: Avoid clobbering ra in the nmethod entry barrier (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32417/head:pull/32417` \
`$ git checkout pull/32417`

Update a local copy of the PR: \
`$ git checkout pull/32417` \
`$ git pull https://git.openjdk.org/jdk.git pull/32417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32417`

View PR using the GUI difftool: \
`$ git pr show -t 32417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32417.diff">https://git.openjdk.org/jdk/pull/32417.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32417#issuecomment-5336769941)
</details>
