### PR TITLE
8390929: G1: Uninitalized G1Policy::_to_collection_set_cards may cause unnecessary GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -69,6 +69,7 @@ G1Policy::G1Policy(STWGCTimer* gc_timer) :
   _young_gen_sizer(),
   _free_regions_at_end_of_collection(0),
   _pending_cards_from_gc(0),
+  _to_collection_set_cards(0),
   _collection_set(nullptr),
   _g1h(nullptr),
   _phase_times_timer(gc_timer),


### PR DESCRIPTION
Hi all,

  `G1Policy::_to_collection_set_cards` is not initialized, so it might cause an unnecessary gc fairly early depending on its value.

The fix is to initialize to zero.

Testing: local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390929](https://bugs.openjdk.org/browse/JDK-8390929): G1: Uninitalized G1Policy::_to_collection_set_cards may cause unnecessary GC (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32495/head:pull/32495` \
`$ git checkout pull/32495`

Update a local copy of the PR: \
`$ git checkout pull/32495` \
`$ git pull https://git.openjdk.org/jdk.git pull/32495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32495`

View PR using the GUI difftool: \
`$ git pr show -t 32495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32495.diff">https://git.openjdk.org/jdk/pull/32495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32495#issuecomment-5394521065)
</details>
