### PR TITLE
8366417: Use InstanceKlass instead of Klass in jfieldIDWorkaround

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -376,12 +376,13 @@ JNI_ENTRY(jmethodID, jni_FromReflectedMethod(JNIEnv *env, jobject method))
     mirror = java_lang_reflect_Method::clazz(reflected);
     slot   = java_lang_reflect_Method::slot(reflected);
   }
-  Klass* k1 = java_lang_Class::as_Klass(mirror);
+  // The mirror is always an InstanceKlass.
+  InstanceKlass* k1 = java_lang_Class::as_InstanceKlass(mirror);
 
   // Make sure class is initialized before handing id's out to methods
   k1->initialize(CHECK_NULL);
-  Method* m = InstanceKlass::cast(k1)->method_with_idnum(slot);
-  ret = m==nullptr? nullptr : m->jmethod_id();  // return null if reflected method deleted
+  Method* m = k1->method_with_idnum(slot);
+  ret = m == nullptr? nullptr : m->jmethod_id();  // return null if reflected method deleted
   return ret;
 JNI_END
 
@@ -397,6 +398,7 @@ JNI_ENTRY(jfieldID, jni_FromReflectedField(JNIEnv *env, jobject field))
   // field is a handle to a java.lang.reflect.Field object
   oop reflected   = JNIHandles::resolve_non_null(field);
   oop mirror      = java_lang_reflect_Field::clazz(reflected);
+  // The klass for the field is initialized as an InstanceKlass.
   InstanceKlass* k1 = java_lang_Class::as_InstanceKlass(mirror);
   int slot        = java_lang_reflect_Field::slot(reflected);
   int modifiers   = java_lang_reflect_Field::modifiers(reflected);
