### PR TITLE
8390485: Migrate appcds/aotCache/ tests to AOT workflow

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,12 +92,6 @@ gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#default 8386964
 
 # :hotspot_runtime
 
-runtime/cds/appcds/aotCache/aotClassLinking/AOTClassLinkingVMOptions.java 8390485 generic-all
-runtime/cds/appcds/aotCache/aotClassLinking/AddExports.java 8390485 generic-all
-runtime/cds/appcds/aotCache/aotClassLinking/AddOpens.java 8390485 generic-all
-runtime/cds/appcds/aotCache/aotClassLinking/AddReads.java 8390485 generic-all
-runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java 8390485 generic-all
-runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java 8390485 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8317789 aix-ppc64
 runtime/Monitor/SyncOnValueBasedClassTest.java 8340995 linux-s390x
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/SharedSecretsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/SharedSecretsTest.java
@@ -46,7 +46,7 @@ public class SharedSecretsTest {
     public static void main(String[] args) throws Exception {
         Tester t = new Tester(mainClass);
         t.setCheckExitValue(false);
-        t.runAOTAssemblyWorkflow();
+        t.runAOTTrainingAndAssemblyWorkflow();
     }
 
     static class Tester extends CDSAppTester {

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AOTClassLinkingVMOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AOTClassLinkingVMOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,14 +40,15 @@
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import jdk.test.lib.cds.SimpleCDSAppTester;
 import jdk.test.lib.cds.CDSModulePackager;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
 
 public class AOTClassLinkingVMOptions {
     static final String appJar = ClassFileInstaller.getJarPath("app.jar");
+    static final String mainClass = "Hello";
 
     static int testCaseNum = 0;
     static void testCase(String s) {
@@ -56,53 +57,95 @@ public class AOTClassLinkingVMOptions {
     }
 
     public static void main(String[] args) throws Exception {
-        TestCommon.testDump(appJar, TestCommon.list("Hello"),
-                            "-XX:+AOTClassLinking");
+        SimpleCDSAppTester t = SimpleCDSAppTester.of("AOTClassLinking")
+            .classpath(appJar)
+            .addVmArgs("-XX:+AOTClassLinking")
+            .appCommandLine(mainClass)
+            .runAOTAssemblyWorkflow();
 
         testCase("Archived full module graph must be enabled at runtime");
-        TestCommon.run("-cp", appJar, "-Djdk.module.validation=1", "Hello")
-            .assertAbnormalExit("shared archive file has aot-linked classes." +
+        t.setVmArgs("-Djdk.module.validation=1")
+            .setCheckExitValue(false)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(1);
+                out.shouldMatch("AOT cache has aot-linked classes." +
                                 " It cannot be used when archived full module graph is not used");
+            })
+            .productionRun();
 
         testCase("Cannot use -Djava.system.class.loader");
-        TestCommon.run("-cp", appJar, "-Djava.system.class.loader=dummy", "Hello")
-            .assertAbnormalExit("shared archive file has aot-linked classes." +
-                                " It cannot be used when the java.system.class.loader property is specified.");
+        t.setVmArgs("-Djava.system.class.loader=dummy")
+            .setCheckExitValue(false)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(1);
+                out.shouldMatch("AOT cache has aot-linked classes." +
+                    " It cannot be used when the java.system.class.loader property is specified.");
+            })
+            .productionRun();
 
         testCase("Cannot use a different main module");
-        TestCommon.run("-cp", appJar, "-Xlog:cds", "-m", "jdk.compiler/com.sun.tools.javac.Main")
-            .assertAbnormalExit("shared archive file has aot-linked classes." +
+        t.setVmArgs()
+            .appCommandLine("-m", "jdk.compiler/com.sun.tools.javac.Main")
+            .setCheckExitValue(false)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(1);
+                out.shouldMatch("AOT cache has aot-linked classes." +
                                 " It cannot be used when archived full module graph is not used.");
+            })
+            .productionRun();
+
         testCase("Cannot use security manager");
-        TestCommon.run("-cp", appJar, "-Xlog:cds", "-Djava.security.manager=allow")
-            .assertAbnormalExit("shared archive file has aot-linked classes." +
+        t.setVmArgs("-Djava.security.manager=allow")
+            .appCommandLine(mainClass)
+            .setCheckExitValue(false)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(1);
+                out.shouldMatch("AOT cache has aot-linked classes." +
                                 " It cannot be used with -Djava.security.manager=allow.");
-        TestCommon.run("-cp", appJar, "-Xlog:cds", "-Djava.security.manager=default")
-            .assertAbnormalExit("shared archive file has aot-linked classes." +
+            })
+            .productionRun();
+
+        t.setVmArgs("-Djava.security.manager=default")
+            .appCommandLine(mainClass)
+            .setCheckExitValue(false)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(1);
+                out.shouldMatch("AOT cache has aot-linked classes." +
                                 " It cannot be used with -Djava.security.manager=default.");
+            })
+            .productionRun();
 
         // Dumping with AOTInvokeDynamicLinking disabled
