### PR TITLE
8390257: New test runtime/valhalla/inlinetypes/NPEInPreviewTest.java fails with -Xcomp

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -315,7 +315,7 @@ static bool might_be_null_restricted_field(Method* method, address code_base, in
   if (is_resolved) {
     return field->is_null_free_inline_type();
   } else {
-    // This is rare. The compiler  might not have resolved the field or the klass
+    // This is rare. The compiler might not have resolved the field or the klass
     // in the interpreter first. Just say it might be null restricted because we don't know.
     return true;
   }

--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -315,7 +315,7 @@ static bool might_be_null_restricted_field(Method* method, address code_base, in
   if (is_resolved) {
     return field->is_null_free_inline_type();
   } else {
-    // This is more expensive but rare. The compiler  might not have resolved the field
+    // This is rare. The compiler  might not have resolved the field or the klass
     // in the interpreter first. Just say it might be null restricted because we don't know.
     return true;
   }

--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -305,7 +305,7 @@ static char const* get_field_name(Method* method, int cp_index, Bytecodes::Code 
   return name->as_C_string();
 }
 
-static bool is_null_restricted_field(Method* method, address code_base, int bci) {
+static bool might_be_null_restricted_field(Method* method, address code_base, int bci) {
   ConstantPool* cp = method->constants();
   int cp_index = Bytes::get_native_u2(code_base + bci + 1);
   ResolvedFieldEntry* field = cp->resolved_field_entry_at(cp_index);
@@ -315,18 +315,10 @@ static bool is_null_restricted_field(Method* method, address code_base, int bci)
   if (is_resolved) {
     return field->is_null_free_inline_type();
   } else {
-    // This is more expensive but rare. C1 might not have resolved the field
-    // in the interpreter first.
-    fieldDescriptor fd;
-    Klass* klass = cp->resolved_klass_ref_at(cp_index, bc);
-    assert (klass != nullptr, "must be resolved if we got an NPE here");
-
-    Symbol* name  = cp->name_ref_at(cp_index, bc);
-    Symbol* sig  =  cp->signature_ref_at(cp_index, bc);
-    Klass* owner = InstanceKlass::cast(klass)->find_field(name, sig, false, &fd);
-    return owner != nullptr && fd.is_null_free_inline_type();
+    // This is more expensive but rare. The compiler  might not have resolved the field
+    // in the interpreter first. Just say it might be null restricted because we don't know.
+    return true;
   }
-  return false;
 }
 
 static void print_local_var(outputStream *os, unsigned int bci, Method* method, int slot, bool is_parameter) {
@@ -1205,7 +1197,7 @@ bool ExceptionMessageBuilder::print_NPE_cause(outputStream* os, int bci, int slo
   if (print_NPE_cause0(os, bci, slot, _max_cause_detail, false, " because \"")) {
     if (code == Bytecodes::_aastore) {
       os->print("\" is null or is a null-free array and there's an attempt to store null in it");
-    } else if (code == Bytecodes::_putfield && is_null_restricted_field(_method, code_base, bci)) {
+    } else if (code == Bytecodes::_putfield && might_be_null_restricted_field(_method, code_base, bci)) {
       int cp_index = Bytes::get_native_u2(code_base + bci + 1);
       os->print("\" is null or \"%s\" is a null restricted field and there's an attempt to store null in it",
                 get_field_name(_method, cp_index, code));

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -580,12 +580,6 @@ class ConstantPool : public Metadata {
     return symbol_at(signature_index);
   }
 
-  // Returns a resolved klass or nullptr if not resolved.  Does not try to resolve the class.
-  Klass* resolved_klass_ref_at(int which, Bytecodes::Code code) {
-    jint ref_index = klass_ref_index_at(which, code);
-    return resolved_klass_at(ref_index);
-  }
-
   u2 klass_ref_index_at(int which, Bytecodes::Code code);
   u2 name_and_type_ref_index_at(int which, Bytecodes::Code code);
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -103,7 +103,6 @@ runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/NMT/VirtualAllocCommitMerge.java 8309698 linux-s390x
 runtime/Thread/TestAlwaysPreTouchStacks.java 8383372 macosx-aarch64
-runtime/valhalla/inlinetypes/NPEInPreviewTest.java 8390257 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NPEInPreviewTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NPEInPreviewTest.java
@@ -29,6 +29,7 @@
  *          java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @enablePreview
  * @compile -g NPEInPreviewTest.java
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+ShowCodeDetailsInExceptionMessages NPEInPreviewTest interpreter
@@ -100,6 +101,9 @@ public class NPEInPreviewTest {
 
     static void testActualNullFieldError() {
         String expectedMessage = "Cannot assign field \"nullVal\" because \"self\" is null";
+        // In C1 Xcomp mode, the field or klass isn't resolved, so no idea which this is.
+        String c1ExpectedMessage = "Cannot assign field \"nullVal\" because \"self\" is null or \"nullVal\" is a null " +
+                                   "restricted field and there's an attempt to store null in it";
 
         try {
             NPEInPreviewTest self = null;
@@ -107,7 +111,11 @@ public class NPEInPreviewTest {
         } catch (NullPointerException npe) {
             String message = npe.getMessage();
             System.out.println("*** " + message);
-            Asserts.assertEquals(expectedMessage, message);
+            if (c1Mode) {
+                Asserts.assertEquals(c1ExpectedMessage, message);
+            } else {
+                Asserts.assertEquals(expectedMessage, message);
+            }
         }
     }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -573,8 +573,6 @@ javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 
 # jdk_valhalla
 
-valhalla/valuetypes/NullRestrictedTest.java                     8390260 generic-all
-
 ############################################################################
 
 # core_tools


### PR DESCRIPTION
The new NPE message tried too hard.  If the field is unresolved in the cpCache, the klass might also be unresolved in the constant pool when compiled with -Xcomp for c1.  This change reverts some of the trying in this case and will print the longer message.  Made the new test flagless since it tests with the 3 combinations of compiler flags.
Tested with tier1-6.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390257](https://bugs.openjdk.org/browse/JDK-8390257): New test runtime/valhalla/inlinetypes/NPEInPreviewTest.java fails with -Xcomp (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) Review applies to [de367b11](https://git.openjdk.org/jdk/pull/32449/files/de367b1146804ef2989d2dd888b1b25d9620cf8c)
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role) Review applies to [de367b11](https://git.openjdk.org/jdk/pull/32449/files/de367b1146804ef2989d2dd888b1b25d9620cf8c)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32449/head:pull/32449` \
`$ git checkout pull/32449`

Update a local copy of the PR: \
`$ git checkout pull/32449` \
`$ git pull https://git.openjdk.org/jdk.git pull/32449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32449`

View PR using the GUI difftool: \
`$ git pr show -t 32449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32449.diff">https://git.openjdk.org/jdk/pull/32449.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32449#issuecomment-5341699057)
</details>
