### PR TITLE
8379812: ServiceLoader throws ServiceConfigurationError when service type is an array class

### DIFF
--- a/src/java.base/share/classes/java/util/ServiceLoader.java
+++ b/src/java.base/share/classes/java/util/ServiceLoader.java
@@ -391,6 +391,9 @@ public final class ServiceLoader<S>
     // null when locating provider using a module layer
     private final ClassLoader loader;
 
+    // true if the service type cannot have providers (e.g. an array class)
+    private final boolean empty;
+
     // The lazy-lookup iterator for iterator operations
     private Iterator<Provider<S>> lookupIterator1;
     private final List<S> instantiatedProviders = new ArrayList<>();
@@ -446,6 +449,18 @@ public final class ServiceLoader<S>
     }
 
     /**
+     * Initializes an empty service loader for a service type that cannot have
+     * providers, such as an array class.
+     */
+    private ServiceLoader(Class<S> svc) {
+        this.service = Objects.requireNonNull(svc);
+        this.serviceName = svc.getName();
+        this.layer = null;
+        this.loader = null;
+        this.empty = true;
+    }
+
+    /**
      * Initializes a new instance of this class for locating service providers
      * in a module layer.
      *
@@ -463,6 +478,7 @@ public final class ServiceLoader<S>
         this.serviceName = svc.getName();
         this.layer = layer;
         this.loader = null;
+        this.empty = false;
     }
 
     /**
@@ -501,6 +517,7 @@ public final class ServiceLoader<S>
         this.serviceName = svc.getName();
         this.layer = null;
         this.loader = cl;
+        this.empty = false;
     }
 
     /**
@@ -521,6 +538,14 @@ public final class ServiceLoader<S>
         this.serviceName = svc.getName();
         this.layer = null;
         this.loader = cl;
+        this.empty = false;
+    }
+
+    /**
+     * Returns {@code true} if the given class cannot be a service type.
+     */
+    private static boolean isUnlocatableServiceType(Class<?> service) {
+        return service.isArray();
     }
 
     /**
@@ -1152,6 +1177,9 @@ public final class ServiceLoader<S>
      * Returns a new lookup iterator.
      */
     private Iterator<Provider<S>> newLookupIterator() {
+        if (empty) {
+            return Collections.emptyIterator();
+        }
         assert layer == null || loader == null;
         if (layer != null) {
             return new LayerLookupIterator<>();
@@ -1394,6 +1422,10 @@ public final class ServiceLoader<S>
                                      ClassLoader loader,
                                      Module callerModule)
     {
+        Objects.requireNonNull(service);
+        if (isUnlocatableServiceType(service)) {
+            return new ServiceLoader<>(service);
+        }
         return new ServiceLoader<>(callerModule, service, loader);
     }
 
@@ -1502,6 +1534,10 @@ public final class ServiceLoader<S>
     public static <S> ServiceLoader<S> load(Class<S> service,
                                             ClassLoader loader)
     {
+        Objects.requireNonNull(service);
+        if (isUnlocatableServiceType(service)) {
+            return new ServiceLoader<>(service);
+        }
         return new ServiceLoader<>(Reflection.getCallerClass(), service, loader);
     }
 
@@ -1543,6 +1579,10 @@ public final class ServiceLoader<S>
      */
     @CallerSensitive
     public static <S> ServiceLoader<S> load(Class<S> service) {
+        Objects.requireNonNull(service);
+        if (isUnlocatableServiceType(service)) {
+            return new ServiceLoader<>(service);
+        }
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         return new ServiceLoader<>(Reflection.getCallerClass(), service, cl);
     }
@@ -1576,6 +1616,10 @@ public final class ServiceLoader<S>
      */
     @CallerSensitive
     public static <S> ServiceLoader<S> loadInstalled(Class<S> service) {
+        Objects.requireNonNull(service);
+        if (isUnlocatableServiceType(service)) {
+            return new ServiceLoader<>(service);
+        }
         ClassLoader cl = ClassLoader.getPlatformClassLoader();
         return new ServiceLoader<>(Reflection.getCallerClass(), service, cl);
     }
@@ -1628,6 +1672,10 @@ public final class ServiceLoader<S>
      */
     @CallerSensitive
     public static <S> ServiceLoader<S> load(ModuleLayer layer, Class<S> service) {
+        Objects.requireNonNull(service);
+        if (isUnlocatableServiceType(service)) {
+            return new ServiceLoader<>(service);
+        }
         return new ServiceLoader<>(Reflection.getCallerClass(), layer, service);
     }
 

--- a/src/java.base/share/classes/java/util/ServiceLoader.java
+++ b/src/java.base/share/classes/java/util/ServiceLoader.java
@@ -391,9 +391,6 @@ public final class ServiceLoader<S>
     // null when locating provider using a module layer
     private final ClassLoader loader;
 
-    // true if the service type cannot have providers (e.g. an array class)
-    private final boolean empty;
-
     // The lazy-lookup iterator for iterator operations
     private Iterator<Provider<S>> lookupIterator1;
     private final List<S> instantiatedProviders = new ArrayList<>();
@@ -449,18 +446,6 @@ public final class ServiceLoader<S>
     }
 
     /**
-     * Initializes an empty service loader for a service type that cannot have
-     * providers, such as an array class.
-     */
-    private ServiceLoader(Class<S> svc) {
-        this.service = Objects.requireNonNull(svc);
-        this.serviceName = svc.getName();
-        this.layer = null;
-        this.loader = null;
-        this.empty = true;
-    }
-
-    /**
      * Initializes a new instance of this class for locating service providers
      * in a module layer.
      *
@@ -478,7 +463,6 @@ public final class ServiceLoader<S>
         this.serviceName = svc.getName();
         this.layer = layer;
         this.loader = null;
-        this.empty = false;
     }
 
     /**
@@ -517,7 +501,6 @@ public final class ServiceLoader<S>
         this.serviceName = svc.getName();
         this.layer = null;
         this.loader = cl;
-        this.empty = false;
     }
 
     /**
@@ -538,14 +521,17 @@ public final class ServiceLoader<S>
         this.serviceName = svc.getName();
         this.layer = null;
         this.loader = cl;
-        this.empty = false;
     }
 
     /**
-     * Returns {@code true} if the given class cannot be a service type.
+     * Throws {@code IllegalArgumentException} if the given class is not a valid
+     * service type.
      */
