### PR TITLE
8390824: ProblemList container tests intolerant of non-writable /tmp

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -114,6 +114,8 @@ runtime/valhalla/inlinetypes/NPEInPreviewTest.java 8390257 generic-all
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJFREvents.java 8327723 linux-x64
+containers/docker/TestLimitsUpdating.java 8390823 linux-all
+containers/docker/ShareTmpDir.java 8390823 linux-all
 
 #############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -629,6 +629,8 @@ jdk/jfr/event/oldobject/TestZ.java                              8375615 generic-
 
 # jdk_internal
 
+jdk/internal/platform/docker/TestLimitsUpdating.java 8390823 linux-all
+
 ############################################################################
 
 # jdk_jpackage


### PR DESCRIPTION
Some container tests require writable /tmp folder. Problemlist those, until we find a solution.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390824](https://bugs.openjdk.org/browse/JDK-8390824): ProblemList container tests intolerant of non-writable /tmp (**Sub-task** - P4)


### Reviewers
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)
 * [Ramkumar Sunderbabu](https://openjdk.org/census#rsunderbabu) (@rsunderbabu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32477/head:pull/32477` \
`$ git checkout pull/32477`

Update a local copy of the PR: \
`$ git checkout pull/32477` \
`$ git pull https://git.openjdk.org/jdk.git pull/32477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32477`

View PR using the GUI difftool: \
`$ git pr show -t 32477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32477.diff">https://git.openjdk.org/jdk/pull/32477.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32477#issuecomment-5371055147)
</details>
