### PR TITLE
8390620: Refactor eh_frame to frame in libsaproc

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
@@ -265,14 +265,14 @@ uint32_t DwarfParser::get_decoded_value(unsigned char enc) {
   //   https://gcc.gnu.org/ml/gcc-help/2010-09/msg00166.html
 #if defined(_LP64)
   if (size == 8) {
-    result += _lib->eh_frame.v_addr + static_cast<uintptr_t>(_buf - _lib->eh_frame.data);
+    result += _lib->frame.v_addr + static_cast<uintptr_t>(_buf - _lib->frame.data);
     size = 4;
   } else
 #endif
   if ((enc & 0x70) == 0x10) { // 0x10 = DW_EH_PE_pcrel
-    result += _lib->eh_frame.v_addr + static_cast<uintptr_t>(_buf - _lib->eh_frame.data);
+    result += _lib->frame.v_addr + static_cast<uintptr_t>(_buf - _lib->frame.data);
   } else  if (size == 2) {
-    result = static_cast<int>(result) + _lib->eh_frame.v_addr + static_cast<uintptr_t>(_buf - _lib->eh_frame.data);
+    result = static_cast<int>(result) + _lib->frame.v_addr + static_cast<uintptr_t>(_buf - _lib->frame.data);
     size = 4;
   }
 
@@ -319,8 +319,8 @@ unsigned int DwarfParser::get_pc_range() {
 
 bool DwarfParser::process_dwarf(const uintptr_t pc) {
   // https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA/ehframechpt.html
-  _buf = _lib->eh_frame.data;
-  unsigned char *end = _lib->eh_frame.data + _lib->eh_frame.size;
+  _buf = _lib->frame.data;
+  unsigned char *end = _lib->frame.data + _lib->frame.size;
   while (_buf <= end) {
     uint64_t length = get_entry_length();
     if (length == 0L) {
@@ -331,7 +331,7 @@ bool DwarfParser::process_dwarf(const uintptr_t pc) {
     uint32_t id = *(reinterpret_cast<uint32_t *>(_buf));
     _buf += 4;
     if (id != 0) { // FDE
-      uintptr_t pc_begin = get_decoded_value(_fde_ptr_encoding) + _lib->eh_frame.library_base_addr;
+      uintptr_t pc_begin = get_decoded_value(_fde_ptr_encoding) + _lib->base;
       uintptr_t pc_end = pc_begin + get_pc_range();
 
       if ((pc >= pc_begin) && (pc < pc_end)) {

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.hpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.hpp
@@ -108,7 +108,7 @@ class DwarfParser {
     }
 
     bool is_parseable() {
-      return _lib->eh_frame.data != NULL;
+      return _lib->frame.data != NULL;
     }
 };
 

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
@@ -128,7 +128,7 @@ static void destroy_lib_info(struct ps_prochandle* ph) {
      if (lib->symtab) {
         destroy_symtab(lib->symtab);
      }
-     free(lib->eh_frame.data);
+     free(lib->frame.data);
      free(lib);
      lib = next;
    }
@@ -231,10 +231,9 @@ bool read_eh_frame(struct ps_prochandle* ph, lib_info* lib) {
 
   for (cnt = 0, sh = shbuf; cnt < ehdr.e_shnum; cnt++, sh++) {
     if (strcmp(".eh_frame", sh->sh_name + strtab) == 0) {
-      lib->eh_frame.library_base_addr = lib->base;
-      lib->eh_frame.v_addr = sh->sh_addr;
-      lib->eh_frame.data = read_section_data(lib->fd, &ehdr, sh);
-      lib->eh_frame.size = sh->sh_size;
+      lib->frame.v_addr = sh->sh_addr;
+      lib->frame.data = read_section_data(lib->fd, &ehdr, sh);
+      lib->frame.size = sh->sh_size;
       break;
     }
   }
@@ -242,7 +241,7 @@ bool read_eh_frame(struct ps_prochandle* ph, lib_info* lib) {
   free(strtab);
   free(shbuf);
   lseek(lib->fd, current_pos, SEEK_SET);
-  return lib->eh_frame.data != NULL;
+  return lib->frame.data != NULL;
 }
 
 lib_info* add_lib_info_fd(struct ps_prochandle* ph, const char* libname, int fd, uintptr_t base) {

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h
@@ -34,13 +34,12 @@
 
 #define BUF_SIZE     (PATH_MAX + NAME_MAX + 1)
 
-// .eh_frame data
-typedef struct eh_frame_info {
-  uintptr_t library_base_addr;
+// frame data
+typedef struct frame_info {
   uintptr_t v_addr;
   unsigned char* data;
   int size;
-} eh_frame_info;
+} frame_info;
 
 // list of shared objects
 typedef struct lib_info {
@@ -49,7 +48,7 @@ typedef struct lib_info {
   uintptr_t        end;
   uintptr_t        exec_start;
   uintptr_t        exec_end;
-  eh_frame_info    eh_frame;
+  frame_info       frame;
   struct symtab*   symtab;
   int              fd;        // file descriptor for lib
   struct lib_info* next;


### PR DESCRIPTION
This is a part of [JDK-8382392](https://bugs.openjdk.org/browse/JDK-8382392).

"eh_frame" is a key to unwind native frames, so SA uses "eh_frame" in as a type name and a field name. Before to work for `.debug_frame`, we need to rename it to `frame` because "eh_frame" is no longer an only representation of frame information.

And also this ticket would remove `library_base_addr` from `eh_frame` (`frame` after renaming) because we can get library base address from `base`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390620](https://bugs.openjdk.org/browse/JDK-8390620): Refactor eh_frame to frame in libsaproc (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32436/head:pull/32436` \
`$ git checkout pull/32436`

Update a local copy of the PR: \
`$ git checkout pull/32436` \
`$ git pull https://git.openjdk.org/jdk.git pull/32436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32436`

View PR using the GUI difftool: \
`$ git pr show -t 32436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32436.diff">https://git.openjdk.org/jdk/pull/32436.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32436#issuecomment-5338141461)
</details>
