### PR TITLE
8391060: ZGC: ZMarkingSMR re-orded hazard pointer loads with unlinking results in use after free

### DIFF
--- a/src/hotspot/share/gc/z/zMarkingSMR.cpp
+++ b/src/hotspot/share/gc/z/zMarkingSMR.cpp
@@ -66,6 +66,9 @@ void ZMarkingSMR::free_node(ZMarkStackListNode* node) {
     return;
   }
 
+  // Order the hazard pointers loads w.r.t. the unlinking of the head node.
+  OrderAccess::fence();
+
   ZPerWorkerIterator<ZWorkerState> iter(&_worker_states);
   ZArray<ZMarkStackListNode*>* const scanned_hazards = &local_state->_scanned_hazards;
 


### PR DESCRIPTION
In `ZMarkStackList::pop` there is no memory ordering between the unlinking CAS and the hazard pointer loads in `ZMarkingSMR::free_node`.

This reordering can lead to one thread missing another threads hazard pointer publishing while the publishing thread misses the head change. This results in a use after free.

The solution is to order the hazard pointer loads relative to the head unlinking. As we batch the unlinking it is enough to do this only when we decide to process the hazard pointers.

After this change we have both ordered the hazard pointer store and the re-read of the head on the use site and the head unlink and the hazard pointer reads on the free side.

Testing (in progress):
 * linux-aarch64, linux-aarch64-debug ZGC tier 1-7, and extra runs of stress tests
 * GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391060](https://bugs.openjdk.org/browse/JDK-8391060): ZGC: ZMarkingSMR re-orded hazard pointer loads with unlinking results in use after free (**Bug** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32516/head:pull/32516` \
`$ git checkout pull/32516`

Update a local copy of the PR: \
`$ git checkout pull/32516` \
`$ git pull https://git.openjdk.org/jdk.git pull/32516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32516`

View PR using the GUI difftool: \
`$ git pr show -t 32516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32516.diff">https://git.openjdk.org/jdk/pull/32516.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32516#issuecomment-5409691092)
</details>
