### PR TITLE
8390917: NullPointerException test fails with new message

### DIFF
--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NullPointerException/NullPointerExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NullPointerException/NullPointerExceptionTest.java
@@ -111,8 +111,15 @@ public class NullPointerExceptionTest {
         }
         if (obtainedMsg != expectedMsg && // E.g. both are null.
             !obtainedMsg.equals(expectedMsg)) {
-            System.out.println("expected msg: " + expectedMsg);
-            Asserts.assertEquals(expectedMsg, obtainedMsg);
+            try {
+                System.out.println("expected msg: " + expectedMsg);
+                Asserts.assertEquals(expectedMsg, obtainedMsg);
+            } catch (RuntimeException rte) {
+                // Due to lack of information about null restricted fields in Xcomp, we may also guess
+                // that that was the reason for the NPE.
+                Asserts.assertTrue(obtainedMsg.contains(expectedMsg) &&
+                                   obtainedMsg.contains("is a null restricted field and there's an attempt to store null in it"));
+            }
         }
         System.out.println("\n----");
     }


### PR DESCRIPTION
Please review this small test fix. The C1 compiler doesn't resolve the field in the cpCache so the new NPE message hedges to say that the field could have been a null restricted field, and adds that to the error message.
This doesn't fail on aarch64 because c1 patching will deoptimize the error reporting method testFailedAction, and then resolved the cpCache for the field.  X86 doesn't do this so the test needs the addition of the new message for this case.
This is only if you run with -Xcomp which is an atypical way for customers to run.
Tested with the new test 100x.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390917](https://bugs.openjdk.org/browse/JDK-8390917): NullPointerException test fails with new message (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32493/head:pull/32493` \
`$ git checkout pull/32493`

Update a local copy of the PR: \
`$ git checkout pull/32493` \
`$ git pull https://git.openjdk.org/jdk.git pull/32493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32493`

View PR using the GUI difftool: \
`$ git pr show -t 32493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32493.diff">https://git.openjdk.org/jdk/pull/32493.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32493#issuecomment-5389112981)
</details>
