### PR TITLE
8328078: C2 compilation bailout with "too many D-U pinch points"

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -2885,6 +2885,7 @@ void Scheduling::anti_do_def( Block *b, Node *def, OptoReg::Name def_reg, int is
         // Yes, found a use/kill pinch-point
         pinch->set_req(0,nullptr);  //
         pinch->replace_by(kill); // Move anti-dep edges up
+        _pinch_free_list.push(pinch);
         pinch = kill;
         _reg_node.map(def_reg,pinch);
         return;

--- a/test/hotspot/jtreg/compiler/c2/TestDUPinchPointReuse.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDUPinchPointReuse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8328078
+ * @summary Test that block scheduling reuses detached D-U pinch-point nodes
+ * @requires vm.compiler2.enabled
+ * @library /test/lib
+ * @run main ${test.main.class}
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AbortVMOnCompilationFailure -XX:+OptoScheduling
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+
+package compiler.c2;
+
+import jdk.test.lib.Asserts;
+
+public class TestDUPinchPointReuse {
+    private static String append(String s) {
+        return new StringBuilder().append(s).append(s).append(s).append(s).append(s).toString();
+    }
+
+    private static String test() {
+        String s = "x";
+        s = append(s);
+        s = append(s);
+        s = append(s);
+        s = append(s);
+        s = append(s);
+        s = append(s);
+        return s;
+    }
+
+    public static void main(String[] args) {
+        new StringBuilder();
+        Asserts.assertEQ(test().length(), 15625);
+    }
+}

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsMany.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,16 @@
 
 /*
  * @test
- * @bug 8362394
+ * @bug 8328078 8362394
  * @summary Test that repeated stacked string concatenations do not
  *          consume too many compilation resources.
  * @requires vm.compiler2.enabled
  * @library /test/lib /
- * @run main/othervm -XX:-OptoScheduling compiler.stringopts.TestStackedConcatsMany
- * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:-OptoScheduling
- *                   -XX:CompileOnly=compiler.stringopts.TestStackedConcatsMany::f
- *                   compiler.stringopts.TestStackedConcatsMany
+ * @run main ${test.main.class}
+ * @run main/othervm -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileOnly=${test.main.class}::f
+ *                   ${test.main.class}
  */
-
-// The test uses -XX:-OptoScheduling to avoid the assert "too many D-U pinch points" on aarch64 (JDK-8328078).
 
 package compiler.stringopts;
 

--- a/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsManyUTF16Overflow.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestStackedConcatsManyUTF16Overflow.java
@@ -27,14 +27,12 @@
  * @summary Test that UTF-16 string concat overflow does not produce a negative size backing array
  * @requires vm.compiler2.enabled & os.maxMemory > 4G
  * @library /test/lib /
- * @run main/othervm -Xmx4g -XX:-OptoScheduling ${test.main.class}
+ * @run main/othervm -Xmx4g ${test.main.class}
  * @run main/othervm -Xmx4g -Xint ${test.main.class}
- * @run main/othervm -Xmx4g -XX:-TieredCompilation -Xcomp -XX:-OptoScheduling
+ * @run main/othervm -Xmx4g -XX:-TieredCompilation -Xcomp
  *                   -XX:CompileOnly=${test.main.class}::f
  *                   ${test.main.class}
  */
-
-// The test uses -XX:-OptoScheduling to avoid the assert "too many D-U pinch points" on aarch64 (JDK-8328078).
 
 package compiler.stringopts;
 


### PR DESCRIPTION
To encode anti-dependencies in the graph, the scheduler creates "D-U pinch-point" nodes to prevent a combinatorial explosion of edges:
https://github.com/openjdk/jdk/blob/45f3ef3ce2f9aa1bc54359c92bfd267a4f5b26a8/src/hotspot/share/opto/output.cpp#L3066-L3086

When a later kill instruction can serve as such a pinch point, the scheduler transfers the dependency edges to that instruction instead:
https://github.com/openjdk/jdk/blob/45f3ef3ce2f9aa1bc54359c92bfd267a4f5b26a8/src/hotspot/share/opto/output.cpp#L2879-L2887

As a result, the pinch-point node is no longer reachable by `garbage_collect_pinch_nodes()` and thus not reclaimed and not reused:
https://github.com/openjdk/jdk/blob/45f3ef3ce2f9aa1bc54359c92bfd267a4f5b26a8/src/hotspot/share/opto/output.cpp#L3099

If this happens repeatedly, we run out of nodes:
https://github.com/openjdk/jdk/blob/45f3ef3ce2f9aa1bc54359c92bfd267a4f5b26a8/src/hotspot/share/opto/output.cpp#L2855-L2858

The fix is to put the dead pinch-point node on the `_pinch_free_list` so that it's recycled. This seems like an oversight from day one.

Now, in theory at least, we can still run out of nodes even when we recycle. I was not able to come up with a reproducer for that, so I suggest we leave the bailout assert in for now (it was added by [JDK-8303951](https://bugs.openjdk.org/browse/JDK-8303951)).

Thanks to @danielogh for the test idea provided in [JDK-8362394](https://bugs.openjdk.org/browse/JDK-8362394). I also reverted workarounds from other tests.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8328078](https://bugs.openjdk.org/browse/JDK-8328078): C2 compilation bailout with "too many D-U pinch points" (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Contributors
 * Daniel Skantz `<dskantz@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32446/head:pull/32446` \
`$ git checkout pull/32446`

Update a local copy of the PR: \
`$ git checkout pull/32446` \
`$ git pull https://git.openjdk.org/jdk.git pull/32446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32446`

View PR using the GUI difftool: \
`$ git pr show -t 32446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32446.diff">https://git.openjdk.org/jdk/pull/32446.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32446#issuecomment-5341388847)
</details>
