### PR TITLE
8390613: Missing class in loadable descriptors causes AOT crash

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1075,7 +1075,7 @@ static void load_classes_from_loadable_descriptors_attribute(InstanceKlass *ik, 
       TempNewSymbol class_name = Signature::strip_envelope(sig);
       if (class_name == ik->name()) continue;
       log_info(class, preload)("Preloading of class %s during linking of class %s "
-                               "because of the class is listed in the LoadableDescriptors attribute",
+                               "because the class is listed in the LoadableDescriptors attribute",
                                sig->as_C_string(), ik->name()->as_C_string());
       oop loader = ik->class_loader();
       Klass* klass = nullptr;
@@ -1091,7 +1091,7 @@ static void load_classes_from_loadable_descriptors_attribute(InstanceKlass *ik, 
         klass = SystemDictionary::find_instance_or_array_klass(THREAD, class_name, Handle(THREAD, loader));
       } else {
         klass = SystemDictionary::resolve_or_null(class_name,
-                                                        Handle(THREAD, loader), THREAD);
+                                                  Handle(THREAD, loader), THREAD);
       }
       if (HAS_PENDING_EXCEPTION) {
         CLEAR_PENDING_EXCEPTION;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1078,8 +1078,21 @@ static void load_classes_from_loadable_descriptors_attribute(InstanceKlass *ik, 
                                "because of the class is listed in the LoadableDescriptors attribute",
                                sig->as_C_string(), ik->name()->as_C_string());
       oop loader = ik->class_loader();
-      Klass* klass = SystemDictionary::resolve_or_null(class_name,
+      Klass* klass = nullptr;
+
+      if (CDSConfig::is_using_aot_linked_classes() && ik->in_aot_cache() && !ik->defined_by_other_loaders()) {
+        // + We come to here during AOTLinkedClassBulkLoader::link_classes() and it's too early to
+        //   execute any Java code.
+        // + All loadable descriptors that can be resolved would have been resolved during the AOT assembly
+        //   phase, and would have been loaded earlier by AOTLinkedClassBulkLoader, so they can be found in
+        //   the system dictionary.
+        // + If no class of the given name have been loaded yet, it's most likely because the class
+        //   is missing from JAR files. Just ignore it.
+        klass = SystemDictionary::find_instance_or_array_klass(THREAD, class_name, Handle(THREAD, loader));
+      } else {
+        klass = SystemDictionary::resolve_or_null(class_name,
                                                         Handle(THREAD, loader), THREAD);
+      }
       if (HAS_PENDING_EXCEPTION) {
         CLEAR_PENDING_EXCEPTION;
       }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/LoadableDescriptorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/LoadableDescriptorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Handling of missing loadable descriptors.
+ * @bug 8390613
+ * @requires vm.cds.supports.aot.class.linking
+ * @library /test/lib
+ * @enablePreview
+ * @build LoadableDescriptorTest
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar LoadableDescriptorApp Point
+ * @run driver LoadableDescriptorTest -XX:+AOTClassLinking
+ * @run driver LoadableDescriptorTest -XX:-AOTClassLinking
+ */
+
+import jdk.test.lib.cds.SimpleCDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class LoadableDescriptorTest {
+    public static void main(String[] args) throws Exception {
+        final String mainClass = LoadableDescriptorApp.class.getName();
+        final String appJar = ClassFileInstaller.getJarPath("app.jar");
+
+        SimpleCDSAppTester tester = SimpleCDSAppTester.of("LoadableDescriptorTest");
+        tester.addVmArgs("-Xlog:aot+class=debug,class+preload", "--enable-preview", args[0])
+              .appCommandLine(mainClass)
+              .classpath(appJar)
+              .setProductionChecker((OutputAnalyzer out) -> {
+                  out.shouldContain("LoadableDescriptorApp: success")
+                     .shouldContain("Preloading of class Point during linking of class LoadableDescriptorApp (cause: LoadableDescriptors attribute) succeeded")
+                     .shouldContain("Preloading of class Line during linking of class LoadableDescriptorApp (cause: LoadableDescriptors attribute) failed");
+              });
+        tester.runAOTWorkflow();
+    }
+}
+
+class LoadableDescriptorApp {
+    public static void main(String[] args) {
+        LoadableDescriptorApp app = new LoadableDescriptorApp();
+        app.foo(null, null);
+        app.bar(null, null);
+        System.out.println("LoadableDescriptorApp: success");
+    }
+
+    // "Point" and "Line" are (symbolically) declared in the loadable descriptors of the
+    // LoadableDescriptorApp class. However, Line is not in app.jar so it cannot be resolved
+    // when LoadableDescriptorApp is linked.
+
+    void foo(Point p1, Point p2) {}
+    void bar(Line a, Line b) {}
+}
+
+value record Point(byte x, byte y) { }
+value record Line(Point a, Point b) { }
+

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/LoadableDescriptorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/LoadableDescriptorTest.java
@@ -24,12 +24,13 @@
 
 /*
  * @test
- * @summary Handling of missing loadable descriptors.
+ * @summary Handling of missing classes referred to by loadable descriptors.
  * @bug 8390613
  * @requires vm.cds.supports.aot.class.linking
  * @library /test/lib
  * @enablePreview
  * @build LoadableDescriptorTest
+ * @comment Omit the Line class when creating app.jar
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar LoadableDescriptorApp Point
  * @run driver LoadableDescriptorTest -XX:+AOTClassLinking
  * @run driver LoadableDescriptorTest -XX:-AOTClassLinking


### PR DESCRIPTION
All loadable descriptors that can be resolved would have been resolved during the AOT assembly phase, and would have been loaded earlier by `AOTLinkedClassBulkLoader`, so they can be found in the system dictionary using `SystemDictionary::find_instance_or_array_klass()`.

If no class of the given name have been loaded yet, it's most likely because the class is missing from JAR files. Since we are not yet able to execute Java code yet, we can't upcall to the class loaders to resolve the class. So the fix is to ignore the class, as that's allowed by the spec.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390613](https://bugs.openjdk.org/browse/JDK-8390613): Missing class in loadable descriptors causes AOT crash (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32433/head:pull/32433` \
`$ git checkout pull/32433`

Update a local copy of the PR: \
`$ git checkout pull/32433` \
`$ git pull https://git.openjdk.org/jdk.git pull/32433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32433`

View PR using the GUI difftool: \
`$ git pr show -t 32433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32433.diff">https://git.openjdk.org/jdk/pull/32433.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32433#issuecomment-5337380918)
</details>
