### PR TITLE
8390615: jar tool documentation should clarify the -C usage

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -304,8 +304,10 @@ main.help.opt.any=\
 \ Operation modifiers valid in any mode:\n\
 \n\
 \  -C DIR                     Change to the specified directory and include the\n\
-\                             following file. When used in extract mode, extracts\n\
-\                             the JAR to the specified directory
+\                             following file. When used in create mode, if the file\n\
+\                             is a directory then it is processed recursively. When\n\
+\                             used in extract mode, extracts the JAR to the specified\n\
+\                             directory
 main.help.opt.any.file=\
 \  -f, --file=FILE            The archive file name. When omitted, either stdin or\n\
 \                             stdout is used based on the operation\n\

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -144,12 +144,12 @@ error.validator.manifest.inconsistent.automatic.module.name=\
         expected Automatic-Module-Name entry in manifest: {0} to match name of compiled module: {1}
 warn.validator.identical.entry=\
         Warning: entry {0} contains a class that\n\
-        is identical to an entry already in the JAR
+        is identical to an entry already in the JAR file
 warn.validator.resources.with.same.name=\
         Warning: entry {0}, multiple resources with same name
 warn.validator.concealed.public.class=\
         Warning: entry {0} is a public class\n\
-        in a concealed package, placing this JAR on the class path will result\n\
+        in a concealed package, placing this JAR file on the class path will result\n\
         in incompatible public interfaces
 warn.validator.duplicate.cen.entry=\
         Warning: There were {0} central directory entries found for {1}
@@ -166,7 +166,7 @@ warn.validator.order.mismatch=\
 warn.release.unexpected.versioned.entry=\
         unexpected versioned entry {0}
 warn.index.is.ignored=\
-        The JAR index (META-INF/INDEX.LIST) is ignored at run-time since JDK 18
+        The JAR file index (META-INF/INDEX.LIST) is ignored at run-time since JDK 18
 warn.flag.is.deprecated=\
         Warning: The {0} option is deprecated, and may be ignored or removed in a future release\n
 warn.option.is.ignored=\
@@ -207,12 +207,12 @@ usage.compat=\
 \n\
 Usage: jar {ctxui}[vfmn0PMe] [jar-file] [manifest-file] [entry-point] [-C dir] files] ...\n\
 Options:\n\
-\ \   -c  create new archive (including missing parent directories)\n\
-\ \   -t  list table of contents for archive\n\
-\ \   -x  extract named (or all) files from archive\n\
-\ \   -u  update existing archive\n\
+\ \   -c  create new JAR file (including missing parent directories)\n\
+\ \   -t  list table of contents of the JAR file\n\
+\ \   -x  extract named (or all) files from the JAR file\n\
+\ \   -u  update existing JAR file\n\
 \ \   -v  generate verbose output on standard output\n\
-\ \   -f  specify archive file name\n\
+\ \   -f  specify JAR file name\n\
 \ \   -m  include manifest information from specified manifest file\n\
 \ \   -e  specify application entry point for stand-alone application \n\
 \ \       bundled into an executable JAR file\n\
@@ -222,13 +222,13 @@ Options:\n\
 \ \   -i  generate index information for the specified JAR files\n\
 \ \   -C  change to the specified directory and include the following file\n\
 If the file is a directory then it is processed recursively.\n\
-When used in extract mode, extracts the JAR to the specified directory\n\
-The manifest file name, the archive file name and the entry point name are\n\
+When used in extract mode, extracts the JAR file to the specified directory\n\
+The manifest file name, the JAR file name and the entry point name are\n\
 specified in the same order as the 'm', 'f' and 'e' flags.\n\n\
-Example 1: to archive two class files into an archive called classes.jar: \n\
+Example 1: to create a JAR file called classes.jar with two class files: \n\
 \ \      jar cvf classes.jar Foo.class Bar.class \n\
-Example 2: use an existing manifest file 'mymanifest' and archive all the\n\
-\ \          files in the foo/ directory into 'classes.jar': \n\
+Example 2: to create a JAR file called classes.jar, using an existing manifest \n\
+\ \          file mymanifest, and with all the files from the foo/ directory: \n\
 \ \      jar cvfm classes.jar mymanifest -C foo/ .\n
 
 main.usage.summary=\
@@ -256,12 +256,12 @@ restore individual classes or resources from an archive.\n\
 \ jar --create --file foo.jar --main-class com.foo.Main --module-version 1.0\n\
 \     -C foo/classes module-info.class\n\
 \n\
-\ # Update an existing non-modular JAR to a modular JAR, with the module-info.class\n\
+\ # Update an existing non-modular JAR file to a modular JAR file, with the module-info.class\n\
 \ # located in the resources directory:\n\
 \ jar --update --file foo.jar --main-class com.foo.Main --module-version 1.0\n\
 \     -C resources module-info.class\n\
 \n\
-\ # Create a multi-release JAR, placing some files in the META-INF/versions/9 directory:\n\
+\ # Create a multi-release JAR file, placing some files in the META-INF/versions/9 directory:\n\
 \ jar --create --file mr.jar -C foo classes --release 9 -C foo9 classes\n\
 \n\
 To shorten or simplify the jar command, you can specify arguments in a separate\n\
