### PR TITLE
8390546: C2: EncodeISOArray intrinsic uses incorrect destination memory alias

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6256,12 +6256,14 @@ bool LibraryCallKit::inline_encodeISOArray(bool ascii) {
   // 'dst_start' points to dst array + scaled offset
 
   // See GraphKit::compress_string
+  const TypeAryPtr* src_memory_type = TypeAryPtr::get_array_body_type(src_elem);
+  const TypeAryPtr* dst_memory_type = TypeAryPtr::get_array_body_type(dst_elem);
   const TypePtr* adr_type;
-  Node* mem = capture_memory(adr_type, src_type, dst_type);
+  Node* mem = capture_memory(adr_type, src_memory_type, dst_memory_type);
   Node* enc = new EncodeISOArrayNode(control(), mem, adr_type, src_start, dst_start, length, ascii);
   enc = _gvn.transform(enc);
   Node* res_mem = _gvn.transform(new SCMemProjNode(enc));
-  memory_effect(res_mem, src_type, dst_type);
+  memory_effect(res_mem, src_memory_type, dst_memory_type);
 
   set_result(enc);
   clear_upper_avx();

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestEncodeISOArray.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestEncodeISOArray.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390546
+ * @summary Verify that the memory effect of the encodeISOArray intrinsic is correctly wired in.
+ * @library /test/lib
+ * @requires vm.compiler2.enabled
+ * @modules java.base/java.lang:+open java.base/sun.nio.cs:+open
+ * @run main compiler.intrinsics.string.TestEncodeISOArray
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileThreshold=100
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=0 -XX:-UseSSE42Intrinsics
+ *                   compiler.intrinsics.string.TestEncodeISOArray
+ */
+
+package compiler.intrinsics.string;
+
+import jdk.test.lib.Asserts;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class TestEncodeISOArray {
+    private static final int ITERATIONS = 20_000;
+    private static final int FIRST_BYTE = 'C';
+    private static final char[] SOURCE = "C2 go brrr".toCharArray();
+    private static final byte[] UTF16_SOURCE = toUTF16Bytes(SOURCE);
+    private static final byte[] EXPECTED = "C2 go brrr".getBytes(StandardCharsets.UTF_8);
+    private static final MethodType ENCODE_TYPE = MethodType.methodType(int.class, char[].class, int.class, byte[].class, int.class, int.class);
+    private static final MethodType ENCODE_BYTE_TYPE = MethodType.methodType(int.class, byte[].class, int.class, byte[].class, int.class, int.class);
+    private static final MethodHandle ENCODE_ASCII_ARRAY = findEncoder("java.lang.StringCoding", "encodeAsciiArray0", ENCODE_TYPE);
+    private static final MethodHandle ENCODE_ISO_ARRAY = findEncoder("sun.nio.cs.ISO_8859_1$Encoder", "encodeISOArray0", ENCODE_TYPE);
+    private static final MethodHandle ENCODE_BYTE_ISO_ARRAY = findEncoder("java.lang.StringCoding", "encodeISOArray0", ENCODE_BYTE_TYPE);
+
+    private static byte[] toUTF16Bytes(char[] chars) {
+        ByteBuffer buffer = ByteBuffer.allocate(chars.length * Character.BYTES).order(ByteOrder.nativeOrder());
+        for (char c : chars) {
+            buffer.putChar(c);
+        }
+        return buffer.array();
+    }
+
+    private static MethodHandle findEncoder(String className, String methodName, MethodType type) {
+        try {
+            Class<?> holder = Class.forName(className);
+            MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(holder, MethodHandles.lookup());
+            return lookup.findStatic(holder, methodName, type);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    // Original reproducer from JDK-8390546
+    private static byte[] toUtf8Bytes(char[] chars) {
+        ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(chars));
+        return Arrays.copyOfRange(byteBuffer.array(), 0, byteBuffer.limit());
+    }
+
+    // Targeted check that does not depend on the UTF-8 encoder and arraycopy both being inlined.
+    private static int encodeASCIIAndLoadFirstByte() throws Throwable {
+        byte[] destination = new byte[4];
+        int encoded = (int) ENCODE_ASCII_ARRAY.invokeExact(SOURCE, 0, destination, 0, 4);
+        if (encoded != 4) {
+            return -1;
+        }
+        return destination[0];
+    }
+
+    private static int encodeISOAndLoadFirstByte() throws Throwable {
+        byte[] destination = new byte[4];
+        int encoded = (int) ENCODE_ISO_ARRAY.invokeExact(SOURCE, 0, destination, 0, 4);
+        if (encoded != 4) {
+            return -1;
+        }
+        return destination[0];
+    }
+
+    private static int encodeByteISOAndLoadFirstByte() throws Throwable {
+        byte[] destination = new byte[4];
+        int encoded = (int) ENCODE_BYTE_ISO_ARRAY.invokeExact(UTF16_SOURCE, 0, destination, 0, 4);
+        if (encoded != 4) {
+            return -1;
+        }
+        return destination[0];
+    }
+
+    private static boolean runOriginalReproducer() {
+        for (int i = 0; i < ITERATIONS; i++) {
+            if (!Arrays.equals(toUtf8Bytes(SOURCE), EXPECTED)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean runASCIITest() throws Throwable {
+        for (int i = 0; i < ITERATIONS; i++) {
+            if (encodeASCIIAndLoadFirstByte() != FIRST_BYTE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean runISOTest() throws Throwable {
+        for (int i = 0; i < ITERATIONS; i++) {
+            if (encodeISOAndLoadFirstByte() != FIRST_BYTE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean runByteISOTest() throws Throwable {
+        for (int i = 0; i < ITERATIONS; i++) {
+            if (encodeByteISOAndLoadFirstByte() != FIRST_BYTE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void main(String[] args) throws Throwable {
+        Asserts.assertTrue(runOriginalReproducer(), "Original reproducer failed");
+        Asserts.assertTrue(runASCIITest(), "ASCII encoding failed");
+        Asserts.assertTrue(runISOTest(), "ISO-8859-1 encoding failed");
+        Asserts.assertTrue(runByteISOTest(), "Byte ISO-8859-1 encoding failed");
+    }
+}


### PR DESCRIPTION
This is a regression from [JDK-8373591](https://bugs.openjdk.org/browse/JDK-8373591) in JDK 27-ea+24. `LibraryCallKit::inline_encodeISOArray` passes `src_type` and `dst_type` to `capture_memory()` and `memory_effect()`. When used as memory address types, these array oop types have offset zero and therefore alias the array header rather than its payload.

As a result, C2 does not connect the intrinsic to the `BYTES` memory slice and later loads from that slice can observe the pre-intrinsic state or stale memory. This affects `_encodeAsciiArray`, `_encodeISOArray` and `_encodeByteISOArray`.

The fix is to pass the array body types to both helpers. I verified that all sub tests fail without the fix and pass with the fix on both Linux x64 and Linux AArch64.

Many thanks to Lorenzo Dematte <lorenzo.dematte@protonmail.com> who originally reported this and provided a reproducer that I incorporated into the test.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390546](https://bugs.openjdk.org/browse/JDK-8390546): C2: EncodeISOArray intrinsic uses incorrect destination memory alias (**Bug** - P1) ⚠️ Issue is not open.


### Contributors
 * Lorenzo Dematte `<lorenzo.dematte@protonmail.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32425/head:pull/32425` \
`$ git checkout pull/32425`

Update a local copy of the PR: \
`$ git checkout pull/32425` \
`$ git pull https://git.openjdk.org/jdk.git pull/32425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32425`

View PR using the GUI difftool: \
`$ git pr show -t 32425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32425.diff">https://git.openjdk.org/jdk/pull/32425.diff</a>

</details>
