### PR TITLE
8383460: Replace "sharing" in VM version string with "aot" information

### DIFF
--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
 
 const char* Abstract_VM_Version::_s_vm_release = Abstract_VM_Version::vm_release();
 const char* Abstract_VM_Version::_s_internal_vm_info_string = Abstract_VM_Version::internal_vm_info_string();
@@ -140,31 +141,28 @@ const char* Abstract_VM_Version::vm_vendor() {
 
 
 // The VM info string should be a constant, but its value cannot be finalized until after VM arguments
-// have been fully processed. And we want to avoid dynamic memory allocation which will cause ASAN
-// report error, so we enumerate all the cases by static const string value.
+// have been fully processed. The result is C-heap allocated, and should be freed by the caller.
 const char* Abstract_VM_Version::vm_info_string() {
+  stringStream ss;
   switch (Arguments::mode()) {
-    case Arguments::_int:
-      if (is_vm_statically_linked()) {
-        return CDSConfig::is_using_archive() ? "interpreted mode, static, sharing" : "interpreted mode, static";
-      } else {
-        return CDSConfig::is_using_archive() ? "interpreted mode, sharing" : "interpreted mode";
-      }
-    case Arguments::_mixed:
-      if (is_vm_statically_linked()) {
-        return CDSConfig::is_using_archive() ? "mixed mode, static, sharing" : "mixed mode, static";
-      } else {
-        return CDSConfig::is_using_archive() ? "mixed mode, sharing" : "mixed mode";
-      }
-    case Arguments::_comp:
-      if (is_vm_statically_linked()) {
-        return CDSConfig::is_using_archive() ? "compiled mode, static, sharing" : "compiled mode, static";
-      } else {
-        return CDSConfig::is_using_archive() ? "compiled mode, sharing" : "compiled mode";
-      }
+  case Arguments::_int:   ss.print("%s", "interpreted mode"); break;
+  case Arguments::_mixed: ss.print("%s", "mixed mode"); break;
+  case Arguments::_comp:  ss.print("%s", "compiled mode"); break;
+  default: ShouldNotReachHere();
   }
-  ShouldNotReachHere();
-  return "";
+
+  if (is_vm_statically_linked()) {
+    ss.print("%s", ", static");
+  }
+  if (CDSConfig::is_dumping_preimage_static_archive()) {
+    ss.print("%s", ", aot training");
+  } else if (CDSConfig::is_dumping_final_static_archive()) {
+    ss.print("%s", ", aot assembly");
+  } else if (CDSConfig::is_using_archive()) {
+    ss.print("%s", CDSConfig::new_aot_flags_used() ? ", aot production" : ", sharing");
+  }
+
+  return ss.as_string(/*c_heap=*/true);
 }
 
 // NOTE: do *not* use stringStream. this function is called by

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -400,7 +400,9 @@ void Arguments::init_system_properties() {
   PropertyList_add(&_system_properties, new SystemProperty("jdk.debug", VM_Version::jdk_debug_level(),  false));
 
   // Initialize the vm.info now, but it will need updating after argument parsing.
-  _vm_info = new SystemProperty("java.vm.info", VM_Version::vm_info_string(), true);
+  const char* vm_info_str = VM_Version::vm_info_string();
+  _vm_info = new SystemProperty("java.vm.info", vm_info_str, true);
+  FREE_C_HEAP_ARRAY(vm_info_str);
 
   // Following are JVMTI agent writable properties.
   // Properties values are set to nullptr and they are
@@ -1347,8 +1349,10 @@ void Arguments::set_mode_flags(Mode mode) {
 
   // Ensure Agent_OnLoad has the correct initial values.
   // This may not be the final mode; mode may change later in onload phase.
+  const char* vm_info_str = VM_Version::vm_info_string();
   PropertyList_unique_add(&_system_properties, "java.vm.info",
-                          VM_Version::vm_info_string(), AddProperty, UnwriteableProperty, ExternalProperty);
+                          vm_info_str, AddProperty, UnwriteableProperty, ExternalProperty);
+  FREE_C_HEAP_ARRAY(vm_info_str);
 
   UseInterpreter             = true;
   UseCompiler                = true;

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -667,7 +667,9 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   // is initially computed. See Abstract_VM_Version::vm_info_string().
   // This update must happen before we initialize the java classes, but
   // after any initialization logic that might modify the flags.
-  Arguments::update_vm_info_property(VM_Version::vm_info_string());
+  const char* vm_info_str = VM_Version::vm_info_string();
+  Arguments::update_vm_info_property(vm_info_str);
+  FREE_C_HEAP_ARRAY(vm_info_str);
 
   JavaThread* THREAD = JavaThread::current(); // For exception macros.
   HandleMark hm(THREAD);
@@ -1327,10 +1329,14 @@ void Threads::print_on(outputStream* st, bool print_stacks,
   char buf[32];
   st->print_raw_cr(os::local_time_string(buf, sizeof(buf)));
 
+  const char* vm_info_str = VM_Version::vm_info_string();
   st->print_cr("Full thread dump %s (%s %s)",
                VM_Version::vm_name(),
                VM_Version::vm_release(),
-               VM_Version::vm_info_string());
+               vm_info_str);
+  FREE_C_HEAP_ARRAY(vm_info_str);
+
+
   JDK_Version::current().to_string(buf, sizeof(buf));
   const char* runtime_name = JDK_Version::runtime_name() != nullptr ?
                              JDK_Version::runtime_name() : "";

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -516,18 +516,20 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
                 buf, jdk_debug_level, runtime_version);
 
    // This is the long version with some default settings added
+   const char* vm_info_str = VM_Version::vm_info_string();
    st->print_cr("# Java VM: %s%s%s (%s%s, %s%s%s%s, %s, %s)",
                  VM_Version::vm_name(),
                 (*vendor_version != '\0') ? " " : "", vendor_version,
                  jdk_debug_level,
                  VM_Version::vm_release(),
-                 VM_Version::vm_info_string(),
+                 vm_info_str,
                  TieredCompilation ? ", tiered" : "",
                  UseCompressedOops ? ", compressed oops" : "",
                  UseCompactObjectHeaders ? ", compact obj headers" : "",
                  GCConfig::hs_err_name(),
                  VM_Version::vm_platform_string()
                );
+   FREE_C_HEAP_ARRAY(vm_info_str);
 }
 
 // Returns true if at least one thread reported a fatal error and fatal error handling is in process.

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
@@ -101,7 +101,7 @@ public class AOTFlags {
             "-XX:AOTMode=off",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
-        out.shouldNotContain(", sharing");
+        out.shouldNotContain(", aot production");
         out.shouldNotContain("Opened AOT cache hello.aot.");
         out.shouldContain("Hello World");
         out.shouldHaveExitValue(0);
@@ -115,7 +115,7 @@ public class AOTFlags {
             "-XX:AOTMode=auto",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
-        out.shouldContain(", sharing");
+        out.shouldContain(", aot production");
         out.shouldContain("Opened AOT cache hello.aot.");
         out.shouldContain("Hello World");
         out.shouldHaveExitValue(0);
@@ -130,7 +130,7 @@ public class AOTFlags {
                 "-XX:AOTMode=" + mode,
                 "-cp", appJar, helloClass);
             out = CDSTestUtils.executeAndLog(pb, "prod");
-            out.shouldContain(", sharing");
+            out.shouldContain(", aot production");
             out.shouldContain("Opened AOT cache hello.aot.");
             out.shouldContain("Hello World");
             out.shouldHaveExitValue(0);


### PR DESCRIPTION
[1] When using the new AOT workflow, the word "sharing" is replaced with "aot training", "aot assembly", or "aot production" as appropriate.
[2] Changed `Abstract_VM_Version::vm_info_string()` to return a c-heap allocated string. The caller should free it. The old way of enumerating every single possibility is not scalable.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383460](https://bugs.openjdk.org/browse/JDK-8383460): Replace "sharing" in VM version string with "aot" information (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32486/head:pull/32486` \
`$ git checkout pull/32486`

Update a local copy of the PR: \
`$ git checkout pull/32486` \
`$ git pull https://git.openjdk.org/jdk.git pull/32486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32486`

View PR using the GUI difftool: \
`$ git pr show -t 32486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32486.diff">https://git.openjdk.org/jdk/pull/32486.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32486#issuecomment-5373034621)
</details>
