### PR TITLE
8390619: Validate sender SP before to return sender frame in LinuxAMD64CFrame.java

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/amd64/LinuxAMD64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/amd64/LinuxAMD64CFrame.java
@@ -79,7 +79,8 @@ public final class LinuxAMD64CFrame extends DwarfCFrame {
      };
    }
 
-   // In SysV AMD64, the stack must be consumed because return address would be stored on the stack.
+   // In SysV AMD64, SP should be less than sender SP because return address should be
+   // pushed onto the stack.
    protected boolean isValidFrame(Address senderCFA, Address senderFP, Address senderSP) {
      return super.isValidFrame(senderCFA, senderFP) && sp().lessThan(senderSP);
    }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/amd64/LinuxAMD64CFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/amd64/LinuxAMD64CFrame.java
@@ -79,6 +79,11 @@ public final class LinuxAMD64CFrame extends DwarfCFrame {
      };
    }
 
+   // In SysV AMD64, the stack must be consumed because return address would be stored on the stack.
+   protected boolean isValidFrame(Address senderCFA, Address senderFP, Address senderSP) {
+     return super.isValidFrame(senderCFA, senderFP) && sp().lessThan(senderSP);
+   }
+
    @Override
    public CFrame sender(ThreadProxy th, Address senderSP, Address senderFP, Address senderPC) {
      if (linuxDbg().isSignalTrampoline(pc())) {
@@ -124,7 +129,7 @@ public final class LinuxAMD64CFrame extends DwarfCFrame {
 
      try {
        Address senderCFA = getSenderCFA(senderDwarf, senderSP, senderFP);
-       return isValidFrame(senderCFA, senderFP)
+       return isValidFrame(senderCFA, senderFP, senderSP)
          ? new LinuxAMD64CFrame(linuxDbg(), senderSP, senderFP, senderCFA, senderPC, senderDwarf, fallback)
          : null;
      } catch (DebuggerException e) {


### PR DESCRIPTION
This is a part of [JDK-8382392](https://bugs.openjdk.org/browse/JDK-8382392).

`LinuxAMD64CFrame` validates sender frame with CFA and FP. But SP should also be validated because return address would be pushed onto stack - it means SP should grow always when the function is called (`CALL` instruction for example).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390619](https://bugs.openjdk.org/browse/JDK-8390619): Validate sender SP before to return sender frame in LinuxAMD64CFrame.java (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32435/head:pull/32435` \
`$ git checkout pull/32435`

Update a local copy of the PR: \
`$ git checkout pull/32435` \
`$ git pull https://git.openjdk.org/jdk.git pull/32435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32435`

View PR using the GUI difftool: \
`$ git pr show -t 32435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32435.diff">https://git.openjdk.org/jdk/pull/32435.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32435#issuecomment-5338108948)
</details>
