### PR TITLE
8390641: C1/C2 on x86_64 - remove unused variables

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -262,7 +262,6 @@ void LIR_Assembler::osr_entry() {
   //
 
   // build frame
-  ciMethod* m = compilation()->method();
   __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
 
   // OSR buffer is
@@ -1339,7 +1338,6 @@ void LIR_Assembler::type_profile_helper(Register mdo,
 
 void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, Label* failure, Label* obj_is_null) {
   // we always need a stub for the failure case.
-  CodeStub* stub = op->stub();
   Register obj = op->object()->as_register();
   Register k_RInfo = op->tmp1()->as_register();
   Register klass_RInfo = op->tmp2()->as_register();
@@ -2341,7 +2339,7 @@ void LIR_Assembler::emit_static_call_stub() {
     return;
   }
 
-  int start = __ offset();
+  [[maybe_unused]] int start = __ offset();
 
   // make sure that the displacement word of the call ends up word aligned
   __ align(BytesPerWord, __ offset() + NativeMovConstReg::instruction_size_rex + NativeCall::displacement_offset);
@@ -2937,7 +2935,6 @@ void LIR_Assembler::emit_load_klass(LIR_OpLoadKlass* op) {
 void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
   ciMethod* method = op->profiled_method();
   int bci          = op->profiled_bci();
-  ciMethod* callee = op->profiled_callee();
   Register tmp_load_klass = rscratch1;
 
   // Update counter for all call types

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -2339,7 +2339,7 @@ void LIR_Assembler::emit_static_call_stub() {
     return;
   }
 
-  [[maybe_unused]] int start = __ offset();
+  DEBUG_ONLY(int start = __ offset();)
 
   // make sure that the displacement word of the call ends up word aligned
   __ align(BytesPerWord, __ offset() + NativeMovConstReg::instruction_size_rex + NativeCall::displacement_offset);

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -674,7 +674,7 @@ LIR_Opr LIRGenerator::atomic_cmpxchg(BasicType type, LIR_Opr addr, LIRItem& cmp_
 }
 
 LIR_Opr LIRGenerator::atomic_xchg(BasicType type, LIR_Opr addr, LIRItem& value) {
-  [[maybe_unused]] bool is_oop = is_reference_type(type);
+  DEBUG_ONLY(bool is_oop = is_reference_type(type);)
   LIR_Opr result = new_register(type);
   value.load_item();
   // Because we want a 2-arg form of xchg and xadd

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -674,7 +674,7 @@ LIR_Opr LIRGenerator::atomic_cmpxchg(BasicType type, LIR_Opr addr, LIRItem& cmp_
 }
 
 LIR_Opr LIRGenerator::atomic_xchg(BasicType type, LIR_Opr addr, LIRItem& value) {
-  bool is_oop = is_reference_type(type);
+  [[maybe_unused]] bool is_oop = is_reference_type(type);
   LIR_Opr result = new_register(type);
   value.load_item();
   // Because we want a 2-arg form of xchg and xadd
@@ -920,7 +920,6 @@ void LIRGenerator::do_update_CRC32(Intrinsic* x) {
   assert(UseCRC32Intrinsics, "need AVX and CLMUL instructions support");
   // Make all state_for calls early since they can emit code
   LIR_Opr result = rlock_result(x);
-  int flags = 0;
   switch (x->id()) {
     case vmIntrinsics::_updateCRC32: {
       LIRItem crc(x->argument_at(0), this);

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -814,7 +814,6 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
 OopMapSet* Runtime1::generate_code_for(StubId id, StubAssembler* sasm) {
 
   // for better readability
-  const bool must_gc_arguments = true;
   const bool dont_gc_arguments = false;
 
   // default value; overwritten for some optimized stubs that are called from methods that do not use the fpu

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2243,7 +2243,6 @@ void C2_MacroAssembler::reduce16S(int opcode, Register dst, Register src1, XMMRe
 
 void C2_MacroAssembler::reduce32S(int opcode, Register dst, Register src1, XMMRegister src2, XMMRegister vtmp1, XMMRegister vtmp2) {
   assert_different_registers(src2, vtmp1);
-  int vector_len = Assembler::AVX_256bit;
   vextracti64x4_high(vtmp1, src2);
   reduce_operation_256(T_SHORT, opcode, vtmp1, vtmp1, src2);
   reduce16S(opcode, dst, src1, vtmp1, vtmp1, vtmp2);
@@ -2507,7 +2506,6 @@ XMMRegister C2_MacroAssembler::get_lane(BasicType typ, XMMRegister dst, XMMRegis
   int esize =  type2aelembytes(typ);
   int elem_per_lane = 16/esize;
   int lane = elemindex / elem_per_lane;
-  int eindex = elemindex % elem_per_lane;
 
   if (lane >= 2) {
     assert(UseAVX > 2, "required");
@@ -5188,7 +5186,7 @@ void C2_MacroAssembler::vector_castF2X_avx(BasicType to_elem_bt, XMMRegister dst
 void C2_MacroAssembler::vector_castF2X_evex(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
                                             XMMRegister xtmp2, KRegister ktmp1, KRegister ktmp2, AddressLiteral float_sign_flip,
                                             Register rscratch, int vec_enc) {
-  int to_elem_sz = type2aelembytes(to_elem_bt);
+  [[maybe_unused]] int to_elem_sz = type2aelembytes(to_elem_bt);
   assert(to_elem_sz <= 4, "");
   vcvttps2dq(dst, src, vec_enc);
   vector_cast_fp_to_int_special_cases_evex(T_FLOAT, dst, src, xtmp1, xtmp2, ktmp1, ktmp2, rscratch, float_sign_flip, vec_enc);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -5186,7 +5186,7 @@ void C2_MacroAssembler::vector_castF2X_avx(BasicType to_elem_bt, XMMRegister dst
 void C2_MacroAssembler::vector_castF2X_evex(BasicType to_elem_bt, XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
                                             XMMRegister xtmp2, KRegister ktmp1, KRegister ktmp2, AddressLiteral float_sign_flip,
                                             Register rscratch, int vec_enc) {
-  [[maybe_unused]] int to_elem_sz = type2aelembytes(to_elem_bt);
+  DEBUG_ONLY(int to_elem_sz = type2aelembytes(to_elem_bt);)
   assert(to_elem_sz <= 4, "");
   vcvttps2dq(dst, src, vec_enc);
   vector_cast_fp_to_int_special_cases_evex(T_FLOAT, dst, src, xtmp1, xtmp2, ktmp1, ktmp2, rscratch, float_sign_flip, vec_enc);

--- a/src/hotspot/cpu/x86/c2_init_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_init_x86.cpp
@@ -36,7 +36,6 @@ void Compile::pd_compiler2_init() {
   if (UseAVX < 3) {
     int delta = XMMRegister::max_slots_per_register * XMMRegister::number_of_registers;
     int bottom = ConcreteRegisterImpl::max_fpr;
-    int top = bottom + delta;
     int middle = bottom + (delta / 2);
     int xmm_slots = XMMRegister::max_slots_per_register;
     int lower = xmm_slots / 2;

--- a/src/hotspot/cpu/x86/c2_stubGenerator_x86_64_string.cpp
+++ b/src/hotspot/cpu/x86/c2_stubGenerator_x86_64_string.cpp
@@ -220,7 +220,7 @@ static void generate_string_indexof_stubs(StubGenerator *stubgen, address *fnptr
 
   assert(StubInfo::entry_count(stub_id) == 1, "sanity check");
   GrowableArray<address> extras;
-  const int expected_extra_count = 2 * NUMBER_OF_CASES;
+  [[maybe_unused]] const int expected_extra_count = 2 * NUMBER_OF_CASES;
   address start = stubgen->load_archive_data(stub_id, nullptr, &extras);
   if (start != nullptr) {
     assert(extras.length() == expected_extra_count,
@@ -1009,7 +1009,6 @@ static void broadcast_first_and_last_needle(Register needle, Register needle_len
                                             MacroAssembler *_masm) {
   bool isUL = (ae == StrIntrinsicNode::UL);
   bool isUU = (ae == StrIntrinsicNode::UU);
-  bool isU = (isUU || isUL);
   Label L_short;
 
   // Always need needle broadcast to ymm registers
@@ -1775,8 +1774,6 @@ static void setup_jump_tables(StrIntrinsicNode::ArgEncoding ae, Label &L_error, 
   bool isUU = (ae == StrIntrinsicNode::UU);
   bool isU = isUL || isUU;  // At least one is UTF-16
   const XMMRegister byte_1 = XMM_BYTE_1;
-
-  int jmp_ndx = 0;
 
   ////////////////////////////////////////////////
   //  On entry to each case, the register state is:

--- a/src/hotspot/cpu/x86/c2_stubGenerator_x86_64_string.cpp
+++ b/src/hotspot/cpu/x86/c2_stubGenerator_x86_64_string.cpp
@@ -220,7 +220,7 @@ static void generate_string_indexof_stubs(StubGenerator *stubgen, address *fnptr
 
   assert(StubInfo::entry_count(stub_id) == 1, "sanity check");
   GrowableArray<address> extras;
-  [[maybe_unused]] const int expected_extra_count = 2 * NUMBER_OF_CASES;
+  DEBUG_ONLY(const int expected_extra_count = 2 * NUMBER_OF_CASES;)
   address start = stubgen->load_archive_data(stub_id, nullptr, &extras);
   if (start != nullptr) {
     assert(extras.length() == expected_extra_count,

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3097,7 +3097,6 @@ void LIRGenerator::do_Base(Base* x) {
   __ std_entry(LIR_OprFact::illegalOpr);
   // Emit moves from physical registers / stack slots to virtual registers
   CallingConvention* args = compilation()->frame_map()->incoming_arguments();
-  IRScope* irScope = compilation()->hir()->top_scope();
   int java_index = 0;
   for (int i = 0; i < args->length(); i++) {
     LIR_Opr src = args->at(i);
@@ -3445,7 +3444,7 @@ void LIRGenerator::do_RuntimeCall(address routine, Intrinsic* x) {
   assert(x->number_of_arguments() == 0, "wrong type");
   // Enforce computation of _reserved_argument_area_size which is required on some platforms.
   BasicTypeList signature;
-  CallingConvention* cc = frame_map()->c_calling_convention(&signature);
+  frame_map()->c_calling_convention(&signature);
   LIR_Opr reg = result_register_for(x->type());
   __ call_runtime_leaf(routine, getThreadTemp(),
                        reg, new LIR_OprList());

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,6 @@ void RangeCheckEliminator::Visitor::do_LogicOp(LogicOp *lo) {
 void RangeCheckEliminator::Visitor::do_Phi(Phi *phi) {
   if (!phi->type()->as_IntType() && !phi->type()->as_ObjectType()) return;
 
-  BlockBegin *block = phi->block();
   int op_count = phi->operand_count();
   bool has_upper = true;
   bool has_lower = true;
@@ -220,7 +219,6 @@ void RangeCheckEliminator::Visitor::do_ArithmeticOp(ArithmeticOp *ao) {
 
   if (ao->op() == Bytecodes::_irem) {
     Bound* x_bound = _rce->get_bound(x);
-    Bound* y_bound = _rce->get_bound(y);
     if (x_bound->lower() >= 0 && x_bound->lower_instr() == nullptr && y->as_ArrayLength() != nullptr) {
       _bound = new Bound(0, nullptr, -1, y);
     } else if (x_bound->has_lower() && x_bound->lower() >= 0 && y->type()->as_IntConstant() &&
@@ -872,7 +870,6 @@ void RangeCheckEliminator::process_access_indexed(BlockBegin *loop_header, Block
       }
 
       // Lower instruction
-      Value index_instr = ai->index();
       Value lower_instr = index_bound->lower_instr();
       if (!loop_invariant(loop_header, lower_instr)) {
         TRACE_RANGE_CHECK_ELIMINATION(


### PR DESCRIPTION
While investigating the unused variables warnings with MSVC, I found some places in C1/C2 when building on x86_64 that can be adjusted.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390641](https://bugs.openjdk.org/browse/JDK-8390641): C1/C2 on x86_64 - remove unused variables (**Enhancement** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32445/head:pull/32445` \
`$ git checkout pull/32445`

Update a local copy of the PR: \
`$ git checkout pull/32445` \
`$ git pull https://git.openjdk.org/jdk.git pull/32445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32445`

View PR using the GUI difftool: \
`$ git pr show -t 32445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32445.diff">https://git.openjdk.org/jdk/pull/32445.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32445#issuecomment-5341255057)
</details>