@@ -274,7 +274,7 @@ text file and pass it to the jar command with the at sign (@) as a prefix.\n\
 main.help.opt.main=\
 \ Main operation mode:\n
 main.help.opt.main.create=\
-\  -c, --create               Create the archive. When the archive file name specified\n\
+\  -c, --create               Create the JAR file. When the JAR file name specified\n\
 \                             by -f or --file contains a path, missing parent directories\n\
 \                             will also be created
 main.help.opt.main.generate-index=\
@@ -286,16 +286,16 @@ main.help.opt.main.list=\
 main.help.opt.main.update=\
 \  -u, --update               Update an existing JAR file
 main.help.opt.main.extract=\
-\  -x, --extract              Extract named (or all) files from the JAR.\n\
+\  -x, --extract              Extract named (or all) files from the JAR file.\n\
 \                             If a file with the same name appears more than once in\n\
-\                             the archive, each copy will be extracted, with later copies\n\
+\                             the JAR file, each copy will be extracted, with later copies\n\
 \                             overwriting (replacing) earlier copies unless -k is specified.
 main.help.opt.main.describe-module=\
 \  -d, --describe-module      Print the module descriptor, or automatic module name
 main.help.opt.main.validate=\
 \      --validate             Validate the contents of the JAR file. This option:\n\
 \                             - Validates that the API exported by a multi-release\n\
-\                             JAR is consistent across all different release\n\
+\                             JAR file is consistent across all different release\n\
 \                             versions.\n\
 \                             - Issues a warning if there are invalid or duplicate file names
 
@@ -306,13 +306,13 @@ main.help.opt.any=\
 \  -C DIR                     Change to the specified directory and include the\n\
 \                             following file. When used in create mode, if the file\n\
 \                             is a directory then it is processed recursively. When\n\
-\                             used in extract mode, extracts the JAR to the specified\n\
+\                             used in extract mode, extracts the JAR file to the specified\n\
 \                             directory
 main.help.opt.any.file=\
-\  -f, --file=FILE            The archive file name. When omitted, either stdin or\n\
+\  -f, --file=FILE            The JAR file name. When omitted, either stdin or\n\
 \                             stdout is used based on the operation\n\
 \      --release VERSION      Places all files, that follow, in a versioned directory\n\
-\                             of the JAR (i.e. META-INF/versions/<VERSION>/)
+\                             of the JAR file (i.e. META-INF/versions/<VERSION>/)
 main.help.opt.any.verbose=\
 \  -v, --verbose              Generate verbose output on standard output
 main.help.opt.create=\
@@ -322,7 +322,7 @@ main.help.opt.create.update=\
 main.help.opt.create.update.main-class=\
 \  -e, --main-class=CLASSNAME The application entry point for stand-alone\n\
 \                             applications bundled into a modular, or executable,\n\
-\                             JAR
+\                             JAR file
 main.help.opt.create.update.manifest=\
 \  -m, --manifest=FILE        Include the manifest information from the given\n\
 \                             manifest file
@@ -330,12 +330,12 @@ main.help.opt.create.update.no-manifest=\
 \  -M, --no-manifest          Do not create a manifest file for the entries
 main.help.opt.create.update.module-version=\
 \      --module-version=VERSION    The module version, when creating a modular\n\
-\                             JAR, or updating a non-modular JAR
+\                             JAR file, or updating a non-modular JAR file
 main.help.opt.create.update.hash-modules=\
 \      --hash-modules=PATTERN Compute and record the hashes of modules \n\
 \                             matched by the given pattern and that depend upon\n\
-\                             directly or indirectly on a modular JAR being\n\
-\                             created or a non-modular JAR being updated
+\                             directly or indirectly on a modular JAR file being\n\
+\                             created or a non-modular JAR file being updated
 main.help.opt.create.update.module-path=\
 \  -p, --module-path          Location of module dependence for generating\n\
 \                             the hash
@@ -359,8 +359,8 @@ main.help.opt.extract.keep-old-files=\
 \  -k, --keep-old-files       Do not overwrite existing files.\n\
 \                             If a JAR file entry with the same name exists in the target\n\
 \                             directory, the existing file will not be overwritten.\n\
-\                             As a result, if a file appears more than once in an\n\
-\                             archive, later copies will not overwrite earlier copies.\n\
+\                             As a result, if a file appears more than once in a\n\
+\                             JAR file, later copies will not overwrite earlier copies.\n\
 \                             Also note that some file system can be case insensitive.
 main.help.opt.other=\
 \ Other options:\n
@@ -372,12 +372,12 @@ main.help.opt.other.version=\
 \      --version              Print program version
 main.help.postopt=\
 \ A JAR file is a modular JAR file if a module descriptor, 'module-info.class', is\n\
