### PR TITLE
8389932: C2: Merge bits F and G in VerifyIterativeGVN together

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -727,10 +727,8 @@
           "the IGVN worklist drains")                                       \
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \
-          "Verify Iterative Global Value Numbering =GFEDCBA, with:"         \
-          "  G: verify Node::Identity return an existing node"              \
-          "  F: verify Node::Ideal does not return nullptr if the node"     \
-                "hash has changed"                                          \
+          "Verify Iterative Global Value Numbering =FEDCBA, with:"          \
+          "  F: verify IGVN method return invariants"                       \
           "  E: verify node specific invariants"                            \
           "  D: verify Node::Identity did not miss opportunities"           \
           "  C: verify Node::Ideal did not miss opportunities"              \

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -686,9 +686,9 @@ Node* PhaseGVN::apply_ideal(Node* k, bool can_reshape) {
 }
 
 Node* PhaseGVN::apply_identity(Node* n) {
-  DEBUG_ONLY(uint old_unique = is_verify_Identity_return() ? C->unique() : 0;)
+  DEBUG_ONLY(uint old_unique = is_verify_IGVN_method_return() ? C->unique() : 0;)
   Node* const i = n->Identity(this);
-  assert(!is_verify_Identity_return() || i->_idx < old_unique,
+  assert(!is_verify_IGVN_method_return() || i->_idx < old_unique,
          "Identity() must return an existing node");
   return i;
 }
@@ -2235,18 +2235,12 @@ Node *PhaseIterGVN::transform_old(Node* n) {
   DEBUG_ONLY(dead_loop_check(k);)
   DEBUG_ONLY(bool is_new = (k->outcnt() == 0);)
   C->remove_modified_node(k);
-#ifndef PRODUCT
-  uint hash_before = is_verify_Ideal_return() ? k->hash() : 0;
-#endif
+  DEBUG_ONLY(uint hash_before = is_verify_IGVN_method_return() ? k->hash() : 0;)
   Node* i = apply_ideal(k, /*can_reshape=*/true);
   assert(i != k || is_new || i->outcnt() > 0, "don't return dead nodes");
-#ifndef PRODUCT
-  if (is_verify_Ideal_return()) {
-    assert(k->outcnt() == 0 || i != nullptr || hash_before == k->hash(), "hash changed after Ideal returned nullptr for %s", k->Name());
-  }
-  verify_step(k);
-#endif
-
+  assert(!is_verify_IGVN_method_return() || k->outcnt() == 0 ||
+         i != nullptr || hash_before == k->hash(), "hash changed after Ideal returned nullptr for %s", k->Name());
+  NOT_PRODUCT(verify_step(k);)
   DEBUG_ONLY(uint loop_count = 1;)
   if (i != nullptr) {
     set_progress();
@@ -2270,17 +2264,12 @@ Node *PhaseIterGVN::transform_old(Node* n) {
     // Try idealizing again
     DEBUG_ONLY(is_new = (k->outcnt() == 0);)
     C->remove_modified_node(k);
-#ifndef PRODUCT
-    uint hash_before = is_verify_Ideal_return() ? k->hash() : 0;
-#endif
+    DEBUG_ONLY(uint hash_before = is_verify_IGVN_method_return() ? k->hash() : 0;)
     i = apply_ideal(k, /*can_reshape=*/true);
     assert(i != k || is_new || (i->outcnt() > 0), "don't return dead nodes");
-#ifndef PRODUCT
-    if (is_verify_Ideal_return()) {
-      assert(k->outcnt() == 0 || i != nullptr || hash_before == k->hash(), "hash changed after Ideal returned nullptr for %s", k->Name());
-    }
-    verify_step(k);
-#endif
+    assert(!is_verify_IGVN_method_return() || k->outcnt() == 0 ||
+           i != nullptr || hash_before == k->hash(), "hash changed after Ideal returned nullptr for %s", k->Name());
+    NOT_PRODUCT(verify_step(k);)
     DEBUG_ONLY(loop_count++;)
   }
 

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -458,7 +458,9 @@ public:
   void dump_infinite_loop_info(Node* n, const char* where);
   // Check for a simple dead loop when a data node references itself.
   void dead_loop_check(Node *n);
-
+  // This checks that:
+  // - Identity() returns only existing nodes (GVN and IGVN).
+  // - Ideal() does not return nullptr if the node's hash has changed (IGVN).
   static bool is_verify_IGVN_method_return() {
     // '-XX:VerifyIterativeGVN=100000'
     return ((VerifyIterativeGVN % 1'000'000) / 100'000) == 1;
@@ -676,15 +678,15 @@ public:
   }
   static bool is_verify_Ideal() {
     // '-XX:VerifyIterativeGVN=100'
-    return ((VerifyIterativeGVN % 1000) / 100) == 1;
+    return ((VerifyIterativeGVN % 1'000) / 100) == 1;
   }
   static bool is_verify_Identity() {
     // '-XX:VerifyIterativeGVN=1000'
-    return ((VerifyIterativeGVN % 10000) / 1000) == 1;
+    return ((VerifyIterativeGVN % 10'000) / 1'000) == 1;
   }
   static bool is_verify_invariants() {
     // '-XX:VerifyIterativeGVN=10000'
-    return ((VerifyIterativeGVN % 100000) / 10000) == 1;
+    return ((VerifyIterativeGVN % 100'000) / 10'000) == 1;
   }
 protected:
   // Sub-quadratic implementation of '-XX:VerifyIterativeGVN=1' (Use-Def verification).

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -458,12 +458,10 @@ public:
   void dump_infinite_loop_info(Node* n, const char* where);
   // Check for a simple dead loop when a data node references itself.
   void dead_loop_check(Node *n);
-#endif
 
-#ifndef PRODUCT
-  static bool is_verify_Identity_return() {
-    // '-XX:VerifyIterativeGVN=1000000'
-    return ((VerifyIterativeGVN % 10'000'000) / 1'000'000) == 1;
+  static bool is_verify_IGVN_method_return() {
+    // '-XX:VerifyIterativeGVN=100000'
+    return ((VerifyIterativeGVN % 1'000'000) / 100'000) == 1;
   }
 #endif
 };
@@ -687,10 +685,6 @@ public:
   static bool is_verify_invariants() {
     // '-XX:VerifyIterativeGVN=10000'
     return ((VerifyIterativeGVN % 100000) / 10000) == 1;
-  }
-  static bool is_verify_Ideal_return() {
-    // '-XX:VerifyIterativeGVN=100000'
-    return ((VerifyIterativeGVN % 1000000) / 100000) == 1;
   }
 protected:
   // Sub-quadratic implementation of '-XX:VerifyIterativeGVN=1' (Use-Def verification).

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -329,7 +329,7 @@ JVMFlag::Error TypeProfileLevelConstraintFunc(uint value, bool verbose) {
 }
 
 JVMFlag::Error VerifyIterativeGVNConstraintFunc(uint value, bool verbose) {
-  const int max_modes = 7;
+  const int max_modes = 6;
   uint original_value = value;
   for (int i = 0; i < max_modes; i++) {
     if (value % 10 > 1) {

--- a/test/hotspot/jtreg/compiler/c2/TestVerifyIterativeGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestVerifyIterativeGVN.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8238756 8351889
  * @requires vm.debug == true & vm.flavor == "server"
- * @summary Run with -Xcomp to test -XX:VerifyIterativeGVN=1111111 in debug builds.
+ * @summary Run with -Xcomp to test -XX:VerifyIterativeGVN=111111 in debug builds.
  *
- * @run main/othervm/timeout=300 -Xcomp -XX:VerifyIterativeGVN=1111111 compiler.c2.TestVerifyIterativeGVN
+ * @run main/othervm/timeout=300 -Xcomp -XX:VerifyIterativeGVN=111111 compiler.c2.TestVerifyIterativeGVN
  */
 package compiler.c2;
 


### PR DESCRIPTION
Please review this change. Thanks!

**Description:**

[JDK-8347266](https://bugs.openjdk.org/browse/JDK-8347266) introduces a new bit G instead of merging it with F because there are still issues when enabling F. All of F-related issues have now been addressed, then we can merge them.

**Test:** 

- GHA

- `hotspot:hotspot_compiler` with and without `-XX:VerifyIterativeGVN=100000`

--------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389932](https://bugs.openjdk.org/browse/JDK-8389932): C2: Merge bits F and G in VerifyIterativeGVN together (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32432/head:pull/32432` \
`$ git checkout pull/32432`

Update a local copy of the PR: \
`$ git checkout pull/32432` \
`$ git pull https://git.openjdk.org/jdk.git pull/32432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32432`

View PR using the GUI difftool: \
`$ git pr show -t 32432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32432.diff">https://git.openjdk.org/jdk/pull/32432.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32432#issuecomment-5337333244)
</details>
