### PR TITLE
8324189: Test javax/sound/sampled/Clip/SetPositionHang.java timed out

### DIFF
--- a/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import javax.sound.sampled.LineUnavailableException;
 /**
  * @test
  * @bug 8266421 8269091
+ * @key sound
  * @summary Tests that Clip.setFramePosition/setMicrosecondPosition do not hang.
  */
 public final class SetPositionHang implements Runnable {


### PR DESCRIPTION
javax/sound/sampled/Clip/SetPositionHang.java is missing the `sound` key.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8324189](https://bugs.openjdk.org/browse/JDK-8324189): Test javax/sound/sampled/Clip/SetPositionHang.java timed out (**Bug** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32482/head:pull/32482` \
`$ git checkout pull/32482`

Update a local copy of the PR: \
`$ git checkout pull/32482` \
`$ git pull https://git.openjdk.org/jdk.git pull/32482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32482`

View PR using the GUI difftool: \
`$ git pr show -t 32482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32482.diff">https://git.openjdk.org/jdk/pull/32482.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32482#issuecomment-5370174416)
</details>
