### PR TITLE
8389912: [REDO] Regression >6% on Crypto-MLDSA.sign on x64

### DIFF
--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -3735,10 +3735,9 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
       //     from_instr: andI_rReg_ndd, MatchRule: ( Set dst (AndI  src1 src2) ).       src1: (position(DEF) = -1, position(USE) = 1)
       //     to_instr: andI_rReg_mem, MatchRule:   ( Set dst (AndI  dst (LoadI  src)) ). dst: (position(DEF) = 0,  position(USE) = 1)
       if (from_instr->operand_position(this->_name, Component::DEF) != to_instr->operand_position(mRule2->_name, Component::DEF)) {
-        return Not_cisc_spillable;
+        cisc_spillable = Not_cisc_spillable;
       }
     }
-    cisc_spillable = Maybe_cisc_spillable;
   } else {
     const InstructForm *form2_inst = form2 ? form2->is_instruction() : nullptr;
     const char *name_left  = mRule2->_lChild ? mRule2->_lChild->_opType : nullptr;
@@ -3762,7 +3761,7 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
         reg_type       = _result;
         return Is_cisc_spillable;
       } else {
-        return Not_cisc_spillable;
+        cisc_spillable = Not_cisc_spillable;
       }
     }
     // Detect reg vs memory
@@ -3772,7 +3771,7 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
       reg_type       = _result;
       return Is_cisc_spillable;
     } else {
-      return Not_cisc_spillable;
+      cisc_spillable = Not_cisc_spillable;
     }
   }
 
@@ -3786,9 +3785,6 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
       left_spillable = Maybe_cisc_spillable;
     } else  if (_lChild != nullptr) {
       left_spillable = _lChild->cisc_spill_match(globals, registers, mRule2->_lChild, operand, reg_type, from_instr, to_instr);
-      if (left_spillable == Not_cisc_spillable) {
-        return Not_cisc_spillable;
-      }
     }
 
     // Check right operands
