### PR TITLE
8390807: Reduce run time of test AOTCodeFlags.java

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,9 @@
  * @comment Both C1 and C2 JIT compilers are required because the test verifies
  *          compiler's runtime blobs generation.
  * @library /test/lib /test/setup_aot
- * @build AOTCodeFlags JavacBenchApp
+ * @build AOTCodeFlags
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
- *                 JavacBenchApp
- *                 JavacBenchApp$ClassFile
- *                 JavacBenchApp$FileManager
- *                 JavacBenchApp$SourceFile
+ *                 AOTCodeFlagsTestApp
  * @run driver/timeout=1500 AOTCodeFlags
  */
 /**
@@ -48,12 +45,9 @@
  * @comment Both C1 and C2 JIT compilers are required because the test verifies
  *          compiler's runtime blobs generation.
  * @library /test/lib /test/setup_aot
- * @build AOTCodeFlags JavacBenchApp
+ * @build AOTCodeFlags
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
- *                 JavacBenchApp
- *                 JavacBenchApp$ClassFile
- *                 JavacBenchApp$FileManager
- *                 JavacBenchApp$SourceFile
+ *                 AOTCodeFlagsTestApp
  * @run driver/timeout=1500 AOTCodeFlags Z
  */
 /**
@@ -65,12 +59,9 @@
  * @comment Both C1 and C2 JIT compilers are required because the test verifies
  *          compiler's runtime blobs generation.
  * @library /test/lib /test/setup_aot
- * @build AOTCodeFlags JavacBenchApp
+ * @build AOTCodeFlags
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
- *                 JavacBenchApp
- *                 JavacBenchApp$ClassFile
- *                 JavacBenchApp$FileManager
- *                 JavacBenchApp$SourceFile
+ *                 AOTCodeFlagsTestApp
  * @run driver/timeout=1500 AOTCodeFlags Shenandoah
  */
 /**
@@ -82,12 +73,9 @@
  * @comment Both C1 and C2 JIT compilers are required because the test verifies
  *          compiler's runtime blobs generation.
  * @library /test/lib /test/setup_aot
- * @build AOTCodeFlags JavacBenchApp
+ * @build AOTCodeFlags
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
- *                 JavacBenchApp
- *                 JavacBenchApp$ClassFile
- *                 JavacBenchApp$FileManager
- *                 JavacBenchApp$SourceFile
+ *                 AOTCodeFlagsTestApp
  * @run driver/timeout=1500 AOTCodeFlags Parallel
  */
 
