### PR TITLE
8389452: Inherited @Contended annotation corrupts concrete value class layout

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2080,7 +2080,7 @@ void MethodAnnotationCollector::apply_to(const methodHandle& m) {
 
 void ClassFileParser::ClassAnnotationCollector::apply_to(InstanceKlass* ik) {
   assert(ik != nullptr, "invariant");
-  if (has_annotation(_jdk_internal_vm_annotation_Contended)) {
+  if (ik->is_identity_class() && has_annotation(_jdk_internal_vm_annotation_Contended)) {
     ik->set_is_contended(is_contended());
   }
   if (has_annotation(_jdk_internal_ValueBased)) {
@@ -5676,8 +5676,9 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
     oop_map_blocks->copy(ik->start_of_nonstatic_oop_maps());
   }
 
-  if (_has_contended_fields || _parsed_annotations->is_contended() ||
-      ( _super_klass != nullptr && _super_klass->has_contended_annotations())) {
+  if (ik->is_identity_class() &&
+      (_has_contended_fields || _parsed_annotations->is_contended() ||
+       (_super_klass != nullptr && _super_klass->has_contended_annotations()))) {
     ik->set_has_contended_annotations(true);
   }
 
@@ -6409,7 +6410,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
 
   _layout_info = new FieldLayoutInfo();
   FieldLayoutBuilder lb(class_name(), loader_data(), super_klass(), _cp, /*_fields*/ _temp_field_info,
-      _parsed_annotations->is_contended(), is_inline_type(),
+      access_flags().is_identity_class() && _parsed_annotations->is_contended(), is_inline_type(),
       access_flags().is_abstract() && !access_flags().is_identity_class() && !access_flags().is_interface(),
       _must_be_atomic, _layout_info, _inline_layout_info_array);
   lb.build_layout();

--- a/src/java.base/share/classes/jdk/internal/vm/annotation/Contended.java
+++ b/src/java.base/share/classes/jdk/internal/vm/annotation/Contended.java
@@ -67,6 +67,12 @@ import java.lang.annotation.Target;
  * groups. Contention group tags are not inherited, and the same tag used
  * in a superclass and subclass, represent distinct contention groups.
  *
+ * <div class="preview-block">
+ * <div class="preview-comment">
+ * <p> This annotation has no effect when used on or inside value classes.
+ * </div>
+ * </div>
+ *
  * @since 1.8
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ContendedValueClassInheritanceTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ContendedValueClassInheritanceTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8389452
+ * @summary Test that contended annotations are ignored on value class layouts
+ * @library /test/lib
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @compile FieldLayoutAnalyzer.java ContendedValueClassInheritanceTest.java
+ * @run main runtime.valhalla.inlinetypes.field_layout.ContendedValueClassInheritanceTest
+ */
+
+package runtime.valhalla.inlinetypes.field_layout;
+
+import jdk.internal.vm.annotation.Contended;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.ProcessTools;
+
+public class ContendedValueClassInheritanceTest {
+    private static final int CONTENDED_PADDING_WIDTH = 128;
+
+    static abstract value class Base {
+        long base = 0;
+    }
+
+    @Contended
+    static abstract value class ContendedBase {
+        long base = 0;
+    }
+
+    static value class Value extends ContendedBase {
+        int value = 0;
+    }
+
+    @Contended
+    static value class ContendedValue extends Base {
+        int value = 0;
+    }
+
+    static class Identity extends ContendedBase {
+        int value;
+    }
+
+    @Contended
+    static class ContendedIdentity extends Base {
+        int value;
+    }
+
+    static class TestRunner {
+        public static void main(String[] args) {
+            new Value();
+            new ContendedValue();
+            new Identity();
+            new ContendedIdentity();
+        }
+    }
+
+    private static FieldLayoutAnalyzer.ClassLayout getLayout(FieldLayoutAnalyzer fla, Class<?> type) {
+        String className = type.getName().replace('.', '/');
+        FieldLayoutAnalyzer.ClassLayout layout = fla.getClassLayoutFromName(className);
+        Asserts.assertNotNull(layout, "Missing layout for " + type.getName());
+        return layout;
+    }
+
+    private static int contendedPaddingBlocks(FieldLayoutAnalyzer.ClassLayout layout) {
+        int count = 0;
+        for (FieldLayoutAnalyzer.FieldBlock block : layout.nonStaticFields) {
+            if (block.type() == FieldLayoutAnalyzer.BlockType.PADDING && block.size() == CONTENDED_PADDING_WIDTH) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static void assertSameFieldLayout(FieldLayoutAnalyzer.ClassLayout first,
+                                              FieldLayoutAnalyzer.ClassLayout second,
+                                              String fieldName) {
+        FieldLayoutAnalyzer.FieldBlock firstField = first.getFieldFromName(fieldName, false);
+        FieldLayoutAnalyzer.FieldBlock secondField = second.getFieldFromName(fieldName, false);
+        Asserts.assertEquals(firstField.offset(), secondField.offset(), fieldName + " offset");
+        Asserts.assertEquals(firstField.size(), secondField.size(), fieldName + " size");
+        Asserts.assertEquals(firstField.alignment(), secondField.alignment(), fieldName + " alignment");
+    }
+
+    private static void checkLayouts(FieldLayoutAnalyzer fla) {
+        // Contended annotations should not affect value base classes.
+        var base = getLayout(fla, Base.class);
+        var contendedBase = getLayout(fla, ContendedBase.class);
+
+        Asserts.assertEquals(base.instanceSize, contendedBase.instanceSize);
+        assertSameFieldLayout(base, contendedBase, "base");
+        Asserts.assertEquals(contendedPaddingBlocks(contendedBase), 0);
+
+        // Neither inherited nor declared contended annotations should affect value subclasses.
+        var value = getLayout(fla, Value.class);
+        var contendedValue = getLayout(fla, ContendedValue.class);
+
+        Asserts.assertEquals(value.instanceSize, contendedValue.instanceSize);
+        Asserts.assertEquals(value.payloadSize, contendedValue.payloadSize);
+
+        assertSameFieldLayout(value, contendedValue, "base");
+        assertSameFieldLayout(value, contendedValue, "value");
+
+        Asserts.assertEquals(contendedPaddingBlocks(value), 0);
+        Asserts.assertEquals(contendedPaddingBlocks(contendedValue), 0);
+
+        // Only the contended identity subclass gets leading and trailing padding.
+        var identity = getLayout(fla, Identity.class);
+        var contendedIdentity = getLayout(fla, ContendedIdentity.class);
+        var identityField = identity.getFieldFromName("value", false);
+        var contendedIdentityField = contendedIdentity.getFieldFromName("value", false);
+
+        assertSameFieldLayout(identity, contendedIdentity, "base");
+
+        Asserts.assertEquals(contendedIdentityField.offset(), identityField.offset() + CONTENDED_PADDING_WIDTH);
+        Asserts.assertEquals(contendedIdentity.instanceSize, identity.instanceSize + 2 * CONTENDED_PADDING_WIDTH);
+
+        Asserts.assertEquals(contendedPaddingBlocks(identity), 0);
+        Asserts.assertEquals(contendedPaddingBlocks(contendedIdentity), 2);
+    }
+
+    public static void main(String[] args) throws Exception {
+        var out = ProcessTools.executeTestJava(
+                "--enable-preview",
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+PrintFieldLayout",
+                "-XX:-RestrictContended",
+                "-XX:ContendedPaddingWidth=" + CONTENDED_PADDING_WIDTH,
+                "-Xshare:off",
+                "-cp", System.getProperty("java.class.path"),
+                TestRunner.class.getName());
+        out.shouldHaveExitValue(0);
+
+        FieldLayoutAnalyzer.LogOutput log = new FieldLayoutAnalyzer.LogOutput(out.asLines());
+        FieldLayoutAnalyzer fla = FieldLayoutAnalyzer.createFieldLayoutAnalyzer(log);
+        try {
+            checkLayouts(fla);
+            fla.check();
+        } catch (Throwable t) {
+            System.out.print(out.getOutput());
+            throw t;
+        }
+    }
+}


### PR DESCRIPTION
Hi everyone,

The `@Contended` notation is not supported on value classes. The intended behavior is for the annotation to be ignored without affecting the class layout. However, value classes are currently still marked as contended internally. When another class inherits from a value class marked as contended, this causes padding to be inserted between the inherited fields and the subclass fields, which causes a crash on debug builds.

To fix this, I have changed the handling so that a class is only marked as contended if it is an identity class. Since value classes cannot be contended, filtering the annotation when it is processed avoids carrying an invalid state that would require extra checks later on. With this change, contended and non-contended value classes behave identically, and inheriting from a value class annotated with `@Contended` no longer introduces padding.

Testing:
- Oracle tiers 1-3
- A new regression test covering value and identity subclasses inheriting from contended and non-contended base value classes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389452](https://bugs.openjdk.org/browse/JDK-8389452): Inherited @<!---->Contended annotation corrupts concrete value class layout (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32470/head:pull/32470` \
`$ git checkout pull/32470`

Update a local copy of the PR: \
`$ git checkout pull/32470` \
`$ git pull https://git.openjdk.org/jdk.git pull/32470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32470`

View PR using the GUI difftool: \
`$ git pr show -t 32470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32470.diff">https://git.openjdk.org/jdk/pull/32470.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32470#issuecomment-5356878646)
</details>
