### PR TITLE
8388404: Initialize nm_offset

### DIFF
--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -195,7 +195,7 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj, int indent, int ba
         bool is_null = false;
         InlineKlass* vk = InlineKlass::cast(field_holder()->get_inline_type_field_klass(index()));
         int field_offset = offset() - vk->payload_offset();
-        int nm_offset;
+        int nm_offset = 0;
 
         if (!is_null_free_inline_type()) {
           assert(has_null_marker(), "should have null marker");
@@ -220,6 +220,7 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj, int indent, int ba
 
         if (this->field_flags().has_null_marker()) {
           for (int i = 0; i < indent + 1; i++) st->print("  ");
+          assert(nm_offset > 0, "must be");
           st->print_cr(" - [null_marker] @%d %s",
                     base_offset + nm_offset,
                     is_null ? "Field marked as null" : "Field marked as non-null");


### PR DESCRIPTION
Hi everyone,

`fieldDescriptor::print_on_for` uses `nm_offset` when printing the null marker of a nullable flattened field. The control flow ensures that the offset is set before use, but some static analysis tools can miss this. To resolve this and also make the code a bit more explicit I suggest we initialize `nm_offset` and assert that it was subsequently assigned before it is used.

Testing:
- Oracle tiers 1-3


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388404](https://bugs.openjdk.org/browse/JDK-8388404): Initialize nm_offset (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32504/head:pull/32504` \
`$ git checkout pull/32504`

Update a local copy of the PR: \
`$ git checkout pull/32504` \
`$ git pull https://git.openjdk.org/jdk.git pull/32504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32504`

View PR using the GUI difftool: \
`$ git pr show -t 32504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32504.diff">https://git.openjdk.org/jdk/pull/32504.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32504#issuecomment-5394655745)
</details>
