### PR TITLE
8390505: jlink is not thread safe when used via ToolProvider API

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -89,7 +89,7 @@ public class JlinkTask {
     // jlink API ignores by default. Remove when signing is implemented.
     static final boolean IGNORE_SIGNING_DEFAULT = true;
 
-    private static final TaskHelper taskHelper
+    private final TaskHelper taskHelper
             = new TaskHelper(JLINK_BUNDLE);
     private static final Option<?>[] recognizedOptions = {
         new Option<JlinkTask>(false, (task, opt, arg) -> {
@@ -110,7 +110,7 @@ public class JlinkTask {
             task.options.limitMods.clear();
             for (String mn : arg.split(",")) {
                 if (mn.isEmpty()) {
-                    throw taskHelper.newBadArgs("err.mods.must.be.specified",
+                    throw task.taskHelper.newBadArgs("err.mods.must.be.specified",
                             "--limit-modules");
                 }
                 task.options.limitMods.add(mn);
@@ -119,7 +119,7 @@ public class JlinkTask {
         new Option<JlinkTask>(true, (task, opt, arg) -> {
             for (String mn : arg.split(",")) {
                 if (mn.isEmpty()) {
-                    throw taskHelper.newBadArgs("err.mods.must.be.specified",
+                    throw task.taskHelper.newBadArgs("err.mods.must.be.specified",
                             "--add-modules");
                 }
                 task.options.addMods.add(mn);
@@ -139,18 +139,18 @@ public class JlinkTask {
             String[] values = arg.split("=");
             // check values
             if (values.length != 2 || values[0].isEmpty() || values[1].isEmpty()) {
-                throw taskHelper.newBadArgs("err.launcher.value.format", arg);
+                throw task.taskHelper.newBadArgs("err.launcher.value.format", arg);
             } else {
                 String commandName = values[0];
                 String moduleAndMain = values[1];
                 int idx = moduleAndMain.indexOf("/");
                 if (idx != -1) {
                     if (moduleAndMain.substring(0, idx).isEmpty()) {
-                        throw taskHelper.newBadArgs("err.launcher.module.name.empty", arg);
+                        throw task.taskHelper.newBadArgs("err.launcher.module.name.empty", arg);
                     }
 
                     if (moduleAndMain.substring(idx + 1).isEmpty()) {
-                        throw taskHelper.newBadArgs("err.launcher.main.class.empty", arg);
+                        throw task.taskHelper.newBadArgs("err.launcher.main.class.empty", arg);
                     }
                 }
                 task.options.launchers.put(commandName, moduleAndMain);
@@ -162,7 +162,7 @@ public class JlinkTask {
             } else if ("big".equals(arg)) {
                 task.options.endian = ByteOrder.BIG_ENDIAN;
             } else {
-                throw taskHelper.newBadArgs("err.unknown.byte.order", arg);
+                throw task.taskHelper.newBadArgs("err.unknown.byte.order", arg);
             }
         }, "--endian"),
         new Option<JlinkTask>(false, (task, opt, arg) -> {
@@ -174,7 +174,7 @@ public class JlinkTask {
         new Option<JlinkTask>(true, (task, opt, arg) -> {
             Path path = Paths.get(arg);
             if (Files.exists(path)) {
-                throw taskHelper.newBadArgs("err.dir.exists", path);
+                throw task.taskHelper.newBadArgs("err.dir.exists", path);
             }
             task.options.packagedModulesPath = path;
         }, true, "--keep-packaged-modules"),
@@ -201,7 +201,7 @@ public class JlinkTask {
     private static final String PROGNAME = "jlink";
     private final OptionsValues options = new OptionsValues();
 
-    private static final OptionsHelper<JlinkTask> optionsHelper
+    private final OptionsHelper<JlinkTask> optionsHelper
             = taskHelper.newOptionsHelper(JlinkTask.class, recognizedOptions);
     private PrintWriter log;
 
@@ -375,6 +375,7 @@ public class JlinkTask {
         // First create the image provider
         try (ImageHelper imageProvider =
                      createImageProvider(config,
+                             new TaskHelper(JLINK_BUNDLE),
                              null,
                              IGNORE_SIGNING_DEFAULT,
                              false,
@@ -513,6 +514,7 @@ public class JlinkTask {
 
         // First create the image provider
         try (ImageHelper imageProvider = createImageProvider(config,
+                taskHelper,
                 options.packagedModulesPath,
                 options.ignoreSigning,
                 options.bindServices,
@@ -606,7 +608,7 @@ public class JlinkTask {
      * @throws IllegalArgumentException  If  the `java.base` module reference `target`
      * is not compatible with this jlink.
      */
-    private static void checkJavaBaseVersion(ModuleReference target) {
+    private void checkJavaBaseVersion(ModuleReference target) {
         String currentRelease = getCurrentRuntimeVersion();
 
         String targetRelease = getReleaseInfo(target).orElseThrow(() -> new IllegalArgumentException(
@@ -653,6 +655,7 @@ public class JlinkTask {
 
 
     private static ImageHelper createImageProvider(JlinkConfiguration config,
+                                                   TaskHelper taskHelper,
                                                    Path retainModulesPath,
                                                    boolean ignoreSigning,
                                                    boolean bindService,
@@ -733,7 +736,7 @@ public class JlinkTask {
         Map<String, Path> mods = cf.modules().stream()
             .collect(Collectors.toMap(ResolvedModule::name, JlinkTask::toPathLocation));
         // determine the target platform of the image being created
-        Platform targetPlatform = targetPlatform(cf, mods, config.linkFromRuntimeImage());
+        Platform targetPlatform = targetPlatform(cf, taskHelper, mods, config.linkFromRuntimeImage());
         // if the user specified any --endian, then it must match the target platform's native
         // endianness
         if (endian != null && endian != targetPlatform.arch().byteOrder()) {
@@ -764,6 +767,7 @@ public class JlinkTask {
                                      version,
                                      ignoreSigning,
                                      config,
+                                     taskHelper,
                                      log))
                 .collect(Collectors.toSet());
 
@@ -778,6 +782,7 @@ public class JlinkTask {
                                       Runtime.Version version,
                                       boolean ignoreSigning,
                                       JlinkConfiguration config,
+                                      TaskHelper taskHelper,
                                       PrintWriter log) {
         if (path.toString().endsWith(".jmod")) {
             return new JmodArchive(module, path);
@@ -812,7 +817,7 @@ public class JlinkTask {
             // directory. I.e. Files.isDirectory() would be true.
             Path modInfoPath = path.resolve("module-info.class");
             if (Files.isRegularFile(modInfoPath)) {
-                return new DirArchive(path, findModuleName(modInfoPath));
+                return new DirArchive(path, findModuleName(taskHelper, modInfoPath));
             } else {
                 throw new IllegalArgumentException(
                         taskHelper.getMessage("err.not.a.module.directory", path));
@@ -825,7 +830,7 @@ public class JlinkTask {
         }
     }
 
-    private static String findModuleName(Path modInfoPath) {
+    private static String findModuleName(TaskHelper taskHelper, Path modInfoPath) {
         try (BufferedInputStream bis = new BufferedInputStream(
                 Files.newInputStream(modInfoPath))) {
             return ModuleDescriptor.read(bis).name();
@@ -836,6 +841,7 @@ public class JlinkTask {
     }
 
     private static Platform targetPlatform(Configuration cf,
+                                           TaskHelper taskHelper,
                                            Map<String, Path> modsPaths,
                                            boolean runtimeImageLink) throws IOException {
         Path javaBasePath = modsPaths.get("java.base");
@@ -850,7 +856,7 @@ public class JlinkTask {
             // this is an attempt to build a cross-platform image. We now attempt to
             // find the target platform's arch and thus its endianness from the java.base
             // module's ModuleTarget attribute
-            String targetPlatformVal = readJavaBaseTargetPlatform(cf);
+            String targetPlatformVal = readJavaBaseTargetPlatform(cf, taskHelper);
             try {
                 return Platform.parsePlatform(targetPlatformVal);
             } catch (IllegalArgumentException iae) {
@@ -879,7 +885,7 @@ public class JlinkTask {
 
     // returns the targetPlatform value from the ModuleTarget attribute of the java.base module.
     // throws IOException if the targetPlatform cannot be determined.
-    private static String readJavaBaseTargetPlatform(Configuration cf) throws IOException {
+    private static String readJavaBaseTargetPlatform(Configuration cf, TaskHelper taskHelper) throws IOException {
         Optional<ResolvedModule> javaBase = cf.findModule("java.base");
         assert javaBase.isPresent() : "java.base module is missing";
         ModuleReference ref = javaBase.get().reference();

--- a/test/jdk/tools/jlink/JLinkToolProviderTest.java
+++ b/test/jdk/tools/jlink/JLinkToolProviderTest.java
@@ -25,7 +25,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.IntStream;
@@ -49,13 +49,11 @@ public class JLinkToolProviderTest {
     }
 
     private static void checkConcurrentAccess(int count) throws Exception {
-        CountDownLatch readyLatch = new CountDownLatch(count);
-        CountDownLatch startLatch = new CountDownLatch(1);
+        Phaser startBarrier = new Phaser(count);
 
         try (var executor = Executors.newFixedThreadPool(count)) {
             List<Future<String>> futures = IntStream.range(0, count).mapToObj(idx -> executor.submit(() -> {
-                readyLatch.countDown();
-                startLatch.await();
+                startBarrier.arriveAndAwaitAdvance();
 
                 StringWriter out = new StringWriter();
                 StringWriter err = new StringWriter();
@@ -64,12 +62,6 @@ public class JLinkToolProviderTest {
                         "--output", Path.of(".").resolve("image-" + idx).toString());
                 return code + ":" + out.toString().trim() + ":" + err.toString().trim();
             })).toList();
-
-            try {
-                readyLatch.await();
-            } finally {
-                startLatch.countDown();
-            }
 
             for (Future<String> future : futures) {
                 String result = future.get();
@@ -83,6 +75,6 @@ public class JLinkToolProviderTest {
     public static void main(String[] args) throws Exception {
         checkJlinkOptions("--help");
         checkJlinkOptions("--list-plugins");
-        checkConcurrentAccess(3);
+        checkConcurrentAccess(Math.max(2, Runtime.getRuntime().availableProcessors() / 4));
     }
 }

--- a/test/jdk/tools/jlink/JLinkToolProviderTest.java
+++ b/test/jdk/tools/jlink/JLinkToolProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,12 @@
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
 import java.util.spi.ToolProvider;
 
 /*
@@ -42,8 +48,41 @@ public class JLinkToolProviderTest {
         JLINK_TOOL.run(pw, pw, options);
     }
 
+    private static void checkConcurrentAccess(int count) throws Exception {
+        CountDownLatch readyLatch = new CountDownLatch(count);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        try (var executor = Executors.newFixedThreadPool(count)) {
+            List<Future<String>> futures = IntStream.range(0, count).mapToObj(idx -> executor.submit(() -> {
+                readyLatch.countDown();
+                startLatch.await();
+
+                StringWriter out = new StringWriter();
+                StringWriter err = new StringWriter();
+                int code = JLINK_TOOL.run(new PrintWriter(out), new PrintWriter(err),
+                        "--add-modules", "java.base",
+                        "--output", Path.of(".").resolve("image-" + idx).toString());
+                return code + ":" + out.toString().trim() + ":" + err.toString().trim();
+            })).toList();
+
+            try {
+                readyLatch.await();
+            } finally {
+                startLatch.countDown();
+            }
+
+            for (Future<String> future : futures) {
+                String result = future.get();
+                if (!"0::".equals(result)) {
+                    throw new AssertionError(result);
+                }
+            }
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         checkJlinkOptions("--help");
         checkJlinkOptions("--list-plugins");
+        checkConcurrentAccess(3);
     }
 }


### PR DESCRIPTION
Running two or more `jlink` invocations concurrently in the same JVM through the `ToolProvider` API causes the simultaneous `run` calls to interfere with one another, even when each invocation targets a distinct `--output` directory and the invocations share no inputs. They may fail with errors such as:
```
Error: java.lang.IllegalStateException: stream has already been operated upon or closed
Error: Resource XYZ already present
```
The problem is that Main.run(...) correctly creates a new `JlinkTask` for each call, but `JlinkTask` defeats this isolation by sharing static `TaskHelper` and `OptionsHelper` instances. Concurrent invocations can therefore overwrite one another’s parsed options and plugin pipelines.

The proposed solution is to make `taskHelper` and `optionsHelper` instance fields of `JlinkTask`. This preserves actual concurrency. Synchronizing the provider would unnecessarily serialize image creation and would not protect separate provider instances or direct calls to `Main.run(...)`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8390505: jlink is not thread safe when used via ToolProvider API`

### Issue
 * [JDK-8390505](https://bugs.openjdk.org/browse/JDK-8390505): jlink is not thread safe when used via ToolProvider API (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32469/head:pull/32469` \
`$ git checkout pull/32469`

Update a local copy of the PR: \
`$ git checkout pull/32469` \
`$ git pull https://git.openjdk.org/jdk.git pull/32469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32469`

View PR using the GUI difftool: \
`$ git pr show -t 32469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32469.diff">https://git.openjdk.org/jdk/pull/32469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32469#issuecomment-5356638072)
</details>
