### PR TITLE
8387571: Typos/grammar/duplicated word/missing hyperlink errors in javac man page

### DIFF
--- a/src/jdk.compiler/share/man/javac.md
+++ b/src/jdk.compiler/share/man/javac.md
@@ -139,7 +139,7 @@ file system locations may be directories, JAR files or JMOD files.
 <a id="option-at">`@`*filename*</a>
 :   Reads options and file names from a file. To shorten or simplify the
     `javac` command, you can specify one or more files that contain arguments
-    to the `javac` command (except [`-J`](#option-J) options). This lets you to create
+    to the `javac` command (except [`-J`](#option-J) options). This lets you create
     `javac` commands of any length on any operating system.
     See [Command-Line Argument Files].
 
@@ -233,7 +233,7 @@ file system locations may be directories, JAR files or JMOD files.
     If you are compiling for a release of the platform that supports the
     Extension Mechanism, then this option specifies the directories that
     contain the extension classes.
-    See [Compiling for Other Releases of the Platform].
+    See [Compiling for Earlier Releases of the Platform].
 
     **Note:** This can only be used when compiling for releases prior to JDK 9.
     As applicable, see the descriptions in [`--release`](#option-release), [`-source`](#option-source), or
@@ -297,7 +297,7 @@ file system locations may be directories, JAR files or JMOD files.
 
 <a id="option-J">`-J`*option*</a>
 :   Passes *option* to the runtime system, where *option* is one of the Java
-    options described on [java](java.html) command. For example, `-J-Xms48m`
+    options described for the [java](java.html) command. For example, `-J-Xms48m`
     sets the startup memory to 48 MB.
 
     **Note:** The `CLASSPATH` environment variable, `-classpath` option, `-bootclasspath`
@@ -1150,7 +1150,7 @@ This may be useful when performing white-box testing; relying on access
 to internal API in production code is strongly discouraged.
 
 You can patch additional content into any module using the
-[`--patch-module`](#option-patch-module) option. See [Patching a Module] for more details.
+[`--patch-module`](#option-patch-module) option. See [Patching Modules] for more details.
 
 ## Searching for Module, Package and Type Declarations
 
@@ -1234,7 +1234,7 @@ If the module is one of those currently being compiled, the module declaration
 will be either the file named `module-info.class` in the root of the
 package hierarchy for the module in the class output directory, or the
 file named `module-info.java` in one of the locations on the source path
-or one the module source path for the module.
+or on the module source path for the module.
 
 ### Searching for the Declaration of a Type When the Reference is not in a Module
 
@@ -1273,7 +1273,7 @@ readable by the enclosing module.
 If so, `javac` will simply and directly go to the definition of that module
 to find the definition of the required type.
 Unless the module is another of the modules being compiled, `javac` will
-only look for compiled class files files. In other words, `javac` will
+only look for compiled class files. In other words, `javac` will
 not look for source files in platform modules or modules on the module path.
 
 If the type being referenced is not in some other readable module,
@@ -1476,7 +1476,7 @@ specified, then the user class path is used. Processors are located by
 means of service provider-configuration files named
 `META-INF/services/javax.annotation.processing.Processor` on the
 search path.  Such files should contain the names of any
-annotationation processors to be used, listed one per
+annotation processors to be used, listed one per
 line. Alternatively, processors can be specified explicitly, using the
 [`-processor`](#option-processor) option.
 
@@ -1651,7 +1651,7 @@ internal and subject to change at any time.
     >   `int divideByZero = 42 / 0;`
 
 `empty`
-:   Warns about empty statements after `if`statements, for example:
+:   Warns about empty statements after `if` statements, for example:
 
     ```
     class E {


### PR DESCRIPTION
This PR fixes several typos in the javac's man page, as noted in the bugreport.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387571](https://bugs.openjdk.org/browse/JDK-8387571): Typos/grammar/duplicated word/missing hyperlink errors in javac man page (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32509/head:pull/32509` \
`$ git checkout pull/32509`

Update a local copy of the PR: \
`$ git checkout pull/32509` \
`$ git pull https://git.openjdk.org/jdk.git pull/32509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32509`

View PR using the GUI difftool: \
`$ git pr show -t 32509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32509.diff">https://git.openjdk.org/jdk/pull/32509.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32509#issuecomment-5397960753)
</details>
