### PR TITLE
8390469: LogTest_large_message_vm_Test::TestBody crashes in case of low disc space

### DIFF
--- a/test/hotspot/gtest/logging/test_log.cpp
+++ b/test/hotspot/gtest/logging/test_log.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,7 @@ TEST_VM_F(LogTest, large_message) {
   fclose(fp);
 
   size_t count = 0;
+  ASSERT_NE(nullptr, output);
   for (size_t ps = 0 ; output[ps + count] != '\0'; output[ps + count] == Xchar ? count++ : ps++);
   EXPECT_EQ(sizeof(big_msg) - 1, count);
 }


### PR DESCRIPTION
In case of very low disc space/full disc we run into this crash in the LogTest_large_message_vm_Test gtest.
In case of no (low?) disc space it test  LogTest_large_message_vm_Test  we run into this crash, this should be avoided.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
# SIGSEGV (0xb) at pc=0x0000ffffae1c40b4, pid=23787, tid=23787
#
# JRE version: OpenJDK Runtime Environment (28.0) (build 28-internal-adhoc.sapmachine.jdk)
# Java VM: OpenJDK 64-Bit Server VM (28-internal-adhoc.sapmachine.jdk, mixed mode, sharing, tiered, compressed oops, compact obj headers, g1 gc, linux-aarch64)
# Problematic frame:
# V [libjvm.so+0x5940b4] LogTest_large_message_vm_Test::TestBody()+0x13a8
#

--------------- S U M M A R Y ------------

Command Line: -XX:+ExecutingUnitTests -Xmx200m

Host: AArch64, 16 cores, 61G, SUSE Linux Enterprise Server 15 SP4
Time: Sun Aug 16 06:00:47 2026 CEST elapsed time: 43.338240 seconds (0d 0h 0m 43s)

--------------- T H R E A D ---------------

Current thread (0x0000aaaae6a4ae80): JavaThread "main" [_thread_in_native, id=23787, stack(0x0000ffffc700e000,0x0000ffffc720c000) (2040K)]

Stack: [0x0000ffffc700e000,0x0000ffffc720c000], sp=0x0000ffffc7209f50, free space=2031k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V [libjvm.so+0x5940b4] LogTest_large_message_vm_Test::TestBody()+0x13a8 (test_log.cpp:68)
V [libjvm.so+0x15825c4] testing::Test::Run()+0xe4 (gtest.cc:2670)
V [libjvm.so+0x1582758] testing::TestInfo::Run()+0x178 (gtest.cc:2836)
V [libjvm.so+0x1582a44] testing::TestSuite::Run()+0x2d8 (gtest.cc:3015)
V [libjvm.so+0x158f4a4] testing::internal::UnitTestImpl::RunAllTests()+0x334 (gtest.cc:5920)
V [libjvm.so+0x158f960] testing::UnitTest::Run()+0x74 (gtest.cc:2670)
V [libjvm.so+0x403458] runUnitTestsInner(int, char**)+0x398 (gtest.h:2317)
C [gtestLauncher+0x7e0] main+0x1c (gtestLauncher.cpp:40)
C [libc.so.6+0x23fa0] __libc_start_main+0xe8
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390469](https://bugs.openjdk.org/browse/JDK-8390469): LogTest_large_message_vm_Test::TestBody crashes in case of low disc space (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32418/head:pull/32418` \
`$ git checkout pull/32418`

Update a local copy of the PR: \
`$ git checkout pull/32418` \
`$ git pull https://git.openjdk.org/jdk.git pull/32418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32418`

View PR using the GUI difftool: \
`$ git pr show -t 32418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32418.diff">https://git.openjdk.org/jdk/pull/32418.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32418#issuecomment-5359338284)
</details>
