### PR TITLE
8390625: C2_MacroAssembler::vector_iota_entry_index hits assert(regs[i] != regs[j])

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -2436,7 +2436,8 @@ void C2_MacroAssembler::neon_reverse_bytes(FloatRegister dst, FloatRegister src,
 void C2_MacroAssembler::neon_rearrange_hsd(FloatRegister dst, FloatRegister src,
                                            FloatRegister shuffle, FloatRegister tmp,
                                            BasicType bt, bool isQ) {
-  assert_different_registers(dst, src, shuffle, tmp);
+  assert_different_registers(dst, src, tmp);
+  assert_different_registers(shuffle, tmp);
   SIMD_Arrangement size1 = isQ ? T16B : T8B;
   SIMD_Arrangement size2 = esize2arrangement((uint)type2aelembytes(bt), isQ);
 

--- a/test/hotspot/jtreg/compiler/vectorapi/TestSelectFromSameOperand.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestSelectFromSameOperand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390625
+ * @summary Test VectorRearrange with the same source and shuffle operand
+ * @requires vm.compiler2.enabled
+ * @modules jdk.incubator.vector
+ * @library /test/lib
+ * @run main/othervm -Xbatch ${test.main.class}
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.ShortVector;
+import jdk.test.lib.Asserts;
+
+public class TestSelectFromSameOperand {
+    private static final short[] INPUT = {7, 6, 5, 4, 3, 2, 1, 0};
+    private static final short[] OUTPUT = new short[INPUT.length];
+
+    public static void test() {
+        // The already masked 'vector' becomes both source and shuffle of the VectorRearrange node
+        ShortVector vector = ShortVector.fromArray(ShortVector.SPECIES_128, INPUT, 0).and((short) 7);
+        vector.selectFrom(vector).intoArray(OUTPUT, 0);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 100_000; i++) {
+            test();
+        }
+        for (int i = 0; i < OUTPUT.length; i++) {
+            Asserts.assertEQ(OUTPUT[i], (short) i);
+        }
+    }
+}
+


### PR DESCRIPTION
This issue is very similar to [JDK-8387149](https://bugs.openjdk.org/browse/JDK-8387149) / https://git.openjdk.org/jdk/pull/31850 (@ruben-arm) but with `selectFrom` one vector instead. Root cause and fix are basically the same:

[selectFrom](https://docs.oracle.com/en/java/javase/26/docs/api/jdk.incubator.vector/jdk/incubator/vector/Vector.html#selectFrom(jdk.incubator.vector.Vector)) masks every element in the shuffle vector operand with `laneCount - 1`. In the test, that vector is already masked with the same value by `.and((short) 7)`, so IGVN folds the useless mask and constructs `VectorRearrange(vector, vector)`. Both operands then use the same register and trigger the assert. The assert is too strong.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390625](https://bugs.openjdk.org/browse/JDK-8390625): C2_MacroAssembler::vector_iota_entry_index hits assert(regs[i] != regs[j]) (**Bug** - P3)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32440/head:pull/32440` \
`$ git checkout pull/32440`

Update a local copy of the PR: \
`$ git checkout pull/32440` \
`$ git pull https://git.openjdk.org/jdk.git pull/32440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32440`

View PR using the GUI difftool: \
`$ git pr show -t 32440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32440.diff">https://git.openjdk.org/jdk/pull/32440.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32440#issuecomment-5338917799)
</details>
