### PR TITLE
8379453: Fix problems with ErrorLogTimeout

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -521,10 +521,10 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, CreateCoredumpOnCrash, true,                                \
           "Create core/mini dump on VM fatal error")                        \
                                                                             \
-  product(uint64_t, ErrorLogTimeout, 2 * 60,                                \
+  product(uint, ErrorLogTimeout, 2 * 60,                                    \
           "Timeout, in seconds, to limit the time spent on writing an "     \
-          "error log in case of a crash.")                                  \
-          range(0, (uint64_t)max_jlong/1000)                                \
+          "error log in case of a crash. A value of 0 disables the "        \
+          "timeout.")                                                       \
                                                                             \
   product(bool, ErrorLogSecondaryErrorDetails, false, DIAGNOSTIC,           \
           "If enabled, show details on secondary crashes in the error log") \

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1782,12 +1782,12 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
         // The current step had a timeout. Lets continue reporting with the next step.
         st->print_raw("[timeout occurred during error reporting in step \"");
         st->print_raw(_current_step_info);
-        st->print_cr("\"] after " INT64_FORMAT " s.",
+        st->print_cr("\"] after " JLONG_FORMAT " s.",
                      ((os::javaTimeNanos() - get_step_start_time()) / SECONDS_TO_NANOS_FACTOR));
       } else if (_reporting_did_timeout.load_relaxed()) {
         // We hit ErrorLogTimeout. Reporting will stop altogether. Let's wrap things
         // up, the process is about to be stopped by the WatcherThread.
-        st->print_cr("------ Timeout during error reporting after " INT64_FORMAT " s. ------",
+        st->print_cr("------ Timeout during error reporting after " JLONG_FORMAT " s. ------",
                      ((os::javaTimeNanos() - get_reporting_start_time()) / SECONDS_TO_NANOS_FACTOR));
         st->flush();
         // Watcherthread is about to call os::die. Lets just wait.

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -540,15 +540,11 @@ bool VMError::is_error_reported_in_current_thread() {
   return _first_error_tid.load_relaxed() == os::current_thread_id();
 }
 
-// Helper, return current timestamp for timeout handling.
-jlong VMError::get_current_timestamp() {
-  return os::javaTimeNanos();
-}
 // Factor to translate the timestamp to seconds.
-#define TIMESTAMP_TO_SECONDS_FACTOR (1000 * 1000 * 1000)
+#define SECONDS_TO_NANOS_FACTOR (1000 * 1000 * 1000)
 
 void VMError::record_reporting_start_time() {
-  const jlong now = get_current_timestamp();
+  const jlong now = os::javaTimeNanos();
   _reporting_start_time.store_relaxed(now);
 }
 
@@ -557,7 +553,7 @@ jlong VMError::get_reporting_start_time() {
 }
 
 void VMError::record_step_start_time() {
-  const jlong now = get_current_timestamp();
+  const jlong now = os::javaTimeNanos();
   _step_start_time.store_relaxed(now);
 }
 
@@ -1787,14 +1783,12 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
         st->print_raw("[timeout occurred during error reporting in step \"");
         st->print_raw(_current_step_info);
         st->print_cr("\"] after " INT64_FORMAT " s.",
-                     (int64_t)
-                     ((get_current_timestamp() - get_step_start_time()) / TIMESTAMP_TO_SECONDS_FACTOR));
+                     ((os::javaTimeNanos() - get_step_start_time()) / SECONDS_TO_NANOS_FACTOR));
       } else if (_reporting_did_timeout.load_relaxed()) {
         // We hit ErrorLogTimeout. Reporting will stop altogether. Let's wrap things
         // up, the process is about to be stopped by the WatcherThread.
         st->print_cr("------ Timeout during error reporting after " INT64_FORMAT " s. ------",
-                     (int64_t)
-                     ((get_current_timestamp() - get_reporting_start_time()) / TIMESTAMP_TO_SECONDS_FACTOR));
+                     ((os::javaTimeNanos() - get_reporting_start_time()) / SECONDS_TO_NANOS_FACTOR));
         st->flush();
         // Watcherthread is about to call os::die. Lets just wait.
         os::infinite_sleep();
@@ -2079,14 +2073,14 @@ bool VMError::check_timeout() {
             || (OnError != nullptr && OnError[0] != '\0')
             || Arguments::abort_hook() != nullptr);
 
