### PR TITLE
8390650: Unsafe access with constant zero offset triggers assert in EA

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -169,10 +169,11 @@ bool ConnectionGraph::compute_escape() {
   java_objects_worklist.append(phantom_obj);
   for( uint next = 0; next < ideal_nodes.size(); ++next ) {
     Node* n = ideal_nodes.at(next);
-    if ((n->Opcode() == Op_LoadX || n->Opcode() == Op_StoreX) &&
+    if (n->is_Mem() &&
         !n->in(MemNode::Address)->is_AddP() &&
         _igvn->type(n->in(MemNode::Address))->isa_oopptr()) {
-      // Load/Store at mark work address is at offset 0 so has no AddP which confuses EA
+      // EA expects on-heap memory addresses to be represented by an AddP. An AddP with a zero
+      // offset can be optimized to its oop base, so recreate it.
       Node* addp = AddPNode::make_with_base(n->in(MemNode::Address), n->in(MemNode::Address), _igvn->MakeConX(0));
       _igvn->register_new_node_with_optimizer(addp);
       _igvn->replace_input_of(n, MemNode::Address, addp);

--- a/test/hotspot/jtreg/compiler/intrinsics/TestUnsafeAccessWithZeroOffset.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestUnsafeAccessWithZeroOffset.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8390650
+ * @summary Test unreachable unsafe accesses at offset zero.
+ * @requires vm.compiler2.enabled
+ * @modules java.base/jdk.internal.misc
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=delayinline,${test.main.class}::getOffset
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   ${test.main.class}
+ */
+
+import jdk.internal.misc.Unsafe;
+
+public class TestUnsafeAccessWithZeroOffset {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    static Object testPlain(Object obj, Object x, boolean b) {
+        Object unused = new Object(); // Trigger EA
+        long offset = getOffset();
+        if (b) {
+            // Never reached
+            Object result = UNSAFE.getReference(obj, 0L);
+            UNSAFE.putReference(obj, offset, x);
+            return result;
+        }
+        return null;
+    }
+    
+    static Object testLoadStore(Object obj, Object expected, Object x, boolean b) {
+        Object unused = new Object(); // Trigger EA
+        if (b) {
+            // Never reached
+            return UNSAFE.compareAndExchangeReference(obj, 0L, expected, x);
+        }
+        return null;
+    }
+
+    static long getOffset() {
+        return 0L;
+    }
+
+    static Object testPlainDelayed(Object obj, Object x, boolean b) {
+        Object unused = new Object(); // Trigger EA
+        long offset = getOffset();
+        if (b) {
+            // Never reached
+            Object result = UNSAFE.getReference(obj, offset);
+            UNSAFE.putReference(obj, offset, x);
+            return result;
+        }
+        return null;
+    }
+
+    static Object testLoadStoreDelayed(Object obj, Object expected, Object x, boolean b) {
+        Object unused = new Object(); // Trigger EA
+        long offset = getOffset();
+        if (b) {
+            // Never reached
+            return UNSAFE.compareAndExchangeReference(obj, offset, expected, x);
+        }
+        return null;
+    }
+
+    public static void main(String[] args) {
+        Object value = new Object();
+        testPlain(value, value, false);
+        testLoadStore(value, value, value, false);
+        testPlainDelayed(value, value, false);
+        testLoadStoreDelayed(value, value, value, false);
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/intrinsics/TestUnsafeAccessWithZeroOffset.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestUnsafeAccessWithZeroOffset.java
@@ -48,7 +48,7 @@ public class TestUnsafeAccessWithZeroOffset {
         }
         return null;
     }
-    
+
     static Object testLoadStore(Object obj, Object expected, Object x, boolean b) {
         Object unused = new Object(); // Trigger EA
         if (b) {


### PR DESCRIPTION
The original failure happened with CTW of some internal code. The issue happens when C2 compiles an (unreachable) unsafe access with a constant zero offset and IGVN folds the `AddP` address to the base oop. We then hit an assert in escape analysis because it expects memory addresses to always be represented by an `AddP`. 

By coincidence, we hit a similar issue in Valhalla when adding support for `Unsafe.makePrivateBuffer/finishPrivateBuffer` (see [JDK-8206144](https://github.com/openjdk/valhalla/commit/c439b9e2b957a014aa8ba150e44684e7abafa89c)), which had to read/write a mark word bit and therefore emitted a load/store on the mark word address in the header without an `AddP`. We fixed it like this:
https://github.com/openjdk/jdk/blob/c92288eb8db0eab21773ad3a26b755d2af220105/src/hotspot/share/opto/escape.cpp#L172-L181

Now this code is dead since `Unsafe.makePrivateBuffer/finishPrivateBuffer` and their C2 mark-word loads/stores were removed by [JDK-8373375](https://bugs.openjdk.org/browse/JDK-8373375) and [JDK-8380802](https://bugs.openjdk.org/browse/JDK-8380802).

I think we should still revive the code to handle this case which is a much older issue and independent of Valhalla.

The alternative would be to emit a runtime check and guard it with an `OpaqueConstantBoolNode` such that it's folded later. I quickly prototyped this but it feels way too complicated to handle this edge case. Also, it would not help if we add mark word loads/stores back in the future.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390650](https://bugs.openjdk.org/browse/JDK-8390650): Unsafe access with constant zero offset triggers assert in EA (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32466/head:pull/32466` \
`$ git checkout pull/32466`

Update a local copy of the PR: \
`$ git checkout pull/32466` \
`$ git pull https://git.openjdk.org/jdk.git pull/32466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32466`

View PR using the GUI difftool: \
`$ git pr show -t 32466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32466.diff">https://git.openjdk.org/jdk/pull/32466.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32466#issuecomment-5355962914)
</details>
