### PR TITLE
8390314: Linux: "assert(current_limit <= upper_bound) failed: invariant" build failure on incus (cgroups)

### DIFF
--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -340,7 +340,8 @@ bool CgroupV2MemoryController::read_memory_limit_in_bytes(physical_memory_size_t
       }
     }
   }
-  result = limit;
+  // treat exceeding physical memory as unlimited
+  result = exceeds_physical_mem ? value_unlimited : limit;
   return true;
 }
 

--- a/test/hotspot/jtreg/containers/systemd/SystemdMemoryExceedHostMemTest.java
+++ b/test/hotspot/jtreg/containers/systemd/SystemdMemoryExceedHostMemTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.containers.systemd.SystemdRunOptions;
+import jdk.test.lib.containers.systemd.SystemdTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.whitebox.WhiteBox;
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8390314
+ * @summary Verify no asserts are triggered in cgroup adjusting code
+ *          when memory limit exceeds physical host memory.
+ * @requires systemd.support
+ * @library /test/lib
+ * @modules java.base/jdk.internal.platform
+ * @build HelloSystemd jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:whitebox.jar -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI SystemdMemoryExceedHostMemTest
+ */
+public class SystemdMemoryExceedHostMemTest {
+
+    private static final int MB = 1024 * 1024;
+    private static final WhiteBox wb = WhiteBox.getWhiteBox();
+    private static final String TEST_SLICE_NAME = SystemdMemoryExceedHostMemTest.class.getSimpleName() + "HS";
+
+    public static void main(String[] args) throws Exception {
+       testMemExceedsPhysical();
+    }
+
+    private static void testMemExceedsPhysical() throws Exception {
+        SystemdRunOptions opts = SystemdTestUtils.newOpts("HelloSystemd");
+        int expectedMemLimit = 1024;
+        // 1 GB memory, the lower hierarchy has a value exceeding physical memory
+        opts.memoryLimit(String.format("%dM", expectedMemLimit));
+        // Set the memory limit of a slice stricly larger than the host
+        // max memory
+        String exceedingHostMem = getHostMaxMemory() + "0"; // add a zero
+        opts.sliceDMemoryLimit(exceedingHostMem);
+        opts.cpuLimit("100%"); // 1 core
+        opts.sliceName(TEST_SLICE_NAME);
+
+        OutputAnalyzer out = SystemdTestUtils.buildAndRunSystemdJava(opts);
+        // On affected systems this asserts in fastdebug
+        out.shouldHaveExitValue(0)
+           .shouldContain("Hello Systemd");
+        try {
+            out.shouldContain(String.format("Memory Limit is: %d", (expectedMemLimit * MB)));
+        } catch (RuntimeException e) {
+            // memory delegation needs to be enabled when run as user on cg v2
+            if (SystemdTestUtils.RUN_AS_USER) {
+                String hint = "When run as user on cg v2 memory delegation needs to be configured!";
+                throw new SkippedException(hint);
+            }
+            throw e;
+        }
+    }
+
+    private static String getHostMaxMemory() {
+        return Long.valueOf(wb.hostPhysicalMemory()).toString();
+    }
+}


### PR DESCRIPTION
Please review this rather trivial fix to avoid an assert when walking the cgroup hierarchy on cgroups v2. If the set limit in the interface file in the hierarchy exceeds physical memory then we still set the returned limit value. Later the returned value is being checked against an upper bound (the physical memory). If the returned value exceeds the upper bound and is not unlimited, we hit the assert. Since we don't care about the limit value if it's larger than the physical memory, the fix is to return `value_unlimited` instead of the returned limit exceeding physical memory. This avoids the assert and the invariant holds as the branch is no longer taken in the memory controller adjusting code.

**Testing:**
- [x] Container tests on x86_64 on cgroup v1 and cgroup v2. All pass.
- [x] New regression test fails prior the product fix on a fast debug build and passes after.
- [x] GHA

Thoughts?

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390314](https://bugs.openjdk.org/browse/JDK-8390314): Linux: "assert(current_limit &lt;= upper_bound) failed: invariant" build failure on incus (cgroups) (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32462/head:pull/32462` \
`$ git checkout pull/32462`

Update a local copy of the PR: \
`$ git checkout pull/32462` \
`$ git pull https://git.openjdk.org/jdk.git pull/32462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32462`

View PR using the GUI difftool: \
`$ git pr show -t 32462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32462.diff">https://git.openjdk.org/jdk/pull/32462.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32462#issuecomment-5354371826)
</details>