-\ located in the root of the given directories, or the root of the JAR\n\
-\ itself. The following operations are only valid when creating a modular JAR,\n\
-\ or updating an existing non-modular JAR: '--module-version',\n\
+\ located in the root of the given directories, or the root of the JAR file\n\
+\ itself. The following operations are only valid when creating a modular JAR file,\n\
+\ or updating an existing non-modular JAR file: '--module-version',\n\
 \ '--hash-modules', and '--module-path'.\n\
 \n\
 \ Mandatory or optional arguments to long options are also mandatory or optional\n\
 \ for any corresponding short options.
 main.help.opt.extract.dir=\
-\  --dir                    Directory into which the JAR will be extracted
+\  --dir                    Directory into which the JAR file will be extracted

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ error.bad.reason=\
 error.nosuch.fileordir=\
         {0} : no such file or directory
 error.write.file=\
-        Error in writing existing jar file
+        Error in writing existing JAR file
 error.create.dir=\
         {0} : could not create directory
 error.incorrect.length=\
@@ -99,7 +99,7 @@ error.date.out.of.range=\
 error.validator.jarfile.exception=\
         can not validate {0}: {1}
 error.validator.jarfile.invalid=\
-        invalid multi-release jar file {0} deleted
+        invalid multi-release JAR file {0} deleted
 error.validator.bad.entry.name=\
         entry name malformed, {0}
 error.validator.version.notnumber=\
@@ -144,12 +144,12 @@ error.validator.manifest.inconsistent.automatic.module.name=\
         expected Automatic-Module-Name entry in manifest: {0} to match name of compiled module: {1}
 warn.validator.identical.entry=\
         Warning: entry {0} contains a class that\n\
-        is identical to an entry already in the jar
+        is identical to an entry already in the JAR
 warn.validator.resources.with.same.name=\
         Warning: entry {0}, multiple resources with same name
 warn.validator.concealed.public.class=\
         Warning: entry {0} is a public class\n\
-        in a concealed package, placing this jar on the class path will result\n\
+        in a concealed package, placing this JAR on the class path will result\n\
         in incompatible public interfaces
 warn.validator.duplicate.cen.entry=\
         Warning: There were {0} central directory entries found for {1}
@@ -215,14 +215,14 @@ Options:\n\
 \ \   -f  specify archive file name\n\
 \ \   -m  include manifest information from specified manifest file\n\
 \ \   -e  specify application entry point for stand-alone application \n\
-\ \       bundled into an executable jar file\n\
+\ \       bundled into an executable JAR file\n\
 \ \   -0  store only; use no ZIP compression\n\
 \ \   -P  preserve leading '/' (absolute path) and ".." (parent directory) components from file names\n\
 \ \   -M  do not create a manifest file for the entries\n\
-\ \   -i  generate index information for the specified jar files\n\
+\ \   -i  generate index information for the specified JAR files\n\
 \ \   -C  change to the specified directory and include the following file\n\
-If any file is a directory then it is processed recursively.\n\
-When used in extract mode, extracts the jar to the specified directory\n\
+If the file is a directory then it is processed recursively.\n\
+When used in extract mode, extracts the JAR to the specified directory\n\
 The manifest file name, the archive file name and the entry point name are\n\
 specified in the same order as the 'm', 'f' and 'e' flags.\n\n\
 Example 1: to archive two class files into an archive called classes.jar: \n\
@@ -241,25 +241,33 @@ Usage: jar [OPTION...] [ [--release VERSION] [-C dir] files] ...\n\
 jar creates an archive for classes and resources, and can manipulate or\n\
 restore individual classes or resources from an archive.\n\
 \n\
-\ Examples:\n\
-\ # Create an archive called classes.jar with two class files:\n\
+\ Examples:\n\n\
+\ # Create a JAR file called classes.jar with two class files located in the current directory:\n\
 \ jar --create --file classes.jar Foo.class Bar.class\n\
-\ # Create an archive using an existing manifest, with all the files in foo/:\n\
-\ jar --create --file classes.jar --manifest mymanifest -C foo/ .\n\
-\ # Create a modular jar archive, where the module descriptor is located in\n\
-\ # classes/module-info.class:\n\
+\n\
+\ # Create a JAR file called classes.jar with two class files located in the build directory:\n\
+\ jar --create --file classes.jar -C build Foo.class -C build Bar.class\n\
+\n\
+\ # Create a JAR file using an existing manifest, and with all the files from the foo directory:\n\
+\ jar --create --file classes.jar --manifest mymanifest -C foo .\n\
+\n\
+\ # Create a modular JAR file, whose module descriptor is located in the foo/classes\n\
+\ # directory:\n\
 \ jar --create --file foo.jar --main-class com.foo.Main --module-version 1.0\n\
-\     -C foo/ classes resources\n\
-\ # Update an existing non-modular jar to a modular jar:\n\
+\     -C foo/classes module-info.class\n\
+\n\
+\ # Update an existing non-modular JAR to a modular JAR, with the module-info.class\n\
+\ # located in the resources directory:\n\
 \ jar --update --file foo.jar --main-class com.foo.Main --module-version 1.0\n\
