### PR TITLE
8388373: Exclude preview warnings from '-Xlint' by default

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -136,14 +136,16 @@ public class Lint {
     // Process command line options on demand to allow use of root Lint early during startup
     private void initializeRootIfNeeded() {
         if (values == null) {
-            values = options.getLintCategoriesOf(Option.XLINT, this::getDefaultsLintMissing, this::getDefaultsLintPresent);
+            values = options.getLintCategoriesOf(Option.XLINT,
+                                                 this::getDefaultsXLintAbsent,
+                                                 this::getDefaultsXLintPresent);
             suppressedValues = LintCategory.newEmptySet();
         }
     }
 
     // Obtain the set of on-by-default categories. Note that for a few categories,
     // whether the category is on-by-default depends on other compiler options.
-    private EnumSet<LintCategory> getDefaultsLintMissing() {
+    private EnumSet<LintCategory> getDefaultsXLintAbsent() {
         EnumSet<LintCategory> defaults = LintCategory.newEmptySet();
         Source source = Source.instance(context);
         Stream.of(LintCategory.values())
@@ -158,7 +160,7 @@ public class Lint {
         return defaults;
     }
 
-    private EnumSet<LintCategory> getDefaultsLintPresent() {
+    private EnumSet<LintCategory> getDefaultsXLintPresent() {
         EnumSet<LintCategory> defaults = EnumSet.allOf(LintCategory.class);
         if (options.isSet(Option.PREVIEW)) {
             defaults.remove(LintCategory.PREVIEW);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -136,14 +136,14 @@ public class Lint {
     // Process command line options on demand to allow use of root Lint early during startup
     private void initializeRootIfNeeded() {
         if (values == null) {
-            values = options.getLintCategoriesOf(Option.XLINT, this::getDefaults);
+            values = options.getLintCategoriesOf(Option.XLINT, this::getDefaultsLintMissing, this::getDefaultsLintPresent);
             suppressedValues = LintCategory.newEmptySet();
         }
     }
 
     // Obtain the set of on-by-default categories. Note that for a few categories,
     // whether the category is on-by-default depends on other compiler options.
-    private EnumSet<LintCategory> getDefaults() {
+    private EnumSet<LintCategory> getDefaultsLintMissing() {
         EnumSet<LintCategory> defaults = LintCategory.newEmptySet();
         Source source = Source.instance(context);
         Stream.of(LintCategory.values())
@@ -155,6 +155,14 @@ public class Lint {
                 default       -> lc.enabledByDefault;
             })
           .forEach(defaults::add);
+        return defaults;
+    }
+
+    private EnumSet<LintCategory> getDefaultsLintPresent() {
+        EnumSet<LintCategory> defaults = EnumSet.allOf(LintCategory.class);
+        if (options.isSet(Option.PREVIEW)) {
+            defaults.remove(LintCategory.PREVIEW);
+        }
         return defaults;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -441,7 +441,7 @@ public class JavaCompiler {
         devVerbose    = options.isSet("dev");
         processPcks   = options.isSet("process.packages");
         werrorNonLint = options.isSet(WERROR) || options.isSet(WERROR_CUSTOM, Option.LINT_CUSTOM_ALL);
-        werrorLint    = options.getLintCategoriesOf(WERROR, LintCategory::newEmptySet);
+        werrorLint    = options.getLintCategoriesOf(WERROR, LintCategory::newEmptySet, () -> EnumSet.allOf(LintCategory.class));
 
         verboseCompilePolicy = options.isSet("verboseCompilePolicy");
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Options.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Options.java
@@ -266,9 +266,10 @@ public class Options {
      * <p>
      * The set of categories is calculated as follows. First, an initial set is created:
      * <ul>
-     *  <li>If {@code -Flag} or {@code -Flag:all} appears, the initial set contains all categories; otherwise,
+     *  <li>If {@code -Flag:all} appears, the initial set contains all categories; otherwise,
+     *  <li>If {@code -Flag} appears, the {@code enabledByDefaultWhenLintPresent} parameter is invoked to construct an initial set; otherwise,
      *  <li>If {@code -Flag:none} appears, the initial set is empty; otherwise,
-     *  <li>The {@code defaults} parameter is invoked to construct an initial set.
+     *  <li>The {@code enabledByDefaultWhenLintAbsent} parameter is invoked to construct an initial set.
      * </ul>
      * Next, for each lint category key {@code key}:
      * <ul>
@@ -286,14 +287,13 @@ public class Options {
     public EnumSet<LintCategory> getLintCategoriesOf(Option option,
                                                      Supplier<? extends EnumSet<LintCategory>> enabledByDefaultWhenLintAbsent,
                                                      Supplier<? extends EnumSet<LintCategory>> enabledByDefaultWhenLintPresent) {
-
         // Create the initial set
         EnumSet<LintCategory> categories;
         Option customOption = option.getLintCustom();
-        if (isSet(option)) {
-            categories = enabledByDefaultWhenLintPresent.get();
-        }else if (isSet(option) || isSet(customOption, Option.LINT_CUSTOM_ALL)) {
+        if (isSet(customOption, Option.LINT_CUSTOM_ALL)) {
             categories = EnumSet.allOf(LintCategory.class);
+        } else if (isSet(option)) {
+            categories = enabledByDefaultWhenLintPresent.get();
         } else if (isSet(customOption, Option.LINT_CUSTOM_NONE)) {
             categories = EnumSet.noneOf(LintCategory.class);
         } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Options.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Options.java
@@ -282,17 +282,19 @@ public class Options {
      * @return the specified set of categories
      * @throws IllegalArgumentException if there is no lint custom variant of {@code option}
      */
-    public EnumSet<LintCategory> getLintCategoriesOf(Option option, Supplier<? extends EnumSet<LintCategory>> defaults) {
+    public EnumSet<LintCategory> getLintCategoriesOf(Option option, Supplier<? extends EnumSet<LintCategory>> enabledByDefaultWhenLintMissing, Supplier<? extends EnumSet<LintCategory>> enabledByDefaultWhenLintPresent) {
 
         // Create the initial set
         EnumSet<LintCategory> categories;
         Option customOption = option.getLintCustom();
-        if (isSet(option) || isSet(customOption, Option.LINT_CUSTOM_ALL)) {
+        if (isSet(option)) {
+            categories = enabledByDefaultWhenLintPresent.get();
+        }else if (isSet(option) || isSet(customOption, Option.LINT_CUSTOM_ALL)) {
             categories = EnumSet.allOf(LintCategory.class);
         } else if (isSet(customOption, Option.LINT_CUSTOM_NONE)) {
             categories = EnumSet.noneOf(LintCategory.class);
         } else {
-            categories = defaults.get();
+            categories = enabledByDefaultWhenLintMissing.get();
         }
 
         // Apply specific overrides

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Options.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Options.java
@@ -278,11 +278,14 @@ public class Options {
      * Unrecognized {@code key}s are ignored.
      *
      * @param option the plain (non-custom) version of the option (e.g., {@link Option#XLINT})
-     * @param defaults populates the default set, or null for an empty default set
+     * @param enabledByDefaultWhenLintAbsent the default categories enabled when the option is not present
+     * @param enabledByDefaultWhenLintPresent the default categories enabled when the option is present without details
      * @return the specified set of categories
      * @throws IllegalArgumentException if there is no lint custom variant of {@code option}
      */
-    public EnumSet<LintCategory> getLintCategoriesOf(Option option, Supplier<? extends EnumSet<LintCategory>> enabledByDefaultWhenLintMissing, Supplier<? extends EnumSet<LintCategory>> enabledByDefaultWhenLintPresent) {
+    public EnumSet<LintCategory> getLintCategoriesOf(Option option,
+                                                     Supplier<? extends EnumSet<LintCategory>> enabledByDefaultWhenLintAbsent,
+                                                     Supplier<? extends EnumSet<LintCategory>> enabledByDefaultWhenLintPresent) {
 
         // Create the initial set
         EnumSet<LintCategory> categories;
@@ -294,7 +297,7 @@ public class Options {
         } else if (isSet(customOption, Option.LINT_CUSTOM_NONE)) {
             categories = EnumSet.noneOf(LintCategory.class);
         } else {
-            categories = enabledByDefaultWhenLintMissing.get();
+            categories = enabledByDefaultWhenLintAbsent.get();
         }
 
         // Apply specific overrides

--- a/src/jdk.compiler/share/man/javac.md
+++ b/src/jdk.compiler/share/man/javac.md
@@ -567,7 +567,8 @@ file system locations may be directories, JAR files or JMOD files.
 
 <a id="option-Xlint">`-Xlint`</a>
 :   Enables recommended lint warning categories. In this release, all available
-    lint warning categories are recommended.
+    lint warning categories exception `preview` are recommended. The `preview` category
+    is recommended when compiling without `--enable-preview`.
 
 <a id="option-Xlint-custom">`-Xlint:`\[`-`\]*key*(`,`\[`-`\]*key*)\*</a>
 :   Enables and/or disables lint warning categories using the one or more of the keys described

--- a/src/jdk.compiler/share/man/javac.md
+++ b/src/jdk.compiler/share/man/javac.md
@@ -567,7 +567,7 @@ file system locations may be directories, JAR files or JMOD files.
 
 <a id="option-Xlint">`-Xlint`</a>
 :   Enables recommended lint warning categories. In this release, all available
-    lint warning categories exception `preview` are recommended. The `preview` category
+    lint warning categories except `preview` are recommended. The `preview` category
     is recommended when compiling without `--enable-preview`.
 
 <a id="option-Xlint-custom">`-Xlint:`\[`-`\]*key*(`,`\[`-`\]*key*)\*</a>

--- a/src/jdk.compiler/share/man/javac.md
+++ b/src/jdk.compiler/share/man/javac.md
@@ -566,9 +566,9 @@ file system locations may be directories, JAR files or JMOD files.
     section of the `javadoc` command documentation.
 
 <a id="option-Xlint">`-Xlint`</a>
-:   Enables recommended lint warning categories. In this release, all available
-    lint warning categories except `preview` are recommended. The `preview` category
-    is recommended when compiling without `--enable-preview`.
+:   Enables recommended lint warning categories. All lint warning categories are
+    recommended by default. If preview language features are enabled
+    (`--enable-preview`), all lint warning categories except `preview` are recommended.
 
 <a id="option-Xlint-custom">`-Xlint:`\[`-`\]*key*(`,`\[`-`\]*key*)\*</a>
 :   Enables and/or disables lint warning categories using the one or more of the keys described

--- a/test/langtools/tools/javac/preview/PreviewLint.java
+++ b/test/langtools/tools/javac/preview/PreviewLint.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8388373
+ * @summary Verify -Xlint works as expected in relation to --enable-preview.
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main PreviewLint
+ */
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class PreviewLint extends TestRunner {
+
+    protected ToolBox tb;
+
+    PreviewLint() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String... args) throws Exception {
+        PreviewLint t = new PreviewLint();
+        t.runTests();
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test
+    public void previewAPI(Path base) throws Exception {
+        Path apiSrc = base.resolve("api-src");
+        tb.writeJavaFiles(apiSrc,
+                          """
+                          package preview.api;
+                          @jdk.internal.javac.PreviewFeature(feature=jdk.internal.javac.PreviewFeature.Feature.TEST)
+                          public class Preview {
+                          }
+                          """,
+                          """
+                          package preview.api;
+                          @jdk.internal.javac.PreviewFeature(feature=jdk.internal.javac.PreviewFeature.Feature.TEST, reflective=true)
+                          public class ReflectivePreview {
+                          }
+                          """);
+        Path apiClasses = base.resolve("api-classes");
+
+        new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(apiClasses)
+                .options("-XDrawDiagnostics",
+                         "--patch-module", "java.base=" + apiSrc.toString(),
+                         "-Werror")
+                .files(tb.findJavaFiles(apiSrc))
+                .run()
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        Path testSrc = base.resolve("test-src");
+        tb.writeJavaFiles(testSrc,
+                          """
+                          package test;
+                          import preview.api.Preview;
+                          import preview.api.ReflectivePreview;
+                          public class UseClass {
+                              Preview f1;
+                              ReflectivePreview f2;
+                          }
+                          """);
+        Path testClasses = base.resolve("test-classes");
+        List<String> log;
+        List<String> expected;
+
+        log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(testClasses)
+                .options("--patch-module", "java.base=" + apiClasses.toString(),
+                        "--add-exports", "java.base/preview.api=ALL-UNNAMED",
+                        "-XDrawDiagnostics")
+                .files(tb.findJavaFiles(testSrc))
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+                "UseClass.java:2:19: compiler.err.is.preview: preview.api.Preview",
+                "UseClass.java:5:5: compiler.err.is.preview: preview.api.Preview",
+                "UseClass.java:6:5: compiler.warn.is.preview.reflective: preview.api.ReflectivePreview",
+                "2 errors",
+                "1 warning");
+
+        tb.checkEqual(expected, log);
+
+        log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(testClasses)
+                .options("--patch-module", "java.base=" + apiClasses.toString(),
+                        "--add-exports", "java.base/preview.api=ALL-UNNAMED",
+                        "-Xlint",
+                        "-XDrawDiagnostics")
+                .files(tb.findJavaFiles(testSrc))
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+                "UseClass.java:2:19: compiler.err.is.preview: preview.api.Preview",
+                "UseClass.java:5:5: compiler.err.is.preview: preview.api.Preview",
+                "UseClass.java:6:5: compiler.warn.is.preview.reflective: preview.api.ReflectivePreview",
+                "2 errors",
+                "1 warning");
+
+        tb.checkEqual(expected, log);
+
+        log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(testClasses)
+                .options("--patch-module", "java.base=" + apiClasses.toString(),
+                        "--add-exports", "java.base/preview.api=ALL-UNNAMED",
+                        "--enable-preview", "--source", System.getProperty("java.specification.version"),
+                        "-XDrawDiagnostics")
+                .files(tb.findJavaFiles(testSrc))
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+                "- compiler.note.preview.filename: UseClass.java, DEFAULT",
+                "- compiler.note.preview.recompile");
+
+        tb.checkEqual(expected, log);
+
+        log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(testClasses)
+                .options("--patch-module", "java.base=" + apiClasses.toString(),
+                        "--add-exports", "java.base/preview.api=ALL-UNNAMED",
+                        "--enable-preview", "--source", System.getProperty("java.specification.version"),
+                        "-Xlint",
+                        "-XDrawDiagnostics")
+                .files(tb.findJavaFiles(testSrc))
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+                "- compiler.note.preview.filename: UseClass.java, DEFAULT",
+                "- compiler.note.preview.recompile");
+
+        tb.checkEqual(expected, log);
+
+        log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(testClasses)
+                .options("--patch-module", "java.base=" + apiClasses.toString(),
+                        "--add-exports", "java.base/preview.api=ALL-UNNAMED",
+                        "--enable-preview", "--source", System.getProperty("java.specification.version"),
+                        "-Xlint:preview",
+                        "-XDrawDiagnostics")
+                .files(tb.findJavaFiles(testSrc))
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+                "UseClass.java:5:5: compiler.warn.is.preview: preview.api.Preview",
+                "UseClass.java:6:5: compiler.warn.is.preview.reflective: preview.api.ReflectivePreview",
+                "2 warnings");
+
+        tb.checkEqual(expected, log);
+
+        log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(testClasses)
+                .options("--patch-module", "java.base=" + apiClasses.toString(),
+                        "--add-exports", "java.base/preview.api=ALL-UNNAMED",
+                        "--enable-preview", "--source", System.getProperty("java.specification.version"),
+                        "-Xlint:all",
+                        "-XDrawDiagnostics")
+                .files(tb.findJavaFiles(testSrc))
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+                "UseClass.java:5:5: compiler.warn.is.preview: preview.api.Preview",
+                "UseClass.java:6:5: compiler.warn.is.preview.reflective: preview.api.ReflectivePreview",
+                "2 warnings");
+
+        tb.checkEqual(expected, log);
+    }
+
+}

--- a/test/langtools/tools/javac/preview/PreviewLint.java
+++ b/test/langtools/tools/javac/preview/PreviewLint.java
@@ -213,6 +213,45 @@ public class PreviewLint extends TestRunner {
                 "2 warnings");
 
         tb.checkEqual(expected, log);
+
+        //combine -Xlint and -Xlint:all
+        log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(testClasses)
+                .options("--patch-module", "java.base=" + apiClasses.toString(),
+                        "--add-exports", "java.base/preview.api=ALL-UNNAMED",
+                        "--enable-preview", "--source", System.getProperty("java.specification.version"),
+                        "-Xlint:all", "-Xlint",
+                        "-XDrawDiagnostics")
+                .files(tb.findJavaFiles(testSrc))
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+                "UseClass.java:5:5: compiler.warn.is.preview: preview.api.Preview",
+                "UseClass.java:6:5: compiler.warn.is.preview.reflective: preview.api.ReflectivePreview",
+                "2 warnings");
+
+        tb.checkEqual(expected, log);
+
+        log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .outdir(testClasses)
+                .options("--patch-module", "java.base=" + apiClasses.toString(),
+                        "--add-exports", "java.base/preview.api=ALL-UNNAMED",
+                        "--enable-preview", "--source", System.getProperty("java.specification.version"),
+                        "-Xlint", "-Xlint:all",
+                        "-XDrawDiagnostics")
+                .files(tb.findJavaFiles(testSrc))
+                .run(Task.Expect.SUCCESS)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        expected = List.of(
+                "UseClass.java:5:5: compiler.warn.is.preview: preview.api.Preview",
+                "UseClass.java:6:5: compiler.warn.is.preview.reflective: preview.api.ReflectivePreview",
+                "2 warnings");
+
+        tb.checkEqual(expected, log);
     }
 
 }


### PR DESCRIPTION
The proposal herein is to not enable the `preview` lint category when `--enable-preview -Xlint` is specified. This is to reduce the number of warnings when the user has already subscribed to preview features.

The summary warning is still printed as before, the only change is that `-Xlint` does not enable the `preview` category.

The specification for `-Xlint` says that it enables "recommended" categories, so this change can be seen as not considering the `preview` category to be recommended when preview is enabled.

The behavior in all other cases, like compiling when `--enable-preview` is not specified and/or compiling with `-Xlint:all`/`-Xlint:preview` should remain unchanged.

Please also review the CSR:
https://bugs.openjdk.org/browse/JDK-8390539

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Change requires CSR request [JDK-8390539](https://bugs.openjdk.org/browse/JDK-8390539) to be approved
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8388373](https://bugs.openjdk.org/browse/JDK-8388373): Exclude preview warnings from '-Xlint' by default (**Enhancement** - P4)
 * [JDK-8390539](https://bugs.openjdk.org/browse/JDK-8390539): Exclude preview warnings from '-Xlint' by default (**CSR**)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) Review applies to [682b29af](https://git.openjdk.org/jdk/pull/32444/files/682b29afb003f2f2e9c83d94dce5251a799e4ee5)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32444/head:pull/32444` \
`$ git checkout pull/32444`

Update a local copy of the PR: \
`$ git checkout pull/32444` \
`$ git pull https://git.openjdk.org/jdk.git pull/32444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32444`

View PR using the GUI difftool: \
`$ git pr show -t 32444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32444.diff">https://git.openjdk.org/jdk/pull/32444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32444#issuecomment-5340456700)
</details>
