### PR TITLE
8390948: G1: Simplify the selection logic in G1CollectionSet::select_candidates_from_marking()

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -425,7 +425,7 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
   double optional_threshold_ms = time_remaining_ms * _policy->optional_prediction_fraction();
 
   uint min_num_old_cset_regions = _policy->calc_min_old_cset_length(candidates()->last_marking_candidates_length());
-  uint max_old_cset_length = MAX2(min_num_old_cset_regions, _policy->calc_max_old_cset_length());
+  uint max_num_old_cset_regions = MAX2(min_num_old_cset_regions, _policy->calc_max_old_cset_length());
   bool check_time_remaining = _policy->use_adaptive_num_young_regions();
 
   G1CSetCandidateGroupList* from_marking_groups = &candidates()->from_marking_groups();
@@ -435,13 +435,13 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
   log_debug(gc, ergo, cset)("Start adding marking candidates to collection set. "
                             "Min %u regions, max %u regions, available %u regions (%u groups), "
                             "time remaining %1.2fms, optional threshold %1.2fms",
-                            min_num_old_cset_regions, max_old_cset_length, from_marking_groups->num_regions(), from_marking_groups->length(),
+                            min_num_old_cset_regions, max_num_old_cset_regions, from_marking_groups->num_regions(), from_marking_groups->length(),
                             time_remaining_ms, optional_threshold_ms);
 
   G1CSetCandidateGroupList selected_groups;
 
   for (G1CSetCandidateGroup* group : *from_marking_groups) {
-    if (num_initial_regions + num_optional_regions >= max_old_cset_length) {
+    if (num_initial_regions + num_optional_regions >= max_num_old_cset_regions) {
       // Added maximum number of old regions to the CSet.
       print_finish_message("Maximum number of regions reached", true);
       break;

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -413,7 +413,7 @@ void G1CollectionSet::add_optional_group(G1CSetCandidateGroup* group,
 
 double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms) {
   uint num_expensive_regions = 0;
-  uint num_inital_regions = 0;
+  uint num_initial_regions = 0;
   uint num_initial_groups = 0;
   uint num_optional_regions = 0;
 
@@ -424,8 +424,8 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
 
   double optional_threshold_ms = time_remaining_ms * _policy->optional_prediction_fraction();
 
-  uint min_old_cset_length = _policy->calc_min_old_cset_length(candidates()->last_marking_candidates_length());
-  uint max_old_cset_length = MAX2(min_old_cset_length, _policy->calc_max_old_cset_length());
+  uint min_num_old_cset_regions = _policy->calc_min_old_cset_length(candidates()->last_marking_candidates_length());
+  uint max_old_cset_length = MAX2(min_num_old_cset_regions, _policy->calc_max_old_cset_length());
   bool check_time_remaining = _policy->use_adaptive_num_young_regions();
 
   G1CSetCandidateGroupList* from_marking_groups = &candidates()->from_marking_groups();
@@ -435,13 +435,13 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
   log_debug(gc, ergo, cset)("Start adding marking candidates to collection set. "
                             "Min %u regions, max %u regions, available %u regions (%u groups), "
                             "time remaining %1.2fms, optional threshold %1.2fms",
-                            min_old_cset_length, max_old_cset_length, from_marking_groups->num_regions(), from_marking_groups->length(),
+                            min_num_old_cset_regions, max_old_cset_length, from_marking_groups->num_regions(), from_marking_groups->length(),
                             time_remaining_ms, optional_threshold_ms);
 
   G1CSetCandidateGroupList selected_groups;
 
   for (G1CSetCandidateGroup* group : *from_marking_groups) {
-    if (num_inital_regions + num_optional_regions >= max_old_cset_length) {
+    if (num_initial_regions + num_optional_regions >= max_old_cset_length) {
       // Added maximum number of old regions to the CSet.
       print_finish_message("Maximum number of regions reached", true);
       break;
@@ -459,15 +459,15 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
     }
 
     time_remaining_ms = MAX2(time_remaining_ms - predicted_time_ms, 0.0);
-    // Add regions to old set until we reach the minimum amount
-    if (num_inital_regions < min_old_cset_length) {
+    // Add regions to old set until we reach the minimum amount or reach the optional threshold.
+    if (num_initial_regions < min_num_old_cset_regions || (check_time_remaining && time_remaining_ms > optional_threshold_ms)) {
 
       num_initial_groups++;
 
       add_group_to_collection_set(group);
       selected_groups.append(group);
 
-      num_inital_regions += group->length();
+      num_initial_regions += group->length();
 
       predicted_initial_time_ms += predicted_time_ms;
       // Record the number of regions added with no time remaining
@@ -479,28 +479,15 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
       // to the CSet if we reach the minimum.
       print_finish_message("Region amount reached min", true);
       break;
+    } else if (time_remaining_ms > 0) {
+      // Keep adding optional regions until time is up.
+      add_optional_group(group,
+                         num_optional_regions,
+                         predicted_optional_time_ms,
+                         predicted_time_ms);
     } else {
-      // Keep adding regions to old set until we reach the optional threshold
-      if (time_remaining_ms > optional_threshold_ms) {
-        num_initial_groups++;
-
-        add_group_to_collection_set(group);
-        selected_groups.append(group);
-
-        num_inital_regions += group->length();
-
-        predicted_initial_time_ms += predicted_time_ms;
-
-      } else if (time_remaining_ms > 0) {
-        // Keep adding optional regions until time is up.
-        add_optional_group(group,
-                           num_optional_regions,
-                           predicted_optional_time_ms,
-                           predicted_time_ms);
-      } else {
-        print_finish_message("Predicted time too high", true);
-        break;
-      }
+      print_finish_message("Predicted time too high", true);
+      break;
     }
   }
 
@@ -523,7 +510,7 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
                             selected_groups.num_regions(), selected_groups.length(), _optional_groups.num_regions(), _optional_groups.length(),
                             predicted_initial_time_ms, predicted_optional_time_ms, time_remaining_ms);
 
-  assert(selected_groups.num_regions() == num_inital_regions, "must be");
+  assert(selected_groups.num_regions() == num_initial_regions, "must be");
   assert(_optional_groups.num_regions() == num_optional_regions, "must be");
   return time_remaining_ms;
 }


### PR DESCRIPTION
Hi all,

  please review this refactoring of `G1CollectionSet::select_candidates_from_marking` to correspond to the similar changes in `G1CollectionSet::select_candidates_from_retained()` after JDK-8390940.

It basically removes some code duplication in the same method. While there, also fix some minor naming issues - a typo and changing a "lenght" to "num" for consistency.

I believe it makes the code nicer, but I am open to retract this change.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390948](https://bugs.openjdk.org/browse/JDK-8390948): G1: Simplify the selection logic in G1CollectionSet::select_candidates_from_marking() (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32506/head:pull/32506` \
`$ git checkout pull/32506`

Update a local copy of the PR: \
`$ git checkout pull/32506` \
`$ git pull https://git.openjdk.org/jdk.git pull/32506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32506`

View PR using the GUI difftool: \
`$ git pr show -t 32506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32506.diff">https://git.openjdk.org/jdk/pull/32506.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32506#issuecomment-5406744723)
</details>
