### PR TITLE
8385488: Compiler allows "case _ when" in switches, but JLS doesn't

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -982,6 +982,10 @@ public class JavacParser implements Parser {
         mods = mods != null ? mods : optFinal(0);
         JCExpression e;
         if (token.kind == UNDERSCORE && parsedType == null) {
+            if (!allowVar && Feature.UNNAMED_VARIABLES.allowedInSource(source)){
+                log.error(DiagnosticFlag.SYNTAX, token.pos,
+                        Errors.UseOfUnderscoreNotAllowedNonVariable);
+            }
             nextToken();
             checkSourceLevel(Feature.UNNAMED_VARIABLES);
             pattern = toP(F.at(token.pos).AnyPattern());

--- a/test/langtools/tools/javac/patterns/UnnamedErrors.java
+++ b/test/langtools/tools/javac/patterns/UnnamedErrors.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8304246 8309093
+ * @bug 8304246 8309093 8385488
  * @summary Compiler Implementation for Unnamed patterns and variables
  * @compile/fail/ref=UnnamedErrors.out -XDrawDiagnostics -XDshould-stop.at=FLOW UnnamedErrors.java
  */
@@ -114,6 +114,13 @@ public class UnnamedErrors {
         for(String s : _) {
             int i = 1;
         }
+    }
+
+    int guardedPattern(String s) {
+        return switch (s) {
+            case _ when s.isEmpty() -> 1;
+            default -> 0;
+        };
     }
 
     class Lock implements AutoCloseable {

--- a/test/langtools/tools/javac/patterns/UnnamedErrors.out
+++ b/test/langtools/tools/javac/patterns/UnnamedErrors.out
@@ -24,6 +24,7 @@ UnnamedErrors.java:103:26: compiler.err.expected: =
 UnnamedErrors.java:109:13: compiler.err.use.of.underscore.not.allowed.with.brackets
 UnnamedErrors.java:110:18: compiler.err.use.of.underscore.not.allowed.with.brackets
 UnnamedErrors.java:114:24: compiler.err.use.of.underscore.not.allowed.non.variable
+UnnamedErrors.java:121:18: compiler.err.use.of.underscore.not.allowed.non.variable
 UnnamedErrors.java:10:17: compiler.err.already.defined: kindname.variable, x, kindname.class, UnnamedErrors
 UnnamedErrors.java:35:13: compiler.err.unconditional.pattern.and.default
 UnnamedErrors.java:44:18: compiler.err.pattern.dominated
@@ -33,4 +34,4 @@ UnnamedErrors.java:67:32: compiler.err.flows.through.from.pattern
 UnnamedErrors.java:81:56: compiler.err.already.defined: kindname.variable, x2, kindname.method, guardErrors(java.lang.Object,int,int)
 UnnamedErrors.java:82:13: compiler.err.switch.mixing.case.types
 UnnamedErrors.java:89:30: compiler.err.pattern.dominated
-35 errors
+36 errors


### PR DESCRIPTION
Please review this change to make javac reject `case _ when` and generate a compile time error.
TIA.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change requires CSR request [JDK-8391348](https://bugs.openjdk.org/browse/JDK-8391348) to be approved

### Issues
 * [JDK-8385488](https://bugs.openjdk.org/browse/JDK-8385488): Compiler allows "case _ when" in switches, but JLS doesn't (**Bug** - P4)
 * [JDK-8391348](https://bugs.openjdk.org/browse/JDK-8391348): Compiler allows "case _ when" in switches, but JLS doesn't (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32453/head:pull/32453` \
`$ git checkout pull/32453`

Update a local copy of the PR: \
`$ git checkout pull/32453` \
`$ git pull https://git.openjdk.org/jdk.git pull/32453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32453`

View PR using the GUI difftool: \
`$ git pr show -t 32453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32453.diff">https://git.openjdk.org/jdk/pull/32453.diff</a>

</details>
