### PR TITLE
8390870: ForkJoinTask.get(long, TimeUnit) stuck in busy-wait with another waiter

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
@@ -448,7 +448,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
                         Aux next = a.next;
                         if (a == node) {
                             if (prev != null)
-                                prev.casNext(prev, next);
+                                prev.casNext(a, next);
                             else if (casAux(a, next))
                                 break clean;
                             break;            // check for failed or stale CAS

--- a/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
+++ b/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
@@ -26,17 +26,15 @@
  * @bug 8390870
  * @summary ForkJoinTask.get must honor its timeout and interrupts even
  *          when another thread is waiting on the same task.
- * @run junit GetMultipleWaiters
+ * @run junit/othervm/timeout=20 GetMultipleWaiters
  */
 
-import java.time.Duration;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class GetMultipleWaiters {
 
@@ -49,30 +47,24 @@ class GetMultipleWaiters {
         var task = ForkJoinTask.adapt(() -> {});
         Throwable[] thrown = {null};
 
-        var a = new Thread(() -> {
+        var a = startThreadAndAwaitState(() -> {
             try {
                 task.get();
             } catch (Throwable t) {
                 thrown[0] = t;
             }
-        }, "waiter-A");
-        var b = new Thread(() -> {
+        }, "waiter-A", Thread.State.WAITING);
+        var b = startThreadAndAwaitState(() -> {
             try {
                 task.get();
             } catch (Throwable ignore) {
             }
-        }, "waiter-B");
+        }, "waiter-B", Thread.State.WAITING);
 
         try {
-            a.start();
-            while (a.getState() != Thread.State.WAITING)
-                Thread.sleep(1);
-            b.start();
-            while (b.getState() != Thread.State.WAITING)
-                Thread.sleep(1);
             a.interrupt();
+            a.join();
 
-            assertJoins(a);
             assertInstanceOf(InterruptedException.class, thrown[0]);
         } finally {
             task.cancel(false);
@@ -90,29 +82,23 @@ class GetMultipleWaiters {
         var task = ForkJoinTask.adapt(() -> {});
         Throwable[] thrown = {null};
 
-        var a = new Thread(() -> {
+        var a = startThreadAndAwaitState(() -> {
             try {
                 task.get(1, TimeUnit.SECONDS);
             } catch (Throwable t) {
                 thrown[0] = t;
             }
-        }, "waiter-A");
-        var b = new Thread(() -> {
+        }, "waiter-A", Thread.State.TIMED_WAITING);
+        var b = startThreadAndAwaitState(() -> {
             try {
                 task.get();
             } catch (Throwable ignore) {
             }
-        }, "waiter-B");
+        }, "waiter-B", Thread.State.WAITING);
 
         try {
-            a.start();
-            while (a.getState() != Thread.State.TIMED_WAITING)
-                Thread.sleep(1);
-            b.start();
-            while (b.getState() != Thread.State.WAITING)
-                Thread.sleep(1);
+            a.join();
 
-            assertJoins(a);
             assertInstanceOf(TimeoutException.class, thrown[0]);
         } finally {
             task.cancel(false);
@@ -121,19 +107,11 @@ class GetMultipleWaiters {
         }
     }
 
-    /**
-     * Fails with the thread's state and stack trace if it does not
-     * terminate within 10 seconds.
-     */
-    private void assertJoins(Thread thread) throws InterruptedException {
-        if (!thread.join(Duration.ofSeconds(10))) {
-            var sb = new StringBuilder();
-            sb.append(thread.getName())
-              .append(" did not terminate, state=")
-              .append(thread.getState());
-            for (var e : thread.getStackTrace())
-                sb.append(System.lineSeparator()).append("    at ").append(e);
-            fail(sb.toString());
-        }
+    static Thread startThreadAndAwaitState(Runnable r, String name, Thread.State state) throws Exception {
+        var t = new Thread(r, name);
+        t.start();
+        while (t.getState() != state)
+            Thread.sleep(1);
+        return t;
     }
 }

--- a/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
+++ b/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
@@ -53,13 +53,13 @@ class GetMultipleWaiters {
             } catch (Throwable t) {
                 thrown[0] = t;
             }
-        }, "waiter-A", Thread.State.WAITING);
+        }, "Get-waiter-A", Thread.State.WAITING);
         var b = startThreadAndAwaitState(() -> {
             try {
                 task.get();
             } catch (Throwable ignore) {
             }
-        }, "waiter-B", Thread.State.WAITING);
+        }, "Get-waiter-B", Thread.State.WAITING);
 
         try {
             a.interrupt();
@@ -67,8 +67,7 @@ class GetMultipleWaiters {
 
             assertInstanceOf(InterruptedException.class, thrown[0]);
         } finally {
-            task.cancel(false);
-            a.join();
+            task.complete(null);
             b.join();
         }
     }
