### PR TITLE
8390550: C2 hit MemLimit when run with -Xcomp -XX:VerifyIterativeGVN=1110

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -726,9 +726,9 @@
           "Re-process nodes that could benefit from a deep revisit after "  \
           "the IGVN worklist drains")                                       \
                                                                             \
-  product(uint, MacroExpansionCleanupCount, 32, DIAGNOSTIC,                 \
-          "Execute IGVN optimization to clean graph after this number of "  \
-          "macro nodes are expanded")                                       \
+  product(uint, MacroExpansionCleanupCount, 16, DIAGNOSTIC,                 \
+          "Run IGVN to clean the graph after this many macro nodes are "    \
+          "expanded or when we approach the max live node limit.")          \
           range(1, 100)                                                     \
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -729,7 +729,7 @@
   product(uint, MacroExpansionCleanupCount, 32, DIAGNOSTIC,                 \
           "Execute IGVN optimization to clean graph after this number of "  \
           "macro nodes are expanded")                                       \
-          range(0, 100)                                                     \
+          range(1, 100)                                                     \
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \
           "Verify Iterative Global Value Numbering =GFEDCBA, with:"         \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -726,6 +726,11 @@
           "Re-process nodes that could benefit from a deep revisit after "  \
           "the IGVN worklist drains")                                       \
                                                                             \
