### PR TITLE
8389968: (dc) DatagramChannel.open() attempts to disable IPPROTO_IPV6/IP_MULTICAST_ALL (lnx)

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -294,11 +294,10 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
     }
 
 #if defined(__linux__)
-    if (type == SOCK_DGRAM) {
+    /* IPv4 or IPv6 datagram socket: disable IP_MULTICAST_ALL (Linux 2.6.31) */
+    if (type == SOCK_DGRAM && ipv4_available()) {
         int arg = 0;
-        int level = (domain == AF_INET6) ? IPPROTO_IPV6 : IPPROTO_IP;
-        if ((setsockopt(fd, level, IP_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0) &&
-            (errno != ENOPROTOOPT)) {
+        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0)) {
             JNU_ThrowByNameWithLastError(env,
                                          JNU_JAVANETPKG "SocketException",
                                          "Unable to set IP_MULTICAST_ALL");
@@ -307,25 +306,14 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
         }
     }
 
-    if (domain == AF_INET6 && type == SOCK_DGRAM) {
-        /* By default, Linux uses the route default */
-        int arg = 1;
-        if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &arg,
-                       sizeof(arg)) < 0) {
-            JNU_ThrowByNameWithLastError(env,
-                                         JNU_JAVANETPKG "SocketException",
-                                         "Unable to set IPV6_MULTICAST_HOPS");
-            close(fd);
-            return -1;
-        }
-
-        /* Disable IPV6_MULTICAST_ALL if option supported */
-        arg = 0;
+    /* IPv6 datagram socket: disable IPV6_MULTICAST_ALL (Linux 4.20) if supported */
+    if (type == SOCK_DGRAM && domain == AF_INET6) {
+        int arg = 0;
         if ((setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0) &&
             (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
-                                     JNU_JAVANETPKG "SocketException",
-                                     "Unable to set IPV6_MULTICAST_ALL");
+                                         JNU_JAVANETPKG "SocketException",
+                                         "Unable to set IPV6_MULTICAST_ALL");
             close(fd);
             return -1;
         }


### PR DESCRIPTION
On Linux, DatagramChannel needs to enables the per-socket membership filter so that it doesn't receive multicast datagrams sent to any group that has been joined on the host.  When the socket is IPv4 then it should disable IPPROTO_IP/IP_MULTICAST_ALL. When the socket is IPv6 then it should disable IPPROTO_IPV6/IPV6_MULTICAST_ALL, and additionally disable IPPROTO_IP/IP_MULTICAST_ALL when the system has IPv4 enabled too.

For the IPv6/dual-stack case, the current code disables IPPROTO_IPV6/IP_MULTICAST_ALL instead IPPROTO_IP/IP_MULTICAST_ALL.

In the same code, the setting of IPV6_MULTICAST_HOPS is not needed as the Linux kernel fixed the issue with the default multicast hops setting in 2.6.35 (2010).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389968](https://bugs.openjdk.org/browse/JDK-8389968): (dc) DatagramChannel.open() attempts to disable IPPROTO_IPV6/IP_MULTICAST_ALL (lnx) (**Bug** - P4)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32461/head:pull/32461` \
`$ git checkout pull/32461`

Update a local copy of the PR: \
`$ git checkout pull/32461` \
`$ git pull https://git.openjdk.org/jdk.git pull/32461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32461`

View PR using the GUI difftool: \
`$ git pr show -t 32461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32461.diff">https://git.openjdk.org/jdk/pull/32461.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32461#issuecomment-5371607311)
</details>
