### PR TITLE
8300944: Test vmTestbase/gc/gctests/WeakReference/weak005/weak005.java fails with "Last weak reference has not been cleared"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak005/weak005.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak005/weak005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,10 @@ public class weak005 extends ThreadedGCTest {
             for (int i = 1; i < length; ++i) {
                 references[i] = new WeakReference(references[i - 1]);
             }
-            for (int i = 0; i < length - 1; ++i) {
+            // Release the chain from the end. Otherwise a GC that runs while
+            // an entry is still reachable from the array can clear it and put
+            // it on the pending list, which keeps it alive for the last check.
+            for (int i = length - 2; i >= 0; --i) {
                 references[i] = null;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak005/weak005.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak005/weak005.java
@@ -70,9 +70,8 @@ public class weak005 extends ThreadedGCTest {
             for (int i = 1; i < length; ++i) {
                 references[i] = new WeakReference(references[i - 1]);
             }
-            // Release the chain from the end. Otherwise a GC that runs while
-            // an entry is still reachable from the array can clear it and put
-            // it on the pending list, which keeps it alive for the last check.
+            // Release in reverse order, otherwise an entry cleared mid release
+            // can sit on the pending list and keep the last referent alive.
             for (int i = length - 2; i >= 0; --i) {
                 references[i] = null;
             }

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak005/weak005.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak005/weak005.java
@@ -39,6 +39,7 @@ package gc.gctests.WeakReference.weak005;
 
 import jdk.test.whitebox.WhiteBox;
 import nsk.share.gc.*;
+import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 
 /**
@@ -56,25 +57,24 @@ public class weak005 extends ThreadedGCTest {
         private int length = 10000;
         private int objectSize = 10000;
         private WeakReference[] references;
+        private WeakReference lastReference;
 
         public Worker() {
             System.out.println("Array size: " + length);
             System.out.println("Object size: " + objectSize);
-            references = new WeakReference[length];
         }
 
         private void makeReferences() {
-            references[length - 1] = null;
             MemoryObject obj = new MemoryObject(objectSize);
+            references = new WeakReference[length];
             references[0] = new WeakReference(obj);
             for (int i = 1; i < length; ++i) {
                 references[i] = new WeakReference(references[i - 1]);
             }
-            // Release in reverse order, otherwise an entry cleared mid release
-            // can sit on the pending list and keep the last referent alive.
-            for (int i = length - 2; i >= 0; --i) {
-                references[i] = null;
-            }
+            lastReference = references[length - 1];
+            // Drop all strong references to the chain in one write.
+            references = null;
+            Reference.reachabilityFence(obj);
         }
 
         public void run() {
@@ -83,7 +83,7 @@ public class weak005 extends ThreadedGCTest {
             if (!getExecutionController().continueExecution()) {
                 return;
             }
-            if (references[length - 1].get() != null) {
+            if (lastReference.get() != null) {
                 log.error("Last weak reference has not been cleared");
                 setFailed(true);
             }


### PR DESCRIPTION
The test builds a chain of weak references, clears the array entries from the beginning, and expects the final reference to be cleared by a full GC. If GC runs just before the penultimate entry is cleared, that reference is still strongly reachable from the array while its referent is not. GC may clear it and place it on the pending reference list, which keeps the reference object alive until the reference handler processes it. Clearing its array entry afterward does not remove that reachability, so the final reference may legally remain uncleared.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8300944](https://bugs.openjdk.org/browse/JDK-8300944): Test vmTestbase/gc/gctests/WeakReference/weak005/weak005.java fails with "Last weak reference has not been cleared" (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32422/head:pull/32422` \
`$ git checkout pull/32422`

Update a local copy of the PR: \
`$ git checkout pull/32422` \
`$ git pull https://git.openjdk.org/jdk.git pull/32422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32422`

View PR using the GUI difftool: \
`$ git pr show -t 32422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32422.diff">https://git.openjdk.org/jdk/pull/32422.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32422#issuecomment-5375651878)
</details>
