### PR TITLE
8388795: Add --app-resources CLI option to copy files and directories into the application resources directory

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxPackageBuilder.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxPackageBuilder.java
@@ -134,6 +134,7 @@ final class LinuxPackageBuilder {
                         .desktopIntegrationDirectory(lib)
                         .appModsDirectory(lib.resolve("app/mods"))
                         .contentDirectory(lib)
+                        .resourcesDirectory(lib)
                         .create(),
                 lib.resolve("lib/libapplauncher.so"));
     }

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxPackagingPipeline.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxPackagingPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,6 +113,7 @@ final class LinuxPackagingPipeline {
             .desktopIntegrationDirectory("lib")
             .appModsDirectory("lib/app/mods")
             .contentDirectory("lib")
+            .resourcesDirectory("lib")
             .create();
 
     static final LinuxApplicationLayout APPLICATION_LAYOUT = LinuxApplicationLayout.create(

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPackagingPipeline.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPackagingPipeline.java
@@ -667,6 +667,7 @@ final class MacPackagingPipeline {
             .desktopIntegrationDirectory("Contents/Resources")
             .appModsDirectory("Contents/app/mods")
             .contentDirectory("Contents")
+            .resourcesDirectory("Contents/Resources")
             .create();
 
     static final MacApplicationLayout APPLICATION_LAYOUT = MacApplicationLayout.create(

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ApplicationBuilder.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ApplicationBuilder.java
@@ -65,6 +65,7 @@ final class ApplicationBuilder {
         appDirSources = other.appDirSources;
         externalApp = other.externalApp;
         contentDirSources = other.contentDirSources;
+        resourcesDirSources = other.resourcesDirSources;
         appImageLayout = other.appImageLayout;
         runtimeBuilder = other.runtimeBuilder;
         launchers = other.launchers;
@@ -96,6 +97,7 @@ final class ApplicationBuilder {
                 Optional.ofNullable(copyright).orElseGet(DEFAULTS::copyright),
                 Optional.ofNullable(appDirSources).orElseGet(List::of),
                 Optional.ofNullable(contentDirSources).orElseGet(List::of),
+                Optional.ofNullable(resourcesDirSources).orElseGet(List::of),
                 appImageLayout,
                 Optional.ofNullable(runtimeBuilder),
                 launchersAsList,
@@ -176,6 +178,11 @@ final class ApplicationBuilder {
 
     ApplicationBuilder contentDirSources(Collection<RootedPath> v) {
         contentDirSources = v;
+        return this;
+    }
+
+    ApplicationBuilder resourcesDirSources(Collection<RootedPath> v) {
+        resourcesDirSources = v;
         return this;
     }
 
@@ -339,6 +346,7 @@ final class ApplicationBuilder {
                 app.copyright(),
                 app.appDirSources(),
                 app.contentDirSources(),
+                app.resourcesDirSources(),
                 Objects.requireNonNull(appImageLayout),
                 app.runtimeBuilder(),
                 app.launchers(),
@@ -388,6 +396,7 @@ final class ApplicationBuilder {
     private Collection<RootedPath> appDirSources;
     private ExternalApplication externalApp;
     private Collection<RootedPath> contentDirSources;
+    private Collection<RootedPath> resourcesDirSources;
     private AppImageLayout appImageLayout;
     private RuntimeBuilder runtimeBuilder;
     private ApplicationLaunchers launchers;

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ApplicationImageUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ApplicationImageUtils.java
@@ -85,8 +85,8 @@ final class ApplicationImageUtils {
         return env -> {
             for (var e : List.of(
                     Map.entry(env.app().appDirSources(), env.resolvedLayout().appDirectory()),
-                    Map.entry(env.app().contentDirSources(), env.resolvedLayout().contentDirectory()),
-                    Map.entry(env.app().resourcesDirSources(), env.resolvedLayout().resourcesDirectory())
+                    Map.entry(env.app().resourcesDirSources(), env.resolvedLayout().resourcesDirectory()),
+                    Map.entry(env.app().contentDirSources(), env.resolvedLayout().contentDirectory())
             )) {
                 RootedPath.copy(e.getKey().stream(), e.getValue(),
                         StandardCopyOption.REPLACE_EXISTING, LinkOption.NOFOLLOW_LINKS);

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ApplicationImageUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ApplicationImageUtils.java
@@ -85,7 +85,8 @@ final class ApplicationImageUtils {
         return env -> {
             for (var e : List.of(
                     Map.entry(env.app().appDirSources(), env.resolvedLayout().appDirectory()),
-                    Map.entry(env.app().contentDirSources(), env.resolvedLayout().contentDirectory())
+                    Map.entry(env.app().contentDirSources(), env.resolvedLayout().contentDirectory()),
+                    Map.entry(env.app().resourcesDirSources(), env.resolvedLayout().resourcesDirectory())
             )) {
                 RootedPath.copy(e.getKey().stream(), e.getValue(),
                         StandardCopyOption.REPLACE_EXISTING, LinkOption.NOFOLLOW_LINKS);

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/FromOptions.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/FromOptions.java
@@ -31,6 +31,7 @@ import static jdk.jpackage.internal.cli.StandardOption.ABOUT_URL;
 import static jdk.jpackage.internal.cli.StandardOption.ADDITIONAL_LAUNCHERS;
 import static jdk.jpackage.internal.cli.StandardOption.ADD_MODULES;
 import static jdk.jpackage.internal.cli.StandardOption.APP_CONTENT;
+import static jdk.jpackage.internal.cli.StandardOption.APP_RESOURCES;
 import static jdk.jpackage.internal.cli.StandardOption.APP_VERSION;
 import static jdk.jpackage.internal.cli.StandardOption.COPYRIGHT;
 import static jdk.jpackage.internal.cli.StandardOption.DESCRIPTION;
@@ -187,6 +188,10 @@ final class FromOptions {
             // from the original list of source files for the given destination file.
             return v.reversed().stream().flatMap(Collection::stream).toList();
         }).ifPresent(appBuilder::contentDirSources);
+        APP_RESOURCES.findIn(options).map((List<Collection<RootedPath>> v) -> {
+            return v.reversed().stream().flatMap(Collection::stream).toList();
+        }).ifPresent(appBuilder::resourcesDirSources);
+
 
         if (isRuntimeInstaller) {
             appBuilder.appImageLayout(runtimeLayout);

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardHelpFormatter.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardHelpFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,7 +207,8 @@ final class StandardHelpFormatter {
         private static Stream<? extends OptionSpec<?>> appImageOptions() {
             return Stream.of(
                     StandardOption.INPUT,
-                    StandardOption.APP_CONTENT
+                    StandardOption.APP_CONTENT,
+                    StandardOption.APP_RESOURCES
             ).map(OptionValue::getSpec);
         }
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardOption.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardOption.java
@@ -222,6 +222,18 @@ public final class StandardOption {
             }))
             .createArray(toExplodedPathList());
 
+    public static final OptionValue<List<Collection<RootedPath>>> APP_RESOURCES = existingPathOption("app-resources")
+            .tokenizer(pathSeparator())
+            .valuePattern("additional resources")
+            .outOfScope(NOT_BUILDING_APP_IMAGE)
+            .map(explodedPathOptionMapper(explodedPathConverter().withPathFileName().create()))
+            .mutate(createOptionSpecBuilderMutator((b, context) -> {
+                if (context.os() == OperatingSystem.WINDOWS) {
+                    b.description("help.option.app-resources" + resourceKeySuffix(context.os()));
+                }
+            }))
+            .createArray(toExplodedPathList());
+
     static final OptionValue<Path[]> FILE_ASSOCIATIONS_INTERNAL = fileOption("file-associations")
             .tokenizer(pathSeparator())
             .outOfScope(BundlingOperationModifier.BUNDLE_RUNTIME)

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardOption.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardOption.java
@@ -228,9 +228,7 @@ public final class StandardOption {
             .outOfScope(NOT_BUILDING_APP_IMAGE)
             .map(explodedPathOptionMapper(explodedPathConverter().withPathFileName().create()))
             .mutate(createOptionSpecBuilderMutator((b, context) -> {
-                if (context.os() == OperatingSystem.WINDOWS) {
-                    b.description("help.option.app-resources" + resourceKeySuffix(context.os()));
-                }
+                b.description("help.option.app-resources" + resourceKeySuffix(context.os()));
             }))
             .createArray(toExplodedPathList());
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardOption.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/cli/StandardOption.java
@@ -225,6 +225,7 @@ public final class StandardOption {
     public static final OptionValue<List<Collection<RootedPath>>> APP_RESOURCES = existingPathOption("app-resources")
             .tokenizer(pathSeparator())
             .valuePattern("additional resources")
+            .description("help.option.app-resources" + resourceKeySuffix(OperatingSystem.current()))
             .outOfScope(NOT_BUILDING_APP_IMAGE)
             .map(explodedPathOptionMapper(explodedPathConverter().withPathFileName().create()))
             .mutate(createOptionSpecBuilderMutator((b, context) -> {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/Application.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/Application.java
@@ -101,6 +101,15 @@ public non-sealed interface Application extends BundleSpec {
     Collection<RootedPath> contentDirSources();
 
     /**
+     * Gets the source paths that should be copied into
+     * {@link ApplicationLayout#resourcesDirectory()} directory of the image of this
+     * application.
+     *
+     * @return the source paths
+     */
+    Collection<RootedPath> resourcesDirSources();
+
+    /**
      * Gets the unresolved app image layout of this application.
      *
      * @return the unresolved app image layout of this application
@@ -252,6 +261,7 @@ public non-sealed interface Application extends BundleSpec {
             String copyright,
             Collection<RootedPath> appDirSources,
             Collection<RootedPath> contentDirSources,
+            Collection<RootedPath> resourcesDirSources,
             AppImageLayout imageLayout,
             Optional<RuntimeBuilder> runtimeBuilder,
             List<Launcher> launchers,

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/ApplicationLayout.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/ApplicationLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,6 +100,7 @@ public interface ApplicationLayout extends AppImageLayout, ApplicationLayoutMixi
             appModsDirectory = appLayout.appModsDirectory();
             desktopIntegrationDirectory = appLayout.desktopIntegrationDirectory();
             contentDirectory = appLayout.contentDirectory();
+            resourcesDirectory = appLayout.resourcesDirectory();
         }
 
         public ApplicationLayout create() {
@@ -111,11 +112,13 @@ public interface ApplicationLayout extends AppImageLayout, ApplicationLayoutMixi
             Objects.requireNonNull(appModsDirectory);
             Objects.requireNonNull(desktopIntegrationDirectory);
             Objects.requireNonNull(contentDirectory);
+            Objects.requireNonNull(resourcesDirectory);
 
             return ApplicationLayout.create(new AppImageLayout.Stub(
                     rootDirectory, runtimeDirectory), new ApplicationLayoutMixin.Stub(
                     launchersDirectory, appDirectory, appModsDirectory,
-                    desktopIntegrationDirectory, contentDirectory));
+                    desktopIntegrationDirectory, contentDirectory,
+                    resourcesDirectory));
         }
 
         public Builder setAll(String path) {
@@ -130,6 +133,7 @@ public interface ApplicationLayout extends AppImageLayout, ApplicationLayoutMixi
             appModsDirectory(path);
             desktopIntegrationDirectory(path);
             contentDirectory(path);
+            resourcesDirectory(path);
             return this;
         }
 
@@ -141,6 +145,7 @@ public interface ApplicationLayout extends AppImageLayout, ApplicationLayoutMixi
             appModsDirectory(mapNullablePath(mapper, appModsDirectory));
             desktopIntegrationDirectory(mapNullablePath(mapper, desktopIntegrationDirectory));
             contentDirectory(mapNullablePath(mapper, contentDirectory));
+            resourcesDirectory(mapNullablePath(mapper, resourcesDirectory));
             return this;
         }
 
@@ -207,6 +212,15 @@ public interface ApplicationLayout extends AppImageLayout, ApplicationLayoutMixi
             return this;
         }
 
+        public Builder resourcesDirectory(String v) {
+            return resourcesDirectory(Path.of(v));
+        }
+
+        public Builder resourcesDirectory(Path v) {
+            resourcesDirectory = v;
+            return this;
+        }
+
         private Path rootDirectory = Path.of("");
         private Path launchersDirectory;
         private Path appDirectory;
@@ -214,5 +228,6 @@ public interface ApplicationLayout extends AppImageLayout, ApplicationLayoutMixi
         private Path appModsDirectory;
         private Path desktopIntegrationDirectory;
         private Path contentDirectory;
+        private Path resourcesDirectory;
     }
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/ApplicationLayoutMixin.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/model/ApplicationLayoutMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,8 +57,13 @@ public interface ApplicationLayoutMixin {
     Path contentDirectory();
 
     /**
+     * Path to directory with additional application resources.
+     */
+    Path resourcesDirectory();
+
+    /**
      * Default implementation of {@link ApplicationLayoutMixin} interface.
      */
-    record Stub(Path launchersDirectory, Path appDirectory, Path appModsDirectory, Path desktopIntegrationDirectory, Path contentDirectory) implements ApplicationLayoutMixin {
+    record Stub(Path launchersDirectory, Path appDirectory, Path appModsDirectory, Path desktopIntegrationDirectory, Path contentDirectory, Path resourcesDirectory) implements ApplicationLayoutMixin {
     }
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
@@ -134,14 +134,14 @@ help.option.add-modules=\
 help.option.app-content=\
 \          A comma separated list of paths to files and/or directories\n\
 \          to add to the application payload.\n\
-\          --app-content is processed before --app-resources, independent\n\
+\          --app-content is processed after --app-resources, independent\n\
 \          of command-line order.\n\
 \          This option can be used more than once.
 
 help.option.app-content.mac=\
 \          A comma separated list of paths to files and/or directories\n\
 \          to add to the application payload.\n\
-\          --app-content is processed before --app-resources, independent\n\
+\          --app-content is processed after --app-resources, independent\n\
 \          of command-line order.\n\
 \          This option can be used more than once.\n\
 \          Note: The value should be a directory with the "Resources"\n\
@@ -151,31 +151,25 @@ help.option.app-content.mac=\
 \          notarization.
 
 help.option.app-resources.linux=\
-\          A colon (":") list of paths to files and/or directories\n\
-\          to add to the application resources directory.\n\
-\          A colliding file from --app-resources replaces\n\
-\          one from --app-content.\n\
-\          This option can be used more than once.\n\
-\          Destination:\n\
-\              Linux: application image lib directory
+\          A colon-separated list of paths to files and/or directories\n\
+\          to add to the application's "lib" directory.\n\
+\          If a file from --app-resources conflicts with one from\n\
+\          --app-content, the file from --app-content is used.\n\
+\          This option can be used more than once.
 
 help.option.app-resources.mac=\
-\          A colon (":") list of paths to files and/or directories\n\
-\          to add to the application resources directory.\n\
-\          A colliding file from --app-resources replaces\n\
-\          one from --app-content.\n\
-\          This option can be used more than once.\n\
-\          Destination:\n\
-\              macOS: Contents/Resources
+\          A colon-separated list of paths to files and/or directories\n\
+\          to add to the application's "Contents/Resources" directory.\n\
+\          If a file from --app-resources conflicts with one from\n\
+\          --app-content, the file from --app-content is used.\n\
+\          This option can be used more than once.
 
 help.option.app-resources.win=\
-\          A semicolon (";") list of paths to files and/or directories\n\
-\          to add to the application resources directory.\n\
-\          A colliding file from --app-resources replaces\n\
-\          one from --app-content.\n\
-\          This option can be used more than once.\n\
-\          Destination:\n\
-\              Windows: application image root
+\          A semicolon-separated list of paths to files and/or directories\n\
+\          to add to the application image root directory.\n\
+\          If a file from --app-resources conflicts with one from\n\
+\          --app-content, the file from --app-content is used.\n\
+\          This option can be used more than once.
 
 help.option.app-image=\
 \          Location of the predefined application image that is used\n\

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
@@ -134,17 +134,43 @@ help.option.add-modules=\
 help.option.app-content=\
 \          A comma separated list of paths to files and/or directories\n\
 \          to add to the application payload.\n\
+\          --app-content is processed before --app-resources, independent\n\
+\          of command-line order.\n\
 \          This option can be used more than once.
 
 help.option.app-content.mac=\
 \          A comma separated list of paths to files and/or directories\n\
 \          to add to the application payload.\n\
+\          --app-content is processed before --app-resources, independent\n\
+\          of command-line order.\n\
 \          This option can be used more than once.\n\
 \          Note: The value should be a directory with the "Resources"\n\
 \          subdirectory (or any other directory that is valid in the "Contents"\n\
 \          directory of the application bundle). Otherwise, jpackage may produce\n\
 \          invalid application bundle which may fail code signing and/or\n\
 \          notarization.
+
+help.option.app-resources=\
+\          A colon (":") list of paths to files and/or directories\n\
+\          to add to the application resources directory.\n\
+\          A colliding file from --app-resources replaces\n\
+\          one from --app-content.\n\
+\          This option can be used more than once.\n\
+\          Destination:\n\
+\              Windows: application image root\n\
+\              Linux: application image lib directory\n\
+\              macOS: Contents/Resources
+
+help.option.app-resources.win=\
+\          A semicolon (";") list of paths to files and/or directories\n\
+\          to add to the application resources directory.\n\
+\          A colliding file from --app-resources replaces\n\
+\          one from --app-content.\n\
+\          This option can be used more than once.\n\
+\          Destination:\n\
+\              Windows: application image root\n\
+\              Linux: application image lib directory\n\
+\              macOS: Contents/Resources
 
 help.option.app-image=\
 \          Location of the predefined application image that is used\n\

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/HelpResources.properties
@@ -150,15 +150,22 @@ help.option.app-content.mac=\
 \          invalid application bundle which may fail code signing and/or\n\
 \          notarization.
 
-help.option.app-resources=\
+help.option.app-resources.linux=\
 \          A colon (":") list of paths to files and/or directories\n\
 \          to add to the application resources directory.\n\
 \          A colliding file from --app-resources replaces\n\
 \          one from --app-content.\n\
 \          This option can be used more than once.\n\
 \          Destination:\n\
-\              Windows: application image root\n\
-\              Linux: application image lib directory\n\
+\              Linux: application image lib directory
+
+help.option.app-resources.mac=\
+\          A colon (":") list of paths to files and/or directories\n\
+\          to add to the application resources directory.\n\
+\          A colliding file from --app-resources replaces\n\
+\          one from --app-content.\n\
+\          This option can be used more than once.\n\
+\          Destination:\n\
 \              macOS: Contents/Resources
 
 help.option.app-resources.win=\
@@ -168,9 +175,7 @@ help.option.app-resources.win=\
 \          one from --app-content.\n\
 \          This option can be used more than once.\n\
 \          Destination:\n\
-\              Windows: application image root\n\
-\              Linux: application image lib directory\n\
-\              macOS: Contents/Resources
+\              Windows: application image root
 
 help.option.app-image=\
 \          Location of the predefined application image that is used\n\

--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -255,7 +255,7 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
 :   A comma separated list of paths to files and/or directories
     to add to the application payload.
 
-    --app-content is processed before --app-resources, independent
+    --app-content is processed after --app-resources, independent
     of command-line order.
 
     This option can be used more than once.
@@ -272,8 +272,8 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
     platform-specific path separator (`:` on Linux and macOS; `;` on Windows),
     to add to the application resources directory.
 
-    A colliding file from --app-resources replaces
-    one from --app-content.
+    A colliding file from --app-content replaces
+    one from --app-resources.
 
     This option can be used more than once.
 

--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -255,6 +255,9 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
 :   A comma separated list of paths to files and/or directories
     to add to the application payload.
 
+    --app-content is processed before --app-resources, independent
+    of command-line order.
+
     This option can be used more than once.
 
     macOS note: The value should be a directory with the "Resources"
@@ -262,6 +265,22 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
                 "Contents" directory of the application bundle). Otherwise,
                 jpackage may produce invalid application bundle which may fail
                 code signing and/or notarization.
+
+<a id="option-app-resources">`--app-resources` *additional-resources*</a>
+
+:   A list of paths to files and/or directories separated by the
+    platform-specific path separator (`:` on Linux and macOS; `;` on Windows),
+    to add to the application resources directory.
+
+    A colliding file from --app-resources replaces
+    one from --app-content.
+
+    This option can be used more than once.
+
+    Destination:
+        Windows: application image root
+        Linux: application image lib directory
+        macOS: Contents/Resources
 
 ### Options for creating the application launcher(s):
 

--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -278,9 +278,12 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
     This option can be used more than once.
 
     Destination:
-        Windows: application image root
-        Linux: application image lib directory
-        macOS: Contents/Resources
+
+    -   Windows: application image root
+
+    -   Linux: application image lib directory
+
+    -   macOS: Contents/Resources
 
 ### Options for creating the application launcher(s):
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/ApplicationLayout.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/ApplicationLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,8 @@ import java.util.Optional;
 
 public record ApplicationLayout(Path launchersDirectory, Path appDirectory,
         Path runtimeDirectory, Path runtimeHomeDirectory, Path appModsDirectory,
-        Path desktopIntegrationDirectory, Path contentDirectory, Path libapplauncher) {
+        Path desktopIntegrationDirectory, Path contentDirectory, Path resourcesDirectory,
+        Path libapplauncher) {
 
     public ApplicationLayout resolveAt(Path root) {
         return new ApplicationLayout(
@@ -40,6 +41,7 @@ public record ApplicationLayout(Path launchersDirectory, Path appDirectory,
                 resolve(root, appModsDirectory),
                 resolve(root, desktopIntegrationDirectory),
                 resolve(root, contentDirectory),
+                resolve(root, resourcesDirectory),
                 resolve(root, libapplauncher));
     }
 
@@ -50,6 +52,7 @@ public record ApplicationLayout(Path launchersDirectory, Path appDirectory,
                 Path.of("lib/runtime"),
                 Path.of("lib/runtime"),
                 Path.of("lib/app/mods"),
+                Path.of("lib"),
                 Path.of("lib"),
                 Path.of("lib"),
                 Path.of("lib/libapplauncher.so")
@@ -65,6 +68,7 @@ public record ApplicationLayout(Path launchersDirectory, Path appDirectory,
                 Path.of("app/mods"),
                 Path.of(""),
                 Path.of(""),
+                Path.of(""),
                 null
         );
     }
@@ -78,6 +82,7 @@ public record ApplicationLayout(Path launchersDirectory, Path appDirectory,
                 Path.of("Contents/app/mods"),
                 Path.of("Contents/Resources"),
                 Path.of("Contents"),
+                Path.of("Contents/Resources"),
                 null
         );
     }
@@ -113,6 +118,7 @@ public record ApplicationLayout(Path launchersDirectory, Path appDirectory,
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }
@@ -126,6 +132,7 @@ public record ApplicationLayout(Path launchersDirectory, Path appDirectory,
                 lib.resolve("runtime"),
                 lib.resolve("runtime"),
                 lib.resolve("app/mods"),
+                lib,
                 lib,
                 lib,
                 lib.resolve("lib/libapplauncher.so")

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -1508,6 +1508,7 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
             return !(TKit.isOSX() && MacHelper.signPredefinedAppImage(cmd));
         }).create()),
         APP_CONTENT(new Builder("--app-content").multiple().create()),
+        APP_RESOURCES(new Builder("--app-resources").multiple().create()),
         RESOURCE_DIR(new Builder("--resource-dir").create()),
         MAC_DMG_CONTENT(new Builder("--mac-dmg-content").multiple().create()),
         RUNTIME_IMAGE(new Builder("--runtime-image").create());

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
@@ -226,7 +226,7 @@ public final class MacSignVerify {
             }).reduce(Consumer::andThen).orElseThrow().accept(result.getOutput().iterator());
         } else if (!sudo && result.getOutput().stream().findFirst().filter(str -> {
             // By some reason /usr/bin/codesign command fails for some installed bundles.
-            // It is known to fail for some AppContentTest test cases and all FileAssociationsTest test cases.
+            // It is known to fail for some AppContentAndResourcesTest test cases and all FileAssociationsTest test cases.
             // Rerunning the command with "sudo" works, though.
             return str.equals(String.format("%s: Permission denied", path));
         }).isPresent()) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSignVerify.java
@@ -226,7 +226,7 @@ public final class MacSignVerify {
             }).reduce(Consumer::andThen).orElseThrow().accept(result.getOutput().iterator());
         } else if (!sudo && result.getOutput().stream().findFirst().filter(str -> {
             // By some reason /usr/bin/codesign command fails for some installed bundles.
-            // It is known to fail for some AppContentAndResourcesTest test cases and all FileAssociationsTest test cases.
+            // It is known to fail for some AppContentTest test cases and all FileAssociationsTest test cases.
             // Rerunning the command with "sudo" works, though.
             return str.equals(String.format("%s: Permission denied", path));
         }).isPresent()) {

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/AppImageFileTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/AppImageFileTest.java
@@ -230,6 +230,7 @@ public class AppImageFileTest {
                     null,
                     List.of(),
                     List.of(),
+                    List.of(),
                     null,
                     Optional.empty(),
                     new ApplicationLaunchers(

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/PackagingPipelineTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/PackagingPipelineTest.java
@@ -223,6 +223,7 @@ public class PackagingPipelineTest {
                     .runtimeDirectory("runtime")
                     .appModsDirectory("lib")
                     .contentDirectory("lib")
+                    .resourcesDirectory("lib")
                     .desktopIntegrationDirectory("lib")
                     .create();
         } else {
@@ -618,6 +619,7 @@ public class PackagingPipelineTest {
                 "copyright",
                 List.of(),
                 List.of(),
+                List.of(),
                 appImageLayout,
                 runtimeBuilder,
                 List.of(),
@@ -854,6 +856,7 @@ public class PackagingPipelineTest {
             .runtimeDirectory("runtime")
             .appModsDirectory("")
             .contentDirectory("")
+            .resourcesDirectory("")
             .desktopIntegrationDirectory("")
             .create();
 
@@ -863,6 +866,7 @@ public class PackagingPipelineTest {
             .runtimeDirectory("qqq/runtime")
             .appModsDirectory("")
             .contentDirectory("")
+            .resourcesDirectory("")
             .desktopIntegrationDirectory("")
             .create();
 

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/StandardOptionTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/StandardOptionTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.DirectoryNotEmptyException;
@@ -213,10 +214,19 @@ public class StandardOptionTest extends JUnitAdapter.TestSrcInitializer {
         assertEquals(I18N.format("ERR_InvalidInstallerType", name), ex.getMessage());
     }
 
-    @Test
-    public void test_APP_CONTENT_valid(@TempDir Path workDir) throws IOException {
+    private static Stream<Arguments> pathOptionsValid() {
+        return Stream.of(
+            Arguments.of(StandardOption.APP_CONTENT, ","),
+            Arguments.of(StandardOption.APP_RESOURCES, File.pathSeparator)
+        );
+    }
 
-        var spec = StandardOption.APP_CONTENT.getSpec();
+    @ParameterizedTest
+    @MethodSource("pathOptionsValid")
+    public void test_APP_CONTENT_OR_RESOURCES_valid(OptionValue<List<Collection<RootedPath>>> option,
+            String delimiter, @TempDir Path workDir) throws IOException {
+
+        var spec = option.getSpec();
 
         var contentDir = workDir.resolve("a");
         var emptyDir = contentDir.resolve("b/empty-dir");
@@ -228,10 +238,10 @@ public class StandardOptionTest extends JUnitAdapter.TestSrcInitializer {
 
         Object convertedValue = spec.convert(
                 spec.name(),
-                StringToken.of(Stream.of(contentDir, file).map(Path::toString).collect(joining(",")))
+                StringToken.of(Stream.of(contentDir, file).map(Path::toString).collect(joining(delimiter)))
         ).orElseThrow();
 
-        var paths = StandardOption.APP_CONTENT.getFrom(Options.of(Map.of(StandardOption.APP_CONTENT, convertedValue)));
+        var paths = option.getFrom(Options.of(Map.of(option, convertedValue)));
         var sortedPathList = paths.stream().flatMap(Collection::stream).map(RootedPath::branch).sorted().toList();
 
         var expectedPathList = Stream.of(
@@ -245,9 +255,15 @@ public class StandardOptionTest extends JUnitAdapter.TestSrcInitializer {
         assertEquals(expectedPathList, sortedPathList);
     }
 
-    @Test
-    public void test_APP_CONTENT_invalid(@TempDir Path workDir) throws IOException {
-        var spec = StandardOption.APP_CONTENT.getSpec();
+    private static Stream<OptionValue<List<Collection<RootedPath>>>> pathOptionsInvalid() {
+        return Stream.of(StandardOption.APP_CONTENT, StandardOption.APP_RESOURCES);
+    }
+
+    @ParameterizedTest
+    @MethodSource("pathOptionsInvalid")
+    public void test_APP_CONTENT_OR_RESOURCES_invalid(OptionValue<List<Collection<RootedPath>>> option,
+            @TempDir Path workDir) throws IOException {
+        var spec = option.getSpec();
 
         var token = StringToken.of(workDir.resolve("nonexistent").toString());
         var result = spec.convert(spec.name(), token);

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/StandardOptionTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/StandardOptionTest.java
@@ -72,6 +72,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.converter.SimpleArgumentConverter;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -222,9 +224,13 @@ public class StandardOptionTest extends JUnitAdapter.TestSrcInitializer {
     }
 
     @ParameterizedTest
-    @MethodSource("pathOptionsValid")
-    public void test_APP_CONTENT_OR_RESOURCES_valid(OptionValue<List<Collection<RootedPath>>> option,
-            String delimiter, @TempDir Path workDir) throws IOException {
+    @CsvSource({
+        "app-content,COMMA",
+        "app-resources,PATH_SEPARATOR",
+    })
+    public void test_AppContent_valid(
+            @ConvertWith(OptionValueConverter.class) OptionValue<List<Collection<RootedPath>>> option,
+            Delimiter delimiter, @TempDir Path workDir) throws IOException {
 
         var spec = option.getSpec();
 
@@ -238,7 +244,7 @@ public class StandardOptionTest extends JUnitAdapter.TestSrcInitializer {
 
         Object convertedValue = spec.convert(
                 spec.name(),
-                StringToken.of(Stream.of(contentDir, file).map(Path::toString).collect(joining(delimiter)))
+                StringToken.of(Stream.of(contentDir, file).map(Path::toString).collect(joining(delimiter.value)))
         ).orElseThrow();
 
         var paths = option.getFrom(Options.of(Map.of(option, convertedValue)));
@@ -255,13 +261,25 @@ public class StandardOptionTest extends JUnitAdapter.TestSrcInitializer {
         assertEquals(expectedPathList, sortedPathList);
     }
 
-    private static Stream<OptionValue<List<Collection<RootedPath>>>> pathOptionsInvalid() {
-        return Stream.of(StandardOption.APP_CONTENT, StandardOption.APP_RESOURCES);
+    enum Delimiter {
+        COMMA(","),
+        PATH_SEPARATOR(File.pathSeparator),
+        ;
+
+        Delimiter(String value) {
+            this.value = Objects.requireNonNull(value);
+        }
+
+        private final String value;
     }
 
     @ParameterizedTest
-    @MethodSource("pathOptionsInvalid")
-    public void test_APP_CONTENT_OR_RESOURCES_invalid(OptionValue<List<Collection<RootedPath>>> option,
+    @CsvSource({
+        "app-content",
+        "app-resources",
+    })
+    public void test_AppContent_invalid(
+            @ConvertWith(OptionValueConverter.class) OptionValue<?> option,
             @TempDir Path workDir) throws IOException {
         var spec = option.getSpec();
 
@@ -965,6 +983,30 @@ public class StandardOptionTest extends JUnitAdapter.TestSrcInitializer {
                 Set.copyOf(StandardBundlingOperation.CREATE_BUNDLE), "bundle",
                 Set.of(StandardBundlingOperation.values()), "all"
         );
+    }
+
+    static final class OptionValueConverter extends SimpleArgumentConverter {
+
+        @Override
+        protected Object convert(Object source, Class<?> targetType) {
+            if (!OptionValue.class.isAssignableFrom(targetType)) {
+                throw new IllegalArgumentException();
+            }
+
+            if (source == null) {
+                return null;
+            }
+
+            if (source instanceof String optionName) {
+                return Utils.getOptionsWithSpecs(StandardOption.class).filter(op -> {
+                    return op.getOption().spec().names().contains(OptionName.of(optionName));
+                }).findFirst().orElseThrow(() -> {
+                    throw new IllegalArgumentException("Failed to find standard option with the name=[" + optionName + "]");
+                });
+            } else {
+                throw new IllegalArgumentException();
+            }
+        }
     }
 
     private static final Path GOLDEN_JPACKAGE_OPTIONS_MD = TKit.TEST_SRC_ROOT.resolve(

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-linux.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-linux.txt
@@ -129,17 +129,15 @@ Options for creating the application image:
   --app-content <additional content>[,<additional content>...]
           A comma separated list of paths to files and/or directories
           to add to the application payload.
-          --app-content is processed before --app-resources, independent
+          --app-content is processed after --app-resources, independent
           of command-line order.
           This option can be used more than once.
   --app-resources <additional resources>[:<additional resources>...]
-          A colon (":") list of paths to files and/or directories
-          to add to the application resources directory.
-          A colliding file from --app-resources replaces
-          one from --app-content.
+          A colon-separated list of paths to files and/or directories
+          to add to the application's "lib" directory.
+          If a file from --app-resources conflicts with one from
+          --app-content, the file from --app-content is used.
           This option can be used more than once.
-          Destination:
-              Linux: application image lib directory
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged
           (absolute path or relative to the current directory)

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-linux.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-linux.txt
@@ -129,7 +129,19 @@ Options for creating the application image:
   --app-content <additional content>[,<additional content>...]
           A comma separated list of paths to files and/or directories
           to add to the application payload.
+          --app-content is processed before --app-resources, independent
+          of command-line order.
           This option can be used more than once.
+  --app-resources <additional resources>[:<additional resources>...]
+          A colon (":") list of paths to files and/or directories
+          to add to the application resources directory.
+          A colliding file from --app-resources replaces
+          one from --app-content.
+          This option can be used more than once.
+          Destination:
+              Windows: application image root
+              Linux: application image lib directory
+              macOS: Contents/Resources
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged
           (absolute path or relative to the current directory)

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-linux.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-linux.txt
@@ -139,9 +139,7 @@ Options for creating the application image:
           one from --app-content.
           This option can be used more than once.
           Destination:
-              Windows: application image root
               Linux: application image lib directory
-              macOS: Contents/Resources
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged
           (absolute path or relative to the current directory)

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-macos.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-macos.txt
@@ -150,8 +150,6 @@ Options for creating the application image:
           one from --app-content.
           This option can be used more than once.
           Destination:
-              Windows: application image root
-              Linux: application image lib directory
               macOS: Contents/Resources
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-macos.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-macos.txt
@@ -135,12 +135,24 @@ Options for creating the application image:
   --app-content <additional content>[,<additional content>...]
           A comma separated list of paths to files and/or directories
           to add to the application payload.
+          --app-content is processed before --app-resources, independent
+          of command-line order.
           This option can be used more than once.
           Note: The value should be a directory with the "Resources"
           subdirectory (or any other directory that is valid in the "Contents"
           directory of the application bundle). Otherwise, jpackage may produce
           invalid application bundle which may fail code signing and/or
           notarization.
+  --app-resources <additional resources>[:<additional resources>...]
+          A colon (":") list of paths to files and/or directories
+          to add to the application resources directory.
+          A colliding file from --app-resources replaces
+          one from --app-content.
+          This option can be used more than once.
+          Destination:
+              Windows: application image root
+              Linux: application image lib directory
+              macOS: Contents/Resources
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged
           (absolute path or relative to the current directory)

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-macos.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-macos.txt
@@ -135,7 +135,7 @@ Options for creating the application image:
   --app-content <additional content>[,<additional content>...]
           A comma separated list of paths to files and/or directories
           to add to the application payload.
-          --app-content is processed before --app-resources, independent
+          --app-content is processed after --app-resources, independent
           of command-line order.
           This option can be used more than once.
           Note: The value should be a directory with the "Resources"
@@ -144,13 +144,11 @@ Options for creating the application image:
           invalid application bundle which may fail code signing and/or
           notarization.
   --app-resources <additional resources>[:<additional resources>...]
-          A colon (":") list of paths to files and/or directories
-          to add to the application resources directory.
-          A colliding file from --app-resources replaces
-          one from --app-content.
+          A colon-separated list of paths to files and/or directories
+          to add to the application's "Contents/Resources" directory.
+          If a file from --app-resources conflicts with one from
+          --app-content, the file from --app-content is used.
           This option can be used more than once.
-          Destination:
-              macOS: Contents/Resources
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged
           (absolute path or relative to the current directory)

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-windows.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-windows.txt
@@ -129,17 +129,15 @@ Options for creating the application image:
   --app-content <additional content>[,<additional content>...]
           A comma separated list of paths to files and/or directories
           to add to the application payload.
-          --app-content is processed before --app-resources, independent
+          --app-content is processed after --app-resources, independent
           of command-line order.
           This option can be used more than once.
   --app-resources <additional resources>[;<additional resources>...]
-          A semicolon (";") list of paths to files and/or directories
-          to add to the application resources directory.
-          A colliding file from --app-resources replaces
-          one from --app-content.
+          A semicolon-separated list of paths to files and/or directories
+          to add to the application image root directory.
+          If a file from --app-resources conflicts with one from
+          --app-content, the file from --app-content is used.
           This option can be used more than once.
-          Destination:
-              Windows: application image root
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged
           (absolute path or relative to the current directory)

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-windows.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-windows.txt
@@ -140,8 +140,6 @@ Options for creating the application image:
           This option can be used more than once.
           Destination:
               Windows: application image root
-              Linux: application image lib directory
-              macOS: Contents/Resources
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged
           (absolute path or relative to the current directory)

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-windows.txt
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/help-windows.txt
@@ -129,7 +129,19 @@ Options for creating the application image:
   --app-content <additional content>[,<additional content>...]
           A comma separated list of paths to files and/or directories
           to add to the application payload.
+          --app-content is processed before --app-resources, independent
+          of command-line order.
           This option can be used more than once.
+  --app-resources <additional resources>[;<additional resources>...]
+          A semicolon (";") list of paths to files and/or directories
+          to add to the application resources directory.
+          A colliding file from --app-resources replaces
+          one from --app-content.
+          This option can be used more than once.
+          Destination:
+              Windows: application image root
+              Linux: application image lib directory
+              macOS: Contents/Resources
   --input -i <directory path>
           Path of the input directory that contains the files to be packaged
           (absolute path or relative to the current directory)

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/jpackage-options.md
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/cli/jpackage-options.md
@@ -5,6 +5,7 @@
 | --add-modules | bundle |  |  |  | CONCATENATE |
 | --app-content | bundle |  |  |  | CONCATENATE |
 | --app-image | mac-sign, native-bundle |  | x |  | USE_LAST |
+| --app-resources | bundle |  |  |  | CONCATENATE |
 | --app-version | bundle | x | x |  | USE_LAST |
 | --arguments | bundle |  |  | x | CONCATENATE |
 | --copyright | bundle | x | x |  | USE_LAST |

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/model/ApplicationLayoutTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/model/ApplicationLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,6 +131,7 @@ public class ApplicationLayoutTest {
                 .runtimeDirectory("runtime")
                 .appModsDirectory("mods")
                 .contentDirectory("content")
+                .resourcesDirectory("resources")
                 .desktopIntegrationDirectory("lib/apps")
                 .create();
     }

--- a/test/jdk/tools/jpackage/share/AppContentAndResourcesTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentAndResourcesTest.java
@@ -28,6 +28,7 @@ import static jdk.internal.util.OperatingSystem.MACOS;
 import static jdk.internal.util.OperatingSystem.WINDOWS;
 import static jdk.jpackage.internal.util.function.ThrowingFunction.toFunction;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -47,12 +48,14 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
 import jdk.jpackage.internal.util.FileUtils;
 import jdk.jpackage.internal.util.IdentityWrapper;
 import jdk.jpackage.internal.util.function.ThrowingSupplier;
 import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.Annotations.ParameterSupplier;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.ApplicationLayout;
 import jdk.jpackage.test.CannedFormattedString;
 import jdk.jpackage.test.ConfigurationTarget;
 import jdk.jpackage.test.FailedCommandErrorValidator;
@@ -66,34 +69,34 @@ import jdk.jpackage.test.TKit;
 
 
 /**
- * Tests generation of packages with additional content in app image.
+ * Tests generation of packages with additional content or resources in app image.
  */
 
 /*
  * @test
- * @summary jpackage with --app-content option
+ * @summary jpackage with --app-content or --app-resources option
  * @library /test/jdk/tools/jpackage/helpers
  * @key jpackagePlatformPackage
  * @build jdk.jpackage.test.*
- * @build AppContentTest
- * @run main/othervm/timeout=720 -Xmx512m jdk.jpackage.test.Main
- *  --jpt-run=AppContentTest
+ * @build AppContentAndResourcesTest
+ * @run main/othervm/timeout=1440 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=AppContentAndResourcesTest
  */
-public class AppContentTest {
+public class AppContentAndResourcesTest {
 
     @Test
     @ParameterSupplier
     @ParameterSupplier(value="testSymlink", ifNotOS = WINDOWS)
-    public void test(TestSpec testSpec) throws Exception {
-        testSpec.test(new ConfigurationTarget(new PackageTest().configureHelloApp()));
+    public void test(TestCase testCase) throws Exception {
+        testCase.test(new ConfigurationTarget(new PackageTest().configureHelloApp()));
     }
 
     @Test
     @ParameterSupplier("test")
     @ParameterSupplier(value="testSymlink", ifNotOS = WINDOWS)
     @ParameterSupplier
-    public void testAppImage(TestSpec testSpec) throws Exception {
-        testSpec.test(new ConfigurationTarget(JPackageCommand.helloAppImage()));
+    public void testAppImage(TestCase testCase) throws Exception {
+        testCase.test(new ConfigurationTarget(JPackageCommand.helloAppImage()));
     }
 
     @Test(ifOS = MACOS)
@@ -129,9 +132,9 @@ public class AppContentTest {
             //
             // Typical codesign error:
             //
-            // foo/output/WarningsAppContentTest.app: replacing existing signature
-            // foo/output/WarningsAppContentTest.app: code object is not signed at all
-            // In subcomponent: foo/output/WarningsAppContentTest.app/Contents/dukeplug.png
+            // foo/output/WarningsAppContentAndResourcesTest.app: replacing existing signature
+            // foo/output/WarningsAppContentAndResourcesTest.app: code object is not signed at all
+            // In subcomponent: foo/output/WarningsAppContentAndResourcesTest.app/Contents/dukeplug.png
             //
 
             var errorValidator = new FailedCommandErrorValidator(Pattern.compile(cmdlinePattern))
@@ -176,8 +179,14 @@ public class AppContentTest {
         private Path appContent;
     }
 
+    private static Collection<Object[]> withOptions(Stream<TestSpec> specs) {
+        return specs.flatMap(spec -> Stream.of(AppFilesOption.values())
+                .map(option -> new Object[] { new TestCase(option, spec) }))
+                .toList();
+    }
+
     public static Collection<Object[]> test() {
-        return Stream.of(
+        var tests = Stream.of(
                 build().add(TEST_JAVA).add(TEST_DUKE),
                 build().add(TEST_JAVA).add(TEST_BAD),
                 build().startGroup().add(TEST_JAVA).add(TEST_DUKE).endGroup().add(TEST_DIR),
@@ -193,30 +202,93 @@ public class AppContentTest {
                 build().add(createTextFileContent("a/b/c/d", "Foo")).add(createTextFileContent("a", "Bar")),
                 // Same name: one is a file, another is a directory.
                 build().add(createTextFileContent("a", "Bar")).add(createTextFileContent("a/b/c/d", "Foo"))
-        ).map(TestSpec.Builder::create).map(v -> {
-            return new Object[] {v};
-        }).toList();
+        ).map(TestSpec.Builder::create);
+
+        return withOptions(tests);
     }
 
     public static Collection<Object[]> testAppImage() {
-        return Stream.of(
+        var tests = Stream.of(
                 build().add(NonExistentPath.create("*output-app-image*", JPackageCommand::outputBundle))
-        ).map(TestSpec.Builder::create).map(v -> {
-            return new Object[] {v};
-        }).toList();
+        ).map(TestSpec.Builder::create);
+
+        return withOptions(tests);
     }
 
     public static Collection<Object[]> testSymlink() {
-        return Stream.of(
+        var tests = Stream.of(
                 build().add(TEST_JAVA)
                         .add(new SymlinkContentFactory("Links", "duke-link", "duke-target"))
                         .add(new SymlinkContentFactory("", "a/b/foo-link", "c/bar-target"))
-        ).map(TestSpec.Builder::create).map(v -> {
-            return new Object[] {v};
-        }).toList();
+        ).map(TestSpec.Builder::create);
+
+        return withOptions(tests);
     }
 
-    public record TestSpec(List<List<ContentFactory>> contentFactories) {
+    private enum AppFilesOption {
+        CONTENT("--app-content", ",", ApplicationLayout::contentDirectory, true),
+        RESOURCES("--app-resources", File.pathSeparator,
+            ApplicationLayout::resourcesDirectory, false);
+
+        AppFilesOption(String optionName, String delimiter,
+                Function<ApplicationLayout, Path> outputRoot,
+                boolean wrapInResourcesOnMac) {
+            this.optionName = optionName;
+            this.delimiter = delimiter;
+            this.outputRoot = outputRoot;
+            this.wrapInResourcesOnMac = wrapInResourcesOnMac;
+        }
+
+        Path optionPath(Path path) {
+            if (wrapInResourcesOnMac()
+                    && Optional.ofNullable(path.getParent())
+                            .map(Path::getFileName)
+                            .map(RESOURCES_DIR::equals)
+                            .orElse(false)) {
+                return path.getParent();
+            }
+            return path;
+        }
+
+        Path outputRoot(JPackageCommand cmd) {
+            var root = outputRoot.apply(cmd.appLayout());
+            return wrapInResourcesOnMac && TKit.isOSX()
+                    ? root.resolve(RESOURCES_DIR)
+                    : root;
+        }
+
+        String optionName() {
+           return optionName;
+        }
+
+        boolean wrapInResourcesOnMac() {
+            return wrapInResourcesOnMac && TKit.isOSX();
+        }
+
+        private final String optionName;
+        private final String delimiter;
+        private final Function<ApplicationLayout, Path> outputRoot;
+        // On OSX `--app-content` paths will be copied into the "Contents" folder
+        // of the output app image.
+        // "codesign" imposes restrictions on the directory structure of "Contents" folder.
+        // In particular, random files should be placed in "Contents/Resources" folder
+        // otherwise "codesign" will fail to sign.
+        // Need to prepare arguments for `--app-content` accordingly.
+        private final boolean wrapInResourcesOnMac;
+    }
+
+    private record TestCase(AppFilesOption option, TestSpec spec) {
+        void test(ConfigurationTarget target) {
+            spec.test(option, target);
+        }
+
+        @Override
+        public String toString() {
+            return option.optionName() + ": " + spec;
+        }
+    }
+
+    private record TestSpec(List<List<ContentFactory>> contentFactories) {
         public TestSpec {
             contentFactories.stream().flatMap(List::stream).forEach(Objects::requireNonNull);
         }
@@ -228,7 +300,7 @@ public class AppContentTest {
             }).collect(joining("; "));
         }
 
-        void test(ConfigurationTarget target) {
+        void test(AppFilesOption option, ConfigurationTarget target) {
             final int expectedJPackageExitCode;
             if (contentFactories.stream().flatMap(List::stream).anyMatch(NonExistentPath.class::isInstance)) {
                 expectedJPackageExitCode = 1;
@@ -242,26 +314,17 @@ public class AppContentTest {
             .addInitializer(cmd -> {
                 contentFactories.stream().map(group -> {
                     return group.stream().map(contentFactory -> {
-                        return contentFactory.create(cmd);
+                        return contentFactory.create(cmd, option);
                     }).toList();
                 }).forEach(allContent::add);
             }).addInitializer(cmd -> {
                 allContent.stream().map(group -> {
-                    return Stream.of("--app-content", group.stream()
+                    return Stream.of(option.optionName, group.stream()
                             .map(Content::paths)
                             .flatMap(List::stream)
-                            .map(appContentArg -> {
-                                if (COPY_IN_RESOURCES && Optional.ofNullable(appContentArg.getParent())
-                                        .map(Path::getFileName)
-                                        .map(RESOURCES_DIR::equals)
-                                        .orElse(false)) {
-                                    return appContentArg.getParent();
-                                } else {
-                                    return appContentArg;
-                                }
-                            })
+                            .map(path -> option.optionPath(path))
                             .map(Path::toString)
-                            .collect(joining(",")));
+                            .collect(joining(option.delimiter)));
                     }).flatMap(x -> x).forEachOrdered(cmd::addArgument);
             });
 
@@ -278,7 +341,7 @@ public class AppContentTest {
                     return;
                 }
 
-                var appContentRoot = getAppContentRoot(cmd);
+                var appContentRoot = option.outputRoot(cmd);
 
                 Set<PathVerifier> disabledVerifiers = new HashSet<>();
 
@@ -386,17 +449,8 @@ public class AppContentTest {
         return new TestSpec.Builder();
     }
 
-    private static Path getAppContentRoot(JPackageCommand cmd) {
-        final Path contentDir = cmd.appLayout().contentDirectory();
-        if (COPY_IN_RESOURCES) {
-            return contentDir.resolve(RESOURCES_DIR);
-        } else {
-            return contentDir;
-        }
-    }
-
-    private static Path createAppContentRoot() {
-        if (COPY_IN_RESOURCES) {
+    private static Path createAppContentRoot(AppFilesOption option) {
+        if (option.wrapInResourcesOnMac()) {
             return TKit.createTempDirectory("app-content").resolve(RESOURCES_DIR);
         } else {
             return TKit.createTempDirectory("app-content");
@@ -415,7 +469,7 @@ public class AppContentTest {
 
     @FunctionalInterface
     private interface ContentFactory {
-        Content create(JPackageCommand cmd);
+        Content create(JPackageCommand cmd, AppFilesOption option);
     }
 
     private interface Content {
@@ -506,7 +560,7 @@ public class AppContentTest {
                             return new RegularFileVerifier(dstFile, srcFile);
                         } else {
                             return new DirectoryVerifier(dstFile,
-                                    toFunction(AppContentTest::isDirectoryEmpty).apply(srcFile),
+                                    toFunction(AppContentAndResourcesTest::isDirectoryEmpty).apply(srcFile),
                                     new IdentityWrapper<>(this));
                         }
                     }).toList());
@@ -556,7 +610,7 @@ public class AppContentTest {
         }
 
         @Override
-        public Content create(JPackageCommand cmd) {
+        public Content create(JPackageCommand cmd, AppFilesOption option) {
             var nonexistent = makePath.apply(cmd);
             if (Files.exists(nonexistent)) {
                 throw new IllegalStateException();
@@ -669,8 +723,8 @@ public class AppContentTest {
         }
 
         @Override
-        public Content create(JPackageCommand cmd) {
-            final var appContentRoot = createAppContentRoot();
+        public Content create(JPackageCommand cmd, AppFilesOption option) {
+            final var appContentRoot = createAppContentRoot(option);
 
             final var symlinkPath = appContentRoot.resolve(symlinkPath());
             final var symlinkedPath = appContentRoot.resolve(symlinkedPath());
@@ -686,7 +740,7 @@ public class AppContentTest {
             }
 
             List<Path> contentPaths;
-            if (COPY_IN_RESOURCES) {
+            if (option.wrapInResourcesOnMac()) {
                 contentPaths = List.of(appContentRoot);
             } else if (basedir.equals(Path.of(""))) {
                 contentPaths = Stream.of(symlinkPath(), symlinkedPath()).map(path -> {
@@ -743,17 +797,17 @@ public class AppContentTest {
         }
 
         @Override
-        public Content create(JPackageCommand cmd) {
+        public Content create(JPackageCommand cmd, AppFilesOption option) {
             Path srcPath = factory.get();
             if (!srcPath.endsWith(pathInAppContentRoot)) {
                 throw new IllegalArgumentException();
             }
 
             Path dstPath;
-            if (!COPY_IN_RESOURCES) {
+            if (!option.wrapInResourcesOnMac()) {
                 dstPath = srcPath;
             } else {
-                var contentDir = createAppContentRoot();
+                var contentDir = createAppContentRoot(option);
                 dstPath = contentDir.resolve(pathInAppContentRoot);
                 try {
                     FileUtils.copyRecursive(srcPath, dstPath);
@@ -777,14 +831,6 @@ public class AppContentTest {
     private static final ContentFactory TEST_DUKE = createTextFileContent("duke.txt", "Hi Duke!");
     private static final ContentFactory TEST_DIR = createDirTreeContent("apps");
     private static final ContentFactory TEST_BAD = NonExistentPath.create("non-existent");
-
-    // On OSX `--app-content` paths will be copied into the "Contents" folder
-    // of the output app image.
-    // "codesign" imposes restrictions on the directory structure of "Contents" folder.
-    // In particular, random files should be placed in "Contents/Resources" folder
-    // otherwise "codesign" will fail to sign.
-    // Need to prepare arguments for `--app-content` accordingly.
-    private static final boolean COPY_IN_RESOURCES = TKit.isOSX();
 
     private static final Path RESOURCES_DIR = Path.of("Resources");
 }

--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -48,7 +48,6 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import jdk.jpackage.internal.util.FileUtils;
 import jdk.jpackage.internal.util.IdentityWrapper;
 import jdk.jpackage.internal.util.function.ThrowingSupplier;
@@ -78,25 +77,25 @@ import jdk.jpackage.test.TKit;
  * @library /test/jdk/tools/jpackage/helpers
  * @key jpackagePlatformPackage
  * @build jdk.jpackage.test.*
- * @build AppContentAndResourcesTest
+ * @build AppContentTest
  * @run main/othervm/timeout=1440 -Xmx512m jdk.jpackage.test.Main
- *  --jpt-run=AppContentAndResourcesTest
+ *  --jpt-run=AppContentTest
  */
-public class AppContentAndResourcesTest {
+public class AppContentTest {
 
     @Test
     @ParameterSupplier
     @ParameterSupplier(value="testSymlink", ifNotOS = WINDOWS)
-    public void test(TestCase testCase) throws Exception {
-        testCase.test(new ConfigurationTarget(new PackageTest().configureHelloApp()));
+    public void test(TestSpec testSpec) throws Exception {
+        testSpec.test(new ConfigurationTarget(new PackageTest().configureHelloApp()));
     }
 
     @Test
     @ParameterSupplier("test")
     @ParameterSupplier(value="testSymlink", ifNotOS = WINDOWS)
     @ParameterSupplier
-    public void testAppImage(TestCase testCase) throws Exception {
-        testCase.test(new ConfigurationTarget(JPackageCommand.helloAppImage()));
+    public void testAppImage(TestSpec testSpec) throws Exception {
+        testSpec.test(new ConfigurationTarget(JPackageCommand.helloAppImage()));
     }
 
     @Test(ifOS = MACOS)
@@ -132,9 +131,9 @@ public class AppContentAndResourcesTest {
             //
             // Typical codesign error:
             //
-            // foo/output/WarningsAppContentAndResourcesTest.app: replacing existing signature
-            // foo/output/WarningsAppContentAndResourcesTest.app: code object is not signed at all
-            // In subcomponent: foo/output/WarningsAppContentAndResourcesTest.app/Contents/dukeplug.png
+            // foo/output/WarningsAppContentTest.app: replacing existing signature
+            // foo/output/WarningsAppContentTest.app: code object is not signed at all
+            // In subcomponent: foo/output/WarningsAppContentTest.app/Contents/dukeplug.png
             //
 
             var errorValidator = new FailedCommandErrorValidator(Pattern.compile(cmdlinePattern))
@@ -179,9 +178,9 @@ public class AppContentAndResourcesTest {
         private Path appContent;
     }
 
-    private static Collection<Object[]> withOptions(Stream<TestSpec> specs) {
-        return specs.flatMap(spec -> Stream.of(AppFilesOption.values())
-                .map(option -> new Object[] { new TestCase(option, spec) }))
+    private static Collection<Object[]> withOptions(Stream<TestSpec.Builder> specs) {
+        return specs.flatMap(builder -> Stream.of(AppFilesOption.values())
+                .map(option -> new Object[] { builder.create(option) }))
                 .toList();
     }
 
@@ -202,7 +201,7 @@ public class AppContentAndResourcesTest {
                 build().add(createTextFileContent("a/b/c/d", "Foo")).add(createTextFileContent("a", "Bar")),
                 // Same name: one is a file, another is a directory.
                 build().add(createTextFileContent("a", "Bar")).add(createTextFileContent("a/b/c/d", "Foo"))
-        ).map(TestSpec.Builder::create);
+        );
 
         return withOptions(tests);
     }
@@ -210,7 +209,7 @@ public class AppContentAndResourcesTest {
     public static Collection<Object[]> testAppImage() {
         var tests = Stream.of(
                 build().add(NonExistentPath.create("*output-app-image*", JPackageCommand::outputBundle))
-        ).map(TestSpec.Builder::create);
+        );
 
         return withOptions(tests);
     }
@@ -220,13 +219,13 @@ public class AppContentAndResourcesTest {
                 build().add(TEST_JAVA)
                         .add(new SymlinkContentFactory("Links", "duke-link", "duke-target"))
                         .add(new SymlinkContentFactory("", "a/b/foo-link", "c/bar-target"))
-        ).map(TestSpec.Builder::create);
+        );
 
         return withOptions(tests);
     }
 
     private enum AppFilesOption {
-        CONTENT("--app-content", ",", ApplicationLayout::contentDirectory, true),
+        CONTENT("--app-content", ",", ApplicationLayout::contentDirectory, TKit.isOSX()),
         RESOURCES("--app-resources", File.pathSeparator,
             ApplicationLayout::resourcesDirectory, false);
 
@@ -252,7 +251,7 @@ public class AppContentAndResourcesTest {
 
         Path outputRoot(JPackageCommand cmd) {
             var root = outputRoot.apply(cmd.appLayout());
-            return wrapInResourcesOnMac && TKit.isOSX()
+            return wrapInResourcesOnMac
                     ? root.resolve(RESOURCES_DIR)
                     : root;
         }
@@ -262,7 +261,7 @@ public class AppContentAndResourcesTest {
         }
 
         boolean wrapInResourcesOnMac() {
-            return wrapInResourcesOnMac && TKit.isOSX();
+            return wrapInResourcesOnMac;
         }
 
         private final String optionName;
@@ -277,30 +276,28 @@ public class AppContentAndResourcesTest {
         private final boolean wrapInResourcesOnMac;
     }
 
-    private record TestCase(AppFilesOption option, TestSpec spec) {
-        void test(ConfigurationTarget target) {
-            spec.test(option, target);
-        }
-
-        @Override
-        public String toString() {
-            return option.optionName() + ": " + spec;
-        }
-    }
-
-    private record TestSpec(List<List<ContentFactory>> contentFactories) {
+    private record TestSpec(AppFilesOption option,
+            List<List<ContentFactory>> contentFactories) {
         public TestSpec {
+            Objects.requireNonNull(option);
             contentFactories.stream().flatMap(List::stream).forEach(Objects::requireNonNull);
+            if (contentFactories.isEmpty()) {
+                throw new IllegalArgumentException();
+            }
         }
 
         @Override
         public String toString() {
-            return contentFactories.stream().map(group -> {
+            var sb = new StringBuilder();
+
+            sb.append(option).append(" ").append(contentFactories.stream().map(group -> {
                 return group.stream().map(ContentFactory::toString).collect(joining(","));
-            }).collect(joining("; "));
+            }).collect(joining("; ")));
+
+            return sb.toString();
         }
 
-        void test(AppFilesOption option, ConfigurationTarget target) {
+        void test(ConfigurationTarget target) {
             final int expectedJPackageExitCode;
             if (contentFactories.stream().flatMap(List::stream).anyMatch(NonExistentPath.class::isInstance)) {
                 expectedJPackageExitCode = 1;
@@ -392,8 +389,8 @@ public class AppContentAndResourcesTest {
         }
 
         static final class Builder {
-            TestSpec create() {
-                return new TestSpec(groups);
+            TestSpec create(AppFilesOption option) {
+                return new TestSpec(option, groups);
             }
 
             final class GroupBuilder {
@@ -560,7 +557,7 @@ public class AppContentAndResourcesTest {
                             return new RegularFileVerifier(dstFile, srcFile);
                         } else {
                             return new DirectoryVerifier(dstFile,
-                                    toFunction(AppContentAndResourcesTest::isDirectoryEmpty).apply(srcFile),
+                                    toFunction(AppContentTest::isDirectoryEmpty).apply(srcFile),
                                     new IdentityWrapper<>(this));
                         }
                     }).toList());

--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -311,7 +311,7 @@ public class AppContentTest {
             .addInitializer(cmd -> {
                 contentFactories.stream().map(group -> {
                     return group.stream().map(contentFactory -> {
-                        return contentFactory.create(cmd, option);
+                        return contentFactory.create(cmd, option.wrapInResourcesOnMac());
                     }).toList();
                 }).forEach(allContent::add);
             }).addInitializer(cmd -> {
@@ -446,8 +446,8 @@ public class AppContentTest {
         return new TestSpec.Builder();
     }
 
-    private static Path createAppContentRoot(AppFilesOption option) {
-        if (option.wrapInResourcesOnMac()) {
+    private static Path createAppContentRoot(boolean srcRootMustBeResourcesDir) {
+        if (srcRootMustBeResourcesDir) {
             return TKit.createTempDirectory("app-content").resolve(RESOURCES_DIR);
         } else {
             return TKit.createTempDirectory("app-content");
@@ -466,7 +466,7 @@ public class AppContentTest {
 
     @FunctionalInterface
     private interface ContentFactory {
-        Content create(JPackageCommand cmd, AppFilesOption option);
+        Content create(JPackageCommand cmd, boolean srcRootMustBeResourcesDir);
     }
 
     private interface Content {
@@ -607,7 +607,7 @@ public class AppContentTest {
         }
 
         @Override
-        public Content create(JPackageCommand cmd, AppFilesOption option) {
+        public Content create(JPackageCommand cmd, boolean srcRootMustBeResourcesDir) {
             var nonexistent = makePath.apply(cmd);
             if (Files.exists(nonexistent)) {
                 throw new IllegalStateException();
@@ -720,8 +720,8 @@ public class AppContentTest {
         }
 
         @Override
-        public Content create(JPackageCommand cmd, AppFilesOption option) {
-            final var appContentRoot = createAppContentRoot(option);
+        public Content create(JPackageCommand cmd, boolean srcRootMustBeResourcesDir) {
+            final var appContentRoot = createAppContentRoot(srcRootMustBeResourcesDir);
 
             final var symlinkPath = appContentRoot.resolve(symlinkPath());
             final var symlinkedPath = appContentRoot.resolve(symlinkedPath());
@@ -737,7 +737,7 @@ public class AppContentTest {
             }
 
             List<Path> contentPaths;
-            if (option.wrapInResourcesOnMac()) {
+            if (srcRootMustBeResourcesDir) {
                 contentPaths = List.of(appContentRoot);
             } else if (basedir.equals(Path.of(""))) {
                 contentPaths = Stream.of(symlinkPath(), symlinkedPath()).map(path -> {
@@ -794,17 +794,17 @@ public class AppContentTest {
         }
 
         @Override
-        public Content create(JPackageCommand cmd, AppFilesOption option) {
+        public Content create(JPackageCommand cmd, boolean srcRootMustBeResourcesDir) {
             Path srcPath = factory.get();
             if (!srcPath.endsWith(pathInAppContentRoot)) {
                 throw new IllegalArgumentException();
             }
 
             Path dstPath;
-            if (!option.wrapInResourcesOnMac()) {
+            if (!srcRootMustBeResourcesDir) {
                 dstPath = srcPath;
             } else {
-                var contentDir = createAppContentRoot(option);
+                var contentDir = createAppContentRoot(srcRootMustBeResourcesDir);
                 dstPath = contentDir.resolve(pathInAppContentRoot);
                 try {
                     FileUtils.copyRecursive(srcPath, dstPath);

--- a/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
+++ b/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
@@ -42,6 +42,7 @@ import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.AppImageFile;
 import jdk.jpackage.test.ApplicationLayout;
 import jdk.jpackage.test.PackageTest;
+import jdk.jpackage.test.RunnablePackageTest.Action;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.TKit;
 
@@ -65,8 +66,8 @@ import jdk.jpackage.test.TKit;
  * Custom content comes from:
  * <ul>
  * <li>input directory (--input)
- * <li>app content (--app-content)
  * <li>app resources (--app-resources)
+ * <li>app content (--app-content)
  * <ul>
  */
 public class AppImageFillOrderTest {
@@ -130,10 +131,10 @@ public class AppImageFillOrderTest {
     @Test
     @Parameter("false")
     @Parameter("true")
-    public void testAppResourcesOverrideAppContent(boolean resourcesFirst)
+    public void testAppContentOverrideAppResources(boolean resourcesFirst)
             throws IOException {
         var cmd = createJPackage().setFakeRuntime();
-        var inputs = AppResourcesOverrideInputs.create();
+        var inputs = AppContentOverrideInputs.create();
 
         inputs.addTo(cmd, resourcesFirst);
 
@@ -145,24 +146,24 @@ public class AppImageFillOrderTest {
     @Test
     @Parameter("false")
     @Parameter("true")
-    public void testAppResourcesOverrideAppContentInPackage(
+    public void testAppContentOverrideAppResourcesInPackage(
             boolean resourcesFirst) throws IOException {
-        var inputs = AppResourcesOverrideInputs.create();
+        var inputs = AppContentOverrideInputs.create();
 
         new PackageTest()
                 .configureHelloApp()
                 .addInitializer(JPackageCommand::setFakeRuntime)
                 .addInitializer(cmd -> inputs.addTo(cmd, resourcesFirst))
                 .addInstallVerifier(inputs::verify)
-                .run();
+                .run(Action.CREATE_AND_UNPACK);
     }
 
-    private record AppResourcesOverrideInputs(
+    private record AppContentOverrideInputs(
             Path appContentFile,
             Path appResourcesFile,
             Path appContentArg) {
 
-        static AppResourcesOverrideInputs create() throws IOException {
+        static AppContentOverrideInputs create() throws IOException {
             var appContentRoot = TKit.createTempDirectory("app-content");
 
             Path appContentFile;
@@ -181,7 +182,7 @@ public class AppImageFillOrderTest {
                     .resolve("shared.txt");
             TKit.createTextFile(appResourcesFile, List.of("app-resources"));
 
-            return new AppResourcesOverrideInputs(
+            return new AppContentOverrideInputs(
                     appContentFile, appResourcesFile, appContentArg);
         }
 
@@ -199,8 +200,8 @@ public class AppImageFillOrderTest {
             var outputFile = cmd.appLayout().resourcesDirectory()
                     .resolve("shared.txt");
 
-            TKit.assertSameFileContent(appResourcesFile, outputFile);
-            TKit.assertMismatchFileContent(appContentFile, outputFile);
+            TKit.assertSameFileContent(appContentFile, outputFile);
+            TKit.assertMismatchFileContent(appResourcesFile, outputFile);
         }
     }
 

--- a/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
+++ b/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
@@ -21,29 +21,30 @@
  * questions.
  */
 
-import static java.util.stream.Collectors.toMap;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import jdk.jpackage.internal.util.Slot;
 import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.Annotations.ParameterSupplier;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.AppImageFile;
 import jdk.jpackage.test.ApplicationLayout;
+import jdk.jpackage.test.ConfigurationTarget;
+import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.RunnablePackageTest.Action;
-import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.TKit;
 
 /*
@@ -74,8 +75,14 @@ public class AppImageFillOrderTest {
 
     @Test
     @ParameterSupplier
-    public void test(AppImageOverlay overlays[]) {
-        test(createJPackage().setFakeRuntime(), overlays);
+    public void test(AppImageOverlay overlay) {
+        test(initJPackage().andThen(JPackageCommand::setFakeRuntime), false, overlay);
+    }
+
+    @Test
+    @ParameterSupplier("test")
+    public void testAppImage(AppImageOverlay overlay) {
+        test(initJPackage().andThen(JPackageCommand::setFakeRuntime), true, overlay);
     }
 
     /**
@@ -83,27 +90,31 @@ public class AppImageFillOrderTest {
      * @param jlink
      */
     @Test
-    @Parameter("true")
-    @Parameter("false")
-    public void testRuntime(boolean jlink) {
-        var cmd = createJPackage();
-        if (jlink) {
-            cmd.ignoreDefaultRuntime(true);
-        } else {
-            // Configure fake runtime and create it.
-            cmd.setFakeRuntime().executePrerequisiteActions();
+    @Parameter({"true", "true"})
+    @Parameter({"true", "false"})
+    @Parameter({"false", "true"})
+    @Parameter({"false", "false"})
+    public void testRuntime(boolean appImage, boolean jlink) {
 
-            var runtimeDir = Path.of(cmd.getArgumentValue("--runtime-image"));
-            if (!runtimeDir.toAbsolutePath().normalize().startsWith(TKit.workDir().toAbsolutePath().normalize())) {
-                throw new IllegalStateException(String.format(
-                        "Fake runtime [%s] created outside of the test work directory [%s]",
-                        runtimeDir, TKit.workDir()));
+        Consumer<JPackageCommand> initializer = cmd -> {
+            if (jlink) {
+                cmd.ignoreDefaultRuntime(true);
+            } else {
+                // Configure fake runtime and create it.
+                cmd.setFakeRuntime().executePrerequisiteActions();
+
+                var runtimeDir = Path.of(cmd.getArgumentValue("--runtime-image"));
+                if (!runtimeDir.toAbsolutePath().normalize().startsWith(TKit.workDir().toAbsolutePath().normalize())) {
+                    throw new IllegalStateException(String.format(
+                            "Fake runtime [%s] created outside of the test work directory [%s]",
+                            runtimeDir, TKit.workDir()));
+                }
+
+                TKit.createTextFile(runtimeDir.resolve(RUNTIME_RELEASE_FILE), List.of("Foo release"));
             }
+        };
 
-            TKit.createTextFile(runtimeDir.resolve(RUNTIME_RELEASE_FILE), List.of("Foo release"));
-        }
-
-        test(cmd, AppImageAppContentOverlay.APP_CONTENT_RUNTIME_RELEASE_FILE);
+        test(initJPackage().andThen(initializer), appImage, StandardAppImageOverlay.APP_CONTENT_RUNTIME_RELEASE_FILE);
     }
 
     /**
@@ -119,7 +130,7 @@ public class AppImageFillOrderTest {
 
         buildOverlay(cmd, TKit.createTempDirectory("app-content"), AppImageFile.getPathInAppImage(outputBundle))
                 .textContent("This is not a valid XML content")
-                .configureCmdOptions().createOverlayFile();
+                .addAppContentOption().createOverlayFile();
 
         // Run jpackage and verify it created valid .jpackage.xml file ignoring the overlay.
         cmd.executeAndAssertImageCreated();
@@ -128,221 +139,265 @@ public class AppImageFillOrderTest {
         AppImageFile.load(outputBundle);
     }
 
-    @Test
-    @Parameter("false")
-    @Parameter("true")
-    public void testAppContentOverridesAppResources(boolean resourcesFirst)
-            throws IOException {
-        var cmd = createJPackage().setFakeRuntime();
-        var inputs = AppContentOverrideInputs.create();
+    private static void test(Consumer<JPackageCommand> initializer, boolean appImage, AppImageOverlay overlay) {
+        Objects.requireNonNull(overlay);
 
-        inputs.addTo(cmd, resourcesFirst);
-
-        cmd.executeAndAssertImageCreated();
-
-        inputs.verify(cmd);
-    }
-
-    @Test
-    @Parameter("false")
-    @Parameter("true")
-    public void testAppContentOverridesAppResourcesInPackage(
-            boolean resourcesFirst) throws IOException {
-        var inputs = AppContentOverrideInputs.create();
-
-        new PackageTest()
-                .configureHelloApp()
-                .addInitializer(cmd -> {
-                    cmd.setArgumentValue("--name", "Foo");
-                })
-                .addInitializer(JPackageCommand::setFakeRuntime)
-                .addInitializer(cmd -> inputs.addTo(cmd, resourcesFirst))
-                .addInstallVerifier(inputs::verify)
-                .run(Action.CREATE_AND_UNPACK);
-    }
-
-    private record AppContentOverrideInputs(
-            Path appContentFile,
-            Path appResourcesFile,
-            Path appContentArg) {
-
-        static AppContentOverrideInputs create() throws IOException {
-            var appContentRoot = TKit.createTempDirectory("app-content");
-
-            Path appContentFile;
-            Path appContentArg;
-            if (TKit.isOSX()) {
-                appContentArg = Files.createDirectory(
-                        appContentRoot.resolve("Resources"));
-                appContentFile = appContentArg.resolve("shared.txt");
-            } else {
-                appContentFile = appContentRoot.resolve("shared.txt");
-                appContentArg = appContentFile;
-            }
-            TKit.createTextFile(appContentFile, List.of("app-content"));
-
-            var appResourcesFile = TKit.createTempDirectory("app-resources")
-                    .resolve("shared.txt");
-            TKit.createTextFile(appResourcesFile, List.of("app-resources"));
-
-            return new AppContentOverrideInputs(
-                    appContentFile, appResourcesFile, appContentArg);
-        }
-
-        void addTo(JPackageCommand cmd, boolean resourcesFirst) {
-            if (resourcesFirst) {
-                cmd.addArguments("--app-resources", appResourcesFile);
-                cmd.addArguments("--app-content", appContentArg);
-            } else {
-                cmd.addArguments("--app-content", appContentArg);
-                cmd.addArguments("--app-resources", appResourcesFile);
-            }
-        }
-
-        void verify(JPackageCommand cmd) {
-            var outputFile = cmd.appLayout().resourcesDirectory()
-                    .resolve("shared.txt");
-
-            TKit.assertSameFileContent(appContentFile, outputFile);
-            TKit.assertMismatchFileContent(appResourcesFile, outputFile);
-        }
-    }
-
-    private static void test(JPackageCommand cmd, AppImageOverlay... overlays) {
-        if (overlays.length == 0) {
-            throw new IllegalArgumentException();
-        }
-
-        final var outputDir = Path.of(cmd.getArgumentValue("--dest"));
-        final var noOverlaysOutputDir = Path.of(outputDir.toString() + "-no-overlay");
-        cmd.setArgumentValue("--dest", noOverlaysOutputDir);
-
-        // Run the command without overlays with redirected output directory.
-        cmd.execute();
-
-        final Optional<Path> appContentRoot;
-        if (Stream.of(overlays).anyMatch(AppImageAppContentOverlay.class::isInstance)) {
-            appContentRoot = Optional.of(TKit.createTempDirectory("app-content"));
+        final ConfigurationTarget targetWithoutOverlays;
+        if (appImage) {
+            targetWithoutOverlays = new ConfigurationTarget(JPackageCommand.helloAppImage());
         } else {
-            appContentRoot = Optional.empty();
+            targetWithoutOverlays = new ConfigurationTarget(new PackageTest().configureHelloApp());
         }
 
-        // Apply overlays to the command.
-        var fileCopies = Stream.of(overlays).map(overlay -> {
-            switch (overlay) {
-                case AppImageDefaultOverlay v -> {
-                    return v.addOverlay(cmd);
-                }
-                case AppImageAppContentOverlay v -> {
-                    return v.addOverlay(cmd, appContentRoot.orElseThrow());
-                }
+        targetWithoutOverlays
+        .addInitializer(initializer)
+        .addInitializer(cmdWithoutOverlays -> {
+            cmdWithoutOverlays.setArgumentValue("--dest", cmdWithoutOverlays.getArgumentValue("--dest") + "-no-overlay");
+        })
+        .apply(JPackageCommand::execute, _ -> {})
+        .addInstallVerifier(cmdWithoutOverlays -> {
+            final ConfigurationTarget target;
+            if (appImage) {
+                target = new ConfigurationTarget(new JPackageCommand());
+            } else {
+                target = new ConfigurationTarget(new PackageTest().forTypes(cmdWithoutOverlays.packageType()));
             }
-        }).flatMap(Collection::stream).collect(toMap(FileCopy::out, x -> x, (a, b) -> {
-            return b;
-        }, TreeMap::new)).values().stream().toList();
 
-        // Collect paths in the app image that will be affected by overlays.
-        var noOverlayOutputPaths = fileCopies.stream().map(FileCopy::out).toList();
+            Slot<List<FileCopy>> fileCopies = Slot.createEmpty();
 
-        fileCopies = fileCopies.stream().map(v -> {
-            return new FileCopy(v.in(), outputDir.resolve(noOverlaysOutputDir.relativize(v.out())));
-        }).toList();
+            target.addInitializer(cmd -> {
+                cmd.clearArguments()
+                        .addArguments(cmdWithoutOverlays.getAllArguments())
+                        .setDefaultInputOutput()
+                        .setArgumentValue("--input", cmdWithoutOverlays.inputDir());
 
-        // Restore the original output directory for the command and execute it.
-        cmd.setArgumentValue("--dest", outputDir).execute();
+                // Apply overlays to the command.
+                fileCopies.set(overlay.addOverlay(cmd).stream()
+                        .sorted(Comparator.comparing(FileCopy::out).thenComparing(Comparator.comparing(FileCopy::in)))
+                        .toList());
+            })
+            .apply(JPackageCommand::execute, _ -> {})
+            .addInstallVerifier(cmd -> {
 
-        for (var i = 0; i != fileCopies.size(); i++) {
-            var noOverlayPath = noOverlayOutputPaths.get(i);
-            var fc = fileCopies.get(i);
-            TKit.assertSameFileContent(fc.in(), fc.out());
-            TKit.assertMismatchFileContent(noOverlayPath, fc.out());
-        }
+                Function<JPackageCommand, Path> unpackRoot = c -> {
+                    return c.isImagePackageType() ? c.outputBundle() : c.pathToUnpackedPackageFile(c.appInstallationDirectory());
+                };
+
+                for (var fc : fileCopies.get()) {
+                    var noOverlayPath = unpackRoot.apply(cmdWithoutOverlays).resolve(fc.out());
+                    var overlayPath = unpackRoot.apply(cmd).resolve(fc.out());
+                    TKit.assertSameFileContent(fc.in(), overlayPath);
+                    if (Files.exists(noOverlayPath)) {
+                        TKit.assertMismatchFileContent(noOverlayPath, overlayPath);
+                    }
+                }
+            }).test().ifPresent(test -> {
+                test.run(Action.CREATE_AND_UNPACK);
+            });
+        }).test().ifPresent(test -> {
+            test.run(Action.CREATE_AND_UNPACK);
+        });
     }
 
     public static Collection<Object[]> test() {
-        return Stream.of(
+
+        var testCases = new ArrayList<AppImageOverlay>();
+
+        Stream.<AppImageOverlay>of(
 
                 // Overwrite main launcher .cfg file from the input dir.
-                List.of(AppImageDefaultOverlay.INPUT_MAIN_LAUNCHER_CFG),
+                StandardAppImageOverlay.INPUT_MAIN_LAUNCHER_CFG,
 
                 // Overwrite main launcher .cfg file from the app content dir.
-                List.of(AppImageAppContentOverlay.APP_CONTENT_MAIN_LAUNCHER_CFG),
+                StandardAppImageOverlay.APP_CONTENT_MAIN_LAUNCHER_CFG,
 
                 // Overwrite main launcher .cfg file from the input dir and from the app content dir.
                 // The one from app content should win.
-                List.<AppImageOverlay>of(
-                        AppImageDefaultOverlay.INPUT_MAIN_LAUNCHER_CFG,
-                        AppImageAppContentOverlay.APP_CONTENT_MAIN_LAUNCHER_CFG
-                ),
+                AppImageOverlay.group().overlays(
+                        StandardAppImageOverlay.INPUT_MAIN_LAUNCHER_CFG,
+                        StandardAppImageOverlay.APP_CONTENT_MAIN_LAUNCHER_CFG
+                ).last().create(),
 
                 // Overwrite main jar from the app content dir.
-                List.of(AppImageAppContentOverlay.APP_CONTENT_MAIN_JAR)
-        ).map(args -> {
-            return args.toArray(AppImageOverlay[]::new);
-        }).map(args -> {
+                StandardAppImageOverlay.APP_CONTENT_MAIN_JAR,
+
+                // The same file is copied from the --app-resources and --app-content options.
+                // The one from the - app-content should win regardless of the order of the options on the command line.
+                AppImageOverlay.group().overlays(
+                        StandardAppImageOverlay.APP_RESOURCES_USER_FILE,
+                        StandardAppImageOverlay.APP_CONTENT_USER_FILE).last().create(),
+                AppImageOverlay.group().overlays(
+                        StandardAppImageOverlay.APP_CONTENT_USER_FILE,
+                        StandardAppImageOverlay.APP_RESOURCES_USER_FILE).first().create()
+
+        ).forEach(testCases::add);
+
+        return testCases.stream().map(args -> {
             return new Object[] {args};
         }).toList();
     }
 
 
-    public sealed interface AppImageOverlay {
-    }
+    @FunctionalInterface
+    public interface AppImageOverlay {
 
+        Collection<FileCopy> addOverlay(JPackageCommand cmd);
 
-    private enum AppImageDefaultOverlay implements AppImageOverlay {
-        INPUT_MAIN_LAUNCHER_CFG(AppImageFillOrderTest::replaceMainLauncherCfgFile),
-        ;
-
-        AppImageDefaultOverlay(Function<JPackageCommand, FileCopy> func) {
-            Objects.requireNonNull(func);
-            this.func = cmd -> {
-                return List.of(func.apply(cmd));
+        static AppImageOverlay fileOverlay(BiFunction<JPackageCommand, Path, OverlayFileBuilder> initializer) {
+            Objects.requireNonNull(initializer);
+            return cmd -> {
+                return List.of(initializer.apply(cmd, TKit.createTempDirectory("content")).createOverlayFile());
             };
         }
 
-        Collection<FileCopy> addOverlay(JPackageCommand cmd) {
-            return func.apply(cmd);
+        static GroupAppImageOverlay.Builder group() {
+            return new GroupAppImageOverlay.Builder();
         }
-
-        private final Function<JPackageCommand, Collection<FileCopy>> func;
     }
 
 
-    private enum AppImageAppContentOverlay implements AppImageOverlay {
-        // Replace the standard main launcher .cfg file with the custom one from the app content.
-        APP_CONTENT_MAIN_LAUNCHER_CFG((cmd, appContentRoot) -> {
-            return buildOverlay(cmd, appContentRoot, cmd.appLauncherCfgPath(null))
-                    .textContent("!Olleh")
-                    .configureCmdOptions().createOverlayFile();
+    private enum StandardAppImageOverlay implements AppImageOverlay {
+
+        // Replace the standard main launcher .cfg file with the custom one from the input dir.
+        INPUT_MAIN_LAUNCHER_CFG(cmd -> {
+
+            final var outputFile = relativize(cmd, cmd.appLauncherCfgPath(null));
+
+            final var inputDir = Path.of(cmd.getArgumentValue("--input"));
+
+            final var file = inputDir.resolve(outputFile.getFileName());
+
+            TKit.createTextFile(file, List.of("Hello!"));
+
+            return List.of(new FileCopy(file, outputFile));
         }),
+
+        // Replace the standard main launcher .cfg file with the custom one from the app content.
+        APP_CONTENT_MAIN_LAUNCHER_CFG(AppImageOverlay.fileOverlay((cmd, contentRoot) -> {
+            return buildOverlay(cmd, contentRoot, cmd.appLauncherCfgPath(null))
+                    .textContent("!Olleh")
+                    .addAppContentOption();
+        })),
 
         // Replace the jar file that jpackage will pick up from the input directory with the custom one.
-        APP_CONTENT_MAIN_JAR((cmd, appContentRoot) -> {
-            return buildOverlay(cmd, appContentRoot, cmd.appLayout().appDirectory().resolve(cmd.getArgumentValue("--main-jar")))
+        APP_CONTENT_MAIN_JAR(AppImageOverlay.fileOverlay((cmd, contentRoot) -> {
+            return buildOverlay(cmd, contentRoot, cmd.appLayout().appDirectory().resolve(cmd.getArgumentValue("--main-jar")))
                     .textContent("Surprise!")
-                    .configureCmdOptions().createOverlayFile();
-        }),
+                    .addAppContentOption();
+        })),
 
         // Replace "release" file in the runtime directory.
-        APP_CONTENT_RUNTIME_RELEASE_FILE((cmd, appContentRoot) -> {
-            return buildOverlay(cmd, appContentRoot, cmd.appLayout().runtimeHomeDirectory().resolve("release"))
+        APP_CONTENT_RUNTIME_RELEASE_FILE(AppImageOverlay.fileOverlay((cmd, contentRoot) -> {
+            return buildOverlay(cmd, contentRoot, cmd.appLayout().runtimeHomeDirectory().resolve("release"))
                     .textContent("blob")
-                    .configureCmdOptions().createOverlayFile();
-        }),
+                    .addAppContentOption();
+        })),
+
+        // "a/b/c.txt" file in the content directory.
+        APP_CONTENT_USER_FILE(AppImageOverlay.fileOverlay((cmd, contentRoot) -> {
+            var dstDir = TKit.isOSX() ? cmd.appLayout().resourcesDirectory() : cmd.appLayout().contentDirectory();
+            return buildOverlay(cmd, contentRoot, dstDir.resolve("a/b/c.txt"))
+                    .textContent("MACOS_APP_CONTENT_USER_FILE")
+                    .addAppContentOption();
+        })),
+
+        // "a/b/c.txt" file in the resources directory.
+        APP_RESOURCES_USER_FILE(AppImageOverlay.fileOverlay((cmd, contentRoot) -> {
+            return buildOverlay(cmd, contentRoot, cmd.appLayout().resourcesDirectory().resolve("a/b/c.txt"))
+                    .textContent("APP_RESOURCES_USER_FILE")
+                    .addAppResourcesOption();
+        })),
+
         ;
 
-        AppImageAppContentOverlay(BiFunction<JPackageCommand, Path, FileCopy> func) {
-            Objects.requireNonNull(func);
-            this.func = (cmd, appContentRoot) -> {
-                return List.of(func.apply(cmd, appContentRoot));
+        StandardAppImageOverlay(AppImageOverlay impl) {
+            this.impl = Objects.requireNonNull(impl);
+        }
+
+        @Override
+        public Collection<FileCopy> addOverlay(JPackageCommand cmd) {
+            return impl.addOverlay(cmd);
+        }
+
+        private final AppImageOverlay impl;
+    }
+
+
+    private record GroupAppImageOverlay(List<AppImageOverlay> group, Selector selector) implements AppImageOverlay {
+
+        GroupAppImageOverlay {
+            Objects.requireNonNull(selector);
+            group.forEach(Objects::requireNonNull);
+            if (group.size() < 2) {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        enum Selector {
+            LAST,
+            FIRST,
+            EACH,
+            ;
+        }
+
+        @Override
+        public Collection<FileCopy> addOverlay(JPackageCommand cmd) {
+            var fileCopies = group.stream().flatMap(overlay -> {
+                return overlay.addOverlay(cmd).stream();
+            }).toList();
+
+            return switch (selector) {
+                case EACH -> fileCopies;
+                case FIRST -> List.of(fileCopies.getFirst());
+                case LAST -> List.of(fileCopies.getLast());
             };
         }
 
-        Collection<FileCopy> addOverlay(JPackageCommand cmd, Path appContentRoot) {
-            return func.apply(cmd, appContentRoot);
+        @Override
+        public String toString() {
+            if (selector == Selector.EACH) {
+                return String.format("%s", group);
+            } else {
+                return String.format("%s%s", selector, group);
+            }
         }
 
-        private final BiFunction<JPackageCommand, Path, Collection<FileCopy>> func;
+        final static class Builder {
+
+            Builder selector(Selector v) {
+                selector = v;
+                return this;
+            }
+
+            Builder first() {
+                return selector(Selector.FIRST);
+            }
+
+            Builder last() {
+                return selector(Selector.LAST);
+            }
+
+            Builder overlays(Collection<AppImageOverlay> v) {
+                overlays.addAll(v);
+                return this;
+            }
+
+            Builder overlays(AppImageOverlay... v) {
+                return overlays(List.of(v));
+            }
+
+            AppImageOverlay create() {
+                if (overlays.size() == 1) {
+                    return overlays.getFirst();
+                } else {
+                    return new GroupAppImageOverlay(
+                            List.copyOf(overlays), Optional.ofNullable(selector).orElse(Selector.EACH));
+                }
+            }
+
+            private Selector selector;
+            private List<AppImageOverlay> overlays = new ArrayList<>();
+        }
     }
 
 
@@ -354,88 +409,106 @@ public class AppImageFillOrderTest {
     }
 
 
-    private static FileCopy replaceMainLauncherCfgFile(JPackageCommand cmd) {
-        // Replace the standard main launcher .cfg file with the custom one from the input dir.
-        final var outputFile = cmd.appLauncherCfgPath(null);
-
-        final var inputDir = Path.of(cmd.getArgumentValue("--input"));
-
-        final var file = inputDir.resolve(outputFile.getFileName());
-
-        TKit.createTextFile(file, List.of("Hello!"));
-
-        return new FileCopy(file, outputFile);
-    }
-
-    private static AppContentOverlayFileBuilder buildOverlay(JPackageCommand cmd, Path appContentRoot, Path outputFile) {
-        return new AppContentOverlayFileBuilder(cmd, appContentRoot, outputFile);
+    private static OverlayFileBuilder buildOverlay(JPackageCommand cmd, Path appContentRoot, Path outputFile) {
+        return new OverlayFileBuilder(cmd, appContentRoot, outputFile);
     }
 
 
-    private static final class AppContentOverlayFileBuilder {
+    private static final class OverlayFileBuilder {
 
-        AppContentOverlayFileBuilder(JPackageCommand cmd, Path appContentRoot, Path outputFile) {
-            if (outputFile.isAbsolute()) {
-                throw new IllegalArgumentException();
-            }
-
-            if (!outputFile.startsWith(cmd.outputBundle())) {
-                throw new IllegalArgumentException();
-            }
-
+        OverlayFileBuilder(JPackageCommand cmd, Path srcRoot, Path outputFile) {
             this.cmd = Objects.requireNonNull(cmd);
-            this.outputFile = Objects.requireNonNull(outputFile);
-            this.appContentRoot = Objects.requireNonNull(appContentRoot);
+            this.outputFilePathInAppImage = relativize(cmd, outputFile);
+            this.srcRoot = Objects.requireNonNull(srcRoot);
         }
 
         FileCopy createOverlayFile() {
-            final var file = appContentRoot.resolve(pathInAppContentDirectory());
+            if (srcFile == null) {
+                throw new IllegalStateException();
+            }
 
             try {
-                Files.createDirectories(file.getParent());
+                Files.createDirectories(srcFile.getParent());
             } catch (IOException ex) {
                 throw new UncheckedIOException(ex);
             }
-            fileContentInitializer.accept(file);
+            fileContentInitializer.accept(srcFile);
 
-            return new FileCopy(file, outputFile);
+            return new FileCopy(srcFile, outputFilePathInAppImage);
         }
 
-        AppContentOverlayFileBuilder configureCmdOptions() {
-            cmd.addArguments("--app-content", appContentRoot.resolve(pathInAppContentDirectory().getName(0)));
+        OverlayFileBuilder addAppContentOption() {
+            addJPackageOption("--app-content", APP_IMAGE_LAYOUT.contentDirectory());
             return this;
         }
 
-        AppContentOverlayFileBuilder content(Consumer<Path> v) {
+        OverlayFileBuilder addAppResourcesOption() {
+            addJPackageOption("--app-resources", APP_IMAGE_LAYOUT.resourcesDirectory());
+            return this;
+        }
+
+        OverlayFileBuilder content(Consumer<Path> v) {
             fileContentInitializer = v;
             return this;
         }
 
-        AppContentOverlayFileBuilder textContent(String... lines) {
+        OverlayFileBuilder textContent(String... lines) {
             return content(path -> {
                 TKit.createTextFile(path, List.of(lines));
             });
         }
 
-        private Path pathInAppContentDirectory() {
-            return APP_IMAGE_LAYOUT.resolveAt(cmd.outputBundle()).contentDirectory().relativize(outputFile);
+        private void addJPackageOption(String optionName, Path outputDirectoryInAppImage) {
+            Objects.requireNonNull(optionName);
+
+            var relativeSrcFilePath = relativize(outputDirectoryInAppImage, outputFilePathInAppImage);
+
+            cmd.addArguments(optionName, srcRoot.resolve(relativeSrcFilePath.getName(0)));
+
+            srcFile = srcRoot.resolve(relativeSrcFilePath);
         }
 
         private Consumer<Path> fileContentInitializer;
         private final JPackageCommand cmd;
-        private final Path outputFile;
-        private final Path appContentRoot;
+        private final Path outputFilePathInAppImage;
+        private final Path srcRoot;
+        private Path srcFile;
     }
 
 
+    private static Path relativize(Path base, Path path) {
+        if (base.isAbsolute() != path.isAbsolute()) {
+            throw new IllegalArgumentException();
+        }
+
+        if (base.equals(Path.of(""))) {
+            return path;
+        }
+
+        if (!path.startsWith(base)) {
+            throw new IllegalArgumentException();
+        }
+
+        return base.relativize(path);
+    }
+
+    private static Path relativize(JPackageCommand cmd, Path path) {
+        var base = cmd.isImagePackageType() ? cmd.outputBundle() : cmd.appInstallationDirectory();
+        return relativize(base, path);
+    }
+
+    private static Consumer<JPackageCommand> initJPackage() {
+        return cmd -> {
+            // With short name.
+            cmd.setArgumentValue("--name", "Foo");
+
+            // Fresh input dir.
+            cmd.setInputToEmptyDirectory();
+        };
+    }
+
     private static JPackageCommand createJPackage() {
-        // With short name.
-        var cmd = JPackageCommand.helloAppImage().setArgumentValue("--name", "Foo");
-
-        // Clean leftovers in the input dir from the previous test run if any.
-        TKit.deleteDirectoryContentsRecursive(cmd.inputDir());
-
-        return cmd;
+        return JPackageCommand.helloAppImage().mutate(initJPackage());
     }
 
     private static final ApplicationLayout APP_IMAGE_LAYOUT = ApplicationLayout.platformAppImage();

--- a/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
+++ b/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
@@ -41,6 +41,7 @@ import jdk.jpackage.test.Annotations.ParameterSupplier;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.AppImageFile;
 import jdk.jpackage.test.ApplicationLayout;
+import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.TKit;
 
@@ -48,6 +49,7 @@ import jdk.jpackage.test.TKit;
  * @test
  * @summary test order in which jpackage fills app image
  * @library /test/jdk/tools/jpackage/helpers
+ * @key jpackagePlatformPackage
  * @build jdk.jpackage.test.*
  * @compile -Xlint:all -Werror AppImageFillOrderTest.java
  * @run main/othervm/timeout=1440 -Xmx512m
@@ -128,43 +130,78 @@ public class AppImageFillOrderTest {
     @Test
     @Parameter("false")
     @Parameter("true")
-    public void testAppResourcesOverrideAppContent(boolean resourcesFirst) throws IOException {
+    public void testAppResourcesOverrideAppContent(boolean resourcesFirst)
+            throws IOException {
         var cmd = createJPackage().setFakeRuntime();
+        var inputs = AppResourcesOverrideInputs.create();
 
-        var appLayout = APP_IMAGE_LAYOUT.resolveAt(cmd.outputBundle());
-        var outputFile = appLayout.resourcesDirectory().resolve("shared.txt");
-
-        // Create --app-content input
-        var appContentRoot = TKit.createTempDirectory("app-content");
-        Path appContentFile;
-        if (TKit.isOSX()) {
-            appContentFile = Files.createDirectory(appContentRoot.resolve("Resources"))
-                .resolve("shared.txt");
-        } else {
-            appContentFile = appContentRoot.resolve("shared.txt");
-        }
-        TKit.createTextFile(appContentFile, List.of("app-content"));
-
-        // Create --app-resources input
-        var appResourcesFile = TKit.createTempDirectory("app-resources").resolve("shared.txt");
-        TKit.createTextFile(appResourcesFile, List.of("app-resources"));
-
-        var appContentArg = TKit.isOSX() ? appContentFile.getParent() : appContentFile;
-        var appResourcesArg = appResourcesFile;
-
-        if (resourcesFirst) {
-            cmd.addArguments("--app-resources", appResourcesArg);
-            cmd.addArguments("--app-content", appContentArg);
-        } else {
-            cmd.addArguments("--app-content", appContentArg);
-            cmd.addArguments("--app-resources", appResourcesArg);
-        }
+        inputs.addTo(cmd, resourcesFirst);
 
         cmd.executeAndAssertImageCreated();
 
-        // --app-resources must overwrite --app-content
-        TKit.assertSameFileContent(appResourcesFile, outputFile);
-        TKit.assertMismatchFileContent(appContentFile, outputFile);
+        inputs.verify(cmd);
+    }
+
+    @Test
+    @Parameter("false")
+    @Parameter("true")
+    public void testAppResourcesOverrideAppContentInPackage(
+            boolean resourcesFirst) throws IOException {
+        var inputs = AppResourcesOverrideInputs.create();
+
+        new PackageTest()
+                .configureHelloApp()
+                .addInitializer(JPackageCommand::setFakeRuntime)
+                .addInitializer(cmd -> inputs.addTo(cmd, resourcesFirst))
+                .addInstallVerifier(inputs::verify)
+                .run();
+    }
+
+    private record AppResourcesOverrideInputs(
+            Path appContentFile,
+            Path appResourcesFile,
+            Path appContentArg) {
+
+        static AppResourcesOverrideInputs create() throws IOException {
+            var appContentRoot = TKit.createTempDirectory("app-content");
+
+            Path appContentFile;
+            Path appContentArg;
+            if (TKit.isOSX()) {
+                appContentArg = Files.createDirectory(
+                        appContentRoot.resolve("Resources"));
+                appContentFile = appContentArg.resolve("shared.txt");
+            } else {
+                appContentFile = appContentRoot.resolve("shared.txt");
+                appContentArg = appContentFile;
+            }
+            TKit.createTextFile(appContentFile, List.of("app-content"));
+
+            var appResourcesFile = TKit.createTempDirectory("app-resources")
+                    .resolve("shared.txt");
+            TKit.createTextFile(appResourcesFile, List.of("app-resources"));
+
+            return new AppResourcesOverrideInputs(
+                    appContentFile, appResourcesFile, appContentArg);
+        }
+
+        void addTo(JPackageCommand cmd, boolean resourcesFirst) {
+            if (resourcesFirst) {
+                cmd.addArguments("--app-resources", appResourcesFile);
+                cmd.addArguments("--app-content", appContentArg);
+            } else {
+                cmd.addArguments("--app-content", appContentArg);
+                cmd.addArguments("--app-resources", appResourcesFile);
+            }
+        }
+
+        void verify(JPackageCommand cmd) {
+            var outputFile = cmd.appLayout().resourcesDirectory()
+                    .resolve("shared.txt");
+
+            TKit.assertSameFileContent(appResourcesFile, outputFile);
+            TKit.assertMismatchFileContent(appContentFile, outputFile);
+        }
     }
 
     private static void test(JPackageCommand cmd, AppImageOverlay... overlays) {

--- a/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
+++ b/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
@@ -131,7 +131,7 @@ public class AppImageFillOrderTest {
     @Test
     @Parameter("false")
     @Parameter("true")
-    public void testAppContentOverrideAppResources(boolean resourcesFirst)
+    public void testAppContentOverridesAppResources(boolean resourcesFirst)
             throws IOException {
         var cmd = createJPackage().setFakeRuntime();
         var inputs = AppContentOverrideInputs.create();
@@ -146,12 +146,15 @@ public class AppImageFillOrderTest {
     @Test
     @Parameter("false")
     @Parameter("true")
-    public void testAppContentOverrideAppResourcesInPackage(
+    public void testAppContentOverridesAppResourcesInPackage(
             boolean resourcesFirst) throws IOException {
         var inputs = AppContentOverrideInputs.create();
 
         new PackageTest()
                 .configureHelloApp()
+                .addInitializer(cmd -> {
+                    cmd.setArgumentValue("--name", "Foo");
+                })
                 .addInitializer(JPackageCommand::setFakeRuntime)
                 .addInitializer(cmd -> inputs.addTo(cmd, resourcesFirst))
                 .addInstallVerifier(inputs::verify)

--- a/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
+++ b/test/jdk/tools/jpackage/share/AppImageFillOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,7 @@ import jdk.jpackage.test.TKit;
  * <ul>
  * <li>input directory (--input)
  * <li>app content (--app-content)
+ * <li>app resources (--app-resources)
  * <ul>
  */
 public class AppImageFillOrderTest {
@@ -122,6 +123,48 @@ public class AppImageFillOrderTest {
 
         TKit.trace(String.format("Parse [%s] file...", AppImageFile.getPathInAppImage(outputBundle)));
         AppImageFile.load(outputBundle);
+    }
+
+    @Test
+    @Parameter("false")
+    @Parameter("true")
+    public void testAppResourcesOverrideAppContent(boolean resourcesFirst) throws IOException {
+        var cmd = createJPackage().setFakeRuntime();
+
+        var appLayout = APP_IMAGE_LAYOUT.resolveAt(cmd.outputBundle());
+        var outputFile = appLayout.resourcesDirectory().resolve("shared.txt");
+
+        // Create --app-content input
+        var appContentRoot = TKit.createTempDirectory("app-content");
+        Path appContentFile;
+        if (TKit.isOSX()) {
+            appContentFile = Files.createDirectory(appContentRoot.resolve("Resources"))
+                .resolve("shared.txt");
+        } else {
+            appContentFile = appContentRoot.resolve("shared.txt");
+        }
+        TKit.createTextFile(appContentFile, List.of("app-content"));
+
+        // Create --app-resources input
+        var appResourcesFile = TKit.createTempDirectory("app-resources").resolve("shared.txt");
+        TKit.createTextFile(appResourcesFile, List.of("app-resources"));
+
+        var appContentArg = TKit.isOSX() ? appContentFile.getParent() : appContentFile;
+        var appResourcesArg = appResourcesFile;
+
+        if (resourcesFirst) {
+            cmd.addArguments("--app-resources", appResourcesArg);
+            cmd.addArguments("--app-content", appContentArg);
+        } else {
+            cmd.addArguments("--app-content", appContentArg);
+            cmd.addArguments("--app-resources", appResourcesArg);
+        }
+
+        cmd.executeAndAssertImageCreated();
+
+        // --app-resources must overwrite --app-content
+        TKit.assertSameFileContent(appResourcesFile, outputFile);
+        TKit.assertMismatchFileContent(appContentFile, outputFile);
     }
 
     private static void test(JPackageCommand cmd, AppImageOverlay... overlays) {

--- a/test/jdk/tools/jpackage/share/ErrorTest.java
+++ b/test/jdk/tools/jpackage/share/ErrorTest.java
@@ -658,7 +658,8 @@ public final class ErrorTest {
                 List.of("--arguments", "foo"),
                 List.of("--java-options", "-Dfoo.bar=10"),
                 List.of("--add-launcher", "foo=foo.properties"),
-                List.of("--app-content", "dir"));
+                List.of("--app-content", "dir"),
+                List.of("--app-resources", "dir"));
 
         if (TKit.isWindows()) {
             argsStream = Stream.concat(argsStream, Stream.of(List.of("--win-console")));

--- a/test/jdk/tools/jpackage/share/InOutPathTest.java
+++ b/test/jdk/tools/jpackage/share/InOutPathTest.java
@@ -73,6 +73,7 @@ public final class InOutPathTest {
                 }, "--dest and --temp in --input")},
             }));
             data.addAll(additionalContentInput(packageTypeAlias, "--app-content"));
+            data.addAll(additionalContentInput(packageTypeAlias, "--app-resources"));
         }
 
         return data;


### PR DESCRIPTION
- Added `--app-resources`.

Specification:
```
--app-resources

    A File.pathSeparator separated list of paths

    Additional application files and directories to copy into the
    application resources directory.

    This option may be specified multiple times.

    Destination:
        Windows: application image root
        Linux: application image lib directory
        macOS: Contents/Resources
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8390349](https://bugs.openjdk.org/browse/JDK-8390349) to be approved

### Issues
 * [JDK-8388795](https://bugs.openjdk.org/browse/JDK-8388795): Add --app-resources CLI option to copy files and directories into the application resources directory (**Enhancement** - P4)
 * [JDK-8390349](https://bugs.openjdk.org/browse/JDK-8390349): Add --app-resources CLI option to copy files and directories into the application resources directory (**CSR**)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32474/head:pull/32474` \
`$ git checkout pull/32474`

Update a local copy of the PR: \
`$ git checkout pull/32474` \
`$ git pull https://git.openjdk.org/jdk.git pull/32474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32474`

View PR using the GUI difftool: \
`$ git pr show -t 32474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32474.diff">https://git.openjdk.org/jdk/pull/32474.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32474#issuecomment-5362786588)
</details>
