### PR TITLE
8389938: Follow up after removing UseObjectMonitorTable flag

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -351,8 +351,7 @@ G1HeapRegionAttr G1ParScanThreadState::next_region_attr(G1HeapRegionAttr const r
   assert(region_attr.is_young() || region_attr.is_old(), "must be either Young or Old");
 
   if (region_attr.is_young()) {
-    age = !m.has_displaced_mark_helper() ? m.age()
-                                         : m.displaced_mark_helper().age();
+    age = m.age();
     if (age < _tenuring_threshold) {
       return region_attr;
     }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,8 +249,7 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
   size_t new_obj_size = o->size_given_klass(klass);
 
   // Find the objects age, MT safe.
-  uint age = (test_mark.has_displaced_mark_helper() /* o->has_displaced_mark() */) ?
-      test_mark.displaced_mark_helper().age() : test_mark.age();
+  uint age = test_mark.age();
 
   if (!promote_immediately) {
     // Try allocating obj in to-space (unless too old)

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,10 +211,7 @@ oop ShenandoahGenerationalHeap::evacuate_object(oop p, Thread* thread) {
       return ShenandoahForwarding::get_forwardee(p);
     }
 
-    if (mark.has_displaced_mark_helper()) {
-      // We don't want to deal with MT here just to ensure we read the right mark word.
-      // Skip the potential promotion attempt for this one.
-    } else if (age_census()->is_tenurable(from_region->age() + mark.age())) {
+    if (age_census()->is_tenurable(from_region->age() + mark.age())) {
       // If the object is tenurable, try to promote it
       oop result = try_evacuate_object<YOUNG_GENERATION, OLD_GENERATION>(p, thread, from_region->age());
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -301,32 +301,18 @@ inline HeapWord* ShenandoahHeap::allocate_from_gclab(Thread* thread, size_t size
 
 void ShenandoahHeap::increase_object_age(oop obj, uint additional_age) {
   // This operates on new copy of an object. This means that the object's mark-word
-  // is thread-local and therefore safe to access. However, when the mark is
-  // displaced (i.e. stack-locked or monitor-locked), then it must be considered
-  // a shared memory location. It can be accessed by other threads.
-  // In particular, a competing evacuating thread can succeed to install its copy
-  // as the forwardee and continue to unlock the object, at which point 'our'
-  // write to the foreign stack-location would potentially over-write random
-  // information on that stack. Writing to a monitor is less problematic,
-  // but still not safe: while the ObjectMonitor would not randomly disappear,
-  // the other thread would also write to the same displaced header location,
-  // possibly leading to increase the age twice.
-  // For all these reasons, we take the conservative approach and not attempt
-  // to increase the age when the header is displaced.
+  // is thread-local and therefore safe to access.
   markWord w = obj->mark();
   // It is possible that we have copied the object after another thread has
   // already successfully completed evacuation. While harmless (we would never
   // publish our copy), don't even attempt to modify the age when that
   // happens.
-  if (!w.has_displaced_mark_helper() && !w.is_marked()) {
+  if (!w.is_marked()) {
     w = w.set_age(MIN2(markWord::max_age, w.age() + additional_age));
     obj->set_mark(w);
   }
 }
 
-// Return the object's age, or a sentinel value when the age can't
-// necessarily be determined because of concurrent locking by the
-// mutator
 uint ShenandoahHeap::get_object_age(oop obj) {
   markWord w = obj->mark();
   assert(!w.is_marked(), "must not be forwarded");

--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -23,9 +23,6 @@
  */
 
 #include "oops/markWord.hpp"
-#include "runtime/basicLock.inline.hpp"
-#include "runtime/javaThread.hpp"
-#include "runtime/objectMonitor.inline.hpp"
 #include "utilities/ostream.hpp"
 
 #ifdef _LP64
@@ -34,29 +31,13 @@ STATIC_ASSERT(markWord::klass_shift + markWord::klass_bits == 64);
 STATIC_ASSERT(markWord::klass_shift == markWord::hash_bits + markWord::hash_shift);
 #endif
 
-markWord markWord::displaced_mark_helper() const {
-  assert(has_displaced_mark_helper(), "check");
-  // Make sure we have an inflated monitor.
-  guarantee(has_monitor(), "bad header=" INTPTR_FORMAT, value());
-  ObjectMonitor* monitor = this->monitor();
-  return monitor->header();
-}
-
-void markWord::set_displaced_mark_helper(markWord m) const {
-  assert(has_displaced_mark_helper(), "check");
-  // Make sure we have an inflated monitor.
-  guarantee(has_monitor(), "bad header=" INTPTR_FORMAT, value());
-  ObjectMonitor* monitor = this->monitor();
-  monitor->set_header(m);
-}
-
-void markWord::print_on(outputStream* st, bool print_monitor_info) const {
+void markWord::print_on(outputStream* st) const {
   if (is_marked()) {  // last bits = 11
     st->print(" marked(" INTPTR_FORMAT ")", value());
   } else if (has_monitor()) {  // last bits = 10
     // have to check has_monitor() before is_locked()
     // Valhalla: inline types/arrays can't be monitored
-    st->print(" monitor(" INTPTR_FORMAT ")=", value());
+    st->print(" monitor(" INTPTR_FORMAT ")", value());
   } else if (is_locked()) {  // last bits != 01 => 00
     // thin locked
     // Valhalla: inline types can not possess an object monitor

--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -32,43 +32,38 @@ STATIC_ASSERT(markWord::klass_shift == markWord::hash_bits + markWord::hash_shif
 #endif
 
 void markWord::print_on(outputStream* st) const {
-  if (is_marked()) {  // last bits = 11
+  if (is_marked()) {           // last bits = 11
     st->print(" marked(" INTPTR_FORMAT ")", value());
-  } else if (has_monitor()) {  // last bits = 10
-    // have to check has_monitor() before is_locked()
-    // Valhalla: inline types/arrays can't be monitored
-    st->print(" monitor(" INTPTR_FORMAT ")", value());
-  } else if (is_locked()) {  // last bits != 01 => 00
-    // thin locked
-    // Valhalla: inline types can not possess an object monitor
-    st->print(" locked(" INTPTR_FORMAT ")", value());
-  } else {
-    st->print(" mark(");
-    if (is_unlocked()) {   // last bits = 01
-      st->print("is_unlocked");
-      if (is_inline_type()) {
-        st->print(" inline_type");
-      }
-      if (has_no_hash()) {
-        st->print(" no_hash");
-      } else {
-        st->print(" hash=" INTPTR_FORMAT, hash());
-      }
-#ifdef _LP64 // 64 bit encodings have array information
-      // flat or null-free do not imply each other
-      bool flat = is_flat_array();
-      bool null_free = is_null_free_array();
-      if (flat && !null_free) {
-        st->print(" flat_array");
-      } else if (!flat && null_free) {
-        st->print(" null_free_array");
-      } else if (flat && null_free) {
-        st->print(" flat_null_free_array");
-      }
-#endif
-    } else {
-      st->print("??");
-    }
-    st->print(" age=%d)", age());
+    return;
   }
+  st->print(" mark(");
+  if (has_monitor()) {         // last bits = 10
+    st->print("has_monitor");
+  } else if (is_unlocked()) {  // last bits = 01
+    st->print("is_unlocked");
+  } else {                     // last bits = 00
+    assert(is_fast_locked(), "should be");
+    st->print("is_locked");
+  }
+  if (is_inline_type()) {
+    st->print(" inline_type");
+  }
+  if (has_no_hash()) {
+    st->print(" no_hash");
+  } else {
+    st->print(" hash=" INTPTR_FORMAT, hash());
+  }
+#ifdef _LP64 // 64 bit encodings have array information
+  // flat or null-free do not imply each other
+  const bool flat = is_flat_array();
+  const bool null_free = is_null_free_array();
+  if (flat && !null_free) {
+    st->print(" flat_array");
+  } else if (!flat && null_free) {
+    st->print(" null_free_array");
+  } else if (flat && null_free) {
+    st->print(" flat_null_free_array");
+  }
+#endif
+  st->print(" age=%d)", age());
 }

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -82,7 +82,6 @@
 //
 //  - klass - klass identifier used when UseCompactObjectHeaders == true
 
-class ObjectMonitor;
 class outputStream;
 
 class markWord {
@@ -253,27 +252,6 @@ class markWord {
   markWord set_has_monitor() const {
     return markWord((value() & ~lock_mask_in_place) | monitor_value);
   }
-  ObjectMonitor* monitor() const {
-    // Locking with OM table does not use markWord for monitors.
-    ShouldNotCallThis();
-    return (ObjectMonitor*) nullptr;
-  }
-
-  static markWord encode(ObjectMonitor* monitor) {
-    // Locking with OM table does not use markWord for monitors.
-    ShouldNotCallThis();
-    return markWord(0);
-  }
-
-  bool has_monitor_pointer() const {
-    return false; // Locking with OM table does not use markWord for monitors.
-  }
-
-  bool has_displaced_mark_helper() const {
-    return has_monitor_pointer();
-  }
-  markWord displaced_mark_helper() const;
-  void set_displaced_mark_helper(markWord m) const;
 
   // used to encode pointers during GC
   markWord clear_lock_bits() const { return markWord(value() & ~lock_mask_in_place); }
@@ -299,7 +277,6 @@ class markWord {
   }
 
   bool is_flat_array() const {
-    assert(!has_monitor_pointer(), "Bits are not valid if replaced by a monitor pointer: " PTR_FORMAT, value());
     assert(!is_marked(), "Bits might not be valid if marked by the GC: " PTR_FORMAT, value());
 #ifdef _LP64 // 64 bit encodings only
     return (mask_bits(value(), flat_array_bit_in_place) != 0);
@@ -309,7 +286,6 @@ class markWord {
   }
 
   bool is_null_free_array() const {
-    assert(!has_monitor_pointer(), "Bits are not valid if replaced by a monitor pointer: " PTR_FORMAT, value());
     assert(!is_marked(), "Bits might not be valid if marked by the GC: " PTR_FORMAT, value());
 #ifdef _LP64 // 64 bit encodings only
     return (mask_bits(value(), null_free_array_bit_in_place) != 0);
@@ -356,7 +332,7 @@ class markWord {
   }
 
   // Debugging
-  void print_on(outputStream* st, bool print_monitor_info = true) const;
+  void print_on(outputStream* st) const;
 
   // Prepare address of oop for placement into mark
   inline static markWord encode_pointer_as_mark(void* p) { return from_pointer(p).set_marked(); }

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -320,11 +320,6 @@ class oopDesc {
   intptr_t slow_identity_hash();
   inline bool fast_no_hash_check();
 
-  // marks are forwarded to stack when object is locked
-  inline bool     has_displaced_mark() const;
-  inline markWord displaced_mark() const;
-  inline void     set_displaced_mark(markWord m);
-
   // Checks if the mark word needs to be preserved
   inline bool mark_must_be_preserved() const;
   inline bool mark_must_be_preserved(markWord m) const;

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -339,7 +339,6 @@ oop oopDesc::forwardee(markWord mark) const {
   }
 }
 
-// Note that the forwardee is not the same thing as the displaced_mark.
 // The forwardee is used when copying during scavenge and mark-sweep.
 // It does need to clear the low two locking- and GC-related bits.
 oop oopDesc::forwardee() const {
@@ -354,21 +353,13 @@ void oopDesc::unset_self_forwarded() {
 uint oopDesc::age() const {
   markWord m = mark();
   assert(!m.is_marked(), "Attempt to read age from forwarded mark");
-  if (m.has_displaced_mark_helper()) {
-    return m.displaced_mark_helper().age();
-  } else {
-    return m.age();
-  }
+  return m.age();
 }
 
 void oopDesc::incr_age() {
   markWord m = mark();
   assert(!m.is_marked(), "Attempt to increment age of forwarded mark");
-  if (m.has_displaced_mark_helper()) {
-    m.set_displaced_mark_helper(m.displaced_mark_helper().incr_age());
-  } else {
-    set_mark(m.incr_age());
-  }
+  set_mark(m.incr_age());
 }
 
 template <typename OopClosureType>
@@ -432,18 +423,6 @@ bool oopDesc::fast_no_hash_check() {
   markWord mrk = mark_acquire();
   assert(!mrk.is_marked(), "should never be marked");
   return mrk.is_unlocked() && mrk.has_no_hash();
-}
-
-bool oopDesc::has_displaced_mark() const {
-  return mark().has_displaced_mark_helper();
-}
-
-markWord oopDesc::displaced_mark() const {
-  return mark().displaced_mark_helper();
-}
-
-void oopDesc::set_displaced_mark(markWord m) {
-  mark().set_displaced_mark_helper(m);
 }
 
 bool oopDesc::mark_must_be_preserved() const {

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1545,7 +1545,7 @@ JvmtiEnvBase::get_object_monitor_usage(JavaThread* calling_thread, jobject objec
   GrowableArray<JavaThread*>* wantList = nullptr;
 
   ObjectMonitor* mon = mark.has_monitor()
-      ? ObjectSynchronizer::read_monitor(hobj(), mark)
+      ? ObjectSynchronizer::read_monitor(hobj())
       : nullptr;
 
   if (mon != nullptr) {

--- a/src/hotspot/share/runtime/basicLock.hpp
+++ b/src/hotspot/share/runtime/basicLock.hpp
@@ -31,6 +31,8 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/sizes.hpp"
 
+class ObjectMonitor;
+
 class BasicLock {
   friend class VMStructs;
  private:

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1502,7 +1502,7 @@ bool Deoptimization::relock_objects(JavaThread* thread, GrowableArray<MonitorInf
         assert(mon_info->owner()->is_locked(), "object must be locked now");
         assert(obj->mark().has_monitor(), "must be");
         assert(!deoptee_thread->lock_stack().contains(obj()), "must be");
-        assert(ObjectSynchronizer::read_monitor(obj(), obj->mark())->has_owner(deoptee_thread), "must be");
+        assert(ObjectSynchronizer::read_monitor(obj())->has_owner(deoptee_thread), "must be");
       }
     }
   }

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -235,9 +235,6 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   void                set_metadata(uintptr_t value);
   volatile uintptr_t* metadata_addr();
 
-  markWord            header() const;
-  void                set_header(markWord hdr);
-
   intptr_t            hash() const;
   void                set_hash(intptr_t hash);
 

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -217,20 +217,6 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   static ByteSize succ_offset()        { return byte_offset_of(ObjectMonitor, _succ); }
   static ByteSize entry_list_offset()  { return byte_offset_of(ObjectMonitor, _entry_list); }
 
-  // ObjectMonitor references can be ORed with markWord::monitor_value
-  // as part of the ObjectMonitor tagging mechanism. When we combine an
-  // ObjectMonitor reference with an offset, we need to remove the tag
-  // value in order to generate the proper address.
-  //
-  // We can either adjust the ObjectMonitor reference and then add the
-  // offset or we can adjust the offset that is added to the ObjectMonitor
-  // reference. The latter avoids an AGI (Address Generation Interlock)
-  // stall so the helper macro adjusts the offset value that is returned
-  // to the ObjectMonitor reference manipulation code:
-  //
-  #define OM_OFFSET_NO_MONITOR_VALUE_TAG(f) \
-    ((in_bytes(ObjectMonitor::f ## _offset())) - checked_cast<int>(markWord::monitor_value))
-
   uintptr_t           metadata() const;
   void                set_metadata(uintptr_t value);
   volatile uintptr_t* metadata_addr();

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -74,18 +74,6 @@ inline volatile uintptr_t* ObjectMonitor::metadata_addr() {
   return &_metadata;
 }
 
-inline markWord ObjectMonitor::header() const {
-  // Locking with OM table does not use header.
-  ShouldNotCallThis();
-  return markWord(metadata());
-}
-
-inline void ObjectMonitor::set_header(markWord hdr) {
-  // Locking with OM table does not use header.
-  ShouldNotCallThis();
-  set_metadata(hdr.value());
-}
-
 inline intptr_t ObjectMonitor::hash() const {
   return metadata();
 }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -373,7 +373,7 @@ bool ObjectSynchronizer::quick_notify(oopDesc* obj, JavaThread* current, bool al
   }
 
   if (mark.has_monitor()) {
-    ObjectMonitor* const mon = read_monitor(obj, mark);
+    ObjectMonitor* const mon = read_monitor(obj);
     if (mon == nullptr) {
       // Racing with inflation/deflation go slow path
       return false;
@@ -715,7 +715,7 @@ bool ObjectSynchronizer::current_thread_holds_lock(JavaThread* current,
   }
 
   while (mark.has_monitor()) {
-    ObjectMonitor* monitor = read_monitor(obj, mark);
+    ObjectMonitor* monitor = read_monitor(obj);
     if (monitor != nullptr) {
       return monitor->is_entered(current) != 0;
     }
@@ -744,7 +744,7 @@ JavaThread* ObjectSynchronizer::get_lock_owner(ThreadsList * t_list, Handle h_ob
   }
 
   while (mark.has_monitor()) {
-    ObjectMonitor* monitor = read_monitor(obj, mark);
+    ObjectMonitor* monitor = read_monitor(obj);
     if (monitor != nullptr) {
       return Threads::owning_thread_from_monitor(t_list, monitor);
     }
@@ -1377,7 +1377,7 @@ void ObjectSynchronizer::chk_in_use_entry(ObjectMonitor* n, outputStream* out,
   }
 
   const markWord mark = obj->mark();
-  ObjectMonitor* const obj_mon = read_monitor(obj, mark);
+  ObjectMonitor* const obj_mon = read_monitor(obj);
   if (n != obj_mon) {
     out->print_cr("ERROR: monitor=" INTPTR_FORMAT ": in-use monitor's "
                   "object does not refer to the same monitor: obj="
@@ -1660,7 +1660,7 @@ bool ObjectSynchronizer::fast_lock_spin_enter(oop obj, LockStack& lock_stack, Ja
       return true;
     } else if (observed_deflation) {
       // Spin while monitor is being deflated.
-      ObjectMonitor* monitor = ObjectSynchronizer::read_monitor(obj, mark);
+      ObjectMonitor* monitor = ObjectSynchronizer::read_monitor(obj);
       return monitor == nullptr || monitor->is_being_async_deflated();
     }
     // Else stop spinning.
@@ -1860,7 +1860,7 @@ ObjectMonitor* ObjectSynchronizer::inflate_locked_or_imse(oop obj, ObjectSynchro
     }
 
     assert(mark.has_monitor(), "must be");
-    ObjectMonitor* monitor = ObjectSynchronizer::read_monitor(obj, mark);
+    ObjectMonitor* monitor = ObjectSynchronizer::read_monitor(obj);
     if (monitor != nullptr) {
       if (monitor->has_anonymous_owner()) {
         LockStack& lock_stack = current->lock_stack();
@@ -2090,10 +2090,6 @@ ObjectMonitor* ObjectSynchronizer::get_monitor_from_table(oop obj) {
 }
 
 ObjectMonitor* ObjectSynchronizer::read_monitor(oop obj) {
-  return ObjectSynchronizer::read_monitor(obj, obj->mark());
-}
-
-ObjectMonitor* ObjectSynchronizer::read_monitor(oop obj, markWord mark) {
   return ObjectSynchronizer::get_monitor_from_table(obj);
 }
 

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -126,7 +126,6 @@ public:
   static const char* inflate_cause_name(const InflateCause cause);
 
   static ObjectMonitor* read_monitor(oop obj);
-  static ObjectMonitor* read_monitor(oop obj, markWord mark);
 
   // Returns the identity hash value for an oop
   // NOTE: It may cause monitor inflation

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -248,7 +248,7 @@ void javaVFrame::print_lock_info_on(outputStream* st, bool is_virtual, int frame
           // The first stage of async deflation does not affect any field
           // used by this comparison so the ObjectMonitor* is usable here.
           if (mark.has_monitor()) {
-            ObjectMonitor* mon = ObjectSynchronizer::read_monitor(monitor->owner(), mark);
+            ObjectMonitor* mon = ObjectSynchronizer::read_monitor(monitor->owner());
             if (// if the monitor is null we must be in the process of locking
                 mon == nullptr ||
                 // we have marked ourself as pending on this monitor

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -1258,7 +1258,7 @@ private:
             // The first stage of async deflation does not affect any field
             // used by this comparison so the ObjectMonitor* is usable here.
             if (mark.has_monitor()) {
-              ObjectMonitor* mon = ObjectSynchronizer::read_monitor(monitor->owner(), mark);
+              ObjectMonitor* mon = ObjectSynchronizer::read_monitor(monitor->owner());
               if (// if the monitor is null we must be in the process of locking
                   mon == nullptr ||
                   // we have marked ourself as pending on this monitor

--- a/test/hotspot/gtest/oops/test_markWord.cpp
+++ b/test/hotspot/gtest/oops/test_markWord.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,6 @@ TEST_VM(markWord, printing) {
 }
 
 static void assert_unlocked_state(markWord mark) {
-  EXPECT_FALSE(mark.has_displaced_mark_helper());
   EXPECT_FALSE(mark.is_fast_locked());
   EXPECT_FALSE(mark.has_monitor());
   EXPECT_FALSE(mark.is_locked());

--- a/test/hotspot/gtest/oops/test_markWord.cpp
+++ b/test/hotspot/gtest/oops/test_markWord.cpp
@@ -71,7 +71,7 @@ class LockerThread : public JavaTestThread {
     // state we have...
     ObjectLocker ol(h_obj, THREAD);
     ol.notify_all(THREAD);
-    assert_test_pattern(h_obj, "monitor");
+    assert_test_pattern(h_obj, "has_monitor");
   }
 };
 
@@ -91,7 +91,7 @@ TEST_VM(markWord, printing) {
   // Thread tries to lock it.
   {
     ObjectLocker ol(h_obj, THREAD);
-    assert_mark_word_print_pattern(h_obj, "locked");
+    assert_mark_word_print_pattern(h_obj, "is_locked");
   }
   assert_mark_word_print_pattern(h_obj, "is_unlocked no_hash");
 
@@ -109,7 +109,7 @@ TEST_VM(markWord, printing) {
     st->doit();
 
     ol.wait_uninterruptibly(THREAD);
-    assert_test_pattern(h_obj, "monitor");
+    assert_test_pattern(h_obj, "has_monitor");
     done.wait_with_safepoint_check(THREAD);  // wait till the thread is done.
   }
 }

--- a/test/hotspot/jtreg/runtime/Monitor/ObjectMonitorTableTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/ObjectMonitorTableTest.java
@@ -24,9 +24,9 @@
 /**
  * @test id=NormalDeflation
  * @summary A collection of small tests using synchronized, wait, notify to try
- *          and achieve good cheap coverage of UseObjectMonitorTable.
+ *          and achieve good cheap coverage of ObjectMonitorTable.
  * @library /test/lib
- * @run main/othervm UseObjectMonitorTableTest
+ * @run main/othervm ObjectMonitorTableTest
  */
 
 /**
@@ -35,7 +35,7 @@
  * @library /test/lib
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions
  *                   -XX:GuaranteedAsyncDeflationInterval=1
- *                   UseObjectMonitorTableTest
+ *                   ObjectMonitorTableTest
  */
 
 import jdk.test.lib.Utils;
@@ -48,7 +48,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.Random;
 import java.util.stream.Stream;
 
-public class UseObjectMonitorTableTest {
+public class ObjectMonitorTableTest {
     static final ThreadFactory TF = Executors.defaultThreadFactory();
 
     static class WaitNotifyTest implements Runnable {
@@ -232,10 +232,10 @@ public class UseObjectMonitorTableTest {
             try {
                 t.join();
             } catch (InterruptedException e) {
-                throw new RuntimeException("UseObjectMonitorTableTest: Unexpected interrupt", e);
+                throw new RuntimeException("ObjectMonitorTableTest: Unexpected interrupt", e);
             }
         });
 
-        System.out.println("UseObjectMonitorTableTest passed.");
+        System.out.println("ObjectMonitorTableTest passed.");
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/misc/HashedGarbageProducer.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/misc/HashedGarbageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,14 +31,6 @@ import nsk.share.gc.gp.GarbageProducer;
  */
 
 /*
-     The description is misleading.  I looked at some old email, and the
-     goal is to stress the code that deals with displaced mark words, so
-     the description should be more like "Stress tests for displaced mark
-     words."  In hotspot, each object has a mark word that stores several
-     things about the object including its hash code (if it has one) and
-     lock state.  Most objects never have a hash code and are never locked,
-     so the mark word is empty.
-
      Most of our garbage collectors use the mark word temporarily during GC
      to store a 'forwarding pointer.'  It's not important what that is, but
      it means that objects that have a hash code or that are locked have to


### PR DESCRIPTION
This PR is a follow-up to [JDK-8389325](https://bugs.openjdk.org/browse/JDK-8389325) ("Remove the UseObjectMonitorTable flag and related code"). It:
- Removes obsolete mark-word and monitor-pointer support.
- Removes displaced-mark related code in garbage collectors (G1, Parallel GC and Shenandoah).
- Renames UseObjectMonitorTableTest to ObjectMonitorTableTest.
- Addresses all the leftover review comments from [JDK-8389325](https://bugs.openjdk.org/browse/JDK-8389325).

Passes tier1-5 tests successfully on supported platforms.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389938](https://bugs.openjdk.org/browse/JDK-8389938): Follow up after removing UseObjectMonitorTable flag (**Enhancement** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) Review applies to [dba3cffb](https://git.openjdk.org/jdk/pull/32471/files/dba3cffb73f8eec4c102a2fdfa68a035923d8edb)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [dba3cffb](https://git.openjdk.org/jdk/pull/32471/files/dba3cffb73f8eec4c102a2fdfa68a035923d8edb)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32471/head:pull/32471` \
`$ git checkout pull/32471`

Update a local copy of the PR: \
`$ git checkout pull/32471` \
`$ git pull https://git.openjdk.org/jdk.git pull/32471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32471`

View PR using the GUI difftool: \
`$ git pr show -t 32471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32471.diff">https://git.openjdk.org/jdk/pull/32471.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32471#issuecomment-5369774903)
</details>
