### PR TITLE
8338094: C1: assert(result->covers(op_id, mode)) failed: op_id not covered by interval

### DIFF
--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1394,7 +1394,7 @@ void LinearScan::build_intervals() {
       // might not happen if the corresponding virtual register used within
       // 'handler' is replaced by another one in an earlier optimization pass.
       // An example of such a replacement is GraphBuilder::shift_op().
-      if (op_id != -1 && has_info(op_id)) {
+      if (compilation()->has_exception_handlers() && op_id != -1 && has_info(op_id)) {
         XHandlers* xhandlers = visitor.all_xhandler();
         for (int k = 0; k < xhandlers->length(); k++) {
           BlockBegin* handler = xhandlers->handler_at(k)->entry_block();

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -542,9 +542,6 @@ void LinearScan::set_live_gen_kill(Value value, LIR_Op* op, BitMap& live_gen, Bi
   if ((con == nullptr || con->is_pinned()) && opr->is_register()) {
     assert(reg_num(opr) == opr->vreg_number() && !is_valid_reg_num(reg_numHi(opr)), "invalid optimization below");
     int reg = opr->vreg_number();
-    if (UseNewCode && reg == 610) {
-      return; // Added only for debugging purposes, according to comment
-    }
     if (!live_kill.at(reg)) {
       live_gen.set_bit(reg);
       TRACE_LINEAR_SCAN(4, tty->print_cr("  Setting live_gen for value %c%d, LIR op_id %d, register number %d", value->type()->tchar(), value->id(), op->id(), reg));
@@ -922,9 +919,6 @@ void LinearScan::add_def(LIR_Opr opr, int def_pos, IntervalUseKind use_kind) {
 }
 
 void LinearScan::add_use(LIR_Opr opr, int from, int to, IntervalUseKind use_kind) {
-  if (UseNewCode && reg_num(opr) == 610 && from == 24 && to == 35) {
-    return; // Added only for debugging purposes, according to comment
-  }
   TRACE_LINEAR_SCAN(2, tty->print(" use "); opr->print(tty); tty->print_cr(" from %d to %d (%d)", from, to, use_kind));
   assert(opr->is_register(), "should not be called otherwise");
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -744,8 +744,9 @@ void LinearScan::compute_global_live_sets() {
   // Perform a backward dataflow analysis to compute live_out and live_in for each block.
   // The loop is executed until a fixpoint is reached (no changes in an iteration)
   // Exception handlers must be processed because not all live values are
-  // present in the state array, e.g. because of global value numbering
-  // TBD: extend comment, write that we complement this at the local level by adding virtual uses below.
+  // present in the state array, e.g. because of global value numbering.
+  // Exception handler live_in information is also used by build_intervals() to
+  // account for local liveness holes in exception-throwing blocks.
   do {
     change_occurred = false;
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -4249,7 +4249,7 @@ Interval* Interval::split_child_at_op_id(int op_id, LIR_OpVisitState::OprMode mo
   }
 
   assert(result != nullptr, "no matching interval found");
-  assert(result->covers(op_id, mode), "op_id not covered by interval");
+  assert(result->covers(op_id, mode), "op_id %d not covered by interval %d", op_id, result->reg_num());
 
   return result;
 }

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1397,6 +1397,30 @@ void LinearScan::build_intervals() {
       }
 
       // BEGIN OF PROTOTYPE SOLUTION
+
+      // If the currently visited operation 'op' may branch into an exception
+      // handler block 'B_handler', add all live-in registers of 'B_handler' as
+      // virtual uses of 'op'. This ensures that all such registers are live
+      // into 'op', which might otherwise not happen if 'op' is scheduled within
+      // a hole of their corresponding intervals, as in the following
+      // post-compute_global_live_sets() scenario:
+      //
+      // R
+      // |  B_loop:
+      // |    live-in:  {.., R, ..}
+      // |    ..
+      // -    kill R
+      //      ..
+      //      op: branch [BE] .. // may branch into B_handler
+      //      ..
+      // -    def R
+      // |    ..
+      // |    branch into B_loop
+      // |    live-out: {.., R, ..}
+      // |
+      // |  B_handler:
+      // |    live-in:  {.., R, ..}
+      // |    ..
       assert(op_id != -1, "expect regular operation");
       if (has_info(op_id)) {
         XHandlers* xhandlers = visitor.all_xhandler();

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1390,7 +1390,7 @@ void LinearScan::build_intervals() {
       // |    ..
       //
       // Normally, the debug information generation logic above will add
-      // registers such R in the above example as uses of 'op', but this might
+      // registers such R in the above scenario as uses of 'op', but this might
       // not happen if the corresponding virtual register used within 'handler'
       // is replaced by another one in an earlier optimization pass. An example
       // of such a replacement is GraphBuilder::shift_op().
@@ -1398,19 +1398,19 @@ void LinearScan::build_intervals() {
         XHandlers* xhandlers = visitor.all_xhandler();
         for (int k = 0; k < xhandlers->length(); k++) {
           BlockBegin* handler = xhandlers->handler_at(k)->entry_block();
-          // TBD: extract into a separate function ('add_uses_from_livein' or similar)
-          auto add_virtual_use = [&](BitMap::idx_t index) {
+          auto add_virtual_use_to_op = [&](BitMap::idx_t index) {
             int reg = static_cast<int>(index);
-            // The T_ILLEGAL type is used by add_use as a sentinel value
+            // The T_ILLEGAL type is used by add_use() as a sentinel value
             // indicating the type is unknown (rather than illegal) so that the
             // type of the interval corresponding to reg is not updated. The use
-            // is extended beyond op (to = op_id + 1) so that liveness is
-            // preserved across possible registers killed by op (e.g.
-            // caller-saved registers if op is a call).
-            TRACE_LINEAR_SCAN(2, tty->print_cr(" use [R%d] from %d to %d (%d)", reg, block_from, op_id + 1, noUse));
+            // is extended beyond 'op' (to = op_id + 1) so that liveness is
+            // preserved across possible registers killed by 'op' (e.g.
+            // caller-saved registers if 'op' is a call).
+            TRACE_LINEAR_SCAN(2, tty->print_cr(" use [R%d] from %d to %d (%d)",
+                                               reg, block_from, op_id + 1, noUse));
             add_use(reg, block_from, op_id + 1, noUse, T_ILLEGAL);
           };
-          handler->live_in().iterate(add_virtual_use);
+          handler->live_in().iterate(add_virtual_use_to_op);
         }
       }
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -3085,14 +3085,7 @@ void LinearScan::do_linear_scan() {
   allocate_registers();
   CHECK_BAILOUT();
 
-  NOT_PRODUCT(print_lir(1, "After allocate_registers"));
-  NOT_PRODUCT(print_intervals("After allocate_registers"));
-
   resolve_data_flow();
-
-  NOT_PRODUCT(print_lir(1, "After resolve_data_flow"));
-  NOT_PRODUCT(print_intervals("After resolve_data_flow"));
-
   if (compilation()->has_exception_handlers()) {
     resolve_exception_handlers();
   }
@@ -4307,7 +4300,7 @@ Interval* Interval::split_child_at_op_id(int op_id, LIR_OpVisitState::OprMode mo
   }
 
   assert(result != nullptr, "no matching interval found");
-  assert(result->covers(op_id, mode), "op_id %d not covered by interval %d", op_id, result->reg_num());
+  assert(result->covers(op_id, mode), "op_id not covered by interval");
 
   return result;
 }

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1439,11 +1439,14 @@ void LinearScan::build_intervals() {
               // The T_ILLEGAL type is used by add_use as a sentinel value
               // indicating the type is unknown (rather than illegal) so that
               // the type of the interval corresponding to reg is not updated.
-              TRACE_LINEAR_SCAN(2, tty->print_cr(" use [R%d|?] from %d to %d (%d)", reg, block_from, op_id, noUse));
+              // The use is extended beyond op (to = op_id + 1) so that liveness
+              // is preserved across possible registers killed by op (e.g.
+              // caller-saved registers if op is a call).
+              TRACE_LINEAR_SCAN(2, tty->print_cr(" use [R%d|?] from %d to %d (%d)", reg, block_from, op_id + 1, noUse));
               // TBD: review 'noUse': should it be a "should" or a "must"
               // register? Or is it correct to use 'noUse' since the register is
               // not physically read by op?
-              add_use(reg, block_from, op_id, noUse, T_ILLEGAL);
+              add_use(reg, block_from, op_id + 1, noUse, T_ILLEGAL);
             }
           }
         }

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1417,6 +1417,7 @@ void LinearScan::build_intervals() {
         XHandlers* xhandlers = visitor.all_xhandler();
         for (int k = 0; k < xhandlers->length(); k++) {
           BlockBegin* handler = xhandlers->handler_at(k)->entry_block();
+          // TBD: extract into a separate function ('add_uses_from_livein' or similar)
           auto add_virtual_use = [&](BitMap::idx_t index) {
             int reg = static_cast<int>(index);
             // The T_ILLEGAL type is used by add_use as a sentinel value

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -767,26 +767,32 @@ void LinearScan::compute_global_live_sets() {
       if (n + e > 0) {
         // block has successors
         if (n > 0) {
+#ifdef ASSERT
           if (TraceLinearScanLevel >= 4) {
             tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->sux_at(0)->block_id());
             print_bitmap(block->sux_at(0)->live_in());
           }
+#endif
           live_out.set_from(block->sux_at(0)->live_in());
           for (int j = 1; j < n; j++) {
+#ifdef ASSERT
             if (TraceLinearScanLevel >= 4) {
               tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->sux_at(j)->block_id());
               print_bitmap(block->sux_at(j)->live_in());
             }
+#endif
             live_out.set_union(block->sux_at(j)->live_in());
           }
         } else {
           live_out.clear();
         }
         for (int j = 0; j < e; j++) {
+#ifdef ASSERT
           if (TraceLinearScanLevel >= 4) {
             tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->exception_handler_at(j)->block_id());
             print_bitmap(block->exception_handler_at(j)->live_in());
           }
+#endif
           live_out.set_union(block->exception_handler_at(j)->live_in());
         }
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1364,11 +1364,11 @@ void LinearScan::build_intervals() {
         add_use(opr, block_from, op_id, use_kind_of_input_operand(op, opr));
       }
 
-      // If the currently visited operation 'op' may branch into an exception
-      // handler block 'handler', add all live-in registers of 'handler' as
-      // virtual uses of 'op'. This ensures that all such registers are live
-      // into 'op', which might otherwise not happen if 'op' is scheduled within
-      // a hole of their corresponding intervals, as in the following
+      // If the visited operation 'op' may branch into an exception handler
+      // block 'handler', add all live-in registers of 'handler' as virtual uses
+      // of 'op'. This ensures that all such registers are live into 'op', which
+      // might otherwise not happen if 'op' is scheduled within a hole of their
+      // corresponding intervals, as in the following
       // post-compute_global_live_sets() scenario:
       //
       // R
@@ -1387,6 +1387,12 @@ void LinearScan::build_intervals() {
       // |  handler:
       // |    live-in:  {.., R, ..}
       // |    ..
+      //
+      // Normally, the debug information generation logic above will add
+      // registers such R in the above example as uses of 'op', but this might
+      // not happen if the corresponding virtual register used within 'handler'
+      // is replaced by another one in an earlier optimization pass. An example
+      // of such a replacement is GraphBuilder::shift_op().
       if (op_id != -1 && has_info(op_id)) {
         XHandlers* xhandlers = visitor.all_xhandler();
         for (int k = 0; k < xhandlers->length(); k++) {

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -751,7 +751,7 @@ void LinearScan::compute_global_live_sets() {
   // The loop is executed until a fixpoint is reached (no changes in an iteration)
   // Exception handlers must be processed because not all live values are
   // present in the state array, e.g. because of global value numbering
-  // TODO: does this assume exception handlers are always jumped to from the end of a block?
+  // TBD: extend comment, write that we complement this at the local level by adding virtual uses below.
   do {
     change_occurred = false;
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -567,6 +567,7 @@ void LinearScan::compute_local_live_sets() {
   // iterate all blocks
   for (int i = 0; i < num_blocks; i++) {
     BlockBegin* block = block_at(i);
+    TRACE_LINEAR_SCAN(4, tty->print_cr("B%d", block->block_id()));
 
     ResourceBitMap live_gen(live_size);
     ResourceBitMap live_kill(live_size);
@@ -586,6 +587,7 @@ void LinearScan::compute_local_live_sets() {
     assert(visitor.no_operands(instructions->at(0)), "first operation must always be a label");
     for (int j = 1; j < num_inst; j++) {
       LIR_Op* op = instructions->at(j);
+      TRACE_LINEAR_SCAN(4, tty->print_cr("op%d", op->id()));
 
       // visit operation to collect all operands
       visitor.visit(op);
@@ -608,6 +610,7 @@ void LinearScan::compute_local_live_sets() {
         if (opr->is_virtual_register()) {
           assert(reg_num(opr) == opr->vreg_number() && !is_valid_reg_num(reg_numHi(opr)), "invalid optimization below");
           reg = opr->vreg_number();
+          TRACE_LINEAR_SCAN(4, tty->print_cr("  input virtual register %d", reg));
           if (!live_kill.at(reg)) {
             live_gen.set_bit(reg);
             TRACE_LINEAR_SCAN(4, tty->print_cr("  Setting live_gen for register %d at instruction %d", reg, op->id()));
@@ -1317,6 +1320,7 @@ void LinearScan::build_intervals() {
   // iterate all blocks in reverse order
   for (i = block_count() - 1; i >= 0; i--) {
     BlockBegin* block = block_at(i);
+    TRACE_LINEAR_SCAN(2, tty->print_cr("B%d", block->block_id()));
     LIR_OpList* instructions = block->lir()->instructions_list();
     int         block_from =   block->first_lir_instruction_id();
     int         block_to =     block->last_lir_instruction_id();
@@ -1352,6 +1356,7 @@ void LinearScan::build_intervals() {
     for (int j = instructions->length() - 1; j >= 1; j--) {
       LIR_Op* op = instructions->at(j);
       int op_id = op->id();
+      TRACE_LINEAR_SCAN(2, tty->print_cr("op%d", op_id));
 
       // visit operation to collect all operands
       visitor.visit(op);
@@ -1390,6 +1395,37 @@ void LinearScan::build_intervals() {
         assert(opr->is_register(), "visitor should only return register operands");
         add_use(opr, block_from, op_id, use_kind_of_input_operand(op, opr));
       }
+
+      // BEGIN OF PROTOTYPE SOLUTION
+      assert(op_id != -1, "expect regular operation");
+      if (has_info(op_id)) {
+        XHandlers* xhandlers = visitor.all_xhandler();
+        for (int k = 0; k < xhandlers->length(); k++) {
+          XHandler* handler = xhandlers->handler_at(k);
+          BlockBegin* entry = handler->entry_block();
+          ResourceBitMap& live_in = entry->live_in();
+          TRACE_LINEAR_SCAN(
+                            4, tty->print("  op %d branches to exception handler entry B%d. "
+                                          "live-in(B%d) = ",
+                                          op_id, entry->block_id(), entry->block_id());
+                            print_bitmap(live_in);
+                            );
+          // TBD: iterate using live_in.iterate, see code at the beginning of LinearScan::build_intervals
+          for (unsigned int reg = 0; reg < live_in.size(); reg++) {
+            if (live_in.at(reg)) {
+              // The T_ILLEGAL type is used by add_use as a sentinel value
+              // indicating the type is unknown (rather than illegal) so that
+              // the type of the interval corresponding to reg is not updated.
+              TRACE_LINEAR_SCAN(2, tty->print_cr(" use [R%d|?] from %d to %d (%d)", reg, block_from, op_id, noUse));
+              // TBD: review 'noUse': should it be a "should" or a "must"
+              // register? Or is it correct to use 'noUse' since the register is
+              // not physically read by op?
+              add_use(reg, block_from, op_id, noUse, T_ILLEGAL);
+            }
+          }
+        }
+      }
+      // END OF PROTOTYPE SOLUTION
 
       // Add uses of live locals from interpreter's point of view for proper
       // debug information generation

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -564,7 +564,6 @@ void LinearScan::compute_local_live_sets() {
   // iterate all blocks
   for (int i = 0; i < num_blocks; i++) {
     BlockBegin* block = block_at(i);
-    TRACE_LINEAR_SCAN(4, tty->print_cr("B%d", block->block_id()));
 
     ResourceBitMap live_gen(live_size);
     ResourceBitMap live_kill(live_size);
@@ -584,7 +583,6 @@ void LinearScan::compute_local_live_sets() {
     assert(visitor.no_operands(instructions->at(0)), "first operation must always be a label");
     for (int j = 1; j < num_inst; j++) {
       LIR_Op* op = instructions->at(j);
-      TRACE_LINEAR_SCAN(4, tty->print_cr("op%d", op->id()));
 
       // visit operation to collect all operands
       visitor.visit(op);
@@ -607,7 +605,6 @@ void LinearScan::compute_local_live_sets() {
         if (opr->is_virtual_register()) {
           assert(reg_num(opr) == opr->vreg_number() && !is_valid_reg_num(reg_numHi(opr)), "invalid optimization below");
           reg = opr->vreg_number();
-          TRACE_LINEAR_SCAN(4, tty->print_cr("  input virtual register %d", reg));
           if (!live_kill.at(reg)) {
             live_gen.set_bit(reg);
             TRACE_LINEAR_SCAN(4, tty->print_cr("  Setting live_gen for register %d at instruction %d", reg, op->id()));
@@ -638,12 +635,9 @@ void LinearScan::compute_local_live_sets() {
 
       // Add uses of live locals from interpreter's point of view for proper debug information generation
       n = visitor.info_count();
-      TRACE_LINEAR_SCAN(4, tty->print("op: "); op->print(); tty->cr());
       for (k = 0; k < n; k++) {
-        TRACE_LINEAR_SCAN(4, tty->print_cr("  k: %d", k));
         CodeEmitInfo* info = visitor.info_at(k);
         ValueStack* stack = info->stack();
-        TRACE_LINEAR_SCAN(4, tty->print("stack: "); stack->print(); tty->cr());
         for_each_state_value(stack, value,
           set_live_gen_kill(value, op, live_gen, live_kill);
           local_has_fpu_registers = local_has_fpu_registers || value->type()->is_float_kind();
@@ -767,32 +761,14 @@ void LinearScan::compute_global_live_sets() {
       if (n + e > 0) {
         // block has successors
         if (n > 0) {
-#ifdef ASSERT
-          if (TraceLinearScanLevel >= 4) {
-            tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->sux_at(0)->block_id());
-            print_bitmap(block->sux_at(0)->live_in());
-          }
-#endif
           live_out.set_from(block->sux_at(0)->live_in());
           for (int j = 1; j < n; j++) {
-#ifdef ASSERT
-            if (TraceLinearScanLevel >= 4) {
-              tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->sux_at(j)->block_id());
-              print_bitmap(block->sux_at(j)->live_in());
-            }
-#endif
             live_out.set_union(block->sux_at(j)->live_in());
           }
         } else {
           live_out.clear();
         }
         for (int j = 0; j < e; j++) {
-#ifdef ASSERT
-          if (TraceLinearScanLevel >= 4) {
-            tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->exception_handler_at(j)->block_id());
-            print_bitmap(block->exception_handler_at(j)->live_in());
-          }
-#endif
           live_out.set_union(block->exception_handler_at(j)->live_in());
         }
 
@@ -1314,7 +1290,6 @@ void LinearScan::build_intervals() {
   // iterate all blocks in reverse order
   for (i = block_count() - 1; i >= 0; i--) {
     BlockBegin* block = block_at(i);
-    TRACE_LINEAR_SCAN(2, tty->print_cr("B%d", block->block_id()));
     LIR_OpList* instructions = block->lir()->instructions_list();
     int         block_from =   block->first_lir_instruction_id();
     int         block_to =     block->last_lir_instruction_id();
@@ -1350,7 +1325,6 @@ void LinearScan::build_intervals() {
     for (int j = instructions->length() - 1; j >= 1; j--) {
       LIR_Op* op = instructions->at(j);
       int op_id = op->id();
-      TRACE_LINEAR_SCAN(2, tty->print_cr("op%d", op_id));
 
       // visit operation to collect all operands
       visitor.visit(op);
@@ -3086,27 +3060,21 @@ void LinearScan::assign_reg_num() {
 
 
 void LinearScan::do_linear_scan() {
-  TRACE_LINEAR_SCAN(3, tty->print_cr("number_instructions()"));
   number_instructions();
 
   NOT_PRODUCT(print_lir(1, "Before Register Allocation"));
 
-  TRACE_LINEAR_SCAN(3, tty->print_cr("compute_local_live_sets()"));
   compute_local_live_sets();
-  TRACE_LINEAR_SCAN(3, tty->print_cr("compute_global_live_sets()"));
   compute_global_live_sets();
   CHECK_BAILOUT();
 
-  TRACE_LINEAR_SCAN(3, tty->print_cr("build_intervals()"));
   build_intervals();
   CHECK_BAILOUT();
-  TRACE_LINEAR_SCAN(3, tty->print_cr("sort_intervals()"));
   sort_intervals_before_allocation();
 
   NOT_PRODUCT(print_intervals("Before Register Allocation"));
   NOT_PRODUCT(LinearScanStatistic::compute(this, _stat_before_alloc));
 
-  TRACE_LINEAR_SCAN(3, tty->print_cr("allocate_registers()"));
   allocate_registers();
   CHECK_BAILOUT();
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1399,39 +1399,38 @@ void LinearScan::build_intervals() {
       // BEGIN OF PROTOTYPE SOLUTION
 
       // If the currently visited operation 'op' may branch into an exception
-      // handler block 'B_handler', add all live-in registers of 'B_handler' as
+      // handler block 'handler', add all live-in registers of 'handler' as
       // virtual uses of 'op'. This ensures that all such registers are live
       // into 'op', which might otherwise not happen if 'op' is scheduled within
       // a hole of their corresponding intervals, as in the following
       // post-compute_global_live_sets() scenario:
       //
       // R
-      // |  B_loop:
+      // |  block:
       // |    live-in:  {.., R, ..}
       // |    ..
       // -    kill R
       //      ..
-      //      op: branch [BE] .. // may branch into B_handler
+      //      op: branch [BE] .. // may branch into 'handler'
       //      ..
       // -    def R
       // |    ..
-      // |    branch into B_loop
+      // |    branch into 'block'
       // |    live-out: {.., R, ..}
       // |
-      // |  B_handler:
+      // |  handler:
       // |    live-in:  {.., R, ..}
       // |    ..
       assert(op_id != -1, "expect regular operation");
       if (has_info(op_id)) {
         XHandlers* xhandlers = visitor.all_xhandler();
         for (int k = 0; k < xhandlers->length(); k++) {
-          XHandler* handler = xhandlers->handler_at(k);
-          BlockBegin* entry = handler->entry_block();
-          ResourceBitMap& live_in = entry->live_in();
+          BlockBegin* handler = xhandlers->handler_at(k)->entry_block();
+          ResourceBitMap& live_in = handler->live_in();
           TRACE_LINEAR_SCAN(
                             4, tty->print("  op %d branches to exception handler entry B%d. "
                                           "live-in(B%d) = ",
-                                          op_id, entry->block_id(), entry->block_id());
+                                          op_id, handler->block_id(), handler->block_id());
                             print_bitmap(live_in);
                             );
           // TBD: iterate using live_in.iterate, see code at the beginning of LinearScan::build_intervals

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1389,11 +1389,11 @@ void LinearScan::build_intervals() {
       // |    live-in:  {.., R, ..}
       // |    ..
       //
-      // Normally, the debug information generation logic above will add
-      // registers such R in the above scenario as uses of 'op', but this might
-      // not happen if the corresponding virtual register used within 'handler'
-      // is replaced by another one in an earlier optimization pass. An example
-      // of such a replacement is GraphBuilder::shift_op().
+      // Normally, the debug information generation logic below will add
+      // registers such as R in the above scenario as uses of 'op', but this
+      // might not happen if the corresponding virtual register used within
+      // 'handler' is replaced by another one in an earlier optimization pass.
+      // An example of such a replacement is GraphBuilder::shift_op().
       if (op_id != -1 && has_info(op_id)) {
         XHandlers* xhandlers = visitor.all_xhandler();
         for (int k = 0; k < xhandlers->length(); k++) {
@@ -3085,12 +3085,12 @@ void LinearScan::do_linear_scan() {
   allocate_registers();
   CHECK_BAILOUT();
 
-  NOT_PRODUCT(print_lir(3, "After allocate_registers"));
+  NOT_PRODUCT(print_lir(1, "After allocate_registers"));
   NOT_PRODUCT(print_intervals("After allocate_registers"));
 
   resolve_data_flow();
 
-  NOT_PRODUCT(print_lir(3, "After resolve_data_flow"));
+  NOT_PRODUCT(print_lir(1, "After resolve_data_flow"));
   NOT_PRODUCT(print_intervals("After resolve_data_flow"));
 
   if (compilation()->has_exception_handlers()) {

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -3085,12 +3085,12 @@ void LinearScan::do_linear_scan() {
   allocate_registers();
   CHECK_BAILOUT();
 
-  NOT_PRODUCT(print_lir(1, "After allocate_registers"));
+  NOT_PRODUCT(print_lir(3, "After allocate_registers"));
   NOT_PRODUCT(print_intervals("After allocate_registers"));
 
   resolve_data_flow();
 
-  NOT_PRODUCT(print_lir(1, "After resolve_data_flow"));
+  NOT_PRODUCT(print_lir(3, "After resolve_data_flow"));
   NOT_PRODUCT(print_intervals("After resolve_data_flow"));
 
   if (compilation()->has_exception_handlers()) {

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -542,6 +542,9 @@ void LinearScan::set_live_gen_kill(Value value, LIR_Op* op, BitMap& live_gen, Bi
   if ((con == nullptr || con->is_pinned()) && opr->is_register()) {
     assert(reg_num(opr) == opr->vreg_number() && !is_valid_reg_num(reg_numHi(opr)), "invalid optimization below");
     int reg = opr->vreg_number();
+    if (UseNewCode && reg == 610) {
+      return; // Added only for debugging purposes, according to comment
+    }
     if (!live_kill.at(reg)) {
       live_gen.set_bit(reg);
       TRACE_LINEAR_SCAN(4, tty->print_cr("  Setting live_gen for value %c%d, LIR op_id %d, register number %d", value->type()->tchar(), value->id(), op->id(), reg));
@@ -635,9 +638,12 @@ void LinearScan::compute_local_live_sets() {
 
       // Add uses of live locals from interpreter's point of view for proper debug information generation
       n = visitor.info_count();
+      TRACE_LINEAR_SCAN(4, tty->print("op: "); op->print(); tty->cr());
       for (k = 0; k < n; k++) {
+        TRACE_LINEAR_SCAN(4, tty->print_cr("  k: %d", k));
         CodeEmitInfo* info = visitor.info_at(k);
         ValueStack* stack = info->stack();
+        TRACE_LINEAR_SCAN(4, tty->print("stack: "); stack->print(); tty->cr());
         for_each_state_value(stack, value,
           set_live_gen_kill(value, op, live_gen, live_kill);
           local_has_fpu_registers = local_has_fpu_registers || value->type()->is_float_kind();
@@ -745,6 +751,7 @@ void LinearScan::compute_global_live_sets() {
   // The loop is executed until a fixpoint is reached (no changes in an iteration)
   // Exception handlers must be processed because not all live values are
   // present in the state array, e.g. because of global value numbering
+  // TODO: does this assume exception handlers are always jumped to from the end of a block?
   do {
     change_occurred = false;
 
@@ -760,14 +767,26 @@ void LinearScan::compute_global_live_sets() {
       if (n + e > 0) {
         // block has successors
         if (n > 0) {
+          if (TraceLinearScanLevel >= 4) {
+            tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->sux_at(0)->block_id());
+            print_bitmap(block->sux_at(0)->live_in());
+          }
           live_out.set_from(block->sux_at(0)->live_in());
           for (int j = 1; j < n; j++) {
+            if (TraceLinearScanLevel >= 4) {
+              tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->sux_at(j)->block_id());
+              print_bitmap(block->sux_at(j)->live_in());
+            }
             live_out.set_union(block->sux_at(j)->live_in());
           }
         } else {
           live_out.clear();
         }
         for (int j = 0; j < e; j++) {
+          if (TraceLinearScanLevel >= 4) {
+            tty->print("live_out B%d u= live_in B%d = ", block->block_id(), block->exception_handler_at(j)->block_id());
+            print_bitmap(block->exception_handler_at(j)->live_in());
+          }
           live_out.set_union(block->exception_handler_at(j)->live_in());
         }
 
@@ -894,6 +913,9 @@ void LinearScan::add_def(LIR_Opr opr, int def_pos, IntervalUseKind use_kind) {
 }
 
 void LinearScan::add_use(LIR_Opr opr, int from, int to, IntervalUseKind use_kind) {
+  if (UseNewCode && reg_num(opr) == 610 && from == 24 && to == 35) {
+    return; // Added only for debugging purposes, according to comment
+  }
   TRACE_LINEAR_SCAN(2, tty->print(" use "); opr->print(tty); tty->print_cr(" from %d to %d (%d)", from, to, use_kind));
   assert(opr->is_register(), "should not be called otherwise");
 
@@ -3016,25 +3038,38 @@ void LinearScan::assign_reg_num() {
 
 
 void LinearScan::do_linear_scan() {
+  TRACE_LINEAR_SCAN(3, tty->print_cr("number_instructions()"));
   number_instructions();
 
   NOT_PRODUCT(print_lir(1, "Before Register Allocation"));
 
+  TRACE_LINEAR_SCAN(3, tty->print_cr("compute_local_live_sets()"));
   compute_local_live_sets();
+  TRACE_LINEAR_SCAN(3, tty->print_cr("compute_global_live_sets()"));
   compute_global_live_sets();
   CHECK_BAILOUT();
 
+  TRACE_LINEAR_SCAN(3, tty->print_cr("build_intervals()"));
   build_intervals();
   CHECK_BAILOUT();
+  TRACE_LINEAR_SCAN(3, tty->print_cr("sort_intervals()"));
   sort_intervals_before_allocation();
 
   NOT_PRODUCT(print_intervals("Before Register Allocation"));
   NOT_PRODUCT(LinearScanStatistic::compute(this, _stat_before_alloc));
 
+  TRACE_LINEAR_SCAN(3, tty->print_cr("allocate_registers()"));
   allocate_registers();
   CHECK_BAILOUT();
 
+  NOT_PRODUCT(print_lir(1, "After allocate_registers"));
+  NOT_PRODUCT(print_intervals("After allocate_registers"));
+
   resolve_data_flow();
+
+  NOT_PRODUCT(print_lir(1, "After resolve_data_flow"));
+  NOT_PRODUCT(print_intervals("After resolve_data_flow"));
+
   if (compilation()->has_exception_handlers()) {
     resolve_exception_handlers();
   }

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1390,8 +1390,6 @@ void LinearScan::build_intervals() {
         add_use(opr, block_from, op_id, use_kind_of_input_operand(op, opr));
       }
 
-      // BEGIN OF PROTOTYPE SOLUTION
-
       // If the currently visited operation 'op' may branch into an exception
       // handler block 'handler', add all live-in registers of 'handler' as
       // virtual uses of 'op'. This ensures that all such registers are live
@@ -1415,37 +1413,24 @@ void LinearScan::build_intervals() {
       // |  handler:
       // |    live-in:  {.., R, ..}
       // |    ..
-      assert(op_id != -1, "expect regular operation");
-      if (has_info(op_id)) {
+      if (op_id != -1 && has_info(op_id)) {
         XHandlers* xhandlers = visitor.all_xhandler();
         for (int k = 0; k < xhandlers->length(); k++) {
           BlockBegin* handler = xhandlers->handler_at(k)->entry_block();
-          ResourceBitMap& live_in = handler->live_in();
-          TRACE_LINEAR_SCAN(
-                            4, tty->print("  op %d branches to exception handler entry B%d. "
-                                          "live-in(B%d) = ",
-                                          op_id, handler->block_id(), handler->block_id());
-                            print_bitmap(live_in);
-                            );
-          // TBD: iterate using live_in.iterate, see code at the beginning of LinearScan::build_intervals
-          for (unsigned int reg = 0; reg < live_in.size(); reg++) {
-            if (live_in.at(reg)) {
-              // The T_ILLEGAL type is used by add_use as a sentinel value
-              // indicating the type is unknown (rather than illegal) so that
-              // the type of the interval corresponding to reg is not updated.
-              // The use is extended beyond op (to = op_id + 1) so that liveness
-              // is preserved across possible registers killed by op (e.g.
-              // caller-saved registers if op is a call).
-              TRACE_LINEAR_SCAN(2, tty->print_cr(" use [R%d|?] from %d to %d (%d)", reg, block_from, op_id + 1, noUse));
-              // TBD: review 'noUse': should it be a "should" or a "must"
-              // register? Or is it correct to use 'noUse' since the register is
-              // not physically read by op?
-              add_use(reg, block_from, op_id + 1, noUse, T_ILLEGAL);
-            }
-          }
+          auto add_virtual_use = [&](BitMap::idx_t index) {
+            int reg = static_cast<int>(index);
+            // The T_ILLEGAL type is used by add_use as a sentinel value
+            // indicating the type is unknown (rather than illegal) so that the
+            // type of the interval corresponding to reg is not updated. The use
+            // is extended beyond op (to = op_id + 1) so that liveness is
+            // preserved across possible registers killed by op (e.g.
+            // caller-saved registers if op is a call).
+            TRACE_LINEAR_SCAN(2, tty->print_cr(" use [R%d] from %d to %d (%d)", reg, block_from, op_id + 1, noUse));
+            add_use(reg, block_from, op_id + 1, noUse, T_ILLEGAL);
+          };
+          handler->live_in().iterate(add_virtual_use);
         }
       }
-      // END OF PROTOTYPE SOLUTION
 
       // Add uses of live locals from interpreter's point of view for proper
       // debug information generation

--- a/test/hotspot/jtreg/compiler/regalloc/TestExceptionBranchWithLiveRangeHole.java
+++ b/test/hotspot/jtreg/compiler/regalloc/TestExceptionBranchWithLiveRangeHole.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.regalloc;
+
+/**
+ * @test
+ * @bug 8338094
+ * @summary Test C1's computation of local live ranges across exception jumps.
+ * @run main/othervm -Xbatch
+ *                   -XX:TieredStopAtLevel=1
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+class TestExceptionBranchWithLiveRangeHole {
+
+    // Test that liveness information is computed correctly by C1 for intervals
+    // that are live at an exception throwing operation solely because they are
+    // used within the exception handler block.
+    static void testThrowIOBE() {
+        int i = 0;
+        int[] array = new int[1];
+        try {
+            for (;;) {
+                i = i << 32;
+                // i should be live at this point, because it is used below in
+                // the exception handler code.
+                array[1] = 0;
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            array[i >>> 32] = 42;
+        }
+    }
+
+    // Variant of the above test using a different type of exception.
+    // Illustrates the need of extending the live range of i beyond the
+    // o.toString() call to model the interference of i with the killed
+    // caller-saved registers.
+    static void testThrowNPE(Object o) {
+        int i = 0;
+        int[] array = new int[1];
+        try {
+            for (;;) {
+                i = i << 32;
+                o.toString();
+            }
+        } catch (NullPointerException e) {
+            array[i >>> 32] = 42;
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            testThrowIOBE();
+        }
+        for (int i = 0; i < 10_000; i++) {
+            testThrowNPE(null);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/regalloc/TestExceptionBranchWithLiveRangeHole.java
+++ b/test/hotspot/jtreg/compiler/regalloc/TestExceptionBranchWithLiveRangeHole.java
@@ -45,8 +45,9 @@ class TestExceptionBranchWithLiveRangeHole {
         try {
             for (;;) {
                 i = i << 32;
-                // i should be live at this point, because it is used below in
-                // the exception handler code.
+                // The pre-shift value of i should be live here, because it is
+                // used below in the exception handler code, after the
+                // canonicalization (i << 32) >>> 32 => i is applied.
                 array[1] = 0;
             }
         } catch (ArrayIndexOutOfBoundsException e) {


### PR DESCRIPTION
This changeset ensures that C1 treats all virtual registers that are live into an exception handler block as live into the operation that may trigger the exception. Often, this is enforced by C1's [global live set computation](https://github.com/openjdk/jdk/blob/661b121b9513b205ace47b9ecfc8d16a32c731f4/src/hotspot/share/c1/c1_LinearScan.cpp#L735-L858) and [debug information generation logic](https://github.com/openjdk/jdk/blob/661b121b9513b205ace47b9ecfc8d16a32c731f4/src/hotspot/share/c1/c1_LinearScan.cpp#L1366-L1377), but the current logic does not handle the corner case of a virtual register whose use in an exception handler block has been replaced by another one by a C1 optimization pass such as [GraphBuilder::shift_op()](https://github.com/openjdk/jdk/blob/661b121b9513b205ace47b9ecfc8d16a32c731f4/src/hotspot/share/c1/c1_GraphBuilder.cpp#L1282-L1320), and the virtual register has a liveness hole in the exception-throwing block (see a more detailed analysis in the [JBS issue](https://bugs.openjdk.org/browse/JDK-8338094)).

An alternative solution would be to disable or limit the scope of [GraphBuilder::shift_op()](https://github.com/openjdk/jdk/blob/661b121b9513b205ace47b9ecfc8d16a32c731f4/src/hotspot/share/c1/c1_GraphBuilder.cpp#L1282-L1320), the only transformation in C1 that is known to lead to this problematic scenario, perhaps turning this changeset into negative verification code. But handling the general case as proposed in this changeset, without imposing complex constraints into C1's canonicalization logic, seems more robust and future-proof.

**Testing:**
- tier1-4, stress testing (linux-x64, windows-x64, linux-aarch64, macosx-aarch64).
- C1 compilation time regression testing (running DaCapo Chopin on linux-x64 and macosx-aarch64 with `-Xbatch -XX:+CITime -XX:TieredStopAtLevel=1`)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8338094](https://bugs.openjdk.org/browse/JDK-8338094): C1: assert(result-&gt;covers(op_id, mode)) failed: op_id not covered by interval (**Bug** - P3)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Contributors
 * Daniel Skantz `<dskantz@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32500/head:pull/32500` \
`$ git checkout pull/32500`

Update a local copy of the PR: \
`$ git checkout pull/32500` \
`$ git pull https://git.openjdk.org/jdk.git pull/32500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32500`

View PR using the GUI difftool: \
`$ git pr show -t 32500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32500.diff">https://git.openjdk.org/jdk/pull/32500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32500#issuecomment-5408462131)
</details>
