### PR TITLE
8390937: G1: Iterating FullCardSet containers in test API only iterates over the first entry

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -967,7 +967,7 @@ public:
 
   void operator()(uint card_idx, uint length) {
     for (uint i = 0; i < length; i++) {
-      _cl.do_card(_region_idx, card_idx);
+      _cl.do_card(_region_idx, card_idx + i);
     }
   }
 };

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -46,6 +46,19 @@ class G1CardSetTest : public ::testing::Test {
     }
   };
 
+  // Verify Full card containers contents (and amount). Assumes that cards returned are in ascending order.
+  class G1VerifyFullCardContainerClosure : public G1CardSet::CardClosure {
+  public:
+    size_t _cur_card;
+
+    G1VerifyFullCardContainerClosure() : _cur_card(0) { }
+
+    void do_card(uint region_idx, uint card_idx) override {
+      ASSERT_TRUE(card_idx == _cur_card);
+      _cur_card++;
+    }
+  };
+
   static WorkerThreads* _workers;
   static uint _max_workers;
 
@@ -374,9 +387,9 @@ void G1CardSetTest::cardset_basic_test() {
     res = card_set.add_card(99, CardsPerRegion - 2);
     ASSERT_TRUE(res == Found);
 
-    G1CountCardsClosure count_cards;
+    G1VerifyFullCardContainerClosure count_cards;
     card_set.iterate_cards(count_cards);
-    ASSERT_TRUE(count_cards._num_cards == config.max_cards_in_region());
+    ASSERT_TRUE(count_cards._cur_card == config.max_cards_in_region());
 
     card_set.clear();
     ASSERT_TRUE(card_set.occupied() == 0);


### PR DESCRIPTION
Hi all,

  please review this tiny change that fixes card set container iteration for "Full" containers - instead of just returning the first card index repeatedly, actually return all of them.

This is an issue of the test API, not actual production use. Either way, adding a test actually checking it is reasonable.

Testing: improved gtest, gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390937](https://bugs.openjdk.org/browse/JDK-8390937): G1: Iterating FullCardSet containers in test API only iterates over the first entry (**Bug** - P5)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32501/head:pull/32501` \
`$ git checkout pull/32501`

Update a local copy of the PR: \
`$ git checkout pull/32501` \
`$ git pull https://git.openjdk.org/jdk.git pull/32501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32501`

View PR using the GUI difftool: \
`$ git pr show -t 32501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32501.diff">https://git.openjdk.org/jdk/pull/32501.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32501#issuecomment-5394515665)
</details>
