### PR TITLE
8390930: G1: Clearing card table worker estimation overflows on large heaps

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -201,8 +201,8 @@ class G1ClearCardTableTask : public G1AbstractSubTask {
         return AlmostNoWork;
       }
 
-      double num_cards = num_regions << G1HeapRegion::LogCardsPerRegion;
-      return ceil(num_cards / num_cards_per_worker);
+      size_t num_cards = (size_t)num_regions << G1HeapRegion::LogCardsPerRegion;
+      return align_up(num_cards, num_cards_per_worker) / num_cards_per_worker;
     }
 
     virtual ~G1ClearCardTableTask() {


### PR DESCRIPTION
Hi all,

  please review this fix to avoid a potential overflow in calculating the number of workers when clearing cards - if on a 2tb heap, with 32mb (default) region size, the intermediate `num_regions` overflows, potentially causing an underestimate of the number of worker threads.

I used align_up() since the cards per worker conveniently is a power of two.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390930](https://bugs.openjdk.org/browse/JDK-8390930): G1: Clearing card table worker estimation overflows on large heaps (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32503/head:pull/32503` \
`$ git checkout pull/32503`

Update a local copy of the PR: \
`$ git checkout pull/32503` \
`$ git pull https://git.openjdk.org/jdk.git pull/32503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32503`

View PR using the GUI difftool: \
`$ git pr show -t 32503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32503.diff">https://git.openjdk.org/jdk/pull/32503.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32503#issuecomment-5394556102)
</details>
