### PR TITLE
8390818: Set UseFPUForSpilling default off on AMD Zen3+ targets

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1573,16 +1573,17 @@ void VM_Version::get_processor_features() {
       if (FLAG_IS_DEFAULT(UseUnalignedLoadStores)) {
         FLAG_SET_DEFAULT(UseUnalignedLoadStores, true);
       }
-#ifdef COMPILER2
-      // Enable UseFPUForSpilling on Zen1/Zen2 (family 0x17) and Hygon Dhyana (family 0x18).
-      // On Zen3 (family 0x19) and beyond it should be default off.
-      if (cpu_family() < 0x19) {
-        if (supports_sse4_2() && FLAG_IS_DEFAULT(UseFPUForSpilling)) {
-          FLAG_SET_DEFAULT(UseFPUForSpilling, true);
-        }
-      }
-#endif // COMPILER2
     }
+
+#ifdef COMPILER2
+    // Enable UseFPUForSpilling on Zen1/Zen2 (family 0x17) and Hygon Dhyana (family 0x18).
+    // On Zen3 (family 0x19) and beyond it should be default off.
+    if (cpu_family() >= 0x17 && cpu_family() < 0x19) {
+      if (supports_sse4_2() && FLAG_IS_DEFAULT(UseFPUForSpilling)) {
+        FLAG_SET_DEFAULT(UseFPUForSpilling, true);
+      }
+    }
+#endif // COMPILER2
 
   }
 

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1574,11 +1574,16 @@ void VM_Version::get_processor_features() {
         FLAG_SET_DEFAULT(UseUnalignedLoadStores, true);
       }
 #ifdef COMPILER2
-      if (supports_sse4_2() && FLAG_IS_DEFAULT(UseFPUForSpilling)) {
-        FLAG_SET_DEFAULT(UseFPUForSpilling, true);
+      // Enable UseFPUForSpilling on Zen1/Zen2 (family 0x17) and Hygon Dhyana (family 0x18).
+      // On Zen3 (family 0x19) and beyond it should be default off.
+      if (cpu_family() < 0x19) {
+        if (supports_sse4_2() && FLAG_IS_DEFAULT(UseFPUForSpilling)) {
+          FLAG_SET_DEFAULT(UseFPUForSpilling, true);
+        }
       }
-#endif
+#endif // COMPILER2
     }
+
   }
 
   if (is_intel()) { // Intel cpus specific settings


### PR DESCRIPTION
Hi,

The following newly added Valhalla benchmarks show significantly improved performance if `UseFPUForSpilling` is turned off. Speedups below are measured on Zen5 (Turin) for `org.openjdk.bench.valhalla.array.fill.*`, with the flag disabled relative to the current AMD default:

| Benchmark | s=100 | s=1024 | s=4096 |
|---|---:|---:|---:|
| `ValueOopNullFree.arrayfill_static` | 1.81x | 2.40x | 2.45x |
| `ValueOopNullFreeNonAtomic.arrayfill_static` | 1.81x | 2.41x | 2.44x |
| `ValueOopNullFree.arrayfill_instance` | 2.02x | 2.06x | 2.10x |
| `ValueOopNullFreeNonAtomic.arrayfill_instance` | 2.02x | 2.08x | 2.09x |
| `ValueOopNullFree.arrayfill_local` | 1.49x | 1.79x | 1.63x |
| `ValueOopNullFreeNonAtomic.arrayfill_local` | 1.46x | 1.74x | 1.79x |
| `Value032NullFree.arrayfill_instance` | 1.29x | 1.42x | 1.47x |
| `Value032NullFreeNonAtomic.arrayfill_instance` | 1.40x | 1.41x | 1.47x |
| `ValueOop.arrayfill_local` | 1.23x | 1.30x | 1.33x |
| `ValueOop.arrayfill_static` | 1.18x | 1.20x | 1.20x |
| `ValueOop.arrayfill_new` | 1.07x | 1.15x | 1.08x |

In the hot strip-mined inner loop both configurations compile to the same 45 instructions. The only semantic difference is the spill of one loop-carried value and its two reloads:

| Slot | `UseFPUForSpilling` on (AMD default) | `UseFPUForSpilling` off |
|---:|---|---|
| 6 | `vmovd xmm0, r13d` | `mov DWORD PTR [rsp], r13d` |
| 9 | `vmovd ebx, xmm0` | `mov r10d, DWORD PTR [rsp]` |
| 34 | `vmovd r13d, xmm0` | `mov r13d, DWORD PTR [rsp]` |

Since the spilled value sits on the loop-carried dependency chain, the cost of the round trip through the FPU is exposed directly as loop latency, whereas the stack-slot form benefits from store-to-load forwarding.

On benchmarking these micros on all the generations of Zen servers, it was observed that enabling `UseFPUForSpilling` is beneficial on Zen1 (Naples), neutral on Zen2 (Rome), and degrades performance on Zen3 (Milan), Zen4 (Bergamo) and Zen5 (Turin).

This patch therefore restricts the flag to AMD family 0x17 (Zen1/Zen2) and leaves it at the product default (off) on family 0x19 and above.

Please review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390818](https://bugs.openjdk.org/browse/JDK-8390818): Set UseFPUForSpilling default off on AMD Zen3+ targets (**Enhancement** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - Committer)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32499/head:pull/32499` \
`$ git checkout pull/32499`

Update a local copy of the PR: \
`$ git checkout pull/32499` \
`$ git pull https://git.openjdk.org/jdk.git pull/32499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32499`

View PR using the GUI difftool: \
`$ git pr show -t 32499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32499.diff">https://git.openjdk.org/jdk/pull/32499.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32499#issuecomment-5393505757)
</details>
