### PR TITLE
8389858: [VectorAPI] VectorMask.toVector API note incorrectly describes the result for fp masks

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -545,13 +545,10 @@ public abstract sealed class VectorMask<E> extends jdk.internal.vm.vector.Vector
      * {@code ETYPE} value and the {@code ETYPE} value representing
      * {@code -1}, respectively.
      *
-     * @apiNote For the sake of static type checking, users may wish
-     * to check the resulting vector against the expected integral
-     * lane type or species.  If the mask is for a float-point
-     * species, then the resulting vector will have the same shape and
-     * lane size, but an integral type.  If the mask is for an
-     * integral species, the resulting vector will be of exactly that
-     * species.
+     * @apiNote The returned vector has the same species as this mask.
+     * For a floating-point species, a set mask lane is represented in
+     * the returned vector by the floating-point value {@code -1},
+     * rather than by setting all bits of the corresponding vector lane.
      *
      * @return a vector representation of this mask
      * @see Vector#check(Class)


### PR DESCRIPTION
The API note currently says:

"If the mask is for a float-point species, then the resulting vector will have the same shape and lane size, but an integral type."

This does not match the method signature or its implementation:

    public abstract Vector<E> toVector();

For a floating-point mask, toVector() returns a vector of the same floating-point element type and species as the mask. For example:

    VectorMask<Float> fm = VectorMask.fromValues(
            FloatVector.SPECIES_128,
            true, false, true, false);

    Vector<Float> fv = fm.toVector();

    fv // [-1.0, 0.0, -1.0, 0.0]
    fv.elementType() // float
    fv.species() // Species[float, 4, S_128_BIT]
    fv.getClass().getName() // jdk.incubator.vector.FloatVector128

Similarly, VectorMask<Double/Float16>.toVector() returns a FP Vector, not a integral Vector.

This behavior also agrees with the main method description, which states that the resulting lanes contain the arithmetic values 0 or -1 for both integral and floating-point element types.

This is a doc-only fix to correct the API note.  (Note: an alternative is to simply remove this API note)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8389858](https://bugs.openjdk.org/browse/JDK-8389858): [VectorAPI] VectorMask.toVector API note incorrectly describes the result for fp masks (**Bug** - P4)
 * [JDK-8390592](https://bugs.openjdk.org/browse/JDK-8390592): [VectorAPI] VectorMask.toVector API note incorrectly describes the result for fp masks (**CSR**) (Withdrawn)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32430/head:pull/32430` \
`$ git checkout pull/32430`

Update a local copy of the PR: \
`$ git checkout pull/32430` \
`$ git pull https://git.openjdk.org/jdk.git pull/32430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32430`

View PR using the GUI difftool: \
`$ git pr show -t 32430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32430.diff">https://git.openjdk.org/jdk/pull/32430.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32430#issuecomment-5333980372)
</details>