-  const jlong now = get_current_timestamp();
+  const jlong now = os::javaTimeNanos();
 
   // Global timeout hit?
   if (!ignore_global_timeout) {
     const jlong reporting_start_time = get_reporting_start_time();
     // Timestamp is stored in nanos.
     if (reporting_start_time > 0) {
-      const jlong end = reporting_start_time + (jlong)ErrorLogTimeout * TIMESTAMP_TO_SECONDS_FACTOR;
+      const jlong end = reporting_start_time + (jlong)ErrorLogTimeout * SECONDS_TO_NANOS_FACTOR;
       if (end <= now && !_reporting_did_timeout.load_relaxed()) {
         // We hit ErrorLogTimeout and we haven't interrupted the reporting
         // thread yet.
@@ -2100,11 +2094,14 @@ bool VMError::check_timeout() {
   // Reporting step timeout?
   const jlong step_start_time = get_step_start_time();
   if (step_start_time > 0) {
-    // A step times out after a quarter of the total timeout. Steps are mostly fast unless they
-    // hang for some reason, so this simple rule allows for three hanging step and still
-    // hopefully leaves time enough for the rest of the steps to finish.
-    const int max_step_timeout_secs = 5;
-    const jlong timeout_duration = MAX2((jlong)max_step_timeout_secs, (jlong)ErrorLogTimeout * TIMESTAMP_TO_SECONDS_FACTOR / 4);
+    // Steps are very fast. If they are not fast, they typically hang without recovering. There are a few
+    // exceptions to this (printing a callstack from debug information located on a slow file system, or
+    // printing a memory map of an extremely fragmented process). To give those rare slow steps enough
+    // breathing space while still allowing us to skip any hanging steps, we use a per-step timeout of
+    // <total timeout>/4, or 5 seconds, whichever is smaller.
+    const jlong step_timeout_nanos = ((jlong)ErrorLogTimeout * SECONDS_TO_NANOS_FACTOR) / 4;
+    const jlong max_step_timeout_nanos = 5LL * SECONDS_TO_NANOS_FACTOR;
+    const jlong timeout_duration = MIN2(max_step_timeout_nanos, step_timeout_nanos);
     const jlong end = step_start_time + timeout_duration;
     if (end <= now && !_step_did_timeout.load_relaxed()) {
       // The step timed out and we haven't interrupted the reporting

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -133,9 +133,6 @@ class VMError : public AllStatic {
   static void reporting_started();
   static void interrupt_reporting_thread();
 
-  // Helper function to get the current timestamp.
-  static jlong get_current_timestamp();
-
   // Accessors to get/set the start times for step and total timeout.
   static void record_reporting_start_time();
   static jlong get_reporting_start_time();

--- a/test/hotspot/gtest/runtime/test_globals.cpp
+++ b/test/hotspot/gtest/runtime/test_globals.cpp
@@ -58,7 +58,7 @@ TEST_VM(FlagGuard, size_t_flag) {
 }
 
 TEST_VM(FlagGuard, uint64_t_flag) {
-  TEST_FLAG(ErrorLogTimeout, uint64_t, 1337);
+  TEST_FLAG(MaxDirectMemorySize, uint64_t, 4294967297);
 }
 
 TEST_VM(FlagGuard, double_flag) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
@@ -109,7 +109,7 @@ public class ClhsdbFlags {
                 "-XX:NativeMemoryTracking=off",    // ccstr
                 "-XX:OnError='echo error'",        // ccstrlist
                 "-XX:CompileThresholdScaling=1.0", // double
-                "-XX:ErrorLogTimeout=120");        // uint64_t
+                "-XX:MaxDirectMemorySize=4294967297");        // uint64_t
             theApp = new LingeredApp();
             LingeredApp.startAppExactJvmOpts(theApp, vmArgs);
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
@@ -127,7 +127,7 @@ public class ClhsdbFlags {
                     "NativeMemoryTracking = \"off\"",
                     "OnError = \"'echo error'\"",
                     "CompileThresholdScaling = 1.0",
-                    "ErrorLogTimeout = 120"));
+                    "MaxDirectMemorySize = 4294967297"));
 
             test.run(theApp.getPid(), cmds, expStrMap, null);
         } catch (Exception ex) {


### PR DESCRIPTION
Fix a number of smaller issues surrounding ErrorLogTimeout, some of which I introduced with https://bugs.openjdk.org/browse/JDK-8303861:

- Make ErrorLogTimeout an `unsigned`. Its "number of seconds", and unsigned gives us 130+ years, which is enough for the error log timeout.
- Clarified the special value "0" to mean "no error log timeout"
- renamed TIMESTAMP_TO_SECONDS_FACTOR to the less confusing SECONDS_TO_NANOS_FACTOR, and removed the useless `VMError::get_current_timestamp()` wrapper.
- Fixed the calculation of error step timeouts to actually use a 5-second cap as intended, and clarified the comment.
- Test changes: Some tests relied on ErrorLogTimeout to be a uint64_t. Replaced those with a different parameter that still is.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379453](https://bugs.openjdk.org/browse/JDK-8379453): Fix problems with ErrorLogTimeout (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32510/head:pull/32510` \
`$ git checkout pull/32510`

Update a local copy of the PR: \
`$ git checkout pull/32510` \
`$ git pull https://git.openjdk.org/jdk.git pull/32510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32510`

View PR using the GUI difftool: \
`$ git pr show -t 32510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32510.diff">https://git.openjdk.org/jdk/pull/32510.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32510#issuecomment-5411813593)
</details>
