### PR TITLE
8390545: java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java fails on OL9

### DIFF
--- a/test/jdk/java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java
@@ -58,7 +58,6 @@ public class JPopupMenuOverlapping extends OverlappingTestBase {
     {testEmbeddedFrame = true;}
 
     private boolean lwClicked = false;
-    private Point loc;
     private JPopupMenu popup;
     private JFrame frame=null;
 
@@ -86,11 +85,12 @@ public class JPopupMenuOverlapping extends OverlappingTestBase {
         }
         propagateAWTControls(frame);
         frame.setVisible(true);
-        loc = frame.getContentPane().getLocationOnScreen();
     }
 
     @Override
     protected boolean performTest() {
+        Point loc = frame.getContentPane().getLocationOnScreen();
+
         // run robot
         Robot robot = Util.createRobot();
         robot.setAutoDelay(ROBOT_DELAY);


### PR DESCRIPTION
Fixes a timing issue in `JPopupMenuOverlapping`.

The test previously cached the content pane screen location immediately after showing the frame.
This may not work correctly with every Linux window manager, as multiple `ConfigureNotify` events may be delivered while the window geometry is being settled.

The location is now obtained in `performTest()`, after the window has settled:

https://github.com/openjdk/jdk/blob/8a507d85e9b7c7a0acfd7fa72b898b9a9ce2d5ee/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java#L496-L504

Testing looks good.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390545](https://bugs.openjdk.org/browse/JDK-8390545): java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java fails on OL9 (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32420/head:pull/32420` \
`$ git checkout pull/32420`

Update a local copy of the PR: \
`$ git checkout pull/32420` \
`$ git pull https://git.openjdk.org/jdk.git pull/32420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32420`

View PR using the GUI difftool: \
`$ git pr show -t 32420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32420.diff">https://git.openjdk.org/jdk/pull/32420.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32420#issuecomment-5330425064)
</details>
