### PR TITLE
8390506: Several JMH benchmarks fail with java.lang.NullPointerException

### DIFF
--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/InlineCursor.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/InlineCursor.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs;
+package org.openjdk.bench.valhalla.sandbox.corelibs;
 
 import java.util.ConcurrentModificationException;
 import java.util.NoSuchElementException;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayList.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayList.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs;
+package org.openjdk.bench.valhalla.sandbox.corelibs;
 
 import java.util.AbstractList;
 import java.util.Arrays;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayListCursorTest.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayListCursorTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  */
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs;
+package org.openjdk.bench.valhalla.sandbox.corelibs;
 
 import java.util.List;
 import java.util.Iterator;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/GetX.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/GetX.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Setup;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMap.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import java.io.IOException;
 import java.io.InvalidObjectException;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapBench.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapBench.java
@@ -55,7 +55,7 @@ import static java.util.stream.Collectors.toMap;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(1)
+@Fork(value = 1, jvmArgsAppend = {"--enable-preview"})
 @State(Scope.Thread)
 public class HashMapBench {
     private IntFunction<Map<Integer, Integer>> mapSupplier;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapBench.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapBench.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -65,8 +65,8 @@ public class HashMapBench {
     private int size;
 
     @Param(value = {
-            "org.openjdk.bench.valhalla.corelibs.mapprotos.HashMap",
-//            "org.openjdk.bench.valhalla.corelibs.mapprotos.XHashMap",
+            "org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos.HashMap",
+//            "org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos.XHashMap",
             "java.util.HashMap",
         })
     private String mapType;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapToArray.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapToArray.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
+@Fork(value = 1, jvmArgsAppend = {"--enable-preview"})
 @State(Scope.Thread)
 public class HashMapToArray {
 

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapToArray.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMapToArray.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -57,8 +57,8 @@ public class HashMapToArray {
 
 
     @Param(value = {
-            "org.openjdk.bench.valhalla.corelibs.mapprotos.HashMap",
-//            "org.openjdk.bench.valhalla.corelibs.mapprotos.XHashMap",
+            "org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos.HashMap",
+//            "org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos.XHashMap",
             "java.util.HashMap",
         })
     private String mapType;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/MapBase.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/MapBase.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -61,8 +61,8 @@ public class MapBase {
 
     @Param(value = {
             "java.util.HashMap",
-            "org.openjdk.bench.valhalla.corelibs.mapprotos.HashMap",
-//            "org.openjdk.bench.valhalla.corelibs.mapprotos.XHashMap",
+            "org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos.HashMap",
+//            "org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos.XHashMap",
 //            "java.util.HashMap0",
     })
     public String mapType;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/MapBase.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/MapBase.java
@@ -40,7 +40,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-@Fork(1)
+@Fork(value = 1, jvmArgsAppend = {"--enable-preview"})
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @BenchmarkMode(Mode.AverageTime)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/PutX.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/PutX.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Setup;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/ReplX.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/ReplX.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Setup;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/WalkX.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/WalkX.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.CompilerControl;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/XAbstractMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/XAbstractMap.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import java.util.AbstractCollection;
 import java.util.AbstractSet;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/XHashMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/XHashMap.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package org.openjdk.bench.valhalla.sandbox.corelibs.corelibs.mapprotos;
+package org.openjdk.bench.valhalla.sandbox.corelibs.mapprotos;
 
 import java.io.IOException;
 import java.io.InvalidObjectException;


### PR DESCRIPTION
Hi all,

This patch adjusts several package names from the double `corelibs` (`.corelibs.corelibs`) to a simple `corelibs` and fixes the package names of the param fields (adding `sandbox.` in the middle). Then the `java.lang.NullPointerException` of the issue can be solved.

Best Regards,
-- Guoxiong

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390506](https://bugs.openjdk.org/browse/JDK-8390506): Several JMH benchmarks fail with java.lang.NullPointerException (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32423/head:pull/32423` \
`$ git checkout pull/32423`

Update a local copy of the PR: \
`$ git checkout pull/32423` \
`$ git pull https://git.openjdk.org/jdk.git pull/32423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32423`

View PR using the GUI difftool: \
`$ git pr show -t 32423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32423.diff">https://git.openjdk.org/jdk/pull/32423.diff</a>

</details>
