### PR TITLE
8390459: [Valhalla] compiler/valhalla/inlinetypes/TestArrays.java#id6 fails IR matching

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/Scenario.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/Scenario.java
@@ -105,6 +105,17 @@ public class Scenario {
     }
 
     /**
+     * Prepend additional VM flags to this scenario.
+     *
+     * @param flags the additional scenario VM flags.
+     */
+    public void prependFlags(String... flags) {
+        if (flags != null) {
+            this.flags.addAll(0, Arrays.asList(flags));
+        }
+    }
+
+    /**
      * Get all scenario specific VM flags as defined in {@link #Scenario(int, String...)}.
      *
      * @return the scenario VM flags.

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -35,13 +35,14 @@ public class InlineTypes {
     public static final Scenario[] DEFAULT_SCENARIOS = {
             new Scenario(0,
                          "-XX:-UseACmpProfile",
-                         "-XX:+AlwaysIncrementalInline",
                          "-XX:FlatArrayElementMaxOops=5",
                          "-XX:+UseArrayFlattening",
                          "-XX:-UseArrayLoadStoreProfile",
                          "-XX:+UseFieldFlattening",
                          "-XX:+InlineTypePassFieldsAsArgs",
-                         "-XX:+InlineTypeReturnedAsFields"
+                         "-XX:+InlineTypeReturnedAsFields",
+                         "-XX:+IgnoreUnrecognizedVMOptions",
+                         "-XX:+AlwaysIncrementalInline"
             ),
             new Scenario(1,
                          "-XX:-UseACmpProfile",
@@ -65,12 +66,13 @@ public class InlineTypes {
             ),
             new Scenario(3,
                          "-DVerifyIR=false",
-                         "-XX:+AlwaysIncrementalInline",
                          "-XX:FlatArrayElementMaxOops=0",
                          "-XX:-UseArrayFlattening",
                          "-XX:-UseFieldFlattening",
                          "-XX:+InlineTypePassFieldsAsArgs",
-                         "-XX:+InlineTypeReturnedAsFields"
+                         "-XX:+InlineTypeReturnedAsFields",
+                         "-XX:+IgnoreUnrecognizedVMOptions",
+                         "-XX:+AlwaysIncrementalInline"
             ),
             new Scenario(4,
                          "-DVerifyIR=false",
@@ -83,17 +85,17 @@ public class InlineTypes {
             ),
             new Scenario(5,
                          "-XX:-UseACmpProfile",
-                         "-XX:+AlwaysIncrementalInline",
                          "-XX:FlatArrayElementMaxOops=5",
                          "-XX:+UseArrayFlattening",
                          "-XX:-UseArrayLoadStoreProfile",
                          "-XX:+UseFieldFlattening",
                          "-XX:-InlineTypePassFieldsAsArgs",
-                         "-XX:-InlineTypeReturnedAsFields"
+                         "-XX:-InlineTypeReturnedAsFields",
+                         "-XX:+IgnoreUnrecognizedVMOptions",
+                         "-XX:+AlwaysIncrementalInline"
             ),
             new Scenario(6,
                          "-XX:-UseACmpProfile",
-                         "-XX:+AlwaysIncrementalInline",
                          "-XX:FlatArrayElementMaxOops=5",
                          "-XX:+UseArrayFlattening",
                          "-XX:-UseArrayLoadStoreProfile",
@@ -102,7 +104,9 @@ public class InlineTypes {
                          "-XX:+UseNullFreeAtomicValueFlattening",
                          "-XX:+UseNullFreeNonAtomicValueFlattening",
                          "-XX:+InlineTypePassFieldsAsArgs",
-                         "-XX:+InlineTypeReturnedAsFields"
+                         "-XX:+InlineTypeReturnedAsFields",
+                         "-XX:+IgnoreUnrecognizedVMOptions",
+                         "-XX:+AlwaysIncrementalInline"
             ),
     };
 
@@ -115,7 +119,6 @@ public class InlineTypes {
                                   "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
                                   "-XX:+UnlockDiagnosticVMOptions",
                                   "-XX:+UnlockExperimentalVMOptions",
-                                  "-XX:+IgnoreUnrecognizedVMOptions",
                                   // Force inline the methods called by ValueClass::validateArrayArguments used by the array factories
                                   "-XX:CompileCommand=inline,jdk.internal.value.ValueClass::isConcreteValueClass",
                                   "-XX:CompileCommand=inline,java.lang.Class::isValue",

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -109,17 +109,17 @@ public class InlineTypes {
     static {
         // Add common flags
         for (Scenario scenario : DEFAULT_SCENARIOS) {
-            scenario.addFlags("--enable-preview",
-                              "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                              "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-                              "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                              "-XX:+UnlockDiagnosticVMOptions",
-                              "-XX:+UnlockExperimentalVMOptions",
-                              "-XX:+IgnoreUnrecognizedVMOptions",
-                              // Force inline the methods called by ValueClass::validateArrayArguments used by the array factories
-                              "-XX:CompileCommand=inline,jdk.internal.value.ValueClass::isConcreteValueClass",
-                              "-XX:CompileCommand=inline,java.lang.Class::isValue",
-                              "-XX:CompileCommand=inline,java.lang.reflect.Modifier::isAbstract");
+            scenario.prependFlags("--enable-preview",
+                                  "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
+                                  "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
+                                  "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                  "-XX:+UnlockDiagnosticVMOptions",
+                                  "-XX:+UnlockExperimentalVMOptions",
+                                  "-XX:+IgnoreUnrecognizedVMOptions",
+                                  // Force inline the methods called by ValueClass::validateArrayArguments used by the array factories
+                                  "-XX:CompileCommand=inline,jdk.internal.value.ValueClass::isConcreteValueClass",
+                                  "-XX:CompileCommand=inline,java.lang.Class::isValue",
+                                  "-XX:CompileCommand=inline,java.lang.reflect.Modifier::isAbstract");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -34,13 +34,6 @@ public class InlineTypes {
 
     public static final Scenario[] DEFAULT_SCENARIOS = {
             new Scenario(0,
-                         "--enable-preview",
-                         "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                         "-XX:+UnlockDiagnosticVMOptions",
-                         "-XX:+UnlockExperimentalVMOptions",
-                         "-XX:+IgnoreUnrecognizedVMOptions",
                          "-XX:-UseACmpProfile",
                          "-XX:+AlwaysIncrementalInline",
                          "-XX:FlatArrayElementMaxOops=5",
@@ -51,13 +44,6 @@ public class InlineTypes {
                          "-XX:+InlineTypeReturnedAsFields"
             ),
             new Scenario(1,
-                         "--enable-preview",
-                         "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                         "-XX:+UnlockDiagnosticVMOptions",
-                         "-XX:+UnlockExperimentalVMOptions",
-                         "-XX:+IgnoreUnrecognizedVMOptions",
                          "-XX:-UseACmpProfile",
                          "-XX:-UseCompressedOops",
                          "-XX:FlatArrayElementMaxOops=5",
@@ -68,13 +54,6 @@ public class InlineTypes {
                          "-XX:-InlineTypeReturnedAsFields"
             ),
             new Scenario(2,
-                         "--enable-preview",
-                         "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                         "-XX:+UnlockDiagnosticVMOptions",
-                         "-XX:+UnlockExperimentalVMOptions",
-                         "-XX:+IgnoreUnrecognizedVMOptions",
                          "-XX:-UseACmpProfile",
                          "-XX:-UseCompressedOops",
                          "-XX:FlatArrayElementMaxOops=0",
@@ -85,13 +64,6 @@ public class InlineTypes {
                          "-XX:+InlineTypeReturnedAsFields"
             ),
             new Scenario(3,
-                         "--enable-preview",
-                         "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                         "-XX:+UnlockDiagnosticVMOptions",
-                         "-XX:+UnlockExperimentalVMOptions",
-                         "-XX:+IgnoreUnrecognizedVMOptions",
                          "-DVerifyIR=false",
                          "-XX:+AlwaysIncrementalInline",
                          "-XX:FlatArrayElementMaxOops=0",
@@ -101,13 +73,6 @@ public class InlineTypes {
                          "-XX:+InlineTypeReturnedAsFields"
             ),
             new Scenario(4,
-                         "--enable-preview",
-                         "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                         "-XX:+UnlockDiagnosticVMOptions",
-                         "-XX:+UnlockExperimentalVMOptions",
-                         "-XX:+IgnoreUnrecognizedVMOptions",
                          "-DVerifyIR=false",
                          "-XX:FlatArrayElementMaxOops=-1",
                          "-XX:+UseArrayFlattening",
@@ -117,13 +82,6 @@ public class InlineTypes {
                          "-XX:-ReduceInitialCardMarks"
             ),
             new Scenario(5,
-                         "--enable-preview",
-                         "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                         "-XX:+UnlockDiagnosticVMOptions",
-                         "-XX:+UnlockExperimentalVMOptions",
-                         "-XX:+IgnoreUnrecognizedVMOptions",
                          "-XX:-UseACmpProfile",
                          "-XX:+AlwaysIncrementalInline",
                          "-XX:FlatArrayElementMaxOops=5",
@@ -134,13 +92,6 @@ public class InlineTypes {
                          "-XX:-InlineTypeReturnedAsFields"
             ),
             new Scenario(6,
-                         "--enable-preview",
-                         "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-                         "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                         "-XX:+UnlockDiagnosticVMOptions",
-                         "-XX:+UnlockExperimentalVMOptions",
-                         "-XX:+IgnoreUnrecognizedVMOptions",
                          "-XX:-UseACmpProfile",
                          "-XX:+AlwaysIncrementalInline",
                          "-XX:FlatArrayElementMaxOops=5",
@@ -156,9 +107,17 @@ public class InlineTypes {
     };
 
     static {
-        // Force inline the methods called by ValueClass::validateArrayArguments used by the array factories
+        // Add common flags
         for (Scenario scenario : DEFAULT_SCENARIOS) {
-            scenario.addFlags("-XX:CompileCommand=inline,jdk.internal.value.ValueClass::isConcreteValueClass",
+            scenario.addFlags("--enable-preview",
+                              "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
+                              "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
+                              "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                              "-XX:+UnlockDiagnosticVMOptions",
+                              "-XX:+UnlockExperimentalVMOptions",
+                              "-XX:+IgnoreUnrecognizedVMOptions",
+                              // Force inline the methods called by ValueClass::validateArrayArguments used by the array factories
+                              "-XX:CompileCommand=inline,jdk.internal.value.ValueClass::isConcreteValueClass",
                               "-XX:CompileCommand=inline,java.lang.Class::isValue",
                               "-XX:CompileCommand=inline,java.lang.reflect.Modifier::isAbstract");
         }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -155,6 +155,15 @@ public class InlineTypes {
             ),
     };
 
+    static {
+        // Force inline the methods called by ValueClass::validateArrayArguments used by the array factories
+        for (Scenario scenario : DEFAULT_SCENARIOS) {
+            scenario.addFlags("-XX:CompileCommand=inline,jdk.internal.value.ValueClass::isConcreteValueClass",
+                              "-XX:CompileCommand=inline,java.lang.Class::isValue",
+                              "-XX:CompileCommand=inline,java.lang.reflect.Modifier::isAbstract");
+        }
+    }
+
     public static TestFramework getFramework() {
         StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
         return new TestFramework(walker.getCallerClass()).setDefaultWarmup(251);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -145,10 +145,10 @@ public class TestArrays {
 
     public static void main(String[] args) {
         Scenario[] scenarios = InlineTypes.DEFAULT_SCENARIOS;
-        scenarios[2].addFlags("--enable-preview", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
-        scenarios[3].addFlags("--enable-preview", "-XX:-MonomorphicArrayCheck", "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseArrayFlattening", "-XX:-UncommonNullCast");
-        scenarios[4].addFlags("--enable-preview", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
-        scenarios[5].addFlags("--enable-preview", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
+        scenarios[2].addFlags("--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
+        scenarios[3].addFlags("--enable-preview", "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseArrayFlattening", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
+        scenarios[4].addFlags("--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
+        scenarios[5].addFlags("--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
 
         InlineTypes.getFramework()
                    .addScenarios(scenarios[Integer.parseInt(args[0])])

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArraysCopyOf.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArraysCopyOf.java
@@ -120,10 +120,10 @@ public class TestArraysCopyOf {
 
     public static void main(String[] args) {
         Scenario[] scenarios = InlineTypes.DEFAULT_SCENARIOS;
-        scenarios[2].addFlags("--enable-preview", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
-        scenarios[3].addFlags("--enable-preview", "-XX:-MonomorphicArrayCheck", "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseArrayFlattening", "-XX:-UncommonNullCast");
-        scenarios[4].addFlags("--enable-preview", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
-        scenarios[5].addFlags("--enable-preview", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
+        scenarios[2].addFlags("--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
+        scenarios[3].addFlags("--enable-preview", "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseArrayFlattening", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
+        scenarios[4].addFlags("--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
+        scenarios[5].addFlags("--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
 
         String[] flagsForScenario = scenarios[Integer.parseInt(args[0])].getFlags().toArray(new String[0]);
         CompileFramework comp = new CompileFramework();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -155,8 +155,8 @@ public class TestIntrinsics {
     public static void main(String[] args) {
 
         Scenario[] scenarios = InlineTypes.DEFAULT_SCENARIOS;
-        scenarios[3].addFlags("-XX:-MonomorphicArrayCheck", "-XX:+UseArrayFlattening");
-        scenarios[4].addFlags("-XX:-MonomorphicArrayCheck", "-XX:+UnlockExperimentalVMOptions", "-XX:PerMethodSpecTrapLimit=0", "-XX:PerMethodTrapLimit=0");
+        scenarios[3].addFlags("-XX:+UseArrayFlattening", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck");
+        scenarios[4].addFlags("-XX:+UnlockExperimentalVMOptions", "-XX:PerMethodSpecTrapLimit=0", "-XX:PerMethodTrapLimit=0", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck");
 
         InlineTypes.getFramework()
                    .addScenarios(scenarios[Integer.parseInt(args[0])])

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -178,8 +178,8 @@ public class TestLWorld {
         class2.getDeclaredFields();
 
         Scenario[] scenarios = InlineTypes.DEFAULT_SCENARIOS;
-        scenarios[3].addFlags("-XX:-MonomorphicArrayCheck", "-XX:+UseArrayFlattening");
-        scenarios[4].addFlags("-XX:-MonomorphicArrayCheck");
+        scenarios[3].addFlags("-XX:+UseArrayFlattening", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck");
+        scenarios[4].addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck");
 
         InlineTypes.getFramework()
                     // TODO 8337821: Temporarily increased MemLimit - remove again with JDK-8378328 once fixed.

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -136,10 +136,10 @@ public class TestNullableArrays {
     public static void main(String[] args) {
 
         Scenario[] scenarios = InlineTypes.DEFAULT_SCENARIOS;
-        scenarios[2].addFlags("-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
-        scenarios[3].addFlags("-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
-        scenarios[4].addFlags("-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
-        scenarios[5].addFlags("-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
+        scenarios[2].addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
+        scenarios[3].addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
+        scenarios[4].addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast");
+        scenarios[5].addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode");
 
         InlineTypes.getFramework()
                    .addScenarios(scenarios[Integer.parseInt(args[0])])

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -164,8 +164,8 @@ public class TestNullableInlineTypes {
     public static void main(String[] args) {
 
         Scenario[] scenarios = InlineTypes.DEFAULT_SCENARIOS;
-        scenarios[3].addFlags("-XX:-MonomorphicArrayCheck", "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseArrayFlattening");
-        scenarios[4].addFlags("-XX:-MonomorphicArrayCheck");
+        scenarios[3].addFlags("-XX:+UnlockDiagnosticVMOptions", "-XX:+UseArrayFlattening", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck");
+        scenarios[4].addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck");
 
         InlineTypes.getFramework()
                    .addScenarios(scenarios[Integer.parseInt(args[0])])

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueClasses.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueClasses.java
@@ -129,8 +129,8 @@ public class TestValueClasses {
         // Don't generate bytecodes but call through runtime for reflective calls
         scenarios[0].addFlags("-Dsun.reflect.inflationThreshold=10000");
         scenarios[1].addFlags("-Dsun.reflect.inflationThreshold=10000");
-        scenarios[3].addFlags("-XX:-MonomorphicArrayCheck", "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseArrayFlattening");
-        scenarios[4].addFlags("-XX:-UseTLAB", "-XX:-MonomorphicArrayCheck");
+        scenarios[3].addFlags("-XX:+UnlockDiagnosticVMOptions", "-XX:+UseArrayFlattening", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck");
+        scenarios[4].addFlags("-XX:-UseTLAB", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-MonomorphicArrayCheck");
 
         InlineTypes.getFramework()
                    .addScenarios(scenarios[Integer.parseInt(args[0])])


### PR DESCRIPTION
Some of our tests intermittently fail IR verification because the new verification code from `validateArrayArguments` added by  [JDK-8383820](https://bugs.openjdk.org/browse/JDK-8383820) is not inlined:

https://github.com/openjdk/jdk/blob/c92288eb8db0eab21773ad3a26b755d2af220105/src/java.base/share/classes/jdk/internal/value/ValueClass.java#L59-L61

https://github.com/openjdk/jdk/blob/c92288eb8db0eab21773ad3a26b755d2af220105/src/java.base/share/classes/jdk/internal/value/ValueClass.java#L123-L126

```
658 CallStaticJava === 5 6 7 8 1 (819 1 22 1154 1 1 70 23 71 70 1 71 1 23 1 22 ) [[ 659 660 661 670 ]] # Static java.lang.reflect.Modifier::isAbstract bool ( int ) ValueClass::isConcreteValueClass @ bci:11 (line 60) ValueClass::validateArrayArguments @ bci:15 (line 89) ValueClass::validateArrayArguments @ bci:2 (line 100) ValueClass::newNullRestrictedNonAtomicArray @ bci:3 (line 136) TestArrays::test139 @ bci:13 (line 3475) !jvms: ValueClass::isConcreteValueClass @ bci:11 (line 60) ValueClass::validateArrayArguments @ bci:15 (line 89) ValueClass::validateArrayArguments @ bci:2 (line 100) ValueClass::newNullRestrictedNonAtomicArray @ bci:3 (line 136) TestArrays::test139 @ bci:13 (line 3475)
```

The fix is to force-inline that code in the test. I did it in the `DEFAULT_SCENARIOS` because multiple tests rely on this code being inlined.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390459](https://bugs.openjdk.org/browse/JDK-8390459): [Valhalla] compiler/valhalla/inlinetypes/TestArrays.java#id6 fails IR matching (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) Review applies to [e0e372ab](https://git.openjdk.org/jdk/pull/32464/files/e0e372abb55faa67fe8e9f24e04d6e43b84e68af)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32464/head:pull/32464` \
`$ git checkout pull/32464`

Update a local copy of the PR: \
`$ git checkout pull/32464` \
`$ git pull https://git.openjdk.org/jdk.git pull/32464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32464`

View PR using the GUI difftool: \
`$ git pr show -t 32464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32464.diff">https://git.openjdk.org/jdk/pull/32464.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32464#issuecomment-5354631861)
</details>
