### PR TITLE
8390947: C2: GTest test_typejavaptr.cpp intermittently fails with assert(ptr2 == TypePtr::Constant || ptr2 == TypePtr::NotNull || ptr2 == TypePtr::BotPTR) failed: unexpected ptr: 0

### DIFF
--- a/test/hotspot/gtest/opto/test_typejavaptr.cpp
+++ b/test/hotspot/gtest/opto/test_typejavaptr.cpp
@@ -51,6 +51,17 @@ class TypeAryKlassPtrMirror;
 //   tests.
 // - Mirror instances are created at compile time, ensuring the absence of unexpected behaviors.
 
+// For GCC, UBSAN breaks the constexpr evaluation, which results in compilation failure.
+// For MSVC, the constexpr evaluation mechanism on GHA seems to have a smaller computing step
+// limit, which results in it failing to compute _2d_samples, which is a constexpr variable.
+// Our workaround to those compiler issues is to compute the variables at runtime instead. The
+// downside is that we do not benefit from the lack-of-UB guarantee of constexpr evaluation.
+#ifdef __clang__
+#define MAYBE_CONSTEXPR constexpr
+#else // __clang__
+#define MAYBE_CONSTEXPR const
+#endif // __clang__
+
 class InterfaceSet {
 public:
   bool _i0;
@@ -987,7 +998,7 @@ constexpr auto TypeAryPtrMirror::generate_1d_elem_samples() {
   return res;
 }
 
-constexpr std::array<AryElemType<TypeOopPtrMirror>, TypeAryPtrMirror::_1d_elem_samples_size> TypeAryPtrMirror::_1d_elem_samples = generate_1d_elem_samples();
+MAYBE_CONSTEXPR std::array<AryElemType<TypeOopPtrMirror>, TypeAryPtrMirror::_1d_elem_samples_size> TypeAryPtrMirror::_1d_elem_samples = generate_1d_elem_samples();
 
 template <class R>
 constexpr void TypeAryPtrMirror::fill_samples_helper(R& res, size_t& sample_idx, TypePtr::PTR ptr, InstanceMirror const_oop, const AryElemType<TypeOopPtrMirror>* elem,
@@ -1128,7 +1139,7 @@ constexpr auto TypeAryPtrMirror::generate_1d_samples() {
   return res;
 }
 
-constexpr std::array<TypeAryPtrMirror, TypeAryPtrMirror::_1d_samples_size> TypeAryPtrMirror::_1d_samples = generate_1d_samples();
+MAYBE_CONSTEXPR std::array<TypeAryPtrMirror, TypeAryPtrMirror::_1d_samples_size> TypeAryPtrMirror::_1d_samples = generate_1d_samples();
 
 constexpr auto TypeAryPtrMirror::generate_2d_elem_samples() {
   std::array<AryElemType<TypeOopPtrMirror>, _2d_elem_samples_size> res;
@@ -1152,7 +1163,7 @@ constexpr auto TypeAryPtrMirror::generate_2d_elem_samples() {
   return res;
 }
 
-constexpr std::array<AryElemType<TypeOopPtrMirror>, TypeAryPtrMirror::_2d_elem_samples_size> TypeAryPtrMirror::_2d_elem_samples = generate_2d_elem_samples();
+MAYBE_CONSTEXPR std::array<AryElemType<TypeOopPtrMirror>, TypeAryPtrMirror::_2d_elem_samples_size> TypeAryPtrMirror::_2d_elem_samples = generate_2d_elem_samples();
 
 constexpr auto TypeAryPtrMirror::generate_2d_samples() {
   std::array<TypeAryPtrMirror, _2d_samples_size> res;
@@ -1194,7 +1205,7 @@ constexpr auto TypeAryPtrMirror::generate_2d_samples() {
   return res;
 }
 
-constexpr std::array<TypeAryPtrMirror, TypeAryPtrMirror::_2d_samples_size> TypeAryPtrMirror::_2d_samples = generate_2d_samples();
+MAYBE_CONSTEXPR std::array<TypeAryPtrMirror, TypeAryPtrMirror::_2d_samples_size> TypeAryPtrMirror::_2d_samples = generate_2d_samples();
 
 class TypeKlassPtrMirror : public TypePtrMirror {
 private:
@@ -1580,7 +1591,7 @@ constexpr auto TypeAryKlassPtrMirror::generate_1d_elem_samples() {
   return res;
 }
 
-constexpr std::array<AryElemType<TypeKlassPtrMirror>, TypeAryKlassPtrMirror::_1d_elem_samples_size> TypeAryKlassPtrMirror::_1d_elem_samples = generate_1d_elem_samples();
+MAYBE_CONSTEXPR std::array<AryElemType<TypeKlassPtrMirror>, TypeAryKlassPtrMirror::_1d_elem_samples_size> TypeAryKlassPtrMirror::_1d_elem_samples = generate_1d_elem_samples();
 
 constexpr auto TypeAryKlassPtrMirror::generate_1d_samples() {
   std::array<TypeAryKlassPtrMirror, _1d_samples_size> res;
@@ -1628,7 +1639,7 @@ constexpr auto TypeAryKlassPtrMirror::generate_1d_samples() {
   return res;
 }
 
-constexpr std::array<TypeAryKlassPtrMirror, TypeAryKlassPtrMirror::_1d_samples_size> TypeAryKlassPtrMirror::_1d_samples = generate_1d_samples();
+MAYBE_CONSTEXPR std::array<TypeAryKlassPtrMirror, TypeAryKlassPtrMirror::_1d_samples_size> TypeAryKlassPtrMirror::_1d_samples = generate_1d_samples();
 
 constexpr auto TypeAryKlassPtrMirror::generate_2d_elem_samples() {
   std::array<AryElemType<TypeKlassPtrMirror>, _2d_elem_samples_size> res;
@@ -1646,7 +1657,7 @@ constexpr auto TypeAryKlassPtrMirror::generate_2d_elem_samples() {
   return res;
 }
 
-constexpr std::array<AryElemType<TypeKlassPtrMirror>, TypeAryKlassPtrMirror::_2d_elem_samples_size> TypeAryKlassPtrMirror::_2d_elem_samples = generate_2d_elem_samples();
+MAYBE_CONSTEXPR std::array<AryElemType<TypeKlassPtrMirror>, TypeAryKlassPtrMirror::_2d_elem_samples_size> TypeAryKlassPtrMirror::_2d_elem_samples = generate_2d_elem_samples();
 
 constexpr auto TypeAryKlassPtrMirror::generate_2d_samples() {
   std::array<TypeAryKlassPtrMirror, _2d_samples_size> res;
@@ -1679,7 +1690,7 @@ constexpr auto TypeAryKlassPtrMirror::generate_2d_samples() {
   return res;
 }
 
-constexpr std::array<TypeAryKlassPtrMirror, TypeAryKlassPtrMirror::_2d_samples_size> TypeAryKlassPtrMirror::_2d_samples = generate_2d_samples();
+MAYBE_CONSTEXPR std::array<TypeAryKlassPtrMirror, TypeAryKlassPtrMirror::_2d_samples_size> TypeAryKlassPtrMirror::_2d_samples = generate_2d_samples();
 
 // OopPtrMirror is the mirror of oop
 class OopPtrMirror {
@@ -1921,16 +1932,6 @@ constexpr std::array<KlassPtrMirror, KlassPtrMirror::_samples_size> KlassPtrMirr
 
 template <class PtrType, class Ptr>
 static void test_meet_join() {
-#ifdef TARGET_COMPILER_visCPP
-  if (PtrType::AryType::_2d_samples[0].ptr() == TypePtr::TopPTR) {
-    // On GHA, the constexpr evaluation mechanism of MSVC seems to have a smaller computing step
-    // limit, which results in it failing to compute _2d_samples, which is a constexpr variable. In
-    // addition, when it fails to evaluate a constexpr variable, instead of throwing an error, MSVC
-    // silently leaves the variable in an invalid state.
-    return;
-  }
-#endif // TARGET_COMPILER_visCPP
-
   constexpr size_t samples_size = PtrType::InstType::_samples.size() + PtrType::AryType::_1d_samples.size() + PtrType::AryType::_2d_samples.size();
   if constexpr (PtrType::is_oopptr_type) {
     static_assert(samples_size == 2040);

--- a/test/hotspot/gtest/opto/test_typejavaptr.cpp
+++ b/test/hotspot/gtest/opto/test_typejavaptr.cpp
@@ -1921,6 +1921,16 @@ constexpr std::array<KlassPtrMirror, KlassPtrMirror::_samples_size> KlassPtrMirr
 
 template <class PtrType, class Ptr>
 static void test_meet_join() {
+#ifdef TARGET_COMPILER_visCPP
+  if (PtrType::AryType::_2d_samples[0].ptr() == TypePtr::TopPTR) {
+    // On GHA, the constexpr evaluation mechanism of MSVC seems to have a smaller computing step
+    // limit, which results in it failing to compute _2d_samples, which is a constexpr variable. In
+    // addition, when it fails to evaluate a constexpr variable, instead of throwing an error, MSVC
+    // silently leaves the variable in an invalid state.
+    return;
+  }
+#endif // TARGET_COMPILER_visCPP
+
   constexpr size_t samples_size = PtrType::InstType::_samples.size() + PtrType::AryType::_1d_samples.size() + PtrType::AryType::_2d_samples.size();
   if constexpr (PtrType::is_oopptr_type) {
     static_assert(samples_size == 2040);


### PR DESCRIPTION
Hi,

This PR fixes a test issue on GHA that is caused by an MSVC bug. Normally, when the compiler fails to compute a `constexpr` variable, it should throw an error. However, MSVC just ignores that failure, which results in the supposedly `constexpr` variable in an invalid state. The second factor is that MSVC on GHA seems to have a lower limit for `constexpr` evaluation steps, so it does not succeed in computing the mirror instances of the test.

The fix I propose is just to check whether that is the case and abort the test, this is guarded in `#ifdef TARGET_COMPILER_visCPP`.

Please take a look and leave your review, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390947](https://bugs.openjdk.org/browse/JDK-8390947): C2: GTest test_typejavaptr.cpp intermittently fails with assert(ptr2 == TypePtr::Constant || ptr2 == TypePtr::NotNull || ptr2 == TypePtr::BotPTR) failed: unexpected ptr: 0 (**Bug** - P3)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32521/head:pull/32521` \
`$ git checkout pull/32521`

Update a local copy of the PR: \
`$ git checkout pull/32521` \
`$ git pull https://git.openjdk.org/jdk.git pull/32521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32521`

View PR using the GUI difftool: \
`$ git pr show -t 32521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32521.diff">https://git.openjdk.org/jdk/pull/32521.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32521#issuecomment-5412861630)
</details>