-        TestCommon.testDump(appJar, TestCommon.list("Hello"),
-                            "-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTClassLinking", "-XX:-AOTInvokeDynamicLinking");
+        t.setVmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTClassLinking", "-XX:-AOTInvokeDynamicLinking")
+            .appCommandLine(mainClass)
+            .setCheckExitValue(true)
+            .runAOTAssemblyWorkflow();
 
         testCase("Use the archive that was created with -XX:-AOTInvokeDynamicLinking.");
-        TestCommon.run("-cp", appJar, "Hello")
-            .assertNormalExit("Hello");
+        t.setVmArgs()
+            .appCommandLine(mainClass)
+            .setCheckExitValue(true)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(0);
+                out.shouldMatch("Hello");
+            })
+            .productionRun();
 
         testCase("Archived full module graph must be enabled at runtime (with -XX:-AOTInvokeDynamicLinking)");
-        TestCommon.run("-cp", appJar, "-Djdk.module.validation=1", "Hello")
-            .assertAbnormalExit("shared archive file has aot-linked classes." +
+        t.setVmArgs("-Djdk.module.validation=1")
+            .appCommandLine(mainClass)
+            .setCheckExitValue(false)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(1);
+                out.shouldMatch("AOT cache has aot-linked classes." +
                                 " It cannot be used when archived full module graph is not used");
+            })
+            .productionRun();
 
         // NOTE: tests for ClassFileLoadHook + AOTClassLinking is in
         // ../jvmti/ClassFileLoadHookTest.java
 
