### PR TITLE
8390386: [Linux] Systemd tests failing on systemd newer than 257

### DIFF
--- a/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
@@ -249,7 +249,7 @@ public class SystemdTestUtils {
 
     private static String getMemoryDSliceContent(SystemdRunOptions runOpts) {
         String format = "[Slice]\n" + basicMemoryContentFormat();
-        return String.format(format, runOpts.sliceDMemoryLimit);
+        return String.format(format, runOpts.sliceDMemoryLimit, runOpts.sliceDMemoryLimit);
     }
 
     private static String getCPUDSliceContent(SystemdRunOptions runOpts) {
@@ -268,13 +268,14 @@ public class SystemdTestUtils {
         return """
                 MemoryAccounting=true
                 MemoryLimit=%s
+                MemoryMax=%s
                 """;
     }
 
     private static String getMemorySliceContent(SystemdRunOptions runOpts) {
         String format = basicMemoryContentFormat();
 
-        return String.format(format, runOpts.memoryLimit);
+        return String.format(format, runOpts.memoryLimit, runOpts.memoryLimit);
     }
 
     private static String getBasicSliceFormat() {


### PR DESCRIPTION
Please review this simple test fix for newer systemd versions (for example on Fedora 44). Without this patch, the existing systemd-based jtreg tests fail.

The issue is related to the deprecation of the `MemoryLimit` property which we specify in the systemd configuration files to apply a cgroup limit. `MemoryLimit` has no effect on systemd newer than version 257. `MemoryLimit` translates to the old and deprecated cgroupv1 setting of a memory limit. Newer systemd versions use `MemoryMax` property as the systemd configuration for enforcing a limit and ignore `MemoryLimit`.

I propose to set both `MemoryLimit` and `MemoryMax` in the systemd configuration files as a) the systemd version in use is not known ahead of time b) on old, cgroup v1 systems and systemd versions `MemoryLimit` is still needed for the test to work (without [JDK-8370572](https://bugs.openjdk.org/browse/JDK-8370572)). With [JDK-8370572](https://bugs.openjdk.org/browse/JDK-8370572) it still works, but not in the way it was intended. The hierarchical limit takes precedence and overrules the actual interface files at various levels. `MemoryMax` specified there doesn't do any harm.

**Testing**
- [x] Ran the systemd tests on an affected system (F44). Pass with the patch, fail without it. Similarly, ran the systemd tests on an older RHEL 8 system where they also pass.

Thoughts?

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390386](https://bugs.openjdk.org/browse/JDK-8390386): [Linux] Systemd tests failing on systemd newer than 257 (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32454/head:pull/32454` \
`$ git checkout pull/32454`

Update a local copy of the PR: \
`$ git checkout pull/32454` \
`$ git pull https://git.openjdk.org/jdk.git pull/32454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32454`

View PR using the GUI difftool: \
`$ git pr show -t 32454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32454.diff">https://git.openjdk.org/jdk/pull/32454.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32454#issuecomment-5345031847)
</details>
