### PR TITLE
8369182: Don't force recompile of abstract_vm_version.cpp

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -285,13 +285,6 @@ ifeq ($(call isTargetOs, windows), true)
   $(BUILD_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
 endif
 
-# Always recompile abstract_vm_version.cpp if libjvm needs to be relinked. This ensures
-# that the internal vm version is updated as it relies on __DATE__ and __TIME__
-# macros.
-ABSTRACT_VM_VERSION_OBJ := $(JVM_OUTPUTDIR)/objs/abstract_vm_version$(OBJ_SUFFIX)
-$(ABSTRACT_VM_VERSION_OBJ): $(filter-out $(ABSTRACT_VM_VERSION_OBJ), \
-    $(BUILD_LIBJVM_TARGET_DEPS))
-
 ifneq ($(GENERATE_COMPILE_COMMANDS_ONLY), true)
   ifeq ($(call isTargetOs, windows), true)
     # It doesn't matter which jvm.lib file gets exported, but we need


### PR DESCRIPTION
After [8288396: Always create reproducible builds](https://github.com/openjdk/jdk/commit/b4ab5fe1daf22a543e1bd973bcd34322360054b4), `abstract_vm_version.cpp` uses `HOTSPOT_BUILD_TIME` instead of `__DATE__` and `__TIME__`.

However, `abstract_vm_version.o` still depends on the other `libjvm` target dependencies. This can cause it to be rebuilt when an unrelated HotSpot source file is changed. This dependency is no longer needed.

Testing:
- Touched `src/hotspot/share/runtime/arguments.cpp` and rebuilt with `LOG=debug`.
- `arguments.cpp` was recompiled, but no compile command for `abstract_vm_version.cpp` was generated.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8369182](https://bugs.openjdk.org/browse/JDK-8369182): Don't force recompile of abstract_vm_version.cpp (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32505/head:pull/32505` \
`$ git checkout pull/32505`

Update a local copy of the PR: \
`$ git checkout pull/32505` \
`$ git pull https://git.openjdk.org/jdk.git pull/32505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32505`

View PR using the GUI difftool: \
`$ git pr show -t 32505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32505.diff">https://git.openjdk.org/jdk/pull/32505.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32505#issuecomment-5395448459)
</details>