-    private static boolean isUnlocatableServiceType(Class<?> service) {
-        return service.isArray();
+    private static void checkServiceType(Class<?> service) {
+        if (service.isPrimitive() || service.isArray() || service.isHidden()) {
+            throw new IllegalArgumentException(service.getName()
+                    + ": not a valid service type");
+        }
     }
 
     /**
@@ -1177,9 +1163,6 @@ public final class ServiceLoader<S>
      * Returns a new lookup iterator.
      */
     private Iterator<Provider<S>> newLookupIterator() {
-        if (empty) {
-            return Collections.emptyIterator();
-        }
         assert layer == null || loader == null;
         if (layer != null) {
             return new LayerLookupIterator<>();
@@ -1423,9 +1406,7 @@ public final class ServiceLoader<S>
                                      Module callerModule)
     {
         Objects.requireNonNull(service);
-        if (isUnlocatableServiceType(service)) {
-            return new ServiceLoader<>(service);
-        }
+        checkServiceType(service);
         return new ServiceLoader<>(callerModule, service, loader);
     }
 
@@ -1524,6 +1505,9 @@ public final class ServiceLoader<S>
      *
      * @return A new service loader
      *
+     * @throws IllegalArgumentException
+     *         if {@code service} is a primitive type, array class, or hidden class
+     *
      * @throws ServiceConfigurationError
      *         if the service type is not accessible to the caller or the
      *         caller is in an explicit module and its module descriptor does
@@ -1535,9 +1519,7 @@ public final class ServiceLoader<S>
                                             ClassLoader loader)
     {
         Objects.requireNonNull(service);
-        if (isUnlocatableServiceType(service)) {
-            return new ServiceLoader<>(service);
-        }
+        checkServiceType(service);
         return new ServiceLoader<>(Reflection.getCallerClass(), service, loader);
     }
 
@@ -1572,6 +1554,9 @@ public final class ServiceLoader<S>
      *
      * @return A new service loader
      *
+     * @throws IllegalArgumentException
+     *         if {@code service} is a primitive type, array class, or hidden class
+     *
      * @throws ServiceConfigurationError
      *         if the service type is not accessible to the caller or the
      *         caller is in an explicit module and its module descriptor does
@@ -1580,9 +1565,7 @@ public final class ServiceLoader<S>
     @CallerSensitive
     public static <S> ServiceLoader<S> load(Class<S> service) {
         Objects.requireNonNull(service);
-        if (isUnlocatableServiceType(service)) {
-            return new ServiceLoader<>(service);
-        }
+        checkServiceType(service);
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         return new ServiceLoader<>(Reflection.getCallerClass(), service, cl);
     }
@@ -1609,6 +1592,9 @@ public final class ServiceLoader<S>
      *
      * @return A new service loader
      *
+     * @throws IllegalArgumentException
+     *         if {@code service} is a primitive type, array class, or hidden class
+     *
      * @throws ServiceConfigurationError
      *         if the service type is not accessible to the caller or the
      *         caller is in an explicit module and its module descriptor does
@@ -1617,9 +1603,7 @@ public final class ServiceLoader<S>
     @CallerSensitive
     public static <S> ServiceLoader<S> loadInstalled(Class<S> service) {
         Objects.requireNonNull(service);
-        if (isUnlocatableServiceType(service)) {
-            return new ServiceLoader<>(service);
-        }
+        checkServiceType(service);
         ClassLoader cl = ClassLoader.getPlatformClassLoader();
         return new ServiceLoader<>(Reflection.getCallerClass(), service, cl);
     }
@@ -1663,6 +1647,9 @@ public final class ServiceLoader<S>
      *
      * @return A new service loader
      *
+     * @throws IllegalArgumentException
+     *         if {@code service} is a primitive type, array class, or hidden class
+     *
      * @throws ServiceConfigurationError
      *         if the service type is not accessible to the caller or the
      *         caller is in an explicit module and its module descriptor does
@@ -1673,9 +1660,7 @@ public final class ServiceLoader<S>
     @CallerSensitive
     public static <S> ServiceLoader<S> load(ModuleLayer layer, Class<S> service) {
         Objects.requireNonNull(service);
-        if (isUnlocatableServiceType(service)) {
-            return new ServiceLoader<>(service);
-        }
+        checkServiceType(service);
         return new ServiceLoader<>(Reflection.getCallerClass(), layer, service);
     }
 

--- a/test/jdk/java/util/ServiceLoader/ArrayServiceTypeTest.java
+++ b/test/jdk/java/util/ServiceLoader/ArrayServiceTypeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8379812
+ * @summary ServiceLoader should handle array service types gracefully
+ */
+
+import java.lang.invoke.MethodType;
+import java.util.ServiceLoader;
+
+public class ArrayServiceTypeTest {
+
+    public static void main(String[] args) {
+        assertEmpty(ServiceLoader.loadInstalled(
+                MethodType.genericMethodType(1, true).parameterType(1)));
+        assertEmpty(ServiceLoader.loadInstalled(Object[].class));
+        assertEmpty(ServiceLoader.load(Object[].class));
+        assertEmpty(ServiceLoader.load(Object[].class,
+                ArrayServiceTypeTest.class.getClassLoader()));
+    }
+
+    private static void assertEmpty(ServiceLoader<?> loader) {
+        if (loader.iterator().hasNext()) {
+            throw new RuntimeException("expected empty ServiceLoader, found provider");
+        }
+        if (loader.stream().findAny().isPresent()) {
+            throw new RuntimeException("expected empty stream, found provider");
+        }
+        if (loader.findFirst().isPresent()) {
+            throw new RuntimeException("expected empty findFirst");
+        }
+    }
+}

--- a/test/jdk/java/util/ServiceLoader/ArrayServiceTypeTest.java
+++ b/test/jdk/java/util/ServiceLoader/ArrayServiceTypeTest.java
@@ -24,32 +24,34 @@
 /**
  * @test
  * @bug 8379812
- * @summary ServiceLoader should handle array service types gracefully
+ * @summary ServiceLoader should reject invalid service types
  */
 
 import java.lang.invoke.MethodType;
+import java.lang.module.ModuleLayer;
 import java.util.ServiceLoader;
 
 public class ArrayServiceTypeTest {
 
     public static void main(String[] args) {
-        assertEmpty(ServiceLoader.loadInstalled(
+        assertFails(() -> ServiceLoader.loadInstalled(
                 MethodType.genericMethodType(1, true).parameterType(1)));
-        assertEmpty(ServiceLoader.loadInstalled(Object[].class));
-        assertEmpty(ServiceLoader.load(Object[].class));
-        assertEmpty(ServiceLoader.load(Object[].class,
+        assertFails(() -> ServiceLoader.loadInstalled(Object[].class));
+        assertFails(() -> ServiceLoader.load(Object[].class));
+        assertFails(() -> ServiceLoader.load(Object[].class,
                 ArrayServiceTypeTest.class.getClassLoader()));
+        assertFails(() -> ServiceLoader.load(ModuleLayer.boot(), Object[].class));
+        assertFails(() -> ServiceLoader.load(int.class));
     }
 
-    private static void assertEmpty(ServiceLoader<?> loader) {
-        if (loader.iterator().hasNext()) {
-            throw new RuntimeException("expected empty ServiceLoader, found provider");
-        }
-        if (loader.stream().findAny().isPresent()) {
-            throw new RuntimeException("expected empty stream, found provider");
-        }
-        if (loader.findFirst().isPresent()) {
-            throw new RuntimeException("expected empty findFirst");
+    private static void assertFails(Runnable action) {
+        try {
+            action.run();
+            throw new RuntimeException("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            if (!e.getMessage().contains("not a valid service type")) {
+                throw new RuntimeException("unexpected message: " + e.getMessage(), e);
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary
- Reject invalid service types (primitive, array, and hidden classes) in `ServiceLoader.load*` methods
- Throw `IllegalArgumentException` with a clear `"not a valid service type"` message
- Fixes misleading `ServiceConfigurationError` (`service type not accessible to unnamed module`) when an array class is passed
- Aligns with review feedback on JDK-8379812 — throw instead of returning an empty loader

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).


---
### Problem
`ServiceLoader.loadInstalled()` with an array service type (e.g. from `MethodType.genericMethodType(1, true).parameterType(1)`) throws `ServiceConfigurationError` because `checkCaller()` fails module access checks for array types — even though the real issue is an invalid service type.
---
### Solution
- Add `checkServiceType()` before `checkCaller()`
- Reject primitive, array, and hidden classes
- Throw `IllegalArgumentException`: `<type>: not a valid service type`
- Apply to all public `load*` entry points
- Update `ArrayServiceTypeTest` to expect `IllegalArgumentException`
---
### Testing
- [x] `make run-test TEST=jdk/java/util/ServiceLoader/ArrayServiceTypeTest.java`
- [] `make run-test TEST=jdk/java/util/ServiceLoader`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8379812](https://bugs.openjdk.org/browse/JDK-8379812): ServiceLoader throws ServiceConfigurationError when service type is an array class (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32515/head:pull/32515` \
`$ git checkout pull/32515`

Update a local copy of the PR: \
`$ git checkout pull/32515` \
`$ git pull https://git.openjdk.org/jdk.git pull/32515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32515`

View PR using the GUI difftool: \
`$ git pr show -t 32515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32515.diff">https://git.openjdk.org/jdk/pull/32515.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32515#issuecomment-5514688749)
</details>