+  product(uint, MacroExpansionCleanupCount, 32, DIAGNOSTIC,                 \
+          "Execute IGVN optimization to clean graph after this number of "  \
+          "macro nodes are expanded")                                       \
+          range(0, 100)                                                     \
+                                                                            \
   develop(uint, VerifyIterativeGVN, 0,                                      \
           "Verify Iterative Global Value Numbering =GFEDCBA, with:"         \
           "  G: verify Node::Identity return an existing node"              \

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3320,7 +3320,7 @@ void Compile::Optimize() {
       return;
     }
     print_method(PHASE_AFTER_MACRO_ELIMINATION, 2);
-    if (mex.expand_macro_nodes()) {
+    if (!mex.expand_macro_nodes()) {
       assert(failing(), "must bail out w/ explicit message");
       return;
     }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3460,7 +3460,7 @@ bool PhaseMacroExpand::expand_macro_nodes() {
       break;
     }
     // Make sure expansion will not cause node limit to be exceeded.
-    if (C->check_node_count(macro_expansion_margin, "out of nodes before macro expansion")) {
+    if (C->check_node_count(macro_expansion_estimate, "out of nodes before macro expansion")) {
       return true;
     }
 
@@ -3541,7 +3541,7 @@ bool PhaseMacroExpand::expand_macro_nodes() {
       continue;
     }
     // Make sure expansion will not cause node limit to be exceeded.
-    if (C->check_node_count(macro_expansion_margin, "out of nodes before macro expansion")) {
+    if (C->check_node_count(macro_expansion_estimate, "out of nodes before macro expansion")) {
       return true;
     }
     switch (n->class_id()) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3518,6 +3518,14 @@ bool PhaseMacroExpand::expand_macro_nodes() {
     pending_expansions_to_cleanup = 0;
   }
 
+  // Cleanup graph before expanding Allocate nodes.
+  if (pending_expansions_to_cleanup > 0) {
+    if (cleanup_graph(_igvn)) {
+      return true; // failing
+    }
+    pending_expansions_to_cleanup = 0;
+  }
+
   // All nodes except Allocate nodes are expanded now. There could be
   // new optimization opportunities (such as folding newly created
   // load from a just allocated object). Run IGVN.

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3204,10 +3204,10 @@ static bool cleanup_graph(PhaseIterGVN& igvn) {
   igvn.set_delay_transform(false);
   igvn.optimize();
   if (igvn.C->failing()) {
-    return true;
+    return false;
   }
   igvn.set_delay_transform(true);
-  return false;
+  return true;
 }
 
 //---------------------------eliminate_macro_nodes----------------------
@@ -3323,7 +3323,7 @@ void PhaseMacroExpand::eliminate_macro_nodes(bool eliminate_locks) {
     // other macro nodes can remove all these safepoints, allowing the allocation to be removed.
     // Hence after igvn we retry removing macro nodes if some progress that has been made in this
     // iteration.
-    if (cleanup_graph(_igvn)) {
+    if (!cleanup_graph(_igvn)) {
       return; // failing
     }
 
@@ -3415,18 +3415,18 @@ void PhaseMacroExpand::eliminate_opaque_looplimit_macro_nodes() {
 }
 
 //------------------------------expand_macro_nodes----------------------
-//  Returns true if a failure occurred.
+//  Returns false if a failure occurred.
 bool PhaseMacroExpand::expand_macro_nodes() {
   if (StressMacroExpansion) {
     C->shuffle_macro_nodes();
   }
 
   // Clean up after eliminate_opaque_looplimit_macro_nodes()
-  if (cleanup_graph(_igvn)) {
-    return true; // failing
+  if (!cleanup_graph(_igvn)) {
+    return false; // failing
   }
 
-  // Because we run IGVN after each expansion, some macro nodes may go
+  // Because we run IGVN after set of expansions, some macro nodes may go
   // dead and be removed from the list as we iterate over it. Move
   // Allocate nodes (processed in a second pass) at the beginning of
   // the list and then iterate from the last element of the list until
@@ -3461,7 +3461,7 @@ bool PhaseMacroExpand::expand_macro_nodes() {
     }
     // Make sure expansion will not cause node limit to be exceeded.
     if (C->check_node_count(macro_expansion_estimate, "out of nodes before macro expansion")) {
-      return true;
+      return false;
     }
 
     DEBUG_ONLY(int old_macro_count = C->macro_count();)
@@ -3502,7 +3502,7 @@ bool PhaseMacroExpand::expand_macro_nodes() {
     }
     assert(C->macro_count() == (old_macro_count - 1), "expansion must have deleted one node from macro list");
     if (C->failing()) {
-      return true;
+      return false;
     }
     C->print_method(PHASE_AFTER_MACRO_EXPANSION_STEP, 5, n);
 
@@ -3512,16 +3512,16 @@ bool PhaseMacroExpand::expand_macro_nodes() {
       // skip clean up
       continue;
     }
-    if (cleanup_graph(_igvn)) {
-      return true; // failing
+    if (!cleanup_graph(_igvn)) {
+      return false; // failing
     }
     pending_expansions_to_cleanup = 0;
   }
 
   // Cleanup graph before expanding Allocate nodes.
   if (pending_expansions_to_cleanup > 0) {
-    if (cleanup_graph(_igvn)) {
-      return true; // failing
+    if (!cleanup_graph(_igvn)) {
+      return false; // failing
     }
     pending_expansions_to_cleanup = 0;
   }
@@ -3542,7 +3542,7 @@ bool PhaseMacroExpand::expand_macro_nodes() {
     }
     // Make sure expansion will not cause node limit to be exceeded.
     if (C->check_node_count(macro_expansion_estimate, "out of nodes before macro expansion")) {
-      return true;
+      return false;
     }
     switch (n->class_id()) {
     case Node::Class_Allocate:
@@ -3555,7 +3555,9 @@ bool PhaseMacroExpand::expand_macro_nodes() {
       assert(false, "unknown node type in macro list");
     }
     assert(C->macro_count() < macro_count, "must have deleted a node from macro list");
-    if (C->failing())  return true;
+    if (C->failing()) {
+      return false;
+    }
     C->print_method(PHASE_AFTER_MACRO_EXPANSION_STEP, 5, n);
 
     pending_expansions_to_cleanup++;
@@ -3564,18 +3566,18 @@ bool PhaseMacroExpand::expand_macro_nodes() {
       // skip clean up
       continue;
     }
-    if (cleanup_graph(_igvn)) {
-      return true; // failing
+    if (!cleanup_graph(_igvn)) {
+      return false; // failing
     }
     pending_expansions_to_cleanup = 0;
   }
   if (pending_expansions_to_cleanup > 0) {
-    if (cleanup_graph(_igvn)) {
-      return true; // failing
+    if (!cleanup_graph(_igvn)) {
+      return false; // failing
     }
   }
   _igvn.set_delay_transform(false);
-  return false;
+  return true;
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3199,6 +3199,17 @@ void PhaseMacroExpand::refine_strip_mined_loop_macro_nodes() {
   }
 }
 
+// Clean up the graph so we're less likely to hit the maximum node limit
+static bool cleanup_graph(PhaseIterGVN& igvn) {
+  igvn.set_delay_transform(false);
+  igvn.optimize();
+  if (igvn.C->failing()) {
+    return true;
+  }
+  igvn.set_delay_transform(true);
+  return false;
+}
+
 //---------------------------eliminate_macro_nodes----------------------
 // Eliminate scalar replaced allocations and associated locks.
 void PhaseMacroExpand::eliminate_macro_nodes(bool eliminate_locks) {
@@ -3312,12 +3323,9 @@ void PhaseMacroExpand::eliminate_macro_nodes(bool eliminate_locks) {
     // other macro nodes can remove all these safepoints, allowing the allocation to be removed.
     // Hence after igvn we retry removing macro nodes if some progress that has been made in this
     // iteration.
-    _igvn.set_delay_transform(false);
-    _igvn.optimize();
-    if (C->failing()) {
-      return;
+    if (cleanup_graph(_igvn)) {
+      return; // failing
     }
-    _igvn.set_delay_transform(true);
 
     if (!progress) {
       break;
@@ -3413,13 +3421,10 @@ bool PhaseMacroExpand::expand_macro_nodes() {
     C->shuffle_macro_nodes();
   }
 
-  // Clean up the graph so we're less likely to hit the maximum node
-  // limit
-  _igvn.set_delay_transform(false);
-  _igvn.optimize();
-  if (C->failing())  return true;
-  _igvn.set_delay_transform(true);
-
+  // Clean up after eliminate_opaque_looplimit_macro_nodes()
+  if (cleanup_graph(_igvn)) {
+    return true; // failing
+  }
 
   // Because we run IGVN after each expansion, some macro nodes may go
   // dead and be removed from the list as we iterate over it. Move
@@ -3429,25 +3434,33 @@ bool PhaseMacroExpand::expand_macro_nodes() {
   // the list due to nodes going dead.
   C->sort_macro_nodes();
 
-  // expand arraycopy "macro" nodes first
   // For ReduceBulkZeroing, we must first process all arraycopy nodes
-  // before the allocate nodes are expanded.
+  // before the allocate nodes are expanded. Sorting macro nodes list
+  // enforces it.
+
+  // Worst case is a macro node gets expanded into about 200 nodes.
+  // Allow 50% more for optimization.
+  static const uint macro_expansion_estimate = 300;
+  const uint macro_expansion_margin = macro_expansion_estimate * MacroExpansionCleanupCount;
+  const uint macro_expansion_limit  = C->max_node_limit() > macro_expansion_margin ?
+                                      C->max_node_limit() - macro_expansion_margin : 0;
+  uint pending_expansions_to_cleanup = 0;
+
   while (C->macro_count() > 0) {
     int macro_count = C->macro_count();
-    Node * n = C->macro_node(macro_count-1);
+    Node* n = C->macro_node(macro_count-1);
     assert(n->is_macro(), "only macro nodes expected here");
     if (_igvn.type(n) == Type::TOP || (n->in(0) != nullptr && n->in(0)->is_top())) {
       // node is unreachable, so don't try to expand it
       C->remove_macro_node(n);
       continue;
     }
+    // Reached Allocate nodes - jump to second pass to prcess them.
     if (n->is_Allocate()) {
       break;
     }
     // Make sure expansion will not cause node limit to be exceeded.
-    // Worst case is a macro node gets expanded into about 200 nodes.
-    // Allow 50% more for optimization.
-    if (C->check_node_count(300, "out of nodes before macro expansion")) {
+    if (C->check_node_count(macro_expansion_margin, "out of nodes before macro expansion")) {
       return true;
     }
 
@@ -3488,22 +3501,27 @@ bool PhaseMacroExpand::expand_macro_nodes() {
       }
     }
     assert(C->macro_count() == (old_macro_count - 1), "expansion must have deleted one node from macro list");
-    if (C->failing())  return true;
+    if (C->failing()) {
+      return true;
+    }
     C->print_method(PHASE_AFTER_MACRO_EXPANSION_STEP, 5, n);
 
-    // Clean up the graph so we're less likely to hit the maximum node
-    // limit
-    _igvn.set_delay_transform(false);
-    _igvn.optimize();
-    if (C->failing())  return true;
-    _igvn.set_delay_transform(true);
+    pending_expansions_to_cleanup++;
+    if (pending_expansions_to_cleanup < MacroExpansionCleanupCount &&
+        C->live_nodes() < macro_expansion_limit) {
+      // skip clean up
+      continue;
+    }
+    if (cleanup_graph(_igvn)) {
+      return true; // failing
+    }
+    pending_expansions_to_cleanup = 0;
   }
 
   // All nodes except Allocate nodes are expanded now. There could be
   // new optimization opportunities (such as folding newly created
   // load from a just allocated object). Run IGVN.
 
-  // expand "macro" nodes
   // nodes are removed from the macro list as they are processed
   while (C->macro_count() > 0) {
     int macro_count = C->macro_count();
@@ -3515,9 +3533,7 @@ bool PhaseMacroExpand::expand_macro_nodes() {
       continue;
     }
     // Make sure expansion will not cause node limit to be exceeded.
-    // Worst case is a macro node gets expanded into about 200 nodes.
-    // Allow 50% more for optimization.
-    if (C->check_node_count(300, "out of nodes before macro expansion")) {
+    if (C->check_node_count(macro_expansion_margin, "out of nodes before macro expansion")) {
       return true;
     }
     switch (n->class_id()) {
@@ -3534,14 +3550,22 @@ bool PhaseMacroExpand::expand_macro_nodes() {
     if (C->failing())  return true;
     C->print_method(PHASE_AFTER_MACRO_EXPANSION_STEP, 5, n);
 
-    // Clean up the graph so we're less likely to hit the maximum node
-    // limit
-    _igvn.set_delay_transform(false);
-    _igvn.optimize();
-    if (C->failing())  return true;
-    _igvn.set_delay_transform(true);
+    pending_expansions_to_cleanup++;
+    if (pending_expansions_to_cleanup < MacroExpansionCleanupCount &&
+        C->live_nodes() < macro_expansion_limit) {
+      // skip clean up
+      continue;
+    }
+    if (cleanup_graph(_igvn)) {
+      return true; // failing
+    }
+    pending_expansions_to_cleanup = 0;
   }
-
+  if (pending_expansions_to_cleanup > 0) {
+    if (cleanup_graph(_igvn)) {
+      return true; // failing
+    }
+  }
   _igvn.set_delay_transform(false);
   return false;
 }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3455,7 +3455,7 @@ bool PhaseMacroExpand::expand_macro_nodes() {
       C->remove_macro_node(n);
       continue;
     }
-    // Reached Allocate nodes - jump to second pass to prcess them.
+    // Reached Allocate nodes - jump to second pass to process them.
     if (n->is_Allocate()) {
       break;
     }

--- a/test/hotspot/jtreg/compiler/macronodes/TestMacroExpansion.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestMacroExpansion.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390550
+ * @key stress
+ * @summary Test scalarized calls and entry points around calling convention limits.
+ * @library /test/lib /
+ * @run driver ${test.main.class}
+ */
+
+package compiler.macronodes;
+
+import compiler.lib.compile_framework.CompileFramework;
+import compiler.lib.template_framework.Template;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import static compiler.lib.template_framework.Template.*;
+
+public class TestMacroExpansion {
+    private static final String GENERATED_CLASS_NAME = "GeneratedTest";
+    private static final String PACKAGE_NAME = "compiler.macronodes";
+    private static final String QUALIFIED_NAME = PACKAGE_NAME + "." + GENERATED_CLASS_NAME;
+
+    public static void main(String[] args) throws Exception {
+        CompileFramework compileFramework = new CompileFramework();
+        compileFramework.addJavaSourceCode(GENERATED_CLASS_NAME, generate());
+        compileFramework.compile();
+        String[] command = {
+                "-classpath",
+                compileFramework.getEscapedClassPathOfCompiledClasses(),
+                "-Xcomp",
+                "-XX:-TieredCompilation",
+                "-XX:CompileCommand=compileonly," + QUALIFIED_NAME + "::test",
+                "-XX:+IgnoreUnrecognizedVMOptions",
+                "-XX:VerifyIterativeGVN=1110",
+                QUALIFIED_NAME
+        };
+
+        OutputAnalyzer analyzer = ProcessTools.executeTestJava(command);
+        analyzer.shouldHaveExitValue(0);
+    }
+
+    static String generate() {
+        final int rows = 140;
+        final int args = 9;
+        return Template.make(() -> scope(
+                let("className", GENERATED_CLASS_NAME),
+                let("packageName", PACKAGE_NAME),
+                """
+                package #packageName;
+
+                public class #className {
+                    interface I {
+                    }
+
+                    public static void main(String[] args) {
+                        test();
+                    }
+
+                    static class A implements I {
+                    }
+
+                    static A a = new A();
+
+                    static Object[] arr;
+
+                """,
+                "    static void init(", repeatAndJoin(args, ", ", i -> scope("I i" + i)), ") {\n",
+                "        arr = new Object[] {", repeatAndJoin(args, ", ", i -> scope("i" + i)), "};\n",
+                """
+                    }
+
+                """,
+                repeatAndJoin(rows, "\n", rowIndex -> scope(
+               "    static Object ", repeatAndJoin(args, ", ", index -> scope( "o" + (index + rowIndex * args))), ";"
+            )), "\n",
+                """
+
+                    static void test() {
+                """,
+                repeatAndJoin(rows, "\n", rowIndex -> scope(
+               "        init(", repeatAndJoin(args, ", ", index -> scope( "(I)o" + (index + rowIndex * args))), ");"
+            )), "\n",
+                """
+                    }
+                }
+                """
+        )).render();
+    }
+}

--- a/test/hotspot/jtreg/compiler/macronodes/TestMacroExpansion.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestMacroExpansion.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8390550
  * @key stress
+ * @requires vm.compiler2.enabled
  * @summary Test scalarized calls and entry points around calling convention limits.
  * @library /test/lib /
  * @run driver ${test.main.class}

--- a/test/hotspot/jtreg/compiler/macronodes/TestMacroExpansionCleanupCount.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestMacroExpansionCleanupCount.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=min
+ * @bug 8390550
+ * @requires vm.compiler2.enabled
+ * @summary Test MacroExpansionCleanupCount flag minimum value
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:MacroExpansionCleanupCount=1 ${test.main.class}
+ */
+
+/*
+ * @test id=max
+ * @bug 8390550
+ * @requires vm.compiler2.enabled
+ * @summary Test MacroExpansionCleanupCount flag maximum value
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:MacroExpansionCleanupCount=100 ${test.main.class}
+ */
+
+package compiler.macronodes;
+
+public class TestMacroExpansionCleanupCount {
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Test passed");
+    }
+}


### PR DESCRIPTION
The cause of the issue is that during `SubTypeCheck` node expansion control and memory are affected and a lot of temporary `MergeMem` nodes created as result. Even if temporary nodes are removed from graph after processing they still hold space in nodes arena and other arenas. The more IGVN optimizations are called the more such temporary nodes are created.

In the failed compilation case C2 created about 1M temporary MergeMem nodes (note the method `$Proxy132::<clinit>` is big: 5967 byte codes). Which alone requires about 200Mb of memory in arena.

This is ironically consequences of [JDK-8239072](https://bugs.openjdk.org/browse/JDK-8239072): "subtype check macro node causes node budget to be exhausted" changes which added whole graph IGVN optimization after EACH macro node expansion.

Calling `_igvn.optimize()` after elimination of `Opaque` and `LoopLimit` nodes and before expanding nodes solved the [JDK-8239072](https://bugs.openjdk.org/browse/JDK-8239072) issue alone. So calling it after each macro expansion is excessive.

The simplest solution is to adjust [JDK-8239072](https://bugs.openjdk.org/browse/JDK-8239072) changes to call `_igvn.optimize()` inside iteration only when we reach some node count limit or reasonable number of macro nodes expansion happened.

Tested: tier1,tier2,tier3,hs-aot-stress

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390550](https://bugs.openjdk.org/browse/JDK-8390550): C2 hit MemLimit when run with -Xcomp -XX:VerifyIterativeGVN=1110 (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) Review applies to [2dac5692](https://git.openjdk.org/jdk/pull/32421/files/2dac56929807e2577207756a1fccc20443427a99)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32421/head:pull/32421` \
`$ git checkout pull/32421`

Update a local copy of the PR: \
`$ git checkout pull/32421` \
`$ git pull https://git.openjdk.org/jdk.git pull/32421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32421`

View PR using the GUI difftool: \
`$ git pr show -t 32421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32421.diff">https://git.openjdk.org/jdk/pull/32421.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32421#issuecomment-5331054074)
</details>
