### PR TITLE
8390940: G1: Retained region selection may take more than minimum regions

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -585,10 +585,10 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
       continue;
     }
 
-    if (fits_in_remaining_time || (num_expensive_regions < min_regions)) {
+    if (num_initial_regions < min_regions || fits_in_remaining_time) {
       predicted_initial_time_ms += predicted_time_ms;
       if (!fits_in_remaining_time) {
-        num_expensive_regions++;
+        num_expensive_regions += group->length();
       }
 
       add_group_to_collection_set(group);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -538,7 +538,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
   double predicted_initial_time_ms = 0.0;
   double predicted_optional_time_ms = 0.0;
 
-  uint const min_regions = _policy->min_retained_old_cset_length();
+  uint const min_num_regions = _policy->min_retained_old_cset_length();
   // We want to make sure that on the one hand we process the retained regions asap,
   // but on the other hand do not take too many of them as optional regions.
   // So we split the time budget into budget we will unconditionally take into the
@@ -552,7 +552,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
   log_debug(gc, ergo, cset)("Start adding retained candidates to collection set. "
                             "Min %u regions, available %u regions (%u groups), "
                             "time remaining %1.2fms, optional remaining %1.2fms",
-                            min_regions, retained_groups->num_regions(), retained_groups->length(),
+                            min_num_regions, retained_groups->num_regions(), retained_groups->length(),
                             time_remaining_ms, optional_time_remaining_ms);
 
   G1CSetCandidateGroupList remove_from_retained;
@@ -585,7 +585,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
       continue;
     }
 
-    if (num_initial_regions < min_regions || fits_in_remaining_time) {
+    if (num_initial_regions < min_num_regions || fits_in_remaining_time) {
       predicted_initial_time_ms += predicted_time_ms;
       if (!fits_in_remaining_time) {
         num_expensive_regions += group->length();


### PR DESCRIPTION
Hi all,

  please review this change the fixes G1 candidate selection from retained regions: it could select one more region than intended. See the CR for details.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390940](https://bugs.openjdk.org/browse/JDK-8390940): G1: Retained region selection may take more than minimum regions (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32502/head:pull/32502` \
`$ git checkout pull/32502`

Update a local copy of the PR: \
`$ git checkout pull/32502` \
`$ git pull https://git.openjdk.org/jdk.git pull/32502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32502`

View PR using the GUI difftool: \
`$ git pr show -t 32502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32502.diff">https://git.openjdk.org/jdk/pull/32502.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32502#issuecomment-5394498029)
</details>