@@ -171,6 +159,10 @@ public class AOTCodeFlags {
             args.addAll(List.of("-Xlog:aot+codecache+init=debug",
                                 "-Xlog:aot+codecache+exit=debug",
                                 "-Xlog:aot+codecache+stubs=debug"));
+
+            // Avoid finishing and exiting app before compilations are finished.
+            args.add("-Xbatch");
+
             switch (runMode) {
             case RunMode.ASSEMBLY:
                 args.addAll(getVMArgsForTestMode(aMode));
@@ -186,7 +178,7 @@ public class AOTCodeFlags {
 
         @Override
         public String[] appCommandLine(RunMode runMode) {
-            return new String[] { "JavacBenchApp", "10" };
+            return new String[] { "AOTCodeFlagsTestApp" };
         }
 
         @Override
@@ -253,5 +245,27 @@ public class AOTCodeFlags {
                 }
             }
         }
+    }
+}
+
+// Run long enough and with enough iterations to ensure C1 and C2 compilations.
+class AOTCodeFlagsTestApp {
+    public static volatile int counter;
+
+    public static void main(String args[]) {
+        long started = System.currentTimeMillis();
+
+        while (System.currentTimeMillis() - started < 150) {
+            outer();
+        }
+    }
+    static void outer() {
+        for (int i = 0; i < 50 * 1000; i++) {
+            inner();
+        }
+    }
+
+    static void inner() {
+        counter++;
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeFlags.java
@@ -33,7 +33,7 @@
  * @library /test/lib /test/setup_aot
  * @build AOTCodeFlags
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
- *                 AOTCodeFlagsTestApp
+ *                 AOTCodeSimpleTestApp
  * @run driver/timeout=1500 AOTCodeFlags
  */
 /**
@@ -47,7 +47,7 @@
  * @library /test/lib /test/setup_aot
  * @build AOTCodeFlags
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
- *                 AOTCodeFlagsTestApp
+ *                 AOTCodeSimpleTestApp
  * @run driver/timeout=1500 AOTCodeFlags Z
  */
 /**
@@ -61,7 +61,7 @@
  * @library /test/lib /test/setup_aot
  * @build AOTCodeFlags
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
- *                 AOTCodeFlagsTestApp
+ *                 AOTCodeSimpleTestApp
  * @run driver/timeout=1500 AOTCodeFlags Shenandoah
  */
 /**
@@ -75,7 +75,7 @@
  * @library /test/lib /test/setup_aot
  * @build AOTCodeFlags
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
- *                 AOTCodeFlagsTestApp
+ *                 AOTCodeSimpleTestApp
  * @run driver/timeout=1500 AOTCodeFlags Parallel
  */
 
@@ -86,6 +86,7 @@ import jdk.test.lib.cds.CDSAppTester;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class AOTCodeFlags {
+    private static String appName = AOTCodeSimpleTestApp.class.getName();
     private static String gcName = null;
     public static void main(String... args) throws Exception {
         Tester t = new Tester(args.length == 0 ? null : args[0]);
@@ -160,7 +161,7 @@ public class AOTCodeFlags {
                                 "-Xlog:aot+codecache+exit=debug",
                                 "-Xlog:aot+codecache+stubs=debug"));
 
-            // Avoid finishing and exiting app before compilations are finished.
+            // Ensure compilations are finished before the JVM exits.
             args.add("-Xbatch");
 
             switch (runMode) {
@@ -178,7 +179,7 @@ public class AOTCodeFlags {
 
         @Override
         public String[] appCommandLine(RunMode runMode) {
-            return new String[] { "AOTCodeFlagsTestApp" };
+            return new String[] { appName };
         }
 
         @Override
@@ -245,27 +246,5 @@ public class AOTCodeFlags {
                 }
             }
         }
-    }
-}
-
-// Run long enough and with enough iterations to ensure C1 and C2 compilations.
-class AOTCodeFlagsTestApp {
-    public static volatile int counter;
-
-    public static void main(String args[]) {
-        long started = System.currentTimeMillis();
-
-        while (System.currentTimeMillis() - started < 150) {
-            outer();
-        }
-    }
-    static void outer() {
-        for (int i = 0; i < 50 * 1000; i++) {
-            inner();
-        }
-    }
-
-    static void inner() {
-        counter++;
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeSimpleTestApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCode/AOTCodeSimpleTestApp.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Run long enough and with enough iterations to ensure C1 and C2 compilations.
+// Note: run with -Xbatch to ensure compilations are finished before the JVM exits.
+public class AOTCodeSimpleTestApp {
+    public static volatile int counter;
+
+    public static void main(String args[]) {
+        long started = System.currentTimeMillis();
+
+        while (System.currentTimeMillis() - started < 150) {
+            outer();
+        }
+    }
+    static void outer() {
+        for (int i = 0; i < 50 * 1000; i++) {
+            inner();
+        }
+    }
+
+    static void inner() {
+        counter++;
+    }
+}


### PR DESCRIPTION
This test runs JavacBench 16 times so it takes long time to finish.

This PR tries to replace the test app with a smaller program, but run with `-Xbatch` and use a large enough number of iterations to ensure that C1/C2 stubs are generated.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390807](https://bugs.openjdk.org/browse/JDK-8390807): Reduce run time of test AOTCodeFlags.java (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32473/head:pull/32473` \
`$ git checkout pull/32473`

Update a local copy of the PR: \
`$ git checkout pull/32473` \
`$ git pull https://git.openjdk.org/jdk.git pull/32473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32473`

View PR using the GUI difftool: \
`$ git pr show -t 32473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32473.diff">https://git.openjdk.org/jdk/pull/32473.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32473#issuecomment-5361323211)
</details>
