### PR TITLE
8387962: Aarch64: Bug in movk-compatible ccs allocation with +COH

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5494,9 +5494,7 @@ MacroAssembler::KlassDecodeMode  MacroAssembler::klass_decode_mode(address base,
     }
   }
 
-  const uint64_t shifted_base =
-    (uint64_t)base >> shift;
-  if ((shifted_base & 0xffff0000ffffffff) == 0) {
+  if (((uint64_t)base & 0xffff0000ffffffff) == 0) {
     return KlassDecodeMovk;
   }
 
@@ -5547,7 +5545,7 @@ void MacroAssembler::emit_encode_klass_not_null(Register dst, Register src, Regi
 
   case KlassDecodeMovk:
     if (shift != 0) {
-      ubfx(dst, src, shift, 32);
+      ubfm(dst, src, shift, 31);
     } else {
       movw(dst, src);
     }
@@ -5609,13 +5607,9 @@ void MacroAssembler::emit_decode_klass_not_null(Register dst, Register src, Regi
     eor(dst, dst, (uint64_t)base);
     break;
 
-  case KlassDecodeMovk: { // 1-3 instructions
-    const uint64_t shifted_base =
-      (uint64_t)base >> shift;
-
-    if (dst != src) movw(dst, src);
-    movk(dst, shifted_base >> 32, 32);
-    lsl(dst, dst, shift);
+  case KlassDecodeMovk: { // 1-2 instructions
+    lsl(dst, src, shift);
+    movk(dst, (uint64_t)base >> 32, 32);
     break;
   }
 

--- a/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
+++ b/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
@@ -625,6 +625,9 @@ struct GtestFriendToMacroAssembler {
       // test movk-based
       // Only bits in the third quadrant and not a valid immediate
       build_and_run_encode_decode_klass((address)0x0000'A000'0000'0000ULL, 0, MA::KlassDecodeMovk);
+      build_and_run_encode_decode_klass((address)0x0000'0005'0000'0000ULL, 0, MA::KlassDecodeMovk);
+      build_and_run_encode_decode_klass((address)0x0000'0005'0000'0000ULL, 2, MA::KlassDecodeMovk);
+      build_and_run_encode_decode_klass((address)0x0000'0005'0000'0000ULL, 10, MA::KlassDecodeMovk);
 
       // test Fallback mode.
       // base has low bits that intersect with nKlass, no other mode would work


### PR DESCRIPTION
Fixes a small bug in class space allocation on aarch64:

We attempt to allocate for movk-compatible mode by allocating a base that is 32-bit aligned and < 2ˆ48 (so, bits [32,48) are allowed). 

https://github.com/openjdk/jdk/blob/51bb52c5c0a5a764dd080dc23bed0829fd0ae638/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp#L102-L104

However, the decoding then uses the right-shifted base before the movk. So the base would have to be [32+shift, 48+shift) to work with that:

https://github.com/openjdk/jdk/blob/51bb52c5c0a5a764dd080dc23bed0829fd0ae638/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp#L5612-L5620

With +COH, shift can be up to 10, whereas before COH it usually was 0.

So the base we allocated may not actually be usable for movk mode. E.g. if we allocated at 0x5'0000'0000, the right-shifted base would be 0x500'000, which spills into the lower 32 bits reserved for the narrowKlass offset.

[JDK-8387652](https://bugs.openjdk.org/browse/JDK-8387652) sort of handles this now: before that patch, we would abort, but now we use the slightly less optimal fallback decode mode. Still, it should be fixed, and that would also simplify the decoding.

---

Testing: tier1 on aarch64; gtests on aarch64. Note that the gtests are very thorough and test decoding and encoding for all possible corner cases.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387962](https://bugs.openjdk.org/browse/JDK-8387962): Aarch64: Bug in movk-compatible ccs allocation with +COH (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32520/head:pull/32520` \
`$ git checkout pull/32520`

Update a local copy of the PR: \
`$ git checkout pull/32520` \
`$ git pull https://git.openjdk.org/jdk.git pull/32520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32520`

View PR using the GUI difftool: \
`$ git pr show -t 32520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32520.diff">https://git.openjdk.org/jdk/pull/32520.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32520#issuecomment-5425676101)
</details>
