### PR TITLE
8358889: C2 hits assert in backend due to malformed uncommon trap

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1261,12 +1261,13 @@ bool CallStaticJavaNode::is_uncommon_trap() const {
 int CallStaticJavaNode::uncommon_trap_request() const {
   return is_uncommon_trap() ? extract_uncommon_trap_request(this) : 0;
 }
+
 int CallStaticJavaNode::extract_uncommon_trap_request(const Node* call) {
 #ifndef PRODUCT
   if (!(call->req() > TypeFunc::Parms &&
         call->in(TypeFunc::Parms) != nullptr &&
-        call->in(TypeFunc::Parms)->is_Con() &&
-        call->in(TypeFunc::Parms)->bottom_type()->isa_int())) {
+        call->in(TypeFunc::Parms)->bottom_type()->isa_int() &&
+        call->in(TypeFunc::Parms)->bottom_type()->is_int()->is_con())) {
     assert(in_dump() != 0, "OK if dumping");
     tty->print("[bad uncommon trap]");
     return 0;

--- a/test/hotspot/jtreg/compiler/c2/TestSpilledUncommonTrapRequest.java
+++ b/test/hotspot/jtreg/compiler/c2/TestSpilledUncommonTrapRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8358889
+ * @summary Test that a spilled uncommon trap request is handled properly.
+ * @requires vm.compiler2.enabled
+ * @library /test/lib
+ * @run main ${test.main.class}
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xcomp
+ *                   -XX:StressSeed=403 -XX:+StressGCM
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::dontInline
+ *                   ${test.main.class}
+ */
+
+import jdk.test.lib.Asserts;
+
+public class TestSpilledUncommonTrapRequest {
+    static long sum;
+    static final int[] array = new int[64];
+
+    static int max(int first, int second) {
+        return first > second ? first : second;
+    }
+
+    static int dontInline() {
+        return 42;
+    }
+
+    static void test(double[][] doubles) {
+        // Vectorize a loop such that Compile::current()->max_vector_size() > 0 holds
+        for (int i = 0; i < 64; i++) {
+            array[i] = i;
+        }
+
+        // C2 adds an uncommon trap with 'Reason_null_check == 1' and 'Action_maybe_recompile == 1' for the
+        // null-check of the inner array doubles[0] here. This is encoded as
+        // ~((reason << 3) + action) = ~((1 << 3) + 1) = ~9 = -10
+        // which is then shared with the explicit constant -10 passed as argument here.
+        doubles[0][0] = max(dontInline(), -10);
+
+        // Keep the shared -10 live in a loop phi and create enough register pressure for RA to spill it.
+        int product = -10;
+        for (int i = 0; i < 64; i++) {
+            product *= 79;
+            sum++;
+            array[i] = 0;
+        }
+        sum += product;
+    }
+
+    public static void main(String[] args) {
+        test(new double[1][1]);
+        Asserts.assertEQ(sum, 1573390390L);
+    }
+}
+


### PR DESCRIPTION
On AArch64, when `Compile::current()->max_vector_size() > 0`, C2's backend calls `uncommon_trap_request()` to distinguish an uncommon trap from an ordinary call:
https://github.com/openjdk/jdk/blob/f5874509cd549ef4ff4df1038b1d736f37175455/src/hotspot/cpu/aarch64/aarch64.ad#L3662-L3664 ->
https://github.com/openjdk/jdk/blob/f5874509cd549ef4ff4df1038b1d736f37175455/src/hotspot/share/opto/machnode.cpp#L837-L839

This calls `CallStaticJavaNode::extract_uncommon_trap_request` which asserts that the `trap_request` input is always a `ConI`:
https://github.com/openjdk/jdk/blob/f5874509cd549ef4ff4df1038b1d736f37175455/src/hotspot/share/opto/callnode.cpp#L1264-L1271

This is not guaranteed because the register allocator might spill the value on the stack and thus replace the input with a `MachSpillCopyNode`. Since `in_dump()` is not set, we assert. The fix is to check the type of the node instead which is in line with the code just below:
https://github.com/openjdk/jdk/blob/f5874509cd549ef4ff4df1038b1d736f37175455/src/hotspot/share/opto/callnode.cpp#L1275

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8358889](https://bugs.openjdk.org/browse/JDK-8358889): C2 hits assert in backend due to malformed uncommon trap (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32507/head:pull/32507` \
`$ git checkout pull/32507`

Update a local copy of the PR: \
`$ git checkout pull/32507` \
`$ git pull https://git.openjdk.org/jdk.git pull/32507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32507`

View PR using the GUI difftool: \
`$ git pr show -t 32507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32507.diff">https://git.openjdk.org/jdk/pull/32507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32507#issuecomment-5396424591)
</details>