@@ -88,21 +87,20 @@ class GetMultipleWaiters {
             } catch (Throwable t) {
                 thrown[0] = t;
             }
-        }, "waiter-A", Thread.State.TIMED_WAITING);
+        }, "TimedGet-waiter-A", Thread.State.TIMED_WAITING);
         var b = startThreadAndAwaitState(() -> {
             try {
                 task.get();
             } catch (Throwable ignore) {
             }
-        }, "waiter-B", Thread.State.WAITING);
+        }, "TimedGet-waiter-B", Thread.State.WAITING);
 
         try {
             a.join();
 
             assertInstanceOf(TimeoutException.class, thrown[0]);
         } finally {
-            task.cancel(false);
-            a.join();
+            task.complete(null);
             b.join();
         }
     }

--- a/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
+++ b/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390870
+ * @summary ForkJoinTask.get must honor its timeout and interrupts even
+ *          when another thread is waiting on the same task.
+ */
+
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.time.Duration;
+
+public class GetMultipleWaiters {
+
+    public static void main(String[] args) throws Exception {
+        // get() with timeout must time out
+        test(false);
+        // get() must be interruptible
+        test(true);
+    }
+
+    static void test(boolean interrupt) throws Exception {
+        ForkJoinTask<?> task = ForkJoinTask.adapt(() -> {});
+        Throwable[] thrown = {null};
+
+        Thread a = new Thread(() -> {
+            try {
+                if (interrupt)
+                    task.get();
+                else
+                    task.get(1, TimeUnit.SECONDS);
+            } catch (Throwable t) {
+                thrown[0] = t;
+            }
+        }, "waiter-A");
+        Thread b = new Thread(() -> {
+            try {
+                task.get();
+            } catch (Throwable ignore) {}
+        }, "waiter-B");
+        // Do not rely on a timeout to terminate the test if it fails
+        a.setDaemon(true);
+        b.setDaemon(true);
+
+        a.start();
+        while (a.getState() != (interrupt ? Thread.State.WAITING : Thread.State.TIMED_WAITING))
+            Thread.sleep(10);
+        b.start();
+        while (b.getState() != Thread.State.WAITING)
+            Thread.sleep(10);
+        if (interrupt)
+            a.interrupt();
+
+        if (!a.join(Duration.ofSeconds(10))) {
+            System.out.println("waiter-A state=" + a.getState());
+            for (StackTraceElement e : a.getStackTrace())
+                System.out.println("    at " + e);
+            throw new RuntimeException("get() did not return (interrupt=" + interrupt + ")");
+        }
+        Class<?> expected = interrupt ? InterruptedException.class : TimeoutException.class;
+        if (!expected.isInstance(thrown[0]))
+            throw new RuntimeException("expected " + expected.getSimpleName() + ", got " + thrown[0]);
+    }
+}