-        boolean dynamicMode = Boolean.getBoolean("test.dynamic.cds.archive");
-        if (!dynamicMode) {
-            // These tests need to dump the full module graph, which is not possible with
-            // dynamic dump.
-            modulePathTests();
-        }
+        modulePathTests();
     }
 
     static void modulePathTests() throws Exception {
@@ -112,47 +155,61 @@ public class AOTClassLinkingVMOptions {
         String MAIN_MODULE = "com.foos";
         String MAIN_CLASS = "com.foos.Test";
 
-        String[] appClasses = {MAIN_CLASS};
-
         CDSModulePackager modulePackager = new CDSModulePackager(SRC_DIR);
         modulePackager.createModularJarWithMainClass(MAIN_MODULE, MAIN_CLASS);
 
         String modulePath = modulePackager.getOutputDir().toString();
 
         testCase("Cannot use mis-matched module path");
-        TestCommon.testDump(null, appClasses,
-                            "--module-path", modulePath,
-                            "-XX:+AOTClassLinking",
-                            "-m", MAIN_MODULE);
-        TestCommon.run("-Xlog:aot",
-                       "-Xlog:cds",
-                       "--module-path", modulePath,
-                       "-m", MAIN_MODULE)
-            .assertNormalExit("Using AOT-linked classes: true");
+        SimpleCDSAppTester t = SimpleCDSAppTester.of("ModuleTests")
+            .modulepath(modulePath)
+            .addVmArgs("-XX:+AOTClassLinking")
+            .appCommandLine("-m", MAIN_MODULE)
+            .runAOTAssemblyWorkflow();
 
-        TestCommon.run("-Xlog:aot",
-                       "-Xlog:cds",
-                       "--module-path", modulePath + "/bad",
-                       "-m", MAIN_MODULE)
-            .assertAbnormalExit("shared archive file has aot-linked classes. It cannot be used when archived full module graph is not used.");
+        t.setVmArgs("-Xlog:aot", "-Xlog:cds")
+            .modulepath(modulePath)
+            .appCommandLine("-m", MAIN_MODULE)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldContain("Using AOT-linked classes: true");
+            })
+            .productionRun();
+
+        t.setVmArgs("-Xlog:aot=debug", "-Xlog:cds")
+            .modulepath(modulePath + "/bad")
+            .appCommandLine( "-m", MAIN_MODULE)
+            .setCheckExitValue(false)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(1);
+                out.shouldContain("shared class paths mismatch (hint: enable -Xlog:class+path=info to diagnose the failure)");
+            })
+            .productionRun();
 
         testCase("Cannot use mis-matched --add-modules");
-        TestCommon.testDump(null, appClasses,
-                            "--module-path", modulePath,
-                            "-XX:+AOTClassLinking",
-                            "--add-modules", MAIN_MODULE);
-        TestCommon.run("-Xlog:aot",
-                       "-Xlog:cds",
-                       "--module-path", modulePath,
-                       "--add-modules", MAIN_MODULE,
-                       MAIN_CLASS)
-            .assertNormalExit("Using AOT-linked classes: true");
+        t.setVmArgs("-XX:+AOTClassLinking", "--add-modules", MAIN_MODULE)
+        .modulepath(modulePath)
+        .appCommandLine(MAIN_CLASS)
+        .setCheckExitValue(true)
+        .runAOTAssemblyWorkflow();
 
