### PR TITLE
8390826: RISC-V: Use dedicated vector mask logical instructions

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -4518,7 +4518,7 @@ instruct vmaskAllL(vRegMask dst, iRegL src) %{
 
 // ------------------------------ Vector mask basic OPs ------------------------
 
-// vector mask logical ops: and/and-not/or/xor
+// vector mask logical ops
 
 instruct vmask_and(vRegMask dst, vRegMask src1, vRegMask src2) %{
   match(Set dst (AndVMask src1 src2));
@@ -4555,6 +4555,136 @@ instruct vmask_and_notL(vRegMask dst, vRegMask src1, vRegMask src2, immL_M1 m1) 
     __ vmandn_mm(as_VectorRegister($dst$$reg),
                  as_VectorRegister($src1$$reg),
                  as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_or_notI(vRegMask dst, vRegMask src1, vRegMask src2, immI_M1 m1) %{
+  match(Set dst (OrVMask src1 (XorVMask src2 (MaskAll m1))));
+  format %{ "vmask_or_notI $dst, $src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmorn_mm(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_or_notL(vRegMask dst, vRegMask src1, vRegMask src2, immL_M1 m1) %{
+  match(Set dst (OrVMask src1 (XorVMask src2 (MaskAll m1))));
+  format %{ "vmask_or_notL $dst, $src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmorn_mm(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_nandI(vRegMask dst, vRegMask src1, vRegMask src2, immI_M1 m1) %{
+  match(Set dst (XorVMask (AndVMask src1 src2) (MaskAll m1)));
+  format %{ "vmask_nandI $dst, $src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmnand_mm(as_VectorRegister($dst$$reg),
+                 as_VectorRegister($src1$$reg),
+                 as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_nandL(vRegMask dst, vRegMask src1, vRegMask src2, immL_M1 m1) %{
+  match(Set dst (XorVMask (AndVMask src1 src2) (MaskAll m1)));
+  format %{ "vmask_nandL $dst, $src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmnand_mm(as_VectorRegister($dst$$reg),
+                 as_VectorRegister($src1$$reg),
+                 as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_norI(vRegMask dst, vRegMask src1, vRegMask src2, immI_M1 m1) %{
+  match(Set dst (XorVMask (OrVMask src1 src2) (MaskAll m1)));
+  format %{ "vmask_norI $dst, $src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmnor_mm(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_norL(vRegMask dst, vRegMask src1, vRegMask src2, immL_M1 m1) %{
+  match(Set dst (XorVMask (OrVMask src1 src2) (MaskAll m1)));
+  format %{ "vmask_norL $dst, $src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmnor_mm(as_VectorRegister($dst$$reg),
+                as_VectorRegister($src1$$reg),
+                as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_xnorI(vRegMask dst, vRegMask src1, vRegMask src2, immI_M1 m1) %{
+  match(Set dst (XorVMask (XorVMask src1 src2) (MaskAll m1)));
+  match(Set dst (XorVMask src1 (XorVMask src2 (MaskAll m1))));
+  format %{ "vmask_xnorI $dst, $src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmxnor_mm(as_VectorRegister($dst$$reg),
+                 as_VectorRegister($src1$$reg),
+                 as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_xnorL(vRegMask dst, vRegMask src1, vRegMask src2, immL_M1 m1) %{
+  match(Set dst (XorVMask (XorVMask src1 src2) (MaskAll m1)));
+  match(Set dst (XorVMask src1 (XorVMask src2 (MaskAll m1))));
+  format %{ "vmask_xnorL $dst, $src1, $src2" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmxnor_mm(as_VectorRegister($dst$$reg),
+                 as_VectorRegister($src1$$reg),
+                 as_VectorRegister($src2$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_notI(vRegMask dst, vRegMask src, immI_M1 m1) %{
+  match(Set dst (XorVMask src (MaskAll m1)));
+  format %{ "vmask_notI $dst, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmnot_m(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmask_notL(vRegMask dst, vRegMask src, immL_M1 m1) %{
+  match(Set dst (XorVMask src (MaskAll m1)));
+  format %{ "vmask_notL $dst, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmnot_m(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2808,6 +2808,56 @@ public class IRNode {
         machOnlyNameRegex(VMASK_AND_NOT_L, "vmask_and_notL");
     }
 
+    public static final String RISCV_VMASK_OR_NOT_I = PREFIX + "RISCV_VMASK_OR_NOT_I" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_OR_NOT_I, "vmask_or_notI");
+    }
+
+    public static final String RISCV_VMASK_OR_NOT_L = PREFIX + "RISCV_VMASK_OR_NOT_L" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_OR_NOT_L, "vmask_or_notL");
+    }
+
+    public static final String RISCV_VMASK_NAND_I = PREFIX + "RISCV_VMASK_NAND_I" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_NAND_I, "vmask_nandI");
+    }
+
+    public static final String RISCV_VMASK_NAND_L = PREFIX + "RISCV_VMASK_NAND_L" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_NAND_L, "vmask_nandL");
+    }
+
+    public static final String RISCV_VMASK_NOR_I = PREFIX + "RISCV_VMASK_NOR_I" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_NOR_I, "vmask_norI");
+    }
+
+    public static final String RISCV_VMASK_NOR_L = PREFIX + "RISCV_VMASK_NOR_L" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_NOR_L, "vmask_norL");
+    }
+
+    public static final String RISCV_VMASK_XNOR_I = PREFIX + "RISCV_VMASK_XNOR_I" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_XNOR_I, "vmask_xnorI");
+    }
+
+    public static final String RISCV_VMASK_XNOR_L = PREFIX + "RISCV_VMASK_XNOR_L" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_XNOR_L, "vmask_xnorL");
+    }
+
+    public static final String RISCV_VMASK_NOT_I = PREFIX + "RISCV_VMASK_NOT_I" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_NOT_I, "vmask_notI");
+    }
+
+    public static final String RISCV_VMASK_NOT_L = PREFIX + "RISCV_VMASK_NOT_L" + POSTFIX;
+    static {
+        machOnlyNameRegex(RISCV_VMASK_NOT_L, "vmask_notL");
+    }
+
     public static final String VMLA = PREFIX + "VMLA" + POSTFIX;
     static {
         machOnlyNameRegex(VMLA, "vmla");

--- a/test/hotspot/jtreg/compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java
@@ -240,6 +240,160 @@ public class AllBitsSetVectorMatchRuleTest {
         }
     }
 
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_NOT_I, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskNotI() {
+        VectorMask<Integer> avm = VectorMask.fromArray(I_SPECIES, ma, 0);
+        avm.not().intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(!ma[i], mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_NOT_L, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskNotL() {
+        VectorMask<Long> avm = VectorMask.fromArray(L_SPECIES, ma, 0);
+        avm.not().intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Asserts.assertEquals(!ma[i], mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_NAND_I, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskNandI() {
+        VectorMask<Integer> avm = VectorMask.fromArray(I_SPECIES, ma, 0);
+        VectorMask<Integer> bvm = VectorMask.fromArray(I_SPECIES, mb, 0);
+        avm.and(bvm).not().intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(!(ma[i] & mb[i]), mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_NAND_L, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskNandL() {
+        VectorMask<Long> avm = VectorMask.fromArray(L_SPECIES, ma, 0);
+        VectorMask<Long> bvm = VectorMask.fromArray(L_SPECIES, mb, 0);
+        avm.and(bvm).not().intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Asserts.assertEquals(!(ma[i] & mb[i]), mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_NOR_I, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskNorI() {
+        VectorMask<Integer> avm = VectorMask.fromArray(I_SPECIES, ma, 0);
+        VectorMask<Integer> bvm = VectorMask.fromArray(I_SPECIES, mb, 0);
+        avm.or(bvm).not().intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(!(ma[i] | mb[i]), mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_NOR_L, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskNorL() {
+        VectorMask<Long> avm = VectorMask.fromArray(L_SPECIES, ma, 0);
+        VectorMask<Long> bvm = VectorMask.fromArray(L_SPECIES, mb, 0);
+        avm.or(bvm).not().intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Asserts.assertEquals(!(ma[i] | mb[i]), mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_XNOR_I, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskXnorI() {
+        VectorMask<Integer> avm = VectorMask.fromArray(I_SPECIES, ma, 0);
+        VectorMask<Integer> bvm = VectorMask.fromArray(I_SPECIES, mb, 0);
+        avm.xor(bvm).not().intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(!(ma[i] ^ mb[i]), mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_XNOR_L, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskXnorL() {
+        VectorMask<Long> avm = VectorMask.fromArray(L_SPECIES, ma, 0);
+        VectorMask<Long> bvm = VectorMask.fromArray(L_SPECIES, mb, 0);
+        avm.xor(bvm).not().intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Asserts.assertEquals(!(ma[i] ^ mb[i]), mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_XNOR_I, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskEqI() {
+        VectorMask<Integer> avm = VectorMask.fromArray(I_SPECIES, ma, 0);
+        VectorMask<Integer> bvm = VectorMask.fromArray(I_SPECIES, mb, 0);
+        avm.eq(bvm).intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(ma[i] == mb[i], mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_XNOR_L, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskEqL() {
+        VectorMask<Long> avm = VectorMask.fromArray(L_SPECIES, ma, 0);
+        VectorMask<Long> bvm = VectorMask.fromArray(L_SPECIES, mb, 0);
+        avm.eq(bvm).intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Asserts.assertEquals(ma[i] == mb[i], mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_OR_NOT_I, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskOrNotI() {
+        VectorMask<Integer> avm = VectorMask.fromArray(I_SPECIES, ma, 0);
+        VectorMask<Integer> bvm = VectorMask.fromArray(I_SPECIES, mb, 0);
+        avm.or(bvm.not()).intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(ma[i] | !mb[i], mr[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.RISCV_VMASK_OR_NOT_L, "1" }, applyIfPlatform = {"riscv64", "true"})
+    public static void testMaskOrNotL() {
+        VectorMask<Long> avm = VectorMask.fromArray(L_SPECIES, ma, 0);
+        VectorMask<Long> bvm = VectorMask.fromArray(L_SPECIES, mb, 0);
+        avm.or(bvm.not()).intoArray(mr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            Asserts.assertEquals(ma[i] | !mb[i], mr[i]);
+        }
+    }
+
     // Tests that mask.not().and(other) matches to VMASK_AND_NOT (AndVMask commutative rule).
     @Test
     @IR(counts = { IRNode.VMASK_AND_NOT_I, "1" }, applyIfCPUFeatureOr = {"sve", "true", "rvv", "true"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskLogicOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskLogicOperationsBenchmark.java
@@ -99,6 +99,218 @@ public class MaskLogicOperationsBenchmark {
     }
 
     @Benchmark
+    public void byteMaskNot() {
+        for (int i = 0; i < B_SPECIES.loopBound(size); i += B_SPECIES.length()) {
+            VectorMask<Byte> vm = VectorMask.fromArray(B_SPECIES, ma, i);
+            vm.not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void shortMaskNot() {
+        for (int i = 0; i < S_SPECIES.loopBound(size); i += S_SPECIES.length()) {
+            VectorMask<Short> vm = VectorMask.fromArray(S_SPECIES, ma, i);
+            vm.not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void intMaskNot() {
+        for (int i = 0; i < I_SPECIES.loopBound(size); i += I_SPECIES.length()) {
+            VectorMask<Integer> vm = VectorMask.fromArray(I_SPECIES, ma, i);
+            vm.not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void longMaskNot() {
+        for (int i = 0; i < L_SPECIES.loopBound(size); i += L_SPECIES.length()) {
+            VectorMask<Long> vm = VectorMask.fromArray(L_SPECIES, ma, i);
+            vm.not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void byteMaskNand() {
+        VectorMask<Byte> vm1 = VectorMask.fromArray(B_SPECIES, ma, 0);
+        for (int i = 0; i < B_SPECIES.loopBound(size); i += B_SPECIES.length()) {
+            VectorMask<Byte> vm2 = VectorMask.fromArray(B_SPECIES, mb, i);
+            vm1.and(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void shortMaskNand() {
+        VectorMask<Short> vm1 = VectorMask.fromArray(S_SPECIES, ma, 0);
+        for (int i = 0; i < S_SPECIES.loopBound(size); i += S_SPECIES.length()) {
+            VectorMask<Short> vm2 = VectorMask.fromArray(S_SPECIES, mb, i);
+            vm1.and(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void intMaskNand() {
+        VectorMask<Integer> vm1 = VectorMask.fromArray(I_SPECIES, ma, 0);
+        for (int i = 0; i < I_SPECIES.loopBound(size); i += I_SPECIES.length()) {
+            VectorMask<Integer> vm2 = VectorMask.fromArray(I_SPECIES, mb, i);
+            vm1.and(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void longMaskNand() {
+        VectorMask<Long> vm1 = VectorMask.fromArray(L_SPECIES, ma, 0);
+        for (int i = 0; i < L_SPECIES.loopBound(size); i += L_SPECIES.length()) {
+            VectorMask<Long> vm2 = VectorMask.fromArray(L_SPECIES, mb, i);
+            vm1.and(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void byteMaskNor() {
+        VectorMask<Byte> vm1 = VectorMask.fromArray(B_SPECIES, ma, 0);
+        for (int i = 0; i < B_SPECIES.loopBound(size); i += B_SPECIES.length()) {
+            VectorMask<Byte> vm2 = VectorMask.fromArray(B_SPECIES, mb, i);
+            vm1.or(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void shortMaskNor() {
+        VectorMask<Short> vm1 = VectorMask.fromArray(S_SPECIES, ma, 0);
+        for (int i = 0; i < S_SPECIES.loopBound(size); i += S_SPECIES.length()) {
+            VectorMask<Short> vm2 = VectorMask.fromArray(S_SPECIES, mb, i);
+            vm1.or(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void intMaskNor() {
+        VectorMask<Integer> vm1 = VectorMask.fromArray(I_SPECIES, ma, 0);
+        for (int i = 0; i < I_SPECIES.loopBound(size); i += I_SPECIES.length()) {
+            VectorMask<Integer> vm2 = VectorMask.fromArray(I_SPECIES, mb, i);
+            vm1.or(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void longMaskNor() {
+        VectorMask<Long> vm1 = VectorMask.fromArray(L_SPECIES, ma, 0);
+        for (int i = 0; i < L_SPECIES.loopBound(size); i += L_SPECIES.length()) {
+            VectorMask<Long> vm2 = VectorMask.fromArray(L_SPECIES, mb, i);
+            vm1.or(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void byteMaskXnor() {
+        VectorMask<Byte> vm1 = VectorMask.fromArray(B_SPECIES, ma, 0);
+        for (int i = 0; i < B_SPECIES.loopBound(size); i += B_SPECIES.length()) {
+            VectorMask<Byte> vm2 = VectorMask.fromArray(B_SPECIES, mb, i);
+            vm1.xor(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void shortMaskXnor() {
+        VectorMask<Short> vm1 = VectorMask.fromArray(S_SPECIES, ma, 0);
+        for (int i = 0; i < S_SPECIES.loopBound(size); i += S_SPECIES.length()) {
+            VectorMask<Short> vm2 = VectorMask.fromArray(S_SPECIES, mb, i);
+            vm1.xor(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void intMaskXnor() {
+        VectorMask<Integer> vm1 = VectorMask.fromArray(I_SPECIES, ma, 0);
+        for (int i = 0; i < I_SPECIES.loopBound(size); i += I_SPECIES.length()) {
+            VectorMask<Integer> vm2 = VectorMask.fromArray(I_SPECIES, mb, i);
+            vm1.xor(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void longMaskXnor() {
+        VectorMask<Long> vm1 = VectorMask.fromArray(L_SPECIES, ma, 0);
+        for (int i = 0; i < L_SPECIES.loopBound(size); i += L_SPECIES.length()) {
+            VectorMask<Long> vm2 = VectorMask.fromArray(L_SPECIES, mb, i);
+            vm1.xor(vm2).not().intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void byteMaskEq() {
+        VectorMask<Byte> vm1 = VectorMask.fromArray(B_SPECIES, ma, 0);
+        for (int i = 0; i < B_SPECIES.loopBound(size); i += B_SPECIES.length()) {
+            VectorMask<Byte> vm2 = VectorMask.fromArray(B_SPECIES, mb, i);
+            vm1.eq(vm2).intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void shortMaskEq() {
+        VectorMask<Short> vm1 = VectorMask.fromArray(S_SPECIES, ma, 0);
+        for (int i = 0; i < S_SPECIES.loopBound(size); i += S_SPECIES.length()) {
+            VectorMask<Short> vm2 = VectorMask.fromArray(S_SPECIES, mb, i);
+            vm1.eq(vm2).intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void intMaskEq() {
+        VectorMask<Integer> vm1 = VectorMask.fromArray(I_SPECIES, ma, 0);
+        for (int i = 0; i < I_SPECIES.loopBound(size); i += I_SPECIES.length()) {
+            VectorMask<Integer> vm2 = VectorMask.fromArray(I_SPECIES, mb, i);
+            vm1.eq(vm2).intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void longMaskEq() {
+        VectorMask<Long> vm1 = VectorMask.fromArray(L_SPECIES, ma, 0);
+        for (int i = 0; i < L_SPECIES.loopBound(size); i += L_SPECIES.length()) {
+            VectorMask<Long> vm2 = VectorMask.fromArray(L_SPECIES, mb, i);
+            vm1.eq(vm2).intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void byteMaskOrNot() {
+        VectorMask<Byte> vm1 = VectorMask.fromArray(B_SPECIES, ma, 0);
+        for (int i = 0; i < B_SPECIES.loopBound(size); i += B_SPECIES.length()) {
+            VectorMask<Byte> vm2 = VectorMask.fromArray(B_SPECIES, mb, i);
+            vm1.or(vm2.not()).intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void shortMaskOrNot() {
+        VectorMask<Short> vm1 = VectorMask.fromArray(S_SPECIES, ma, 0);
+        for (int i = 0; i < S_SPECIES.loopBound(size); i += S_SPECIES.length()) {
+            VectorMask<Short> vm2 = VectorMask.fromArray(S_SPECIES, mb, i);
+            vm1.or(vm2.not()).intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void intMaskOrNot() {
+        VectorMask<Integer> vm1 = VectorMask.fromArray(I_SPECIES, ma, 0);
+        for (int i = 0; i < I_SPECIES.loopBound(size); i += I_SPECIES.length()) {
+            VectorMask<Integer> vm2 = VectorMask.fromArray(I_SPECIES, mb, i);
+            vm1.or(vm2.not()).intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
+    public void longMaskOrNot() {
+        VectorMask<Long> vm1 = VectorMask.fromArray(L_SPECIES, ma, 0);
+        for (int i = 0; i < L_SPECIES.loopBound(size); i += L_SPECIES.length()) {
+            VectorMask<Long> vm2 = VectorMask.fromArray(L_SPECIES, mb, i);
+            vm1.or(vm2.not()).intoArray(mc, i);
+        }
+    }
+
+    @Benchmark
     public int highMaskRegisterPressureWithNots() {
         int res = 0;
         VectorMask<Byte> vm1 = VectorMask.fromArray(B_SPECIES, ma, 0);


### PR DESCRIPTION
Hi, please consider.

This is a follow-up to [JDK-8390101](https://bugs.openjdk.org/browse/JDK-8390101).

On RISC-V, several VectorMask logical operations involving an all-bits-set mask are currently emitted as sequences of multiple RVV mask instructions. These include:

- VectorMask.not()
- VectorMask.and(...).not()
- VectorMask.or(...).not()
- VectorMask.xor(...).not()
- VectorMask.eq()
- VectorMask.or(other.not())

RVV provides mask logical instructions that can implement these operations directly.

This change adds RISC-V C2 match rules to emit:

- vmnot.m for mask NOT
- vmnand.mm for mask NAND
- vmnor.mm for mask NOR
- vmxnor.mm for mask XNOR and mask equality
- vmorn.mm for mask OR-NOT

The rules cover byte, short, int, and long vector element types and replace multi-instruction mask logical sequences with a single RVV mask instruction.

## Testing

`MaskLogicOperationsBenchmark` on sg2044:

```
                                                                                   Before                 After
Benchmark                                        (size)   Mode  Cnt      Score      Error      Score      Error   Units
MaskLogicOperationsBenchmark.byteMaskEq             256  thrpt   10   9018.332 ±   80.876  12940.779 ± 1240.139  ops/ms
MaskLogicOperationsBenchmark.byteMaskEq             512  thrpt   10   4542.277 ±  474.059   6833.785 ±  852.424  ops/ms
MaskLogicOperationsBenchmark.byteMaskEq            1024  thrpt   10   2485.999 ±   23.447   3783.676 ±   37.133  ops/ms
MaskLogicOperationsBenchmark.byteMaskNand           256  thrpt   10   9239.545 ±   76.134  13712.414 ±   87.500  ops/ms
MaskLogicOperationsBenchmark.byteMaskNand           512  thrpt   10   4865.590 ±   33.147   7037.323 ±  138.414  ops/ms
MaskLogicOperationsBenchmark.byteMaskNand          1024  thrpt   10   2498.022 ±   32.932   3757.491 ±   68.019  ops/ms
MaskLogicOperationsBenchmark.byteMaskNor            256  thrpt   10   9234.898 ±   60.028  13362.605 ±  803.210  ops/ms
MaskLogicOperationsBenchmark.byteMaskNor            512  thrpt   10   4564.248 ±  389.177   7175.499 ±  183.598  ops/ms
MaskLogicOperationsBenchmark.byteMaskNor           1024  thrpt   10   2391.446 ±  128.692   3801.884 ±   61.826  ops/ms
MaskLogicOperationsBenchmark.byteMaskNot            256  thrpt   10  12136.710 ±   42.704  12737.138 ±  583.812  ops/ms
MaskLogicOperationsBenchmark.byteMaskNot            512  thrpt   10   6355.718 ±   31.723   7303.202 ±  163.445  ops/ms
MaskLogicOperationsBenchmark.byteMaskNot           1024  thrpt   10   3184.678 ±   46.596   3769.555 ±   29.849  ops/ms
MaskLogicOperationsBenchmark.byteMaskOrNot          256  thrpt   10   8601.007 ±  719.879  12740.624 ± 1507.283  ops/ms
MaskLogicOperationsBenchmark.byteMaskOrNot          512  thrpt   10   4809.177 ±   16.371   7144.403 ±  253.849  ops/ms
MaskLogicOperationsBenchmark.byteMaskOrNot         1024  thrpt   10   2506.743 ±    4.472   3686.264 ±  158.669  ops/ms
MaskLogicOperationsBenchmark.byteMaskXnor           256  thrpt   10   9185.579 ±   50.773  13342.889 ±  784.611  ops/ms
MaskLogicOperationsBenchmark.byteMaskXnor           512  thrpt   10   4711.714 ±  233.564   6452.076 ±  638.762  ops/ms
MaskLogicOperationsBenchmark.byteMaskXnor          1024  thrpt   10   2494.493 ±   15.519   3572.480 ±  297.684  ops/ms
MaskLogicOperationsBenchmark.intMaskEq              256  thrpt   10   2073.400 ±    5.135   2472.091 ±    5.428  ops/ms
MaskLogicOperationsBenchmark.intMaskEq              512  thrpt   10   1048.405 ±    2.645   1248.988 ±    4.087  ops/ms
MaskLogicOperationsBenchmark.intMaskEq             1024  thrpt   10    526.488 ±    1.489    622.896 ±    2.938  ops/ms
MaskLogicOperationsBenchmark.intMaskNand            256  thrpt   10   2075.758 ±    1.353   2473.220 ±    4.782  ops/ms
MaskLogicOperationsBenchmark.intMaskNand            512  thrpt   10   1048.032 ±    1.180   1241.512 ±   16.265  ops/ms
MaskLogicOperationsBenchmark.intMaskNand           1024  thrpt   10    524.105 ±    2.618    625.106 ±    0.575  ops/ms
MaskLogicOperationsBenchmark.intMaskNor             256  thrpt   10   2068.138 ±    9.930   2475.528 ±    1.095  ops/ms
MaskLogicOperationsBenchmark.intMaskNor             512  thrpt   10   1050.866 ±    0.736   1251.790 ±    1.883  ops/ms
MaskLogicOperationsBenchmark.intMaskNor            1024  thrpt   10    525.298 ±    0.986    624.895 ±    1.216  ops/ms
MaskLogicOperationsBenchmark.intMaskNot             256  thrpt   10   2458.427 ±    1.948   2457.549 ±    1.885  ops/ms
MaskLogicOperationsBenchmark.intMaskNot             512  thrpt   10   1228.623 ±   24.188   1247.589 ±    0.984  ops/ms
MaskLogicOperationsBenchmark.intMaskNot            1024  thrpt   10    622.576 ±    4.406    619.530 ±    9.084  ops/ms
MaskLogicOperationsBenchmark.intMaskOrNot           256  thrpt   10   2075.500 ±    3.012   2476.428 ±    4.104  ops/ms
MaskLogicOperationsBenchmark.intMaskOrNot           512  thrpt   10   1046.363 ±    5.886   1252.890 ±    1.730  ops/ms
MaskLogicOperationsBenchmark.intMaskOrNot          1024  thrpt   10    526.056 ±    1.562    623.275 ±    2.857  ops/ms
MaskLogicOperationsBenchmark.intMaskXnor            256  thrpt   10   2070.466 ±    3.526   2446.226 ±   46.126  ops/ms
MaskLogicOperationsBenchmark.intMaskXnor            512  thrpt   10   1048.819 ±    0.994   1251.266 ±    0.943  ops/ms
MaskLogicOperationsBenchmark.intMaskXnor           1024  thrpt   10    526.267 ±    0.390    624.913 ±    1.733  ops/ms
MaskLogicOperationsBenchmark.longMaskEq             256  thrpt   10   1050.306 ±    0.165   1242.028 ±   13.283  ops/ms
MaskLogicOperationsBenchmark.longMaskEq             512  thrpt   10    526.768 ±    0.426    624.142 ±    1.280  ops/ms
MaskLogicOperationsBenchmark.longMaskEq            1024  thrpt   10    265.019 ±    0.122    314.233 ±    0.403  ops/ms
MaskLogicOperationsBenchmark.longMaskNand           256  thrpt   10   1048.286 ±    0.469   1242.337 ±   11.585  ops/ms
MaskLogicOperationsBenchmark.longMaskNand           512  thrpt   10    525.610 ±    0.431    622.427 ±    1.666  ops/ms
MaskLogicOperationsBenchmark.longMaskNand          1024  thrpt   10    264.681 ±    0.603    314.074 ±    0.154  ops/ms
MaskLogicOperationsBenchmark.longMaskNor            256  thrpt   10   1048.055 ±    0.543   1226.660 ±    9.794  ops/ms
MaskLogicOperationsBenchmark.longMaskNor            512  thrpt   10    526.016 ±    1.356    622.087 ±    0.759  ops/ms
MaskLogicOperationsBenchmark.longMaskNor           1024  thrpt   10    264.539 ±    0.557    314.372 ±    0.261  ops/ms
MaskLogicOperationsBenchmark.longMaskNot            256  thrpt   10   1241.258 ±    1.260   1245.741 ±    1.758  ops/ms
MaskLogicOperationsBenchmark.longMaskNot            512  thrpt   10    617.119 ±    6.206    620.890 ±    6.075  ops/ms
MaskLogicOperationsBenchmark.longMaskNot           1024  thrpt   10    312.830 ±    0.392    314.514 ±    0.156  ops/ms
MaskLogicOperationsBenchmark.longMaskOrNot          256  thrpt   10   1048.181 ±    2.636   1234.480 ±    8.663  ops/ms
MaskLogicOperationsBenchmark.longMaskOrNot          512  thrpt   10    525.119 ±    2.451    622.650 ±    0.313  ops/ms
MaskLogicOperationsBenchmark.longMaskOrNot         1024  thrpt   10    264.993 ±    0.202    313.970 ±    0.279  ops/ms
MaskLogicOperationsBenchmark.longMaskXnor           256  thrpt   10   1047.809 ±    2.390   1242.589 ±   12.864  ops/ms
MaskLogicOperationsBenchmark.longMaskXnor           512  thrpt   10    526.626 ±    0.165    622.408 ±    0.373  ops/ms
MaskLogicOperationsBenchmark.longMaskXnor          1024  thrpt   10    264.869 ±    0.162    314.150 ±    0.425  ops/ms
MaskLogicOperationsBenchmark.shortMaskEq            256  thrpt   10   4001.589 ±  111.097   4714.846 ±  166.680  ops/ms
MaskLogicOperationsBenchmark.shortMaskEq            512  thrpt   10   2044.530 ±   18.828   2439.317 ±   37.263  ops/ms
MaskLogicOperationsBenchmark.shortMaskEq           1024  thrpt   10   1048.464 ±    3.533   1250.140 ±    3.277  ops/ms
MaskLogicOperationsBenchmark.shortMaskNand          256  thrpt   10   3890.173 ±   19.906   4681.852 ±  189.127  ops/ms
MaskLogicOperationsBenchmark.shortMaskNand          512  thrpt   10   2015.875 ±   73.932   2445.336 ±   48.702  ops/ms
MaskLogicOperationsBenchmark.shortMaskNand         1024  thrpt   10   1048.948 ±    2.185   1241.862 ±    5.956  ops/ms
MaskLogicOperationsBenchmark.shortMaskNor           256  thrpt   10   3923.436 ±   94.933   4802.069 ±   12.117  ops/ms
MaskLogicOperationsBenchmark.shortMaskNor           512  thrpt   10   2068.695 ±    6.650   2413.735 ±   18.584  ops/ms
MaskLogicOperationsBenchmark.shortMaskNor          1024  thrpt   10   1049.849 ±    1.759   1247.690 ±    4.547  ops/ms
MaskLogicOperationsBenchmark.shortMaskNot           256  thrpt   10   4710.153 ±   50.733   4680.382 ±   86.138  ops/ms
MaskLogicOperationsBenchmark.shortMaskNot           512  thrpt   10   2443.089 ±   25.180   2357.752 ±   41.659  ops/ms
MaskLogicOperationsBenchmark.shortMaskNot          1024  thrpt   10   1210.572 ±   43.238   1239.140 ±    8.773  ops/ms
MaskLogicOperationsBenchmark.shortMaskOrNot         256  thrpt   10   4012.940 ±   11.516   4707.418 ±  170.822  ops/ms
MaskLogicOperationsBenchmark.shortMaskOrNot         512  thrpt   10   2044.855 ±   58.208   2461.608 ±    9.438  ops/ms
MaskLogicOperationsBenchmark.shortMaskOrNot        1024  thrpt   10   1040.237 ±    6.151   1243.464 ±    3.754  ops/ms
MaskLogicOperationsBenchmark.shortMaskXnor          256  thrpt   10   3846.149 ±   96.289   4573.799 ±  329.342  ops/ms
MaskLogicOperationsBenchmark.shortMaskXnor          512  thrpt   10   2036.955 ±    7.014   2435.019 ±   41.906  ops/ms
MaskLogicOperationsBenchmark.shortMaskXnor         1024  thrpt   10   1050.702 ±    3.196   1252.520 ±    0.873  ops/ms
```

- `compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java` passed on sg2044
- `test/jdk/jdk/incubator/vector` passed on sg2044
- `tier1` on sg2044

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390826](https://bugs.openjdk.org/browse/JDK-8390826): RISC-V: Use dedicated vector mask logical instructions (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32480/head:pull/32480` \
`$ git checkout pull/32480`

Update a local copy of the PR: \
`$ git checkout pull/32480` \
`$ git pull https://git.openjdk.org/jdk.git pull/32480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32480`

View PR using the GUI difftool: \
`$ git pr show -t 32480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32480.diff">https://git.openjdk.org/jdk/pull/32480.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32480#issuecomment-5368629720)
</details>
