### PR TITLE
8387668: javac should warn on use of value classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
@@ -260,7 +260,7 @@ public class Preview {
      * @return true iff sym has been declared using a preview language feature
      */
     public boolean declaredUsingPreviewFeature(Symbol sym) {
-        return false;
+        return sym.isValueClass();
     }
 
     public void checkSourceLevel(DiagnosticPosition pos, Feature feature) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1002,9 +1002,6 @@ public class ClassWriter extends ClassFile {
         Type fldType = v.erasure(types);
         if (fldType.requiresLoadableDescriptors(v.owner)) {
             poolWriter.enterLoadableDescriptorsClass(fldType.tsym);
-            if (preview.isPreview(Source.Feature.VALUE_CLASSES)) {
-                preview.markUsesPreview(null);
-            }
         }
         int acountIdx = beginAttrs();
         int acount = 0;
@@ -1035,17 +1032,11 @@ public class ClassWriter extends ClassFile {
         for (Type t : mtype.getParameterTypes()) {
             if (t.requiresLoadableDescriptors(m.owner)) {
                 poolWriter.enterLoadableDescriptorsClass(t.tsym);
-                if (preview.isPreview(Source.Feature.VALUE_CLASSES)) {
-                    preview.markUsesPreview(null);
-                }
             }
         }
         Type returnType = mtype.getReturnType();
         if (returnType.requiresLoadableDescriptors(m.owner)) {
             poolWriter.enterLoadableDescriptorsClass(returnType.tsym);
-            if (preview.isPreview(Source.Feature.VALUE_CLASSES)) {
-                preview.markUsesPreview(null);
-            }
         }
         int acountIdx = beginAttrs();
         int acount = 0;

--- a/test/langtools/tools/javac/patterns/DominationWithPP.out
+++ b/test/langtools/tools/javac/patterns/DominationWithPP.out
@@ -11,4 +11,6 @@ Domination.java:193:18: compiler.err.pattern.dominated
 Domination.java:202:18: compiler.err.pattern.dominated
 Domination.java:211:18: compiler.err.pattern.dominated
 Domination.java:228:18: compiler.err.pattern.dominated
+- compiler.note.preview.filename: Domination.java, DEFAULT
+- compiler.note.preview.recompile
 13 errors

--- a/test/langtools/tools/javac/patterns/T8309054.java
+++ b/test/langtools/tools/javac/patterns/T8309054.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 8309054
  * @summary Parsing of erroneous patterns succeeds
- * @enablePreview
  * @compile/fail/ref=T8309054.out -XDrawDiagnostics --should-stop=at=FLOW T8309054.java
  */
 

--- a/test/langtools/tools/javac/patterns/T8309054.out
+++ b/test/langtools/tools/javac/patterns/T8309054.out
@@ -1,7 +1,7 @@
-T8309054.java:12:24: compiler.err.expected2: :, ->
-T8309054.java:16:26: compiler.err.expected2: :, ->
-T8309054.java:19:35: compiler.err.expected: ')'
-T8309054.java:13:13: compiler.err.switch.mixing.case.types
-T8309054.java:17:13: compiler.err.switch.mixing.case.types
-T8309054.java:21:17: compiler.err.unexpected.type: kindname.variable, kindname.value
+T8309054.java:11:24: compiler.err.expected2: :, ->
+T8309054.java:15:26: compiler.err.expected2: :, ->
+T8309054.java:18:35: compiler.err.expected: ')'
+T8309054.java:12:13: compiler.err.switch.mixing.case.types
+T8309054.java:16:13: compiler.err.switch.mixing.case.types
+T8309054.java:20:17: compiler.err.unexpected.type: kindname.variable, kindname.value
 6 errors

--- a/test/langtools/tools/javac/patterns/T8314578.java
+++ b/test/langtools/tools/javac/patterns/T8314578.java
@@ -1,7 +1,6 @@
 /**
  * @test /nodynamiccopyright/
  * @bug 8314578
- * @enablePreview
  * @summary Parsing of erroneous patterns succeeds
  * @compile/fail/ref=T8314578.out -XDrawDiagnostics T8314578.java
  */

--- a/test/langtools/tools/javac/patterns/T8314578.out
+++ b/test/langtools/tools/javac/patterns/T8314578.out
@@ -1,4 +1,4 @@
-T8314578.java:14:18: compiler.err.flows.through.from.pattern
-T8314578.java:15:18: compiler.err.flows.through.to.pattern
-T8314578.java:27:18: compiler.err.flows.through.to.pattern
+T8314578.java:13:18: compiler.err.flows.through.from.pattern
+T8314578.java:14:18: compiler.err.flows.through.to.pattern
+T8314578.java:26:18: compiler.err.flows.through.to.pattern
 3 errors

--- a/test/langtools/tools/javac/patterns/T8332463b.out
+++ b/test/langtools/tools/javac/patterns/T8332463b.out
@@ -1,2 +1,4 @@
 T8332463b.java:36:18: compiler.err.pattern.dominated
+- compiler.note.preview.filename: T8332463b.java, DEFAULT
+- compiler.note.preview.recompile
 1 error

--- a/test/langtools/tools/javac/preview/PreviewJRTImage.java
+++ b/test/langtools/tools/javac/preview/PreviewJRTImage.java
@@ -111,6 +111,8 @@ public class PreviewJRTImage {
                         "Test.java:1:16: compiler.warn.sun.proprietary: sun.misc.Unsafe",
                         "Test.java:5:9: compiler.err.type.found.req: java.lang.Boolean, (compiler.misc.type.req.identity)",
                         "Test.java:7:9: compiler.warn.sun.proprietary: sun.misc.Unsafe",
+                        "- compiler.note.preview.filename: Test.java, DEFAULT",
+                        "- compiler.note.preview.recompile",
                         "1 error",
                         "2 warnings"
                 );

--- a/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttrTest2.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttrTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,9 +41,11 @@ import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassFile;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import com.sun.tools.javac.util.Assert;
 
+import toolbox.Task.OutputKind;
 import toolbox.TestRunner;
 import toolbox.ToolBox;
 
@@ -81,24 +83,53 @@ public class LoadableDescriptorsAttrTest2 extends TestRunner {
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 
-        new toolbox.JavacTask(tb)
-                .options("--enable-preview", "-source", Integer.toString(Runtime.version().feature()))
+        List<String> log;
+        List<String> expected;
+
+        expected = List.of(
+            "Ident.java:2:5: compiler.warn.declared.using.preview: kindname.class, Val",
+            "Val.java:1:1: compiler.warn.preview.feature.use.plural: (compiler.misc.feature.value.classes)",
+            "2 warnings"
+        );
+
+        log = new toolbox.JavacTask(tb)
+                .options("--enable-preview",
+                         "-source", Integer.toString(Runtime.version().feature()),
+                         "-XDrawDiagnostics",
+                         "-Xlint:preview")
                 .outdir(classes)
                 .files(findJavaFiles(src))
                 .run()
-                .writeAll();
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.checkEqual(log, expected);
+
         Path classFilePath = classes.resolve("Ident.class");
         var classFile = ClassFile.of().parse(classFilePath);
         Assert.check(classFile.minorVersion() == 65535);
         Assert.check(classFile.findAttribute(Attributes.loadableDescriptors()).isPresent());
 
+        expected = List.of(
+            "- compiler.warn.preview.feature.use.classfile: Val.class, 28",
+            "Ident.java:2:5: compiler.warn.declared.using.preview: kindname.class, Val",
+            "2 warnings"
+        );
+
         // now with the value class in the classpath
-        new toolbox.JavacTask(tb)
-                .options("--enable-preview", "-source", Integer.toString(Runtime.version().feature()), "-cp", classes.toString())
+        log = new toolbox.JavacTask(tb)
+                .options("--enable-preview",
+                         "-source", Integer.toString(Runtime.version().feature()),
+                         "-cp", classes.toString(),
+                         "-XDrawDiagnostics",
+                         "-Xlint:preview")
                 .outdir(classes)
                 .files(src.resolve("Ident.java"))
                 .run()
-                .writeAll();
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.checkEqual(log, expected);
 
         classFilePath = classes.resolve("Ident.class");
         classFile = ClassFile.of().parse(classFilePath);
@@ -121,24 +152,53 @@ public class LoadableDescriptorsAttrTest2 extends TestRunner {
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 
-        new toolbox.JavacTask(tb)
-                .options("--enable-preview", "-source", Integer.toString(Runtime.version().feature()))
+        List<String> log;
+        List<String> expected;
+
+        expected = List.of(
+            "Ident.java:2:12: compiler.warn.declared.using.preview: kindname.class, Val",
+            "Val.java:1:1: compiler.warn.preview.feature.use.plural: (compiler.misc.feature.value.classes)",
+            "2 warnings"
+        );
+
+        log = new toolbox.JavacTask(tb)
+                .options("--enable-preview",
+                         "-source", Integer.toString(Runtime.version().feature()),
+                         "-XDrawDiagnostics",
+                         "-Xlint:preview")
                 .outdir(classes)
                 .files(findJavaFiles(src))
                 .run()
-                .writeAll();
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.checkEqual(log, expected);
+
         Path classFilePath = classes.resolve("Ident.class");
         var classFile = ClassFile.of().parse(classFilePath);
         Assert.check(classFile.minorVersion() == 65535);
         Assert.check(classFile.findAttribute(Attributes.loadableDescriptors()).isPresent());
 
+        expected = List.of(
+            "- compiler.warn.preview.feature.use.classfile: Val.class, 28",
+            "Ident.java:2:12: compiler.warn.declared.using.preview: kindname.class, Val",
+            "2 warnings"
+        );
+
         // now with the value class in the classpath
-        new toolbox.JavacTask(tb)
-                .options("--enable-preview", "-source", Integer.toString(Runtime.version().feature()), "-cp", classes.toString())
+        log = new toolbox.JavacTask(tb)
+                .options("--enable-preview",
+                         "-source", Integer.toString(Runtime.version().feature()),
+                         "-cp", classes.toString(),
+                         "-XDrawDiagnostics",
+                         "-Xlint:preview")
                 .outdir(classes)
                 .files(src.resolve("Ident.java"))
                 .run()
-                .writeAll();
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.checkEqual(log, expected);
 
         classFilePath = classes.resolve("Ident.class");
         classFile = ClassFile.of().parse(classFilePath);
@@ -164,25 +224,52 @@ public class LoadableDescriptorsAttrTest2 extends TestRunner {
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);
 
-        new toolbox.JavacTask(tb)
-                .options("--enable-preview", "-source", Integer.toString(Runtime.version().feature()))
+        List<String> log;
+        List<String> expected;
+
+        expected = List.of(
+            "Ident.java:2:5: compiler.warn.declared.using.preview: kindname.class, Val",
+            "Val.java:1:1: compiler.warn.preview.feature.use.plural: (compiler.misc.feature.value.classes)",
+            "2 warnings"
+        );
+
+        log = new toolbox.JavacTask(tb)
+                .options("--enable-preview",
+                         "-source", Integer.toString(Runtime.version().feature()),
+                         "-XDrawDiagnostics",
+                         "-Xlint:preview")
                 .outdir(classes)
                 .files(findJavaFiles(src))
                 .run()
-                .writeAll();
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.checkEqual(log, expected);
+
         Path classFilePath = classes.resolve("Ident.class");
         var classFile = ClassFile.of().parse(classFilePath);
         Assert.check(classFile.minorVersion() == 65535);
         Assert.check(classFile.findAttribute(Attributes.loadableDescriptors()).isPresent());
 
+        expected = List.of(
+            "Ident.java:2:5: compiler.warn.declared.using.preview: kindname.class, Val",
+            "Val.java:1:1: compiler.warn.preview.feature.use.plural: (compiler.misc.feature.value.classes)",
+            "2 warnings"
+        );
 
         // now with the value class in the classpath
         new toolbox.JavacTask(tb)
-                .options("--enable-preview", "-source", Integer.toString(Runtime.version().feature()), "-cp", classes.toString())
+                .options("--enable-preview",
+                         "-source", Integer.toString(Runtime.version().feature()), "-cp", classes.toString(),
+                         "-XDrawDiagnostics",
+                         "-Xlint:preview")
                 .outdir(classes)
                 .files(src.resolve("Ident.java"))
                 .run()
-                .writeAll();
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.checkEqual(log, expected);
 
         classFilePath = classes.resolve("Ident.class");
         classFile = ClassFile.of().parse(classFilePath);


### PR DESCRIPTION
This is a redo of:
https://github.com/openjdk/valhalla/pull/2601

Consider source files like this:
```
$ cat /tmp/ValueClass.java 
value class ValueClass {}
$ cat /tmp/TestValue.java 
public class TestValue {
    ValueClass c;
}
```

When compiled like this:
```
$ javac --enable-preview --release 28 -Xlint:preview /tmp/ValueClass.java 
/tmp/ValueClass.java:1: warning: [preview] value classes are a preview feature and may be removed in a future release.
value class ValueClass {}
^
1 warning
$ javac --enable-preview --release 28 -Xlint:preview -classpath /tmp /tmp/TestValue.java 
warning: [preview] class file for /tmp/ValueClass.class uses preview features of Java SE 28.
1 warning
```

Note that while the `TestValue.class` is marked as preview, there's no warning on the use of `ValueClass`. This is not aligned with the JEP 12 wording:

> When compiling with preview features enabled, any source code reference to (i) a class or interface declared using a preview language feature, ..., causes a preview warning.

Currently javac marks the classfile preview using an explicit test in the `ClassWriter`, but that does not seem quite right. This PR proposes to mark value classes as `Preview.declaredUsingPreviewFeature == true`, which should automatically produce a warning, and mark the appropriate classfile as preview.

For the example above:
```
$ javac --enable-preview --release 28 -Xlint:preview -classpath /tmp /tmp/TestValue.java 
warning: [preview] class file for /tmp/ValueClass.class uses preview features of Java SE 28.
/tmp/TestValue.java:2: warning: [preview] class ValueClass is declared using a preview feature, which may be removed in a future release.
    ValueClass c;
    ^
2 warnings
```

Note this will also report the warning for `Integer`, when preview is enabled:
```
$ cat /tmp/Test.java 
public class Test {
    Integer i;
}
$ javac /tmp/Test.java
$ javac --enable-preview --release 28 -Xlint:preview /tmp/Test.java
warning: [preview] class file for /@/java.base/java/lang/Integer.sig uses preview features of Java SE 28.
/tmp/Test.java:2: warning: [preview] class Integer is declared using a preview feature, which may be removed in a future release.
    Integer i;
    ^
2 warnings
```

Please note there's a relation to https://github.com/openjdk/jdk/pull/32444, which should ensure the individual warnings won't be shown to the user when `-Xlint` is specified.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8387668: javac should warn on use of value classes`

### Issue
 * [JDK-8387668](https://bugs.openjdk.org/browse/JDK-8387668): javac should warn on use of value classes (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32447/head:pull/32447` \
`$ git checkout pull/32447`

Update a local copy of the PR: \
`$ git checkout pull/32447` \
`$ git pull https://git.openjdk.org/jdk.git pull/32447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32447`

View PR using the GUI difftool: \
`$ git pr show -t 32447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32447.diff">https://git.openjdk.org/jdk/pull/32447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32447#issuecomment-5341251496)
</details>