-\     -C foo/ module-info.class\n\
-\ # Create a multi-release jar, placing some files in the META-INF/versions/9 directory:\n\
+\     -C resources module-info.class\n\
+\n\
+\ # Create a multi-release JAR, placing some files in the META-INF/versions/9 directory:\n\
 \ jar --create --file mr.jar -C foo classes --release 9 -C foo9 classes\n\
 \n\
 To shorten or simplify the jar command, you can specify arguments in a separate\n\
 text file and pass it to the jar command with the at sign (@) as a prefix.\n\
 \n\
-\ Examples:\n\
+\ Examples:\n\n\
 \ # Read additional options and list of class files from the file classes.list\n\
 \ jar --create --file my.jar @classes.list\
 \n
@@ -270,24 +278,24 @@ main.help.opt.main.create=\
 \                             by -f or --file contains a path, missing parent directories\n\
 \                             will also be created
 main.help.opt.main.generate-index=\
-\  -i, --generate-index=FILE  Generate index information for the specified jar\n\
-\                             archives. This option is deprecated and may be \n\
+\  -i, --generate-index=FILE  Generate index information for the specified JAR\n\
+\                             files. This option is deprecated and may be \n\
 \                             removed in a future release.
 main.help.opt.main.list=\
-\  -t, --list                 List the table of contents for the archive
+\  -t, --list                 List the table of contents of the JAR file
 main.help.opt.main.update=\
-\  -u, --update               Update an existing jar archive
+\  -u, --update               Update an existing JAR file
 main.help.opt.main.extract=\
-\  -x, --extract              Extract named (or all) files from the archive.\n\
+\  -x, --extract              Extract named (or all) files from the JAR.\n\
 \                             If a file with the same name appears more than once in\n\
 \                             the archive, each copy will be extracted, with later copies\n\
 \                             overwriting (replacing) earlier copies unless -k is specified.
 main.help.opt.main.describe-module=\
 \  -d, --describe-module      Print the module descriptor, or automatic module name
 main.help.opt.main.validate=\
-\      --validate             Validate the contents of the jar archive. This option:\n\
+\      --validate             Validate the contents of the JAR file. This option:\n\
 \                             - Validates that the API exported by a multi-release\n\
-\                             jar archive is consistent across all different release\n\
+\                             JAR is consistent across all different release\n\
 \                             versions.\n\
 \                             - Issues a warning if there are invalid or duplicate file names
 
@@ -297,12 +305,12 @@ main.help.opt.any=\
 \n\
 \  -C DIR                     Change to the specified directory and include the\n\
 \                             following file. When used in extract mode, extracts\n\
-\                             the jar to the specified directory
+\                             the JAR to the specified directory
 main.help.opt.any.file=\
 \  -f, --file=FILE            The archive file name. When omitted, either stdin or\n\
 \                             stdout is used based on the operation\n\
-\      --release VERSION      Places all following files in a versioned directory\n\
-\                             of the jar (i.e. META-INF/versions/VERSION/)
+\      --release VERSION      Places all files, that follow, in a versioned directory\n\
+\                             of the JAR (i.e. META-INF/versions/<VERSION>/)
 main.help.opt.any.verbose=\
 \  -v, --verbose              Generate verbose output on standard output
 main.help.opt.create=\
@@ -312,7 +320,7 @@ main.help.opt.create.update=\
 main.help.opt.create.update.main-class=\
 \  -e, --main-class=CLASSNAME The application entry point for stand-alone\n\
 \                             applications bundled into a modular, or executable,\n\
-\                             jar archive
+\                             JAR
 main.help.opt.create.update.manifest=\
 \  -m, --manifest=FILE        Include the manifest information from the given\n\
 \                             manifest file
@@ -320,12 +328,12 @@ main.help.opt.create.update.no-manifest=\
 \  -M, --no-manifest          Do not create a manifest file for the entries
 main.help.opt.create.update.module-version=\
 \      --module-version=VERSION    The module version, when creating a modular\n\
-\                             jar, or updating a non-modular jar
+\                             JAR, or updating a non-modular JAR
 main.help.opt.create.update.hash-modules=\
 \      --hash-modules=PATTERN Compute and record the hashes of modules \n\
 \                             matched by the given pattern and that depend upon\n\
-\                             directly or indirectly on a modular jar being\n\
-\                             created or a non-modular jar being updated
+\                             directly or indirectly on a modular JAR being\n\
+\                             created or a non-modular JAR being updated
 main.help.opt.create.update.module-path=\
 \  -p, --module-path          Location of module dependence for generating\n\
 \                             the hash
@@ -347,7 +355,7 @@ main.help.opt.extract=\
 \ Operation modifiers valid only in extract mode:\n
 main.help.opt.extract.keep-old-files=\
 \  -k, --keep-old-files       Do not overwrite existing files.\n\
-\                             If a Jar file entry with the same name exists in the target\n\
+\                             If a JAR file entry with the same name exists in the target\n\
 \                             directory, the existing file will not be overwritten.\n\
 \                             As a result, if a file appears more than once in an\n\
 \                             archive, later copies will not overwrite earlier copies.\n\
