### PR TITLE
8390813: C2: Wrong entries in adlc commutative op lists

### DIFF
--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -3905,14 +3905,14 @@ void MatchNode::count_commutative_op(int& count) {
     "MaxI","MinI","MaxHF","MinHF","MaxF","MinF","MaxD","MinD",
     "MulI","MulL","MulHF","MulF","MulD",
     "OrI","OrL",
-    "XorI","XorL"
+    "XorI","XorL",
   };
 
   static const char *commut_vector_op_list[] = {
     "AddVB", "AddVS", "AddVI", "AddVL", "AddVHF", "AddVF", "AddVD",
     "MulVB", "MulVS", "MulVI", "MulVL", "MulVHF", "MulVF", "MulVD",
     "AndV", "OrV", "XorV", "AndVMask", "OrVMask", "XorVMask",
-    "MaxVHF", "MinVHF", "MaxV", "MinV", "UMaxV", "UMinV"
+    "MaxVHF", "MinVHF", "MaxV", "MinV", "UMaxV", "UMinV",
   };
 
   if (_lChild && _rChild && (_lChild->_lChild || _rChild->_lChild)) {

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -3906,14 +3906,13 @@ void MatchNode::count_commutative_op(int& count) {
     "MulI","MulL","MulHF","MulF","MulD",
     "OrI","OrL",
     "XorI","XorL"
-    "UMax","UMin"
   };
 
   static const char *commut_vector_op_list[] = {
     "AddVB", "AddVS", "AddVI", "AddVL", "AddVHF", "AddVF", "AddVD",
     "MulVB", "MulVS", "MulVI", "MulVL", "MulVHF", "MulVF", "MulVD",
     "AndV", "OrV", "XorV", "AndVMask", "OrVMask", "XorVMask",
-    "MaxVHF", "MinVHF", "MaxV", "MinV", "UMax","UMin"
+    "MaxVHF", "MinVHF", "MaxV", "MinV", "UMaxV", "UMinV"
   };
 
   if (_lChild && _rChild && (_lChild->_lChild || _rChild->_lChild)) {


### PR DESCRIPTION
Hi, please consider.

`MatchNode::count_commutative_op()` in `src/hotspot/share/adlc/formssel.cpp` holds two lists
of ideal node names that adlc treats as commutative. Neither is correct.
 
The scalar list is missing a comma:

    "XorI","XorL"
    "UMax","UMin"
 
String literal concatenation folds `"XorL" "UMax"` into `"XorLUMax"`, so the list really is
`{..., "XorI", "XorLUMax", "UMin"}`. As entries are compared with strcmp(), XorL is no
longer recognized and adlc stops generating its operand-swapped match rules.
 
There are also no scalar UMax/UMin ideal nodes; classes.hpp only defines UMinV/UMaxV.
So the same two names in commut_vector_op_list never match either.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390813](https://bugs.openjdk.org/browse/JDK-8390813): C2: Wrong entries in adlc commutative op lists (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32476/head:pull/32476` \
`$ git checkout pull/32476`

Update a local copy of the PR: \
`$ git checkout pull/32476` \
`$ git pull https://git.openjdk.org/jdk.git pull/32476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32476`

View PR using the GUI difftool: \
`$ git pr show -t 32476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32476.diff">https://git.openjdk.org/jdk/pull/32476.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32476#issuecomment-5365268802)
</details>
