### PR TITLE
8390526: Remove pre-Windows 7 Windows versions from sun/awt/OSInfo.java

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/OSInfo.java
+++ b/src/java.desktop/share/classes/sun/awt/OSInfo.java
@@ -50,7 +50,6 @@ public class OSInfo {
        It allows compare objects by "==" instead of "equals".
      */
     public static final WindowsVersion WINDOWS_UNKNOWN = new WindowsVersion(-1, -1);
-    public static final WindowsVersion WINDOWS_7 = new WindowsVersion(6, 1);
 
     private static final String OS_VERSION = "os.version";
 
@@ -58,11 +57,6 @@ public class OSInfo {
 
     // Cache the OSType for getOSType()
     private static final OSType CURRENT_OSTYPE = getOSTypeImpl();
-
-
-    static {
-        windowsVersionMap.put(WINDOWS_7.toString(), WINDOWS_7);
-    }
 
     private OSInfo() {
         // Don't allow to create instances

--- a/src/java.desktop/share/classes/sun/awt/OSInfo.java
+++ b/src/java.desktop/share/classes/sun/awt/OSInfo.java
@@ -50,13 +50,6 @@ public class OSInfo {
        It allows compare objects by "==" instead of "equals".
      */
     public static final WindowsVersion WINDOWS_UNKNOWN = new WindowsVersion(-1, -1);
-    public static final WindowsVersion WINDOWS_95 = new WindowsVersion(4, 0);
-    public static final WindowsVersion WINDOWS_98 = new WindowsVersion(4, 10);
-    public static final WindowsVersion WINDOWS_ME = new WindowsVersion(4, 90);
-    public static final WindowsVersion WINDOWS_2000 = new WindowsVersion(5, 0);
-    public static final WindowsVersion WINDOWS_XP = new WindowsVersion(5, 1);
-    public static final WindowsVersion WINDOWS_2003 = new WindowsVersion(5, 2);
-    public static final WindowsVersion WINDOWS_VISTA = new WindowsVersion(6, 0);
     public static final WindowsVersion WINDOWS_7 = new WindowsVersion(6, 1);
 
     private static final String OS_VERSION = "os.version";
@@ -68,13 +61,6 @@ public class OSInfo {
 
 
     static {
-        windowsVersionMap.put(WINDOWS_95.toString(), WINDOWS_95);
-        windowsVersionMap.put(WINDOWS_98.toString(), WINDOWS_98);
-        windowsVersionMap.put(WINDOWS_ME.toString(), WINDOWS_ME);
-        windowsVersionMap.put(WINDOWS_2000.toString(), WINDOWS_2000);
-        windowsVersionMap.put(WINDOWS_XP.toString(), WINDOWS_XP);
-        windowsVersionMap.put(WINDOWS_2003.toString(), WINDOWS_2003);
-        windowsVersionMap.put(WINDOWS_VISTA.toString(), WINDOWS_VISTA);
         windowsVersionMap.put(WINDOWS_7.toString(), WINDOWS_7);
     }
 

--- a/src/java.desktop/share/classes/sun/swing/WindowsPlacesBar.java
+++ b/src/java.desktop/share/classes/sun/swing/WindowsPlacesBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,7 @@ public class WindowsPlacesBar extends JToolBar
         setFloatable(false);
         putClientProperty("JToolBar.isRollover", Boolean.TRUE);
 
-        boolean isXPPlatform = (OSInfo.getOSType() == OSInfo.OSType.WINDOWS &&
-                OSInfo.getWindowsVersion().compareTo(OSInfo.WINDOWS_XP) >= 0);
+        boolean isXPPlatform = (OSInfo.getOSType() == OSInfo.OSType.WINDOWS);
 
         if (isXPStyle) {
             buttonSize = new Dimension(83, 69);

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLookAndFeel.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,16 +173,7 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
     @Override
     public void initialize() {
         super.initialize();
-
-        // Set the flag which determines which version of Windows should
-        // be rendered. This flag only need to be set once.
-        // if version <= 4.0 then the classic LAF should be loaded.
-        if (OSInfo.getWindowsVersion().compareTo(OSInfo.WINDOWS_95) <= 0) {
-            isClassicWindows = true;
-        } else {
-            isClassicWindows = false;
-            XPStyle.invalidateStyle();
-        }
+        XPStyle.invalidateStyle();
 
         // Using the fonts set by the user can potentially cause
         // performance and compatibility issues, so allow this feature
@@ -340,11 +331,6 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
         ColorUIResource gray = new ColorUIResource(Color.gray);
         ColorUIResource darkGray = new ColorUIResource(Color.darkGray);
         ColorUIResource scrollBarTrackHighlight = darkGray;
-
-        // Set the flag which determines which version of Windows should
-        // be rendered. This flag only need to be set once.
-        // if version <= 4.0 then the classic LAF should be loaded.
-        isClassicWindows = OSInfo.getWindowsVersion().compareTo(OSInfo.WINDOWS_95) <= 0;
 
         // *** Tree
         Object treeExpandedIcon = WindowsTreeUI.ExpandedIcon.createExpandedIcon();
@@ -599,8 +585,7 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
 
 
         if (!(this instanceof WindowsClassicLookAndFeel) &&
-                (OSInfo.getOSType() == OSInfo.OSType.WINDOWS &&
-                OSInfo.getWindowsVersion().compareTo(OSInfo.WINDOWS_XP) >= 0)) {
+                (OSInfo.getOSType() == OSInfo.OSType.WINDOWS)) {
             String prop = System.getProperty("swing.noxp");
             if (prop == null) {
 
@@ -1595,8 +1580,7 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
     }
 
     static boolean isOnVista() {
-        return OSInfo.getOSType() == OSInfo.OSType.WINDOWS
-                && OSInfo.getWindowsVersion().compareTo(OSInfo.WINDOWS_VISTA) >= 0;
+        return OSInfo.getOSType() == OSInfo.OSType.WINDOWS;
     }
 
     static boolean isOnWindows7() {
@@ -1915,10 +1899,6 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
         WindowsDesktopProperty.flushUnreferencedProperties();
     }
 
-    // Flag which indicates that the Win98/Win2k/WinME features
-    // should be disabled.
-    private static boolean isClassicWindows = false;
-
     /**
      * Gets the state of the flag which indicates if the old Windows
      * look and feel should be rendered. This flag is used by the
@@ -1930,7 +1910,8 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
      * @since 1.4
      */
     public static boolean isClassicWindows() {
-        return isClassicWindows;
+        // we could probably remove the whole method
+        return false;
     }
 
     /**
@@ -2097,18 +2078,6 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
                             String nativeImageName, String fallbackName) {
             this.nativeImageName = nativeImageName;
             this.fallbackName = fallbackName;
-
-            if (OSInfo.getOSType() == OSInfo.OSType.WINDOWS &&
-                    OSInfo.getWindowsVersion().compareTo(OSInfo.WINDOWS_XP) < 0) {
-                // This desktop property is needed to trigger reloading the icon.
-                // It is kept in member variable to avoid GC.
-                this.desktopProperty = new TriggerDesktopProperty(desktopPropertyName) {
-                    @Override protected void updateUI() {
-                        icon = null;
-                        super.updateUI();
-                    }
-                };
-            }
         }
 
         @Override

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLookAndFeel.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLookAndFeel.java
@@ -1579,19 +1579,7 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
         initVistaComponentDefaults(table);
     }
 
-    static boolean isOnVista() {
-        return OSInfo.getOSType() == OSInfo.OSType.WINDOWS;
-    }
-
-    static boolean isOnWindows7() {
-        return OSInfo.getOSType() == OSInfo.OSType.WINDOWS
-                && OSInfo.getWindowsVersion().compareTo(OSInfo.WINDOWS_7) >= 0;
-    }
-
     private void initVistaComponentDefaults(UIDefaults table) {
-        if (! isOnVista()) {
-            return;
-        }
         /* START handling menus for Vista */
         String[] menuClasses = { "MenuItem", "Menu",
                 "CheckBoxMenuItem", "RadioButtonMenuItem",
@@ -1658,29 +1646,6 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
         table.putDefaults(menuDefaults);
 
         /*For Windows7 margin and checkIconOffset should be greater than 0 */
-        if (!isOnWindows7()) {
-            /* no margins */
-            InsetsUIResource insets = new InsetsUIResource(0, 0, 0, 0);
-            for (int i = 0, j = 0; i < menuClasses.length; i++) {
-                String key = menuClasses[i] + ".margin";
-                Object oldValue = table.get(key);
-                menuDefaults[j++] = key;
-                menuDefaults[j++] = new XPValue(insets, oldValue);
-            }
-            table.putDefaults(menuDefaults);
-
-            /* set checkIcon offset */
-            Integer checkIconOffsetInteger =
-                Integer.valueOf(0);
-            for (int i = 0, j = 0; i < menuClasses.length; i++) {
-                String key = menuClasses[i] + ".checkIconOffset";
-                Object oldValue = table.get(key);
-                menuDefaults[j++] = key;
-                menuDefaults[j++] =
-                    new XPValue(checkIconOffsetInteger, oldValue);
-            }
-            table.putDefaults(menuDefaults);
-        }
         /* set width of the gap after check icon */
         Integer afterCheckIconGap = WindowsPopupMenuUI.getSpanBeforeGutter()
                 + WindowsPopupMenuUI.getGutterWidth()

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
@@ -105,23 +105,21 @@ public class WindowsMenuBarUI extends BasicMenuBarUI
     }
     @Override
     protected void installListeners() {
-        if (WindowsLookAndFeel.isOnVista()) {
-            installWindowListener();
-            hierarchyListener =
-                new HierarchyListener() {
-                    public void hierarchyChanged(HierarchyEvent e) {
-                        if ((e.getChangeFlags()
-                                & HierarchyEvent.DISPLAYABILITY_CHANGED) != 0) {
-                            if (menuBar.isDisplayable()) {
-                                installWindowListener();
-                            } else {
-                                uninstallWindowListener();
-                            }
+        installWindowListener();
+        hierarchyListener =
+            new HierarchyListener() {
+                public void hierarchyChanged(HierarchyEvent e) {
+                    if ((e.getChangeFlags()
+                            & HierarchyEvent.DISPLAYABILITY_CHANGED) != 0) {
+                        if (menuBar.isDisplayable()) {
+                            installWindowListener();
+                        } else {
+                            uninstallWindowListener();
                         }
                     }
-            };
-            menuBar.addHierarchyListener(hierarchyListener);
-        }
+                }
+        };
+        menuBar.addHierarchyListener(hierarchyListener);
         super.installListeners();
     }
 

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTableHeaderUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsTableHeaderUI.java
@@ -138,9 +138,7 @@ public class WindowsTableHeaderUI extends BasicTableHeaderUI {
              * We use border to paint it.
              */
             Icon sortIcon;
-            if (WindowsLookAndFeel.isOnVista()
-                && ((sortIcon = getIcon()) instanceof javax.swing.plaf.UIResource
-                    || sortIcon == null)) {
+            if (((sortIcon = getIcon()) instanceof javax.swing.plaf.UIResource || sortIcon == null)) {
                 contentTop += 1;
                 setIcon(null);
                 sortIcon = null;
@@ -196,32 +194,31 @@ public class WindowsTableHeaderUI extends BasicTableHeaderUI {
             } else if (isSelected || hasFocus || hasRollover) {
                 state = State.HOT;
             }
-            /* on Vista there are more states for sorted columns */
-            if (WindowsLookAndFeel.isOnVista()) {
-                SortOrder sortOrder = getColumnSortOrder(header.getTable(), column);
-                if (sortOrder != null) {
-                     switch(sortOrder) {
-                     case ASCENDING:
-                     case DESCENDING:
-                         switch (state) {
-                         case NORMAL:
-                             state = State.SORTEDNORMAL;
-                             break;
-                         case PRESSED:
-                             state = State.SORTEDPRESSED;
-                             break;
-                         case HOT:
-                             state = State.SORTEDHOT;
-                             break;
-                         default:
-                             /* do nothing */
-                         }
+
+            SortOrder sortOrder = getColumnSortOrder(header.getTable(), column);
+            if (sortOrder != null) {
+                 switch(sortOrder) {
+                 case ASCENDING:
+                 case DESCENDING:
+                     switch (state) {
+                     case NORMAL:
+                         state = State.SORTEDNORMAL;
                          break;
-                     default :
+                     case PRESSED:
+                         state = State.SORTEDPRESSED;
+                         break;
+                     case HOT:
+                         state = State.SORTEDHOT;
+                         break;
+                     default:
                          /* do nothing */
                      }
-                }
+                     break;
+                 default :
+                     /* do nothing */
+                 }
             }
+
             skin.paintSkin(g, 0, 0, size.width-1, size.height-1, state);
             super.paint(g);
         }


### PR DESCRIPTION
sun/awt/OSInfo.java contains very old Windows versions like Windows 95,98, ME. Those can be removed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390526](https://bugs.openjdk.org/browse/JDK-8390526): Remove pre-Windows 7 Windows versions from sun/awt/OSInfo.java (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32419/head:pull/32419` \
`$ git checkout pull/32419`

Update a local copy of the PR: \
`$ git checkout pull/32419` \
`$ git pull https://git.openjdk.org/jdk.git pull/32419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32419`

View PR using the GUI difftool: \
`$ git pr show -t 32419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32419.diff">https://git.openjdk.org/jdk/pull/32419.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32419#issuecomment-5329936246)
</details>