@@ -361,13 +369,13 @@ main.help.opt.other.help-extra=\
 main.help.opt.other.version=\
 \      --version              Print program version
 main.help.postopt=\
-\ An archive is a modular jar if a module descriptor, 'module-info.class', is\n\
-\ located in the root of the given directories, or the root of the jar archive\n\
-\ itself. The following operations are only valid when creating a modular jar,\n\
-\ or updating an existing non-modular jar: '--module-version',\n\
+\ A JAR is a modular JAR if a module descriptor, 'module-info.class', is\n\
+\ located in the root of the given directories, or the root of the JAR\n\
+\ itself. The following operations are only valid when creating a modular JAR,\n\
+\ or updating an existing non-modular JAR: '--module-version',\n\
 \ '--hash-modules', and '--module-path'.\n\
 \n\
 \ Mandatory or optional arguments to long options are also mandatory or optional\n\
 \ for any corresponding short options.
 main.help.opt.extract.dir=\
-\  --dir                    Directory into which the jar will be extracted
+\  --dir                    Directory into which the JAR will be extracted

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -371,7 +371,7 @@ main.help.opt.other.help-extra=\
 main.help.opt.other.version=\
 \      --version              Print program version
 main.help.postopt=\
-\ A JAR is a modular JAR if a module descriptor, 'module-info.class', is\n\
+\ A JAR file is a modular JAR file if a module descriptor, 'module-info.class', is\n\
 \ located in the root of the given directories, or the root of the JAR\n\
 \ itself. The following operations are only valid when creating a modular JAR,\n\
 \ or updating an existing non-modular JAR: '--module-version',\n\

--- a/src/jdk.jartool/share/man/jar.md
+++ b/src/jdk.jartool/share/man/jar.md
@@ -59,11 +59,11 @@ also enables individual entries in a file to be signed so that their origin can
 be authenticated. A JAR file can be used as a class path entry, whether or not
 it's compressed.
 
-An archive becomes a modular JAR when you include a module descriptor,
+A JAR file becomes a modular JAR when you include a module descriptor,
 `module-info.class`, in the root of the given directories or in the root of