--- a/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
+++ b/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
@@ -45,7 +45,7 @@ class GetMultipleWaiters {
     @Test
     void testGet() throws Exception {
         var task = ForkJoinTask.adapt(() -> {});
-        Throwable[] thrown = {null};
+        var thrown = new Throwable[1];
 
         var a = startThreadAndAwaitState(() -> {
             try {
@@ -79,7 +79,7 @@ class GetMultipleWaiters {
     @Test
     void testTimedGet() throws Exception {
         var task = ForkJoinTask.adapt(() -> {});
-        Throwable[] thrown = {null};
+        var thrown = new Throwable[1];
 
         var a = startThreadAndAwaitState(() -> {
             try {

--- a/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
+++ b/test/jdk/java/util/concurrent/forkjoin/GetMultipleWaiters.java
@@ -26,62 +26,114 @@
  * @bug 8390870
  * @summary ForkJoinTask.get must honor its timeout and interrupts even
  *          when another thread is waiting on the same task.
+ * @run junit GetMultipleWaiters
  */
 
+import java.time.Duration;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.time.Duration;
 
-public class GetMultipleWaiters {
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
 
-    public static void main(String[] args) throws Exception {
-        // get() with timeout must time out
-        test(false);
-        // get() must be interruptible
-        test(true);
-    }
+class GetMultipleWaiters {
 
-    static void test(boolean interrupt) throws Exception {
-        ForkJoinTask<?> task = ForkJoinTask.adapt(() -> {});
+    /**
+     * get() must be interruptible while another thread is waiting on the
+     * same task.
+     */
+    @Test
+    void testGet() throws Exception {
+        var task = ForkJoinTask.adapt(() -> {});
         Throwable[] thrown = {null};
 
-        Thread a = new Thread(() -> {
+        var a = new Thread(() -> {
             try {
-                if (interrupt)
-                    task.get();
-                else
-                    task.get(1, TimeUnit.SECONDS);
+                task.get();
             } catch (Throwable t) {
                 thrown[0] = t;
             }
         }, "waiter-A");
-        Thread b = new Thread(() -> {
+        var b = new Thread(() -> {
             try {
                 task.get();
-            } catch (Throwable ignore) {}
+            } catch (Throwable ignore) {
+            }
         }, "waiter-B");
-        // Do not rely on a timeout to terminate the test if it fails
-        a.setDaemon(true);
-        b.setDaemon(true);
 
-        a.start();
-        while (a.getState() != (interrupt ? Thread.State.WAITING : Thread.State.TIMED_WAITING))
-            Thread.sleep(10);
-        b.start();
-        while (b.getState() != Thread.State.WAITING)
-            Thread.sleep(10);
-        if (interrupt)
+        try {
+            a.start();
+            while (a.getState() != Thread.State.WAITING)
+                Thread.sleep(1);
+            b.start();
+            while (b.getState() != Thread.State.WAITING)
+                Thread.sleep(1);
             a.interrupt();
 
-        if (!a.join(Duration.ofSeconds(10))) {
-            System.out.println("waiter-A state=" + a.getState());
-            for (StackTraceElement e : a.getStackTrace())
-                System.out.println("    at " + e);
-            throw new RuntimeException("get() did not return (interrupt=" + interrupt + ")");
+            assertJoins(a);
+            assertInstanceOf(InterruptedException.class, thrown[0]);
+        } finally {
+            task.cancel(false);
+            a.join();
+            b.join();
         }
-        Class<?> expected = interrupt ? InterruptedException.class : TimeoutException.class;
-        if (!expected.isInstance(thrown[0]))
-            throw new RuntimeException("expected " + expected.getSimpleName() + ", got " + thrown[0]);
+    }
+
+    /**
+     * get(long, TimeUnit) must time out while another thread is waiting
+     * on the same task.
+     */
+    @Test
+    void testTimedGet() throws Exception {
+        var task = ForkJoinTask.adapt(() -> {});
+        Throwable[] thrown = {null};
+
+        var a = new Thread(() -> {
+            try {
+                task.get(1, TimeUnit.SECONDS);
+            } catch (Throwable t) {
+                thrown[0] = t;
+            }
+        }, "waiter-A");
+        var b = new Thread(() -> {
+            try {
+                task.get();
+            } catch (Throwable ignore) {
+            }
+        }, "waiter-B");
+
+        try {
+            a.start();
+            while (a.getState() != Thread.State.TIMED_WAITING)
+                Thread.sleep(1);
+            b.start();
+            while (b.getState() != Thread.State.WAITING)
+                Thread.sleep(1);
+
+            assertJoins(a);
+            assertInstanceOf(TimeoutException.class, thrown[0]);
+        } finally {
+            task.cancel(false);
+            a.join();
+            b.join();
+        }
+    }
+
+    /**
+     * Fails with the thread's state and stack trace if it does not
+     * terminate within 10 seconds.
+     */
+    private void assertJoins(Thread thread) throws InterruptedException {
+        if (!thread.join(Duration.ofSeconds(10))) {
+            var sb = new StringBuilder();
+            sb.append(thread.getName())
+              .append(" did not terminate, state=")
+              .append(thread.getState());
+            for (var e : thread.getStackTrace())
+                sb.append(System.lineSeparator()).append("    at ").append(e);
+            fail(sb.toString());
+        }
     }
 }


### PR DESCRIPTION
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390870](https://bugs.openjdk.org/browse/JDK-8390870): ForkJoinTask.get(long, TimeUnit) stuck in busy-wait with another waiter (**Bug** - P2)


### Reviewers
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32485/head:pull/32485` \
`$ git checkout pull/32485`

Update a local copy of the PR: \
`$ git checkout pull/32485` \
`$ git pull https://git.openjdk.org/jdk.git pull/32485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32485`

View PR using the GUI difftool: \
`$ git pr show -t 32485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32485.diff">https://git.openjdk.org/jdk/pull/32485.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32485#issuecomment-5412443445)
</details>
