### PR TITLE
8390661: gc/TestGCALotAtSafepoints sub-tests times out

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -380,6 +380,12 @@ void before_exit(JavaThread* thread, bool halt) {
 
   Events::log(thread, "Before exit entered");
 
+  // A GC requested after we shut down the heap blocks that requesting Java thread.
+  // Suppress GC-a-lot for threads entering shutdown as Monitor::lock() calls in the
+  // remainder of the shutdown sequence could otherwise block when executing a
+  // GC-a-lot caused collection.
+  DEBUG_ONLY(thread->set_skip_gcalot(true);)
+
   // Note: don't use a Mutex to guard the entire before_exit(), as
   // JVMTI post_thread_end_event and post_vm_death_event will run native code.
   // A CAS or OSMutex would work just fine but then we need to manipulate

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -384,7 +384,7 @@ void before_exit(JavaThread* thread, bool halt) {
   // Suppress GC-a-lot for threads entering shutdown as Monitor::lock() calls in the
   // remainder of the shutdown sequence could otherwise block when executing a
   // GC-a-lot caused collection.
-  DEBUG_ONLY(thread->set_skip_gcalot(true);)
+  NOT_PRODUCT(thread->set_skip_gcalot(true);)
 
   // Note: don't use a Mutex to guard the entire before_exit(), as
   // JVMTI post_thread_end_event and post_vm_death_event will run native code.

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -281,7 +281,7 @@ void JavaThread::check_possible_safepoint() {
 #endif // CHECK_UNHANDLED_OOPS
 }
 
-void JavaThread::check_for_valid_safepoint_state(bool allow_gcalot) {
+void JavaThread::check_for_valid_safepoint_state() {
   // Don't complain if running a debugging command.
   if (DebuggingContext::is_enabled()) return;
 
@@ -294,7 +294,7 @@ void JavaThread::check_for_valid_safepoint_state(bool allow_gcalot) {
     fatal("LEAF method calling lock?");
   }
 
-  if (GCALotAtAllSafepoints && allow_gcalot) {
+  if (GCALotAtAllSafepoints) {
     // We could enter a safepoint here and thus have a gc
     InterfaceSupport::check_gc_alot();
   }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -284,7 +284,7 @@ class JavaThread: public Thread {
  public:
   // These functions check conditions before possibly going to a safepoint.
   // including NoSafepointVerifier.
-  void check_for_valid_safepoint_state(bool allow_gcalot = true) NOT_DEBUG_RETURN;
+  void check_for_valid_safepoint_state()                         NOT_DEBUG_RETURN;
   void check_possible_safepoint()                                NOT_DEBUG_RETURN;
 
 #ifdef ASSERT

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -248,7 +248,7 @@ bool Monitor::wait(uint64_t timeout) {
   // Although the (HotSpot) monitor is logically released, the underlying
   // OS monitor is still held. Do not execute GC-a-lot here because
   // garbage collection may (in)directly require the current monitor to
-  // progress. 
+  // progress.
   check_safepoint_state(self, false /* allow_gcalot */);
 
   int wait_status;

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -61,7 +61,7 @@ void Mutex::check_block_state(Thread* thread) {
          "locking not allowed when crash protection is set");
 }
 
-void Mutex::check_safepoint_state(Thread* thread, bool allow_gcalot) {
+void Mutex::check_safepoint_state(Thread* thread) {
   check_block_state(thread);
 
   // If the lock acquisition checks for safepoint, verify that the lock was created with rank that
@@ -72,7 +72,7 @@ void Mutex::check_safepoint_state(Thread* thread, bool allow_gcalot) {
 
   if (thread->is_active_Java_thread()) {
     // Also check NoSafepointVerifier, and thread state is _thread_in_vm
-    JavaThread::cast(thread)->check_for_valid_safepoint_state(allow_gcalot);
+    JavaThread::cast(thread)->check_for_valid_safepoint_state();
   }
 }
 
@@ -116,7 +116,7 @@ void Mutex::lock_contended(Thread* self) {
 void Mutex::lock(Thread* self) {
   assert(owner() != self, "invariant");
 
-  check_safepoint_state(self, true /* allow_gcalot */);
+  check_safepoint_state(self);
   check_rank(self);
 
   OrderAccess::fence();
@@ -249,7 +249,10 @@ bool Monitor::wait(uint64_t timeout) {
   // OS monitor is still held. Do not execute GC-a-lot here because
   // garbage collection may (in)directly require the current monitor to
   // progress.
-  check_safepoint_state(self, false /* allow_gcalot */);
+  {
+    SkipGCALot sgcalot(self);
+    check_safepoint_state(self);
+  }
 
   int wait_status;
   InFlightMutexRelease ifmr(this);

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -246,10 +246,10 @@ bool Monitor::wait(uint64_t timeout) {
 
   // Check safepoint state after resetting owner and possible NSV.
   // Although the (HotSpot) monitor is logically released, the underlying
-  // OS monitor is still held. If this is the Heap_lock we would
-  // deadlock in the GC prologue trying to acquire the lock recursively.
-  // Suppress GC-a-lot in that case.
-  check_safepoint_state(self, this != Heap_lock);
+  // OS monitor is still held. Do not execute GC-a-lot here because
+  // garbage collection may (in)directly require the current monitor to
+  // progress. 
+  check_safepoint_state(self, false /* allow_gcalot */);
 
   int wait_status;
   InFlightMutexRelease ifmr(this);

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -141,7 +141,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
  protected:
   void set_owner_implementation(Thread* owner)                        NOT_DEBUG({ raw_set_owner(owner);});
   void check_block_state       (Thread* thread)                       NOT_DEBUG_RETURN;
-  void check_safepoint_state   (Thread* thread, bool allow_gcalot)    NOT_DEBUG_RETURN;
+  void check_safepoint_state   (Thread* thread)                       NOT_DEBUG_RETURN;
   void check_no_safepoint_state(Thread* thread)                       NOT_DEBUG_RETURN;
   void check_rank              (Thread* thread)                       NOT_DEBUG_RETURN;
   void assert_owner            (Thread* expected)                     NOT_DEBUG_RETURN;

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -667,4 +667,28 @@ inline Thread* Thread::current_or_null_safe() {
   return nullptr;
 }
 
+// A SkipGCALot object is used to elide the usual effect of gc-a-lot
+// over a section of execution by a thread.
+class SkipGCALot : public StackObj {
+  private:
+   bool _saved;
+   Thread* _t;
+
+  public:
+#ifdef ASSERT
+    SkipGCALot(Thread* t) : _t(t) {
+      _saved = _t->skip_gcalot();
+      _t->set_skip_gcalot(true);
+    }
+
+    ~SkipGCALot() {
+      assert(_t->skip_gcalot(), "Save-restore protocol invariant");
+      _t->set_skip_gcalot(_saved);
+    }
+#else
+    SkipGCALot(Thread* t) { }
+    ~SkipGCALot() { }
+#endif
+};
+
 #endif // SHARE_RUNTIME_THREAD_HPP

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -487,31 +487,6 @@ void VMThread::loop() {
     inner_execute(_next_vm_operation);
   }
 }
-
-// A SkipGCALot object is used to elide the usual effect of gc-a-lot
-// over a section of execution by a thread. Currently, it's used only to
-// prevent re-entrant calls to GC.
-class SkipGCALot : public StackObj {
-  private:
-   bool _saved;
-   Thread* _t;
-
-  public:
-#ifdef ASSERT
-    SkipGCALot(Thread* t) : _t(t) {
-      _saved = _t->skip_gcalot();
-      _t->set_skip_gcalot(true);
-    }
-
-    ~SkipGCALot() {
-      assert(_t->skip_gcalot(), "Save-restore protocol invariant");
-      _t->set_skip_gcalot(_saved);
-    }
-#else
-    SkipGCALot(Thread* t) { }
-    ~SkipGCALot() { }
-#endif
-};
 
 void VMThread::execute(VM_Operation* op) {
   Thread* t = Thread::current();

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -87,11 +87,6 @@ gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java#generational 83869
 gc/stress/jfr/TestStressAllocationGCEventsWithShenandoah.java#default 8386964 generic-all
 gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#generational 8386964 generic-all
 gc/stress/jfr/TestStressBigAllocationGCEventsWithShenandoah.java#default 8386964 generic-all
-gc/TestGCALotAtAllSafepoints.java#Parallel 8390661 generic-all
-gc/TestGCALotAtAllSafepoints.java#Serial 8390661 generic-all
-gc/TestGCALotAtAllSafepoints.java#G1 8390661 generic-all
-gc/TestGCALotAtAllSafepoints.java#Z 8390661 generic-all
-gc/TestGCALotAtAllSafepoints.java#Shenandoah 8390661 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/gc/TestGCALotAtAllSafepoints.java
+++ b/test/hotspot/jtreg/gc/TestGCALotAtAllSafepoints.java
@@ -34,7 +34,7 @@ package gc;
  * @requires vm.gc.Serial
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseSerialGC -XX:ScavengeALotInterval=1
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseSerialGC
  */
 
 /**
@@ -48,7 +48,7 @@ package gc;
  * @requires vm.gc.Parallel
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseParallelGC -XX:ScavengeALotInterval=1
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseParallelGC
  */
 
 /**
@@ -62,7 +62,7 @@ package gc;
  * @requires vm.gc.G1
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseG1GC -XX:ScavengeALotInterval=1
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseG1GC
  */
 
 /**
@@ -76,7 +76,7 @@ package gc;
  * @requires vm.gc.Z
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseZGC -XX:ScavengeALotInterval=1
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseZGC
  */
 
 /**
@@ -90,7 +90,7 @@ package gc;
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseShenandoahGC -XX:ScavengeALotInterval=13
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseShenandoahGC
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -99,12 +99,16 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestGCALotAtAllSafepoints {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(args[0],
-                                                                             args[1],
                                                                              "-Xmx16m",
+                                                                             // Even this small test can generate thousands of GCs. Reduce them.
+                                                                             "-XX:ScavengeALotInterval=13",
                                                                              "-XX:+GCALotAtAllSafepoints",
                                                                              "-XX:+ScavengeALot",
+                                                                             "-Xlog:gc,gc+start,safepoint",
                                                                              "NoSuchClass");
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+        Process process = ProcessTools.startProcess("gcalot", pb);
+        OutputAnalyzer output = new OutputAnalyzer(process);
         output.shouldMatch("Error: Could not find or load main class NoSuchClass");
         output.shouldHaveExitValue(1);
     }

--- a/test/hotspot/jtreg/gc/TestGCALotAtAllSafepoints.java
+++ b/test/hotspot/jtreg/gc/TestGCALotAtAllSafepoints.java
@@ -34,7 +34,7 @@ package gc;
  * @requires vm.gc.Serial
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseSerialGC
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseSerialGC -XX:ScavengeALotInterval=1
  */
 
 /**
@@ -48,7 +48,7 @@ package gc;
  * @requires vm.gc.Parallel
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseParallelGC
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseParallelGC -XX:ScavengeALotInterval=1
  */
 
 /**
@@ -62,7 +62,7 @@ package gc;
  * @requires vm.gc.G1
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseG1GC
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseG1GC -XX:ScavengeALotInterval=1
  */
 
 /**
@@ -76,7 +76,7 @@ package gc;
  * @requires vm.gc.Z
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseZGC
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseZGC -XX:ScavengeALotInterval=1
  */
 
 /**
@@ -90,7 +90,7 @@ package gc;
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseShenandoahGC
+ * @run driver/timeout=60 gc.TestGCALotAtAllSafepoints -XX:+UseShenandoahGC -XX:ScavengeALotInterval=13
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -99,6 +99,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestGCALotAtAllSafepoints {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(args[0],
+                                                                             args[1],
                                                                              "-Xmx16m",
                                                                              "-XX:+GCALotAtAllSafepoints",
                                                                              "-XX:+ScavengeALot",


### PR DESCRIPTION
Hi all,

  the tests in JDK-8389096 discovered more hangs with . There were two main causes:

* the place where the previous place allowed GC after logical release of a monitor but before releasing the OS monitor in some cases is too weak, there are a few potential cases where a deadlock could happen due to indirect monitor uses. The solution is to just conservatively disable GC-alot GCs in this situation.
* shutdown in particular had the issue where trying to do a GC-alot GC while we are shutting down would hang. One example is that Universe::before_exit() shuts down the GC, then other threads go into ::before_exit(). These threads trying to get - but the GC VM operation blocks if shutting down, so the VM will hang there.

The CI hangs were of the second sort. They were also confusing because jtreg reported that the test completed during timeout handling.

Testing: running the now un-problemlisted tests again for many times, no failure.

Hth,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390661](https://bugs.openjdk.org/browse/JDK-8390661): gc/TestGCALotAtSafepoints sub-tests times out (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32478/head:pull/32478` \
`$ git checkout pull/32478`

Update a local copy of the PR: \
`$ git checkout pull/32478` \
`$ git pull https://git.openjdk.org/jdk.git pull/32478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32478`

View PR using the GUI difftool: \
`$ git pr show -t 32478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32478.diff">https://git.openjdk.org/jdk/pull/32478.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32478#issuecomment-5406731159)
</details>