-the `.jar` archive. The following operations described in [Operation Modifiers
+the JAR itself. The following operations described in [Operation Modifiers
 Valid Only in Create and Update Modes] are valid only when creating or
-updating a modular jar or updating an existing non-modular jar:
+updating a modular JAR or updating an existing non-modular JAR:
 
 -   `--module-version`
 
@@ -117,10 +117,13 @@ mode included in the `jar` command.
 
 [`-C`]{#option-C} *DIR*
 :   When used with the create operation mode, changes the specified directory
-    and includes the *files* specified at the end of the command line.
+    and includes the *file* that follows in the command line.
 
     `jar` \[*OPTION* ...\] \[ \[`--release` *VERSION*\] \[`-C` *dir*\]
-    *files*\]
+    *file*\]
+
+    When used in create operation mode, if the file is a directory then
+    it is processed recursively.
 
     When used with the extract operation mode, specifies the destination directory
     where the JAR file will be extracted. Unlike with the create operation mode,
@@ -196,7 +199,7 @@ or `--create`) the update (`-u` or `--update` ) and the generate-index (`-i` or
 
 [`-k`]{#option--keep-old-files} or `--keep-old-files`
 :   Do not overwrite existing files.
-    If a Jar file entry with the same name exists in the target directory, the
+    If a JAR file entry with the same name exists in the target directory, the
     existing file will not be overwritten.
     As a result, if a file appears more than once in an archive, later copies will not overwrite
     earlier copies.
@@ -222,18 +225,18 @@ As a JAR file is based on ZIP format, it is possible to create a JAR file using 
 other than the `jar` command. The --validate option may be used to perform the following
 integrity checks against a JAR file:
 
-- That there are no duplicate Zip entry file names
-- Verify that the Zip entry file name:
+- That there are no duplicate ZIP entry file names
+- Verify that the ZIP entry file name:
     - is not an absolute path
     - the file name is not '.' or '..'
     - does not contain a backslash, '\\'
     - does not contain a drive letter
     - path element does not include '.' or '..
-- The API exported by a multi-release jar archive is consistent across all different release
+- The API exported by a multi-release JAR is consistent across all different release
   versions.
 
-The jar tool exits with a status of 0 if there were no integrity issues encountered and >0 if an
-error/warning occurred.
+The `jar` tool exits with a status of `0` if there were no integrity issues encountered and `> 0`
+if an error/warning occurred.
 
 When an integrity issue is reported, it will often require that the JAR file is re-created by the
 original source of the JAR file.
@@ -250,21 +253,22 @@ original source of the JAR file.
 
     >   `jar --create --date="2021-01-06T14:36:00+02:00" --file=classes.jar Foo.class Bar.class`
 
--   Create an archive, `classes.jar`, by using an existing manifest,
-    `mymanifest`, that contains all of the files in the directory `foo/`.
+-   Create a JAR file, `classes.jar`, using an existing manifest `mymanifest`,
+    and with all the files from the `foo` directory.
 
-    >   `jar --create --file classes.jar --manifest mymanifest -C foo/`
+    >   `jar --create --file classes.jar --manifest mymanifest -C foo/ .`
 
--   Create a modular JAR archive,`foo.jar`, where the module descriptor is
-    located in `classes/module-info.class`.
+-   Create a modular JAR file, `foo.jar`, whose module descriptor is located in the `foo/classes`
+    directory.
 
     >   `jar --create --file foo.jar --main-class com.foo.Main
-        --module-version 1.0 -C foo/classes resources`
+        --module-version 1.0 -C foo/classes module-info.class`
 
--   Update an existing non-modular JAR, `foo.jar`, to a modular JAR file.
+-   Update an existing non-modular JAR, `foo.jar`, to a modular JAR, with the `module-info.class`
+    located in the `resources` directory.
 
     >   `jar --update --file foo.jar --main-class com.foo.Main
-        --module-version 1.0 -C foo/module-info.class`
+        --module-version 1.0 -C resources module-info.class`
 
 -   Create a versioned or multi-release JAR, `foo.jar`, that places the files
     in the `classes` directory at the root of the JAR, and the files in the
@@ -276,7 +280,7 @@ original source of the JAR file.
     version of the `com.foo.NameProvider` class, this one containing JDK 10
     specific code and compiled for JDK 10.
 
-    Given this setup, create a multirelease JAR file `foo.jar` by running the
+    Given this setup, create a multi-release JAR file `foo.jar` by running the
     following command from the directory containing the directories `classes`
     and `classes-10` .
 
@@ -300,7 +304,7 @@ original source of the JAR file.
     ```
 
     As well as other information, the file `META-INF/MANIFEST.MF`, will contain
-    the following lines to indicate that this is a multirelease JAR file with
+    the following lines to indicate that this is a multi-release JAR file with
     an entry point of `com.foo.Hello`.
 
     ```
@@ -327,7 +331,8 @@ original source of the JAR file.
 
     >   `jar --create --file my.jar @classes.list`
 
-    If one or more entries in the arg file cannot be found then the jar command fails without creating the JAR file.
+    If one or more entries in the arg file cannot be found then the `jar` command fails without
+    creating the JAR file.
 
 -   Extract the JAR file `foo.jar` to `/tmp/bar/` directory:
 

--- a/src/jdk.jartool/share/man/jar.md
+++ b/src/jdk.jartool/share/man/jar.md
@@ -59,7 +59,7 @@ also enables individual entries in a file to be signed so that their origin can
 be authenticated. A JAR file can be used as a class path entry, whether or not
 it's compressed.
 
-A JAR file becomes a modular JAR when you include a module descriptor,
+A JAR file becomes a modular JAR file when you include a module descriptor,
 `module-info.class`, in the root of the given directories or in the root of
 the JAR itself. The following operations described in [Operation Modifiers
 Valid Only in Create and Update Modes] are valid only when creating or

--- a/src/jdk.jartool/share/man/jar.md
+++ b/src/jdk.jartool/share/man/jar.md
@@ -116,14 +116,14 @@ You can use the following options to customize the actions of any operation
 mode included in the `jar` command.
 
 [`-C`]{#option-C} *DIR*
-:   When used with the create operation mode, changes the specified directory
+:   When used with the create operation mode, changes to the specified directory
     and includes the *file* that follows in the command line.
 
     `jar` \[*OPTION* ...\] \[ \[`--release` *VERSION*\] \[`-C` *dir*\]
     *file*\]
 
-    When used in create operation mode, if the file is a directory then
-    it is processed recursively.
+    When used in create mode, if the file is a directory then it is
+    processed recursively.
 
     When used with the extract operation mode, specifies the destination directory
     where the JAR file will be extracted. Unlike with the create operation mode,

--- a/src/jdk.jartool/share/man/jar.md
+++ b/src/jdk.jartool/share/man/jar.md
@@ -41,9 +41,9 @@ individual classes or resources from an archive
 The `jar` command is a general-purpose archiving and compression tool, based on
 the ZIP and ZLIB compression formats. Initially, the `jar` command was designed
 to package Java applets (not supported since JDK 11) or applications; however,
-beginning with JDK 9, users can use the `jar` command to create modular JARs.
+beginning with JDK 9, users can use the `jar` command to create modular JAR files.
 For transportation and deployment, it's usually more convenient to package
-modules as modular JARs.
+modules as modular JAR files.
 
 The syntax for the `jar` command resembles the syntax for the `tar` command. It
 has several main operation modes, defined by one of the mandatory operation
@@ -51,7 +51,7 @@ arguments. Other arguments are either options that modify the behavior of the
 operation or are required to perform the operation.
 
 When modules or the components of an application (files, images and sounds) are
-combined into a single archive, they can be downloaded by a Java agent (such as
+combined into a single JAR file, they can be downloaded by a Java agent (such as
 a browser) in a single HTTP transaction, rather than requiring a new connection
 for each piece. This dramatically improves download times. The `jar` command
 also compresses files, which further improves download time. The `jar` command
@@ -61,9 +61,9 @@ it's compressed.
 
 A JAR file becomes a modular JAR file when you include a module descriptor,
 `module-info.class`, in the root of the given directories or in the root of
-the JAR itself. The following operations described in [Operation Modifiers
+the JAR file itself. The following operations described in [Operation Modifiers
 Valid Only in Create and Update Modes] are valid only when creating or
-updating a modular JAR or updating an existing non-modular JAR:
+updating a modular JAR file or updating an existing non-modular JAR file:
 
 -   `--module-version`
 
@@ -85,22 +85,22 @@ operation argument with other one-letter options. Generally the operation
 argument is the first argument specified on the command line.
 
 [`-c`]{#option--create} or `--create`
-:   Creates the archive.
+:   Creates the JAR file.
 
 [`-i`]{#option--generate-index} *FILE* or `--generate-index=`*FILE*
 :   Generates index information for the specified JAR file.  This option is deprecated
     and may be removed in a future release.
 
 [`-t`]{#option--list} or `--list`
-:   Lists the table of contents for the archive.
+:   Lists the table of contents of the JAR file.
 
 [`-u`]{#option--update} or `--update`
 :   Updates an existing JAR file.
 
 [`-x`]{#option--extract} or `--extract`
-:   Extracts the named (or all) files from the archive.
+:   Extracts the named (or all) files from the JAR file.
     If a file with the same name appears more than once in
-    the archive, each copy will be extracted, with later copies
+    the JAR file, each copy will be extracted, with later copies
     overwriting (replacing) earlier copies unless -k is specified.
 
 [`-d`]{#option--describe-module} or `--describe-module`
@@ -130,7 +130,7 @@ mode included in the `jar` command.
     this option can be specified only once with the extract operation mode.
 
 [`-f`]{#option--file} *FILE* or `--file=`*FILE*
-:   Specifies the archive file name.
+:   Specifies the JAR file name.
 
 [`--release`]{#option--release} *VERSION*
 :   Creates a multirelease JAR file. Places all files specified after the
@@ -138,11 +138,11 @@ mode included in the `jar` command.
     `META-INF/versions/`*VERSION*`/`, where *VERSION* must be must be a
     positive integer whose value is 9 or greater.
 
-    At run time, where more than one version of a class exists in the JAR, the
+    At run time, where more than one version of a class exists in the JAR file, the
     JDK will use the first one it finds, searching initially in the directory
     tree whose *VERSION* number matches the JDK's major version number. It will
     then look in directories with successively lower *VERSION* numbers, and
-    finally look in the root of the JAR.
+    finally look in the root of the JAR file.
 
 `-v` or `--verbose`
 :   Sends or prints verbose output to standard output.
@@ -201,7 +201,7 @@ or `--create`) the update (`-u` or `--update` ) and the generate-index (`-i` or
 :   Do not overwrite existing files.
     If a JAR file entry with the same name exists in the target directory, the
     existing file will not be overwritten.
-    As a result, if a file appears more than once in an archive, later copies will not overwrite
+    As a result, if a file appears more than once in a JAR file, later copies will not overwrite
     earlier copies.
     Also note that some file system can be case insensitive.
 
@@ -232,7 +232,7 @@ integrity checks against a JAR file:
     - does not contain a backslash, '\\'
     - does not contain a drive letter
     - path element does not include '.' or '..
-- The API exported by a multi-release JAR is consistent across all different release
+- The API exported by a multi-release JAR file is consistent across all different release
   versions.
 
 The `jar` tool exits with a status of `0` if there were no integrity issues encountered and `> 0`
@@ -243,12 +243,12 @@ original source of the JAR file.
 
 ## Examples of jar Command Syntax
 
--   Create an archive, `classes.jar`, that contains two class files,
+-   Create a JAR file, `classes.jar`, that contains two class files,
     `Foo.class` and `Bar.class`.
 
     >   `jar --create --file classes.jar Foo.class Bar.class`
 
--   Create an archive, `classes.jar`, that contains two class files,
+-   Create a JAR file, `classes.jar`, that contains two class files,
     `Foo.class` and `Bar.class` setting the last modified date and time to `2021 Jan 6 12:36:00`.
 
     >   `jar --create --date="2021-01-06T14:36:00+02:00" --file=classes.jar Foo.class Bar.class`
@@ -264,15 +264,15 @@ original source of the JAR file.
     >   `jar --create --file foo.jar --main-class com.foo.Main
         --module-version 1.0 -C foo/classes module-info.class`
 
--   Update an existing non-modular JAR, `foo.jar`, to a modular JAR, with the `module-info.class`
-    located in the `resources` directory.
+-   Update an existing non-modular JAR file, `foo.jar`, to a modular JAR file,
+    with the `module-info.class` located in the `resources` directory.
 
     >   `jar --update --file foo.jar --main-class com.foo.Main
         --module-version 1.0 -C resources module-info.class`
 
--   Create a versioned or multi-release JAR, `foo.jar`, that places the files
-    in the `classes` directory at the root of the JAR, and the files in the
-    `classes-10` directory in the `META-INF/versions/10` directory of the JAR.
+-   Create a versioned or multi-release JAR file, `foo.jar`, that places the files
+    in the `classes` directory at the root of the JAR file, and the files in the
+    `classes-10` directory in the `META-INF/versions/10` directory of the JAR file.
 
     In this example, the `classes/com/foo` directory contains two classes,
     `com.foo.Hello` (the entry point class) and `com.foo.NameProvider`, both
@@ -318,9 +318,9 @@ original source of the JAR file.
     that the `com.foo.NameProvider` class is the one in
     `META-INF/versions/10/com/foo/`. Running the program using JDK 8 will
     ensure that the `com.foo.NameProvider` class is the one at the root of the
-    JAR, in `com/foo`.
+    JAR file, in `com/foo`.
 
--   Create an archive, `my.jar`, by reading options and lists of class files
+-   Create a JAR file, `my.jar`, by reading options and lists of class files
     from the file `classes.list`.
 
     **Note:**

--- a/test/jdk/tools/jar/JarExtractTest.java
+++ b/test/jdk/tools/jar/JarExtractTest.java
@@ -223,7 +223,7 @@ public class JarExtractTest {
         final String output = outStream.toString();
         // this message is expected to be the one from the jar --help output which is sourced from
         // jar.properties
-        final String expectedMsg = "--dir                    Directory into which the jar will be extracted";
+        final String expectedMsg = "--dir                    Directory into which the JAR will be extracted";
         assertTrue(output.contains(expectedMsg), "jar --help didn't contain --dir option");
     }
 

--- a/test/jdk/tools/jar/JarExtractTest.java
+++ b/test/jdk/tools/jar/JarExtractTest.java
@@ -223,7 +223,7 @@ public class JarExtractTest {
         final String output = outStream.toString();
         // this message is expected to be the one from the jar --help output which is sourced from
         // jar.properties
-        final String expectedMsg = "--dir                    Directory into which the JAR will be extracted";
+        final String expectedMsg = "--dir                    Directory into which the JAR file will be extracted";
         assertTrue(output.contains(expectedMsg), "jar --help didn't contain --dir option");
     }
 

--- a/test/jdk/tools/jar/mmrjar/Basic.java
+++ b/test/jdk/tools/jar/mmrjar/Basic.java
@@ -486,7 +486,7 @@ public class Basic {
         ),
         NEW_CONCEALED_PACKAGE_WARNING(
             " is a public class" +
-            " in a concealed package, placing this JAR on the class path will result" +
+            " in a concealed package, placing this JAR file on the class path will result" +
             " in incompatible public interfaces"
         );
 

--- a/test/jdk/tools/jar/mmrjar/Basic.java
+++ b/test/jdk/tools/jar/mmrjar/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -486,7 +486,7 @@ public class Basic {
         ),
         NEW_CONCEALED_PACKAGE_WARNING(
             " is a public class" +
-            " in a concealed package, placing this jar on the class path will result" +
+            " in a concealed package, placing this JAR on the class path will result" +
             " in incompatible public interfaces"
         );
 

--- a/test/jdk/tools/jar/multiRelease/Basic.java
+++ b/test/jdk/tools/jar/multiRelease/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -432,7 +432,7 @@ public class Basic extends MRTestBase {
                 output.get(0));
         assertTrue(output.get(1).contains("contains a new public class"),
                 output.get(1));
-        assertTrue(output.get(2).contains("invalid multi-release jar file"),
+        assertTrue(output.get(2).contains("invalid multi-release JAR file"),
                output.get(2));
 
         FileUtils.deleteFileIfExistsWithRetry(Paths.get(jarfile));


### PR DESCRIPTION
Can I please get a review of this doc-only change which updates the text in the `jar --help` output as well as the `jar` man page to clarify the usage of the `-C` option? 

As noted in https://bugs.openjdk.org/browse/JDK-8390615, the current examples in the `jar --help` can cause confusion on the expectations of the `-C` option. The updated text in the man page will also address a related issue noted in https://bugs.openjdk.org/browse/JDK-8389482.

While at it, trivial adjustment to the text in `jar --help` and `jar` man page has been done to use "JAR" (instead of "jar") whenever referencing to a JAR file.

I've run manual experiments to verify that these commands now work as described.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8390615: jar tool documentation should clarify the -C usage`

### Issues
 * [JDK-8390615](https://bugs.openjdk.org/browse/JDK-8390615): jar tool documentation should clarify the -C usage (**Bug** - P4)
 * [JDK-8389482](https://bugs.openjdk.org/browse/JDK-8389482): Documented example in the jar tool's man page is incorrect (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32439/head:pull/32439` \
`$ git checkout pull/32439`

Update a local copy of the PR: \
`$ git checkout pull/32439` \
`$ git pull https://git.openjdk.org/jdk.git pull/32439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32439`

View PR using the GUI difftool: \
`$ git pr show -t 32439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32439.diff">https://git.openjdk.org/jdk/pull/32439.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32439#issuecomment-5338810778)
</details>
