### PR TITLE
8390654: Test gc/TestUseGCOverheadLimit.java#G1 fails on linux-arm32

### DIFF
--- a/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
+++ b/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ package gc;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -62,8 +63,11 @@ public class TestUseGCOverheadLimit {
 
     String[] selectedArgs = args[0].equals("G1") ? g1Args : parallelArgs;
 
+    final String[] vm64bitArgs = {
+      "-XX:-UseCompactObjectHeaders"  // Object sizes are calculated such that the heap is tight.
+    };
+
     final String[] commonArgs = {
-      "-XX:-UseCompactObjectHeaders", // Object sizes are calculated such that the heap is tight.
       "-XX:ParallelGCThreads=1",      // Make GCs take longer.
       "-XX:+UseGCOverheadLimit",
       "-Xlog:gc=debug",
@@ -72,7 +76,9 @@ public class TestUseGCOverheadLimit {
       Allocating.class.getName()
     };
 
-    String[] vmArgs = Stream.concat(Arrays.stream(selectedArgs), Arrays.stream(commonArgs)).toArray(String[]::new);
+    String[] vmArgs = Stream.of(selectedArgs, Platform.is64bit() ? vm64bitArgs : new String[0], commonArgs)
+        .flatMap(Arrays::stream)
+        .toArray(String[]::new);
     OutputAnalyzer output = ProcessTools.executeLimitedTestJava(vmArgs);
     output.shouldNotHaveExitValue(0);
 


### PR DESCRIPTION
In `TestUseGCOverheadLimit.java`, the flag `-XX:-UseCompactObjectHeaders` was being passed unconditionally. However, compact object headers are only supported on 64-bit platforms. This caused failures when running the test on 32-bit platforms.

Fixing this by moving the flag to a separate argument array that is only appended when running on a 64-bit VM.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390654](https://bugs.openjdk.org/browse/JDK-8390654): Test gc/TestUseGCOverheadLimit.java#G1 fails on linux-arm32 (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32451/head:pull/32451` \
`$ git checkout pull/32451`

Update a local copy of the PR: \
`$ git checkout pull/32451` \
`$ git pull https://git.openjdk.org/jdk.git pull/32451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32451`

View PR using the GUI difftool: \
`$ git pr show -t 32451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32451.diff">https://git.openjdk.org/jdk/pull/32451.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32451#issuecomment-5342522309)
</details>