@@ -3823,13 +3819,13 @@ int  MatchRule::matchrule_cisc_spill_match(FormDict& globals, RegisterForm* regi
 
   // Check left operands: at root, must be target of 'Set'
   if( (_lChild == nullptr) || (mRule2->_lChild == nullptr) ) {
-    return Not_cisc_spillable;
+    left_spillable = Not_cisc_spillable;
   } else {
     // Do not support cisc-spilling instruction's target location
     if( root_ops_match(globals, _lChild->_opType, mRule2->_lChild->_opType) ) {
       left_spillable = Maybe_cisc_spillable;
     } else {
-      return Not_cisc_spillable;
+      left_spillable = Not_cisc_spillable;
     }
   }
 

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -3742,17 +3742,19 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
       // or if neither operand is a DEF (pos is -1)
       int from_def_pos = from_instr->operand_position(this->_name, Component::DEF);
       int to_def_pos   = to_instr->operand_position(mRule2->_name, Component::DEF);
-      if (from_def_pos < 0 && to_def_pos < 0) {   // not sure this is a great idea to allow cisc spilling here
-          // fprintf(stderr, "!!! Neither operand is DEF\n");
-          // int from_use_pos = from_instr->operand_position(this->_name, Component::USE);
-          // int to_use_pos   = to_instr->operand_position(mRule2->_name, Component::USE);
-          // if (from_use_pos != to_use_pos) {     // doesn't happen in x86
-          //   fprintf(stderr, "!!! USE positions don't match\n");
-          //   fprintf(stderr, "from_instr %s: operand %s USE index: %d\n", from_instr->_ident, this->_name, from_use_pos);
-          //   fprintf(stderr, "to_instr %s: operand %s USE index: %d\n", to_instr->_ident, mRule2->_name, to_use_pos);
-          // }
-          return Not_cisc_spillable;
-      }
+      // if (from_def_pos < 0 && to_def_pos < 0) {   // not sure this is a great idea to allow cisc spilling here
+      //     fprintf(stderr, "!!! Neither operand is DEF\n");
+      //   fprintf(stderr, "from_instr %s: operand %s DEF index: %d\n", from_instr->_ident, _name, from_def_pos);
+      //   fprintf(stderr, "to_instr %s: operand %s DEF index: %d\n", to_instr->_ident, mRule2->_name, to_def_pos);
+      //     int from_use_pos = from_instr->operand_position(this->_name, Component::USE);
+      //     int to_use_pos   = to_instr->operand_position(mRule2->_name, Component::USE);
+      //     if (from_use_pos != to_use_pos) {     // doesn't happen in x86
+      //       fprintf(stderr, "!!! USE positions don't match\n");
+      //       fprintf(stderr, "from_instr %s: operand %s USE index: %d\n", from_instr->_ident, this->_name, from_use_pos);
+      //       fprintf(stderr, "to_instr %s: operand %s USE index: %d\n", to_instr->_ident, mRule2->_name, to_use_pos);
+      //     }
+      //     return Not_cisc_spillable;
+      // }
       if (from_def_pos != to_def_pos) {
          if (from_def_pos < 0 || to_def_pos < 0) {
           // fprintf(stderr, "One operand is DEF and the other isn't\n");

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -3731,40 +3731,13 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
   const Form *form2 = globals[mRule2->_opType];
   if( form == form2 ) {
     if (form->is_operand()) {
-      // Make sure that the "from" operand and the "to" operand match in terms of being a DEF or USE. For example:
-      // from_instr: andI_rReg_ndd, MatchRule: ( Set dst (AndI  src1 src2) )
-      // MatchNode this: src (position(DEF) = -1, position(USE) = 1)
+      // Disallow cisc-spilling if only 1 operand is a DEF, or both are DEFs but at different positions.
+      //     from_instr: andI_rReg_ndd, MatchRule: ( Set dst (AndI  src1 src2) )
+      //     MatchNode this: src (position(DEF) = -1, position(USE) = 1)
       //
-      // to_instr: andI_rReg_mem, MatchRule: ( Set dst (AndI  dst (LoadI  src)) )
-      // MatchNode mRule2: dst (position(DEF) = 0, position(USE) = 1)
-      //
-      // The test below allows cisc-spilling if both operands are DEFS at the same position,
-      // or if neither operand is a DEF (pos is -1)
-      int from_def_pos = from_instr->operand_position(this->_name, Component::DEF);
-      int to_def_pos   = to_instr->operand_position(mRule2->_name, Component::DEF);
-      // if (from_def_pos < 0 && to_def_pos < 0) {   // not sure this is a great idea to allow cisc spilling here
-      //     fprintf(stderr, "!!! Neither operand is DEF\n");
-      //   fprintf(stderr, "from_instr %s: operand %s DEF index: %d\n", from_instr->_ident, _name, from_def_pos);
-      //   fprintf(stderr, "to_instr %s: operand %s DEF index: %d\n", to_instr->_ident, mRule2->_name, to_def_pos);
-      //     int from_use_pos = from_instr->operand_position(this->_name, Component::USE);
-      //     int to_use_pos   = to_instr->operand_position(mRule2->_name, Component::USE);
-      //     if (from_use_pos != to_use_pos) {     // doesn't happen in x86
-      //       fprintf(stderr, "!!! USE positions don't match\n");
-      //       fprintf(stderr, "from_instr %s: operand %s USE index: %d\n", from_instr->_ident, this->_name, from_use_pos);
-      //       fprintf(stderr, "to_instr %s: operand %s USE index: %d\n", to_instr->_ident, mRule2->_name, to_use_pos);
-      //     }
-      //     return Not_cisc_spillable;
-      // }
-      if (from_def_pos != to_def_pos) {
-         if (from_def_pos < 0 || to_def_pos < 0) {
-          // fprintf(stderr, "One operand is DEF and the other isn't\n");
-          // fprintf(stderr, "from_instr %s: operand %s DEF index: %d\n", from_instr->_ident, _name, from_def_pos);
-          // fprintf(stderr, "to_instr %s: operand %s DEF index: %d\n", to_instr->_ident, mRule2->_name, to_def_pos);
-        } else if (from_def_pos != to_def_pos) { // doesn't happen in x86
-          // fprintf(stderr, "!!! DEF positions don't match\n");
-          // fprintf(stderr, "from_instr %s: operand %s DEF index: %d\n", from_instr->_ident, _name, from_def_pos);
-          // fprintf(stderr, "to_instr %s: operand %s DEF index: %d\n", to_instr->_ident, mRule2->_name, to_def_pos);
-        }
+      //     to_instr: andI_rReg_mem, MatchRule: ( Set dst (AndI  dst (LoadI  src)) )
+      //     MatchNode mRule2: dst (position(DEF) = 0, position(USE) = 1)
+      if (from_instr->operand_position(this->_name, Component::DEF) != to_instr->operand_position(mRule2->_name, Component::DEF)) {
         return Not_cisc_spillable;
       }
     }

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -3732,11 +3732,8 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
   if( form == form2 ) {
     if (form->is_operand()) {
       // Disallow cisc-spilling if only 1 operand is a DEF, or both are DEFs but at different positions.
-      //     from_instr: andI_rReg_ndd, MatchRule: ( Set dst (AndI  src1 src2) )
-      //     MatchNode this: src (position(DEF) = -1, position(USE) = 1)
-      //
-      //     to_instr: andI_rReg_mem, MatchRule: ( Set dst (AndI  dst (LoadI  src)) )
-      //     MatchNode mRule2: dst (position(DEF) = 0, position(USE) = 1)
+      //     from_instr: andI_rReg_ndd, MatchRule: ( Set dst (AndI  src1 src2) ).       src1: (position(DEF) = -1, position(USE) = 1)
+      //     to_instr: andI_rReg_mem, MatchRule:   ( Set dst (AndI  dst (LoadI  src)) ). dst: (position(DEF) = 0,  position(USE) = 1)
       if (from_instr->operand_position(this->_name, Component::DEF) != to_instr->operand_position(mRule2->_name, Component::DEF)) {
         return Not_cisc_spillable;
       }

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -1139,17 +1139,31 @@ const char *InstructForm::mach_base_class(FormDict &globals)  const {
   return nullptr;
 }
 
-// Compare the instruction predicates for textual equality
-bool equivalent_predicates( const InstructForm *instr1, const InstructForm *instr2 ) {
-  const Predicate *pred1  = instr1->_predicate;
-  const Predicate *pred2  = instr2->_predicate;
-  if( pred1 == nullptr && pred2 == nullptr ) {
+// Do the instruction predicates allow target_instr to be replaced by replacement_instr for cisc-spill optimzation.
+static bool hasPredicateSubset( const InstructForm *target_instr, const InstructForm *replacement_instr ) {
+  const Predicate *target_p  = target_instr->_predicate;
+  const Predicate *replacement_p  = replacement_instr->_predicate;
+  if( target_p == nullptr && replacement_p == nullptr ) {
     // no predicates means they are identical
     return true;
   }
-  if( pred1 != nullptr && pred2 != nullptr ) {
+
+  #ifdef AMD64
+  // A replacement_instr with no predicate handles a superset of the cases that target_instr handles.
+  // *Except* when target_instr has "predicate(false)", which shouldn't match anything.
+  // This is safe for x86 which only uses such predicates for instructions that should only be expanded
+  // as part of peephole optimizations. It's unclear if this is safe for s390 due to more complex predicates
+  // like "predicate(false && <more expressions>)". For now only enable for x86 (AMD64)
+  #define PREDICATE_FALSE_EXPR "#line 9\nfalse\n#line 9\n"
+
+  if( replacement_p == nullptr && !ADLParser::equivalent_expressions(target_p->_pred, PREDICATE_FALSE_EXPR) ) {
+    return true;
+  }
+  #endif /* AMD64 */
+
+  if( target_p != nullptr && replacement_p != nullptr ) {
     // compare the predicates
-    if (ADLParser::equivalent_expressions(pred1->_pred, pred2->_pred)) {
+    if (ADLParser::equivalent_expressions(target_p->_pred, replacement_p->_pred)) {
       return true;
     }
   }
@@ -1169,8 +1183,8 @@ bool InstructForm::cisc_spills_to(ArchDesc &AD, InstructForm *instr) {
   const char *op_name            = nullptr;
   const char *reg_type           = nullptr;
   FormDict   &globals            = AD.globalNames();
-  cisc_spill_operand = _matrule->matchrule_cisc_spill_match(globals, AD.get_registers(), instr->_matrule, op_name, reg_type);
-  if( (cisc_spill_operand != Not_cisc_spillable) && (op_name != nullptr) && equivalent_predicates(this, instr) ) {
+  cisc_spill_operand = _matrule->matchrule_cisc_spill_match(globals, AD.get_registers(), instr->_matrule, op_name, reg_type, this, instr);
+  if( (cisc_spill_operand != Not_cisc_spillable) && (op_name != nullptr) && hasPredicateSubset(this, instr) ) {
     cisc_spill_operand = operand_position(op_name, Component::USE);
     int def_oper  = operand_position(op_name, Component::DEF);
     if( def_oper == NameList::Not_in_list && instr->num_opnds() == num_opnds()) {
@@ -3699,7 +3713,8 @@ bool static root_ops_match(FormDict &globals, const char *op1, const char *op2) 
 
 //-------------------------cisc_spill_match_node-------------------------------
 // Recursively check two MatchRules for legal conversion via cisc-spilling
-int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, MatchNode* mRule2, const char* &operand, const char* &reg_type) {
+int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, MatchNode* mRule2, const char* &operand, const char* &reg_type,
+                                InstructForm *from_instr, InstructForm *to_instr) {
   int cisc_spillable  = Maybe_cisc_spillable;
   int left_spillable  = Maybe_cisc_spillable;
   int right_spillable = Maybe_cisc_spillable;
@@ -3715,6 +3730,42 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
   const Form *form  = globals[_opType];
   const Form *form2 = globals[mRule2->_opType];
   if( form == form2 ) {
+    if (form->is_operand()) {
+      // Make sure that the "from" operand and the "to" operand match in terms of being a DEF or USE. For example:
+      // from_instr: andI_rReg_ndd, MatchRule: ( Set dst (AndI  src1 src2) )
+      // MatchNode this: src (position(DEF) = -1, position(USE) = 1)
+      //
+      // to_instr: andI_rReg_mem, MatchRule: ( Set dst (AndI  dst (LoadI  src)) )
+      // MatchNode mRule2: dst (position(DEF) = 0, position(USE) = 1)
+      //
+      // The test below allows cisc-spilling if both operands are DEFS at the same position,
+      // or if neither operand is a DEF (pos is -1)
+      int from_def_pos = from_instr->operand_position(this->_name, Component::DEF);
+      int to_def_pos   = to_instr->operand_position(mRule2->_name, Component::DEF);
+      if (from_def_pos < 0 && to_def_pos < 0) {   // not sure this is a great idea to allow cisc spilling here
+          // fprintf(stderr, "!!! Neither operand is DEF\n");
+          // int from_use_pos = from_instr->operand_position(this->_name, Component::USE);
+          // int to_use_pos   = to_instr->operand_position(mRule2->_name, Component::USE);
+          // if (from_use_pos != to_use_pos) {     // doesn't happen in x86
+          //   fprintf(stderr, "!!! USE positions don't match\n");
+          //   fprintf(stderr, "from_instr %s: operand %s USE index: %d\n", from_instr->_ident, this->_name, from_use_pos);
+          //   fprintf(stderr, "to_instr %s: operand %s USE index: %d\n", to_instr->_ident, mRule2->_name, to_use_pos);
+          // }
+          return Not_cisc_spillable;
+      }
+      if (from_def_pos != to_def_pos) {
+         if (from_def_pos < 0 || to_def_pos < 0) {
+          // fprintf(stderr, "One operand is DEF and the other isn't\n");
+          // fprintf(stderr, "from_instr %s: operand %s DEF index: %d\n", from_instr->_ident, _name, from_def_pos);
+          // fprintf(stderr, "to_instr %s: operand %s DEF index: %d\n", to_instr->_ident, mRule2->_name, to_def_pos);
+        } else if (from_def_pos != to_def_pos) { // doesn't happen in x86
+          // fprintf(stderr, "!!! DEF positions don't match\n");
+          // fprintf(stderr, "from_instr %s: operand %s DEF index: %d\n", from_instr->_ident, _name, from_def_pos);
+          // fprintf(stderr, "to_instr %s: operand %s DEF index: %d\n", to_instr->_ident, mRule2->_name, to_def_pos);
+        }
+        return Not_cisc_spillable;
+      }
+    }
     cisc_spillable = Maybe_cisc_spillable;
   } else {
     const InstructForm *form2_inst = form2 ? form2->is_instruction() : nullptr;
@@ -3739,7 +3790,7 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
         reg_type       = _result;
         return Is_cisc_spillable;
       } else {
-        cisc_spillable = Not_cisc_spillable;
+        return Not_cisc_spillable;
       }
     }
     // Detect reg vs memory
@@ -3749,7 +3800,7 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
       reg_type       = _result;
       return Is_cisc_spillable;
     } else {
-      cisc_spillable = Not_cisc_spillable;
+      return Not_cisc_spillable;
     }
   }
 
@@ -3762,14 +3813,17 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
     if( (_lChild == nullptr) && (mRule2->_lChild == nullptr) ) {
       left_spillable = Maybe_cisc_spillable;
     } else  if (_lChild != nullptr) {
-      left_spillable = _lChild->cisc_spill_match(globals, registers, mRule2->_lChild, operand, reg_type);
+      left_spillable = _lChild->cisc_spill_match(globals, registers, mRule2->_lChild, operand, reg_type, from_instr, to_instr);
+      if (left_spillable == Not_cisc_spillable) {
+        return Not_cisc_spillable;
+      }
     }
 
     // Check right operands
     if( (_rChild == nullptr) && (mRule2->_rChild == nullptr) ) {
       right_spillable =  Maybe_cisc_spillable;
     } else if (_rChild != nullptr) {
-      right_spillable = _rChild->cisc_spill_match(globals, registers, mRule2->_rChild, operand, reg_type);
+      right_spillable = _rChild->cisc_spill_match(globals, registers, mRule2->_rChild, operand, reg_type, from_instr, to_instr);
     }
 
     // Combine results of left and right checks
@@ -3785,7 +3839,7 @@ int MatchNode::cisc_spill_match(FormDict& globals, RegisterForm* registers, Matc
 // general recursive checks done in MatchNode
 int  MatchRule::matchrule_cisc_spill_match(FormDict& globals, RegisterForm* registers,
                                            MatchRule* mRule2, const char* &operand,
-                                           const char* &reg_type) {
+                                           const char* &reg_type, InstructForm *from_instr, InstructForm *to_instr) {
   int cisc_spillable  = Maybe_cisc_spillable;
   int left_spillable  = Maybe_cisc_spillable;
   int right_spillable = Maybe_cisc_spillable;
@@ -3797,13 +3851,13 @@ int  MatchRule::matchrule_cisc_spill_match(FormDict& globals, RegisterForm* regi
 
   // Check left operands: at root, must be target of 'Set'
   if( (_lChild == nullptr) || (mRule2->_lChild == nullptr) ) {
-    left_spillable = Not_cisc_spillable;
+    return Not_cisc_spillable;
   } else {
     // Do not support cisc-spilling instruction's target location
     if( root_ops_match(globals, _lChild->_opType, mRule2->_lChild->_opType) ) {
       left_spillable = Maybe_cisc_spillable;
     } else {
-      left_spillable = Not_cisc_spillable;
+      return Not_cisc_spillable;
     }
   }
 
@@ -3815,7 +3869,7 @@ int  MatchRule::matchrule_cisc_spill_match(FormDict& globals, RegisterForm* regi
       assert(0, "_rChild should not be null");
     }
   } else {
-    right_spillable = _rChild->cisc_spill_match(globals, registers, mRule2->_rChild, operand, reg_type);
+    right_spillable = _rChild->cisc_spill_match(globals, registers, mRule2->_rChild, operand, reg_type, from_instr, to_instr);
   }
 
   // Combine results of left and right checks

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -1140,7 +1140,7 @@ const char *InstructForm::mach_base_class(FormDict &globals)  const {
 }
 
 // Do the instruction predicates allow target_instr to be replaced by replacement_instr for cisc-spill optimzation.
-static bool hasPredicateSubset( const InstructForm *target_instr, const InstructForm *replacement_instr ) {
+static bool has_predicate_subset( const InstructForm *target_instr, const InstructForm *replacement_instr ) {
   const Predicate *target_p  = target_instr->_predicate;
   const Predicate *replacement_p  = replacement_instr->_predicate;
   if( target_p == nullptr && replacement_p == nullptr ) {
@@ -1184,7 +1184,7 @@ bool InstructForm::cisc_spills_to(ArchDesc &AD, InstructForm *instr) {
   const char *reg_type           = nullptr;
   FormDict   &globals            = AD.globalNames();
   cisc_spill_operand = _matrule->matchrule_cisc_spill_match(globals, AD.get_registers(), instr->_matrule, op_name, reg_type, this, instr);
-  if( (cisc_spill_operand != Not_cisc_spillable) && (op_name != nullptr) && hasPredicateSubset(this, instr) ) {
+  if( (cisc_spill_operand != Not_cisc_spillable) && (op_name != nullptr) && has_predicate_subset(this, instr) ) {
     cisc_spill_operand = operand_position(op_name, Component::USE);
     int def_oper  = operand_position(op_name, Component::DEF);
     if( def_oper == NameList::Not_in_list && instr->num_opnds() == num_opnds()) {

--- a/src/hotspot/share/adlc/formssel.hpp
+++ b/src/hotspot/share/adlc/formssel.hpp
@@ -1007,7 +1007,8 @@ public:
   // Recursive version of check in MatchRule
   int        cisc_spill_match(FormDict& globals, RegisterForm* registers,
                               MatchNode* mRule2, const char* &operand,
-                              const char* &reg_type);
+                              const char* &reg_type,
+                              InstructForm *from_instr, InstructForm *to_instr);
   int        cisc_spill_merge(int left_result, int right_result);
 
   virtual bool equivalent(FormDict& globals, MatchNode* mNode2);
@@ -1068,7 +1069,7 @@ public:
   // Check if 'mRule2' is a cisc-spill variant of this MatchRule
   int        matchrule_cisc_spill_match(FormDict &globals, RegisterForm* registers,
                                         MatchRule* mRule2, const char* &operand,
-                                        const char* &reg_type);
+                                        const char* &reg_type, InstructForm *from_instr, InstructForm *to_instr);
 
   // Check if 'mRule2' is equivalent to this MatchRule
   virtual bool equivalent(FormDict& globals, MatchNode* mRule2);

--- a/src/hotspot/share/adlc/formssel.hpp
+++ b/src/hotspot/share/adlc/formssel.hpp
@@ -1007,8 +1007,7 @@ public:
   // Recursive version of check in MatchRule
   int        cisc_spill_match(FormDict& globals, RegisterForm* registers,
                               MatchNode* mRule2, const char* &operand,
-                              const char* &reg_type,
-                              InstructForm *from_instr, InstructForm *to_instr);
+                              const char* &reg_type, InstructForm *from_instr, InstructForm *to_instr);
   int        cisc_spill_merge(int left_result, int right_result);
 
   virtual bool equivalent(FormDict& globals, MatchNode* mNode2);


### PR DESCRIPTION
Re-enables cisc-spilling for legacy x86 instructions (the `has_predicate_subset()` part) from the original PR (https://github.com/openjdk/jdk/pull/31686).

> The predicate matching code in formsself.cpp insisted that both the original and replacement "instructs" have identical predicates.
> 
> This PR loosens this requirement to also allow replacing an instruct with a predicate by an instruct without a predicate - the replacement instruct is logically more general than the original instruct that only applies if the predicate is true.

The bug found running with APX instructions enabled was that the CISC-spilling in ADLC was allowing NDD instructions (for example)` (Set dst (AddI src 1 src2))` to be replaced with legacy instructions` (Set dst (AddI dst memory))`. At JIT time the compiled code would clobber registers.

The fix in this PR is don't enable cisc-spilling for new three-operand (NDD) APX instructions to legacy instructions by detecting differences in the DEF/USE state of the operands in the match rule (the `MatchNode::cisc_spill_match() `part of PR)

Did tiers 1-3 testing with/without APX enabled. 

Performance tests showed that this PR does fix the regression in the MLDSA test (when running with -XX:+UseFPUForSpilling). Another PR in the meantime disabled UseFPUForSpilling by default, which also fixed the regression. This PR on top of that PR gives a boost slightly above R2R variation.

Checking cisc-enabled instructions shows that the NDD instruction are not getting cisc spilled, but the original x86 legacy instructions get the same cisc-spilling support as prior to APX tuning. 

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389912](https://bugs.openjdk.org/browse/JDK-8389912): [REDO] Regression &gt;6% on Crypto-MLDSA.sign on x64 (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Srinivas Vamsi Parasa](https://openjdk.org/census#sparasa) (@vamsi-parasa - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32487/head:pull/32487` \
`$ git checkout pull/32487`

Update a local copy of the PR: \
`$ git checkout pull/32487` \
`$ git pull https://git.openjdk.org/jdk.git pull/32487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32487`

View PR using the GUI difftool: \
`$ git pr show -t 32487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32487.diff">https://git.openjdk.org/jdk/pull/32487.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32487#issuecomment-5456392752)
</details>