@@ -1762,23 +1764,19 @@ JNI_ENTRY(jfieldID, jni_GetFieldID(JNIEnv *env, jclass clazz,
   // Make sure class is initialized before handing id's out to fields
   k->initialize(CHECK_NULL);
 
-  if (!k->is_instance_klass()) {
-    ResourceMark rm;
-    THROW_MSG_NULL(vmSymbols::java_lang_NoSuchFieldError(), err_msg("%s.%s %s", k->external_name(), name, sig));
+  if (k->is_instance_klass()) {
+    InstanceKlass* ik = InstanceKlass::cast(k);
+    fieldDescriptor fd;
+    if (ik->find_field(fieldname, signame, false, &fd)) {
+      // A jfieldID for a non-static field is simply the offset of the field within the instanceOop
+      // It may also have hash bits for k, if VerifyJNIFields is turned on.
+      return jfieldIDWorkaround::to_instance_jfieldID(ik, fd.offset(), fd.is_flat());
+    }
   }
 
-  InstanceKlass* ik = InstanceKlass::cast(k);
-
-  fieldDescriptor fd;
-  if (!ik->find_field(fieldname, signame, false, &fd)) {
-    ResourceMark rm;
-    THROW_MSG_NULL(vmSymbols::java_lang_NoSuchFieldError(), err_msg("%s.%s %s", k->external_name(), name, sig));
-  }
-
-  // A jfieldID for a non-static field is simply the offset of the field within the instanceOop
-  // It may also have hash bits for k, if VerifyJNIFields is turned on.
-  ret = jfieldIDWorkaround::to_instance_jfieldID(ik, fd.offset(), fd.is_flat());
-  return ret;
+  // Not an InstanceKlass or the field wasn't found.
+  ResourceMark rm;
+  THROW_MSG_NULL(vmSymbols::java_lang_NoSuchFieldError(), err_msg("%s.%s %s", k->external_name(), name, sig));
 JNI_END
 
 
@@ -2004,7 +2002,8 @@ JNI_ENTRY(jobject, jni_ToReflectedField(JNIEnv *env, jclass cls, jfieldID fieldI
 
   fieldDescriptor fd;
   bool found = false;
-  Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(cls));
+  // The klass for the field is initialized as an InstanceKlass.
+  InstanceKlass* k = java_lang_Class::as_InstanceKlass(JNIHandles::resolve_non_null(cls));
 
   assert(jfieldIDWorkaround::is_static_jfieldID(fieldID) == (isStatic != 0), "invalid fieldID");
 
@@ -2016,7 +2015,7 @@ JNI_ENTRY(jobject, jni_ToReflectedField(JNIEnv *env, jclass cls, jfieldID fieldI
   } else {
     // Non-static field. The fieldID is really the offset of the field within the instanceOop.
     int offset = jfieldIDWorkaround::from_instance_jfieldID(k, fieldID);
-    found = InstanceKlass::cast(k)->find_field_from_offset(offset, false, &fd);
+    found = k->find_field_from_offset(offset, false, &fd);
   }
   assert(found, "bad fieldID passed into jni_ToReflectedField");
   oop reflected = Reflection::new_field(&fd, CHECK_NULL);

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -203,14 +203,14 @@ bool jfieldIDWorkaround::is_valid_jfieldID(Klass* k, jfieldID id) {
 }
 
 
-intptr_t jfieldIDWorkaround::encode_klass_hash(Klass* k, int offset) {
+intptr_t jfieldIDWorkaround::encode_klass_hash(InstanceKlass* k, int offset) {
   if (offset <= small_offset_mask) {
-    Klass* field_klass = k;
-    Klass* super_klass = field_klass->super();
+    InstanceKlass* field_klass = k;
+    InstanceKlass* super_klass = field_klass->super();
     // With compressed oops the most super class with nonstatic fields would
     // be the owner of fields embedded in the header.
-    while (InstanceKlass::cast(super_klass)->has_nonstatic_fields() &&
-           InstanceKlass::cast(super_klass)->contains_field_offset(offset)) {
+    while (super_klass->has_nonstatic_fields() &&
+           super_klass->contains_field_offset(offset)) {
       field_klass = super_klass;   // super contains the field also
       super_klass = field_klass->super();
     }
@@ -397,7 +397,7 @@ JNI_ENTRY(jfieldID, jni_FromReflectedField(JNIEnv *env, jobject field))
   // field is a handle to a java.lang.reflect.Field object
   oop reflected   = JNIHandles::resolve_non_null(field);
   oop mirror      = java_lang_reflect_Field::clazz(reflected);
-  Klass* k1       = java_lang_Class::as_Klass(mirror);
+  InstanceKlass* k1 = java_lang_Class::as_InstanceKlass(mirror);
   int slot        = java_lang_reflect_Field::slot(reflected);
   int modifiers   = java_lang_reflect_Field::modifiers(reflected);
 
@@ -406,8 +406,8 @@ JNI_ENTRY(jfieldID, jni_FromReflectedField(JNIEnv *env, jobject field))
 
   // First check if this is a static field
   if (modifiers & JVM_ACC_STATIC) {
-    int offset = InstanceKlass::cast(k1)->field_offset( slot );
-    JNIid* id = InstanceKlass::cast(k1)->jni_id_for(offset);
+    int offset = k1->field_offset( slot );
+    JNIid* id = k1->jni_id_for(offset);
     assert(id != nullptr, "corrupt Field object");
     DEBUG_ONLY(id->set_is_static_field_id();)
     // A jfieldID for a static field is a JNIid specifying the field holder and the offset within the Klass*
@@ -418,9 +418,9 @@ JNI_ENTRY(jfieldID, jni_FromReflectedField(JNIEnv *env, jobject field))
   // The slot is the index of the field description in the field-array
   // The jfieldID is the offset of the field within the object
   // It may also have hash bits for k, if VerifyJNIFields is turned on.
-  int offset = InstanceKlass::cast(k1)->field_offset( slot );
-  bool is_flat = InstanceKlass::cast(k1)->field_is_flat(slot);
-  assert(InstanceKlass::cast(k1)->contains_field_offset(offset), "stay within object");
+  int offset = k1->field_offset( slot );
+  bool is_flat = k1->field_is_flat(slot);
+  assert(k1->contains_field_offset(offset), "stay within object");
   ret = jfieldIDWorkaround::to_instance_jfieldID(k1, offset, is_flat);
   return ret;
 JNI_END
@@ -1762,16 +1762,22 @@ JNI_ENTRY(jfieldID, jni_GetFieldID(JNIEnv *env, jclass clazz,
   // Make sure class is initialized before handing id's out to fields
   k->initialize(CHECK_NULL);
 
+  if (!k->is_instance_klass()) {
+    ResourceMark rm;
+    THROW_MSG_NULL(vmSymbols::java_lang_NoSuchFieldError(), err_msg("%s.%s %s", k->external_name(), name, sig));
+  }
+
+  InstanceKlass* ik = InstanceKlass::cast(k);
+
   fieldDescriptor fd;
-  if (!k->is_instance_klass() ||
-      !InstanceKlass::cast(k)->find_field(fieldname, signame, false, &fd)) {
+  if (!ik->find_field(fieldname, signame, false, &fd)) {
     ResourceMark rm;
     THROW_MSG_NULL(vmSymbols::java_lang_NoSuchFieldError(), err_msg("%s.%s %s", k->external_name(), name, sig));
   }
 
   // A jfieldID for a non-static field is simply the offset of the field within the instanceOop
   // It may also have hash bits for k, if VerifyJNIFields is turned on.
-  ret = jfieldIDWorkaround::to_instance_jfieldID(k, fd.offset(), fd.is_flat());
+  ret = jfieldIDWorkaround::to_instance_jfieldID(ik, fd.offset(), fd.is_flat());
   return ret;
 JNI_END
 

--- a/src/hotspot/share/runtime/jfieldIDWorkaround.hpp
+++ b/src/hotspot/share/runtime/jfieldIDWorkaround.hpp
@@ -101,7 +101,7 @@ class jfieldIDWorkaround: AllStatic {
     // the jfieldID is created with.
     return checked_cast<int>(result);
   }
-  static intptr_t encode_klass_hash(Klass* k, int offset);
+  static intptr_t encode_klass_hash(InstanceKlass* k, int offset);
   static bool             klass_hash_ok(Klass* k, jfieldID id);
   static void  verify_instance_jfieldID(Klass* k, jfieldID id);
 
@@ -122,7 +122,7 @@ class jfieldIDWorkaround: AllStatic {
     return ((as_uint & flat_mask_in_place) != 0);
   }
 
-  static jfieldID to_instance_jfieldID(Klass* k, int offset, bool is_flat) {
+  static jfieldID to_instance_jfieldID(InstanceKlass* k, int offset, bool is_flat) {
     intptr_t as_uint = ((offset & large_offset_mask) << offset_shift) |
                         instance_mask_in_place;
     if (is_flat) {


### PR DESCRIPTION
Please review this small change to make some parameters InstanceKlass in jfieldIDWorkaround.hpp methods.  Some are not changed to InstanceKlass because they're generally called with obj->klass() which would require another InstnaceKlass::cast() to call them.
Tested with tier1-4.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8366417](https://bugs.openjdk.org/browse/JDK-8366417): Use InstanceKlass instead of Klass in jfieldIDWorkaround (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32484/head:pull/32484` \
`$ git checkout pull/32484`

Update a local copy of the PR: \
`$ git checkout pull/32484` \
`$ git pull https://git.openjdk.org/jdk.git pull/32484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32484`

View PR using the GUI difftool: \
`$ git pr show -t 32484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32484.diff">https://git.openjdk.org/jdk/pull/32484.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32484#issuecomment-5372463499)
</details>