-        TestCommon.run("-Xlog:cds",
-                       "--module-path", modulePath,
-                       "--add-modules", "java.base",
-                       MAIN_CLASS)
-            .assertAbnormalExit("Mismatched values for property jdk.module.addmods",
-                                "shared archive file has aot-linked classes. It cannot be used when archived full module graph is not used.");
+        t.setVmArgs("-Xlog:aot", "-Xlog:cds", "--add-modules", MAIN_MODULE)
+            .modulepath(modulePath)
+            .appCommandLine(MAIN_CLASS)
+            .setCheckExitValue(true)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldContain("Using AOT-linked classes: true");
+            })
+            .productionRun();
+
+        t.setVmArgs("-Xlog:cds", "--add-modules", "java.base")
+            .modulepath(modulePath)
+            .appCommandLine(MAIN_CLASS)
+            .setCheckExitValue(false)
+            .setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldHaveExitValue(1);
+                out.shouldContain("Mismatched values for property jdk.module.addmods");
+                out.shouldContain("AOT cache has aot-linked classes. It cannot be used when archived full module graph is not used.");
+            })
+            .productionRun();
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AOTClassLinkingVMOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AOTClassLinkingVMOptions.java
@@ -61,7 +61,7 @@ public class AOTClassLinkingVMOptions {
             .classpath(appJar)
             .addVmArgs("-XX:+AOTClassLinking")
             .appCommandLine(mainClass)
-            .runAOTAssemblyWorkflow();
+            .runAOTTrainingAndAssemblyWorkflow();
 
         testCase("Archived full module graph must be enabled at runtime");
         t.setVmArgs("-Djdk.module.validation=1")
@@ -119,7 +119,7 @@ public class AOTClassLinkingVMOptions {
         t.setVmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTClassLinking", "-XX:-AOTInvokeDynamicLinking")
             .appCommandLine(mainClass)
             .setCheckExitValue(true)
-            .runAOTAssemblyWorkflow();
+            .runAOTTrainingAndAssemblyWorkflow();
 
         testCase("Use the archive that was created with -XX:-AOTInvokeDynamicLinking.");
         t.setVmArgs()
@@ -165,7 +165,7 @@ public class AOTClassLinkingVMOptions {
             .modulepath(modulePath)
             .addVmArgs("-XX:+AOTClassLinking")
             .appCommandLine("-m", MAIN_MODULE)
-            .runAOTAssemblyWorkflow();
+            .runAOTTrainingAndAssemblyWorkflow();
 
         t.setVmArgs("-Xlog:aot", "-Xlog:cds")
             .modulepath(modulePath)
@@ -187,10 +187,10 @@ public class AOTClassLinkingVMOptions {
 
         testCase("Cannot use mis-matched --add-modules");
         t.setVmArgs("-XX:+AOTClassLinking", "--add-modules", MAIN_MODULE)
-        .modulepath(modulePath)
-        .appCommandLine(MAIN_CLASS)
-        .setCheckExitValue(true)
-        .runAOTAssemblyWorkflow();
+            .modulepath(modulePath)
+            .appCommandLine(MAIN_CLASS)
+            .setCheckExitValue(true)
+            .runAOTTrainingAndAssemblyWorkflow();
 
         t.setVmArgs("-Xlog:aot", "-Xlog:cds", "--add-modules", MAIN_MODULE)
             .modulepath(modulePath)

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AddExports.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AddExports.java
@@ -44,8 +44,9 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class AddExports {
     static final String SEP = File.separator;
+    // runtime/cds/appcds/jigsaw/modulepath/src
     static final Path SRC = Paths.get(System.getProperty("test.src")).
-        resolve( ".." + SEP + "jigsaw" + SEP + "modulepath" + SEP + "src");
+        resolve( ".." + SEP + ".." + SEP + "jigsaw" + SEP + "modulepath" + SEP + "src");
     static final Path nonModuleNeedsJdkAddExportDir = SRC.resolve("com.nomodule.needsjdkaddexport");
     static final String nonModuleNeedsJdkAddExportJar = "nonModuleNeedsJdkAddExport.jar";
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AddOpens.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AddOpens.java
@@ -46,8 +46,9 @@ public class AddOpens {
 
     private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
+    // runtime/cds/appcds/jigsaw/modulepath/src
     private static final Path SRC_DIR = Paths.get(System.getProperty("test.src")).
-        resolve( ".." + SEP + "jigsaw" + SEP + "modulepath" + SEP + "src");
+        resolve( ".." + SEP + ".." + SEP + "jigsaw" + SEP + "modulepath" + SEP + "src");
 
     private static final Path MODS_DIR = Paths.get("mods");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AddReads.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/aotClassLinking/AddReads.java
@@ -48,8 +48,9 @@ public class AddReads {
 
     private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
+    // runtime/cds/appcds/jigsaw/modulepath/src
     private static final Path SRC_DIR = Paths.get(System.getProperty("test.src")).
-        resolve( ".." + SEP + "jigsaw" + SEP + "modulepath" + SEP + "src");
+        resolve( ".." + SEP + ".." + SEP + "jigsaw" + SEP + "modulepath" + SEP + "src");
 
     private static final Path MODS_DIR = Paths.get("mods");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeCompressedOopsTest.java
@@ -51,7 +51,7 @@ public class AOTCodeCompressedOopsTest {
         {
             Tester t = new Tester();
             t.setHeapConfig(Tester.RunMode.ASSEMBLY, true, true);
-            t.runAOTAssemblyWorkflow();
+            t.runAOTTrainingAndAssemblyWorkflow();
             t.setHeapConfig(Tester.RunMode.PRODUCTION, true, true);
             t.productionRun();
             t.setHeapConfig(Tester.RunMode.PRODUCTION, true, false);
@@ -62,7 +62,7 @@ public class AOTCodeCompressedOopsTest {
         {
             Tester t = new Tester();
             t.setHeapConfig(Tester.RunMode.ASSEMBLY, true, false);
-            t.runAOTAssemblyWorkflow();
+            t.runAOTTrainingAndAssemblyWorkflow();
             t.setHeapConfig(Tester.RunMode.PRODUCTION, true, true);
             t.productionRun();
             t.setHeapConfig(Tester.RunMode.PRODUCTION, true, false);
@@ -73,7 +73,7 @@ public class AOTCodeCompressedOopsTest {
         {
             Tester t = new Tester();
             t.setHeapConfig(Tester.RunMode.ASSEMBLY, false, false);
-            t.runAOTAssemblyWorkflow();
+            t.runAOTTrainingAndAssemblyWorkflow();
             t.setHeapConfig(Tester.RunMode.PRODUCTION, true, true);
             t.productionRun();
             t.setHeapConfig(Tester.RunMode.PRODUCTION, true, false);

--- a/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java
@@ -73,7 +73,7 @@ public class AOTLinkedLambdas {
                 dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IG2");
                 dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IH3"); // unsupported = IH1
             })
-            .runAOTAssemblyWorkflow();
+            .runAOTTrainingAndAssemblyWorkflow();
 
         t.setProductionChecker((OutputAnalyzer out) -> {
                 out.shouldContain("Hello AOTLinkedLambdasApp");

--- a/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java
@@ -43,48 +43,43 @@ import java.util.function.Supplier;
 import static java.util.stream.Collectors.*;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.cds.SimpleCDSAppTester;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class AOTLinkedLambdas {
-    static final String classList = "AOTLinkedLambdas.classlist";
     static final String appJar = ClassFileInstaller.getJarPath("app.jar");
     static final String mainClass = AOTLinkedLambdasApp.class.getName();
 
     public static void main(String[] args) throws Exception {
-        CDSTestUtils.dumpClassList(classList, "-cp", appJar, mainClass)
-            .assertNormalExit(output -> {
-                output.shouldContain("Hello AOTLinkedLambdasApp");
-            });
-
-        CDSOptions opts = (new CDSOptions())
-            .addPrefix("-XX:ExtraSharedClassListFile=" + classList,
+        SimpleCDSAppTester t = SimpleCDSAppTester.of("AOTLinkedLambdas")
+            .classpath(appJar)
+            .addVmArgs("-esa", // see JDK-8340836
                        "-XX:+AOTClassLinking",
                        "-Xlog:aot+resolve=trace",
                        "-Xlog:aot+class=debug",
-                       "-Xlog:cds+class=debug",
-                       "-cp", appJar);
+                       "-Xlog:cds+class=debug")
+            .appCommandLine(mainClass)
+            .setTrainingChecker((OutputAnalyzer output) -> {
+                output.shouldContain("Hello AOTLinkedLambdasApp");
+            })
+            .setAssemblyChecker((OutputAnalyzer dumpOut) -> {
+                dumpOut.shouldContain("Can aot-resolve Lambda proxy of interface type IA");
+                dumpOut.shouldContain("Can aot-resolve Lambda proxy of interface type IB");
+                dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IC");
+                dumpOut.shouldContain("Can aot-resolve Lambda proxy of interface type ID2");
+                dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IE2"); // unsupported = IE1
+                dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IF2");
+                dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IG2");
+                dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IH3"); // unsupported = IH1
+            })
+            .runAOTAssemblyWorkflow();
 
-        OutputAnalyzer dumpOut = CDSTestUtils.createArchiveAndCheck(opts);
-        dumpOut.shouldContain("Can aot-resolve Lambda proxy of interface type IA");
-        dumpOut.shouldContain("Can aot-resolve Lambda proxy of interface type IB");
-        dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IC");
-        dumpOut.shouldContain("Can aot-resolve Lambda proxy of interface type ID2");
-        dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IE2"); // unsupported = IE1
-        dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IF2");
-        dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IG2");
-        dumpOut.shouldContain("Cannot aot-resolve Lambda proxy of interface type IH3"); // unsupported = IH1
-
-        CDSOptions runOpts = (new CDSOptions())
-            .setUseVersion(false)
-            .addPrefix("-Xlog:cds",
-                       "-esa",         // see JDK-8340836
-                       "-cp", appJar)
-            .addSuffix(mainClass);
-
-        CDSTestUtils.run(runOpts)
-            .assertNormalExit("Hello AOTLinkedLambdasApp",
-                              "hello, world");
+        t.setProductionChecker((OutputAnalyzer out) -> {
+                out.shouldContain("Hello AOTLinkedLambdasApp");
+                out.shouldContain("hello, world");
+            })
+            .productionRun();
     }
 }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,42 +39,38 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.cds.SimpleCDSAppTester;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class AOTLinkedVarHandles {
-    static final String classList = "AOTLinkedVarHandles.classlist";
     static final String appJar = ClassFileInstaller.getJarPath("app.jar");
     static final String mainClass = AOTLinkedVarHandlesApp.class.getName();
 
     public static void main(String[] args) throws Exception {
-        CDSTestUtils.dumpClassList(classList, "-cp", appJar, mainClass)
-            .assertNormalExit(output -> {
-                output.shouldContain("Hello AOTLinkedVarHandlesApp");
-            });
-
-        CDSOptions opts = (new CDSOptions())
-            .addPrefix("-XX:ExtraSharedClassListFile=" + classList,
+        SimpleCDSAppTester t = SimpleCDSAppTester.of("AOTLinkedVarHandles")
+            .classpath(appJar)
+            .appCommandLine(mainClass)
+            .addVmArgs("-esa",
                        "-XX:+AOTClassLinking",
                        "-Xlog:aot+resolve=trace",
-                       "-Xlog:cds+class=debug",
-                       "-cp", appJar);
+                       "-Xlog:cds+class=debug")
+            .setTrainingChecker((OutputAnalyzer output) -> {
+                output.shouldContain("Hello AOTLinkedVarHandlesApp");
+            })
+            .setAssemblyChecker((OutputAnalyzer output) -> {
+                String s = "archived method CP entry.* AOTLinkedVarHandlesApp ";
+                output.shouldMatch(s + "java/lang/invoke/VarHandle.compareAndExchangeAcquire:\\(\\[DIDI\\)D =>");
+                output.shouldMatch(s + "java/lang/invoke/VarHandle.get:\\(\\[DI\\)D => ");
+                output.shouldNotContain("rejected .* CP entry.*");
+            })
+            .runAOTAssemblyWorkflow();
 
-        String s = "archived method CP entry.* AOTLinkedVarHandlesApp ";
-        OutputAnalyzer dumpOut = CDSTestUtils.createArchiveAndCheck(opts);
-        dumpOut.shouldMatch(s + "java/lang/invoke/VarHandle.compareAndExchangeAcquire:\\(\\[DIDI\\)D =>");
-        dumpOut.shouldMatch(s + "java/lang/invoke/VarHandle.get:\\(\\[DI\\)D => ");
-        dumpOut.shouldNotContain("rejected .* CP entry.*");
-
-        CDSOptions runOpts = (new CDSOptions())
-            .setUseVersion(false)
-            .addPrefix("-Xlog:cds",
-                       "-esa",
-                       "-cp", appJar)
-            .addSuffix(mainClass);
-
-        CDSTestUtils.run(runOpts)
-            .assertNormalExit("Hello AOTLinkedVarHandlesApp");
+        t.setVmArgs("-Xlog:cds,aot", "-esa")
+        .setProductionChecker((OutputAnalyzer output) -> {
+            output.shouldContain("Hello AOTLinkedVarHandlesApp");
+        })
+        .productionRun();
     }
 }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java
@@ -64,7 +64,7 @@ public class AOTLinkedVarHandles {
                 output.shouldMatch(s + "java/lang/invoke/VarHandle.get:\\(\\[DI\\)D => ");
                 output.shouldNotContain("rejected .* CP entry.*");
             })
-            .runAOTAssemblyWorkflow();
+            .runAOTTrainingAndAssemblyWorkflow();
 
         t.setVmArgs("-Xlog:cds,aot", "-esa")
         .setProductionChecker((OutputAnalyzer output) -> {

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -542,7 +542,7 @@ abstract public class CDSAppTester {
     }
 
     // See JEP 483; stop at the assembly run; do not execute production run
-    public void runAOTAssemblyWorkflow() throws Exception {
+    public void runAOTTrainingAndAssemblyWorkflow() throws Exception {
         this.workflow = Workflow.AOT;
         recordAOTConfiguration();
         createAOTCache();

--- a/test/lib/jdk/test/lib/cds/SimpleCDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/SimpleCDSAppTester.java
@@ -98,6 +98,12 @@ public class SimpleCDSAppTester {
         return this;
     }
 
+    // Replace VM args with new list
+    public SimpleCDSAppTester setVmArgs(String... args) {
+        vmArgs = args;
+        return this;
+    }
+
     public SimpleCDSAppTester appCommandLine(String... args) {
         this.appCommandLine = args;
         return this;
@@ -207,6 +213,16 @@ public class SimpleCDSAppTester {
         return this;
     }
 
+    public SimpleCDSAppTester runAOTAssemblyWorkflow() throws Exception {
+        tester.runAOTAssemblyWorkflow();
+        return this;
+    }
+
+    public SimpleCDSAppTester productionRun() throws Exception {
+        tester.productionRun();
+        return this;
+    }
+
     public SimpleCDSAppTester run(String args[])  throws Exception {
         tester.run(args);
         return this;
@@ -226,7 +242,8 @@ public class SimpleCDSAppTester {
         return tester.aotCacheFile();
     }
 
-    public void setCheckExitValue(boolean b) {
+    public SimpleCDSAppTester setCheckExitValue(boolean b) {
         tester.setCheckExitValue(b);
+        return this;
     }
 }

--- a/test/lib/jdk/test/lib/cds/SimpleCDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/SimpleCDSAppTester.java
@@ -213,8 +213,8 @@ public class SimpleCDSAppTester {
         return this;
     }
 
-    public SimpleCDSAppTester runAOTAssemblyWorkflow() throws Exception {
-        tester.runAOTAssemblyWorkflow();
+    public SimpleCDSAppTester runAOTTrainingAndAssemblyWorkflow() throws Exception {
+        tester.runAOTTrainingAndAssemblyWorkflow();
         return this;
     }
 


### PR DESCRIPTION
After [JDK-8368350](https://bugs.openjdk.org/browse/JDK-8368350), a series of classic CDS tests had to be migrated to the AOT workflow, but a few were missing. Those tests are modified in this patch. Verified with tier 1-5 tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390485](https://bugs.openjdk.org/browse/JDK-8390485): Migrate appcds/aotCache/ tests to AOT workflow (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32455/head:pull/32455` \
`$ git checkout pull/32455`

Update a local copy of the PR: \
`$ git checkout pull/32455` \
`$ git pull https://git.openjdk.org/jdk.git pull/32455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32455`

View PR using the GUI difftool: \
`$ git pr show -t 32455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32455.diff">https://git.openjdk.org/jdk/pull/32455.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32455#issuecomment-5345758999)
</details>
