### PR TITLE
8391022: [valhalla] Missed ValueObjectMethods class initialization in JVM_IHashCode()

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -808,6 +808,7 @@ JVM_ENTRY(jint, JVM_IHashCode(JNIEnv* env, jobject handle))
     Handle ho(THREAD, obj);
     args.push_oop(ho);
     methodHandle method(THREAD, Universe::value_object_hash_code_method());
+    method->method_holder()->initialize(CHECK_0); // Ensure class ValueObjectMethods is initialized
     JavaCalls::call(&result, method, &args, THREAD);
     Exceptions::wrap_exception_in_internal_error("Internal error in hashCode", CHECK_0);
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValueObjectMethodsInit.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValueObjectMethodsInit.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test ValueObjectMethods class initialization
+ * @bug 8391022
+ * @requires vm.cds.supports.aot.class.linking
+ * @comment DeoptimizeALot flag requires debug VM
+ * @requires vm.debug
+ * @library /test/lib
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ * @build TestValueObjectMethodsInit
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar
+ *                 ValueObjectMethodsClassApp
+ *                 ValueObjectMethodsClassApp$Value
+ * @run driver TestValueObjectMethodsInit
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestValueObjectMethodsInit {
+    public static void main(String[] args) throws Exception {
+        final String appJar = ClassFileInstaller.getJarPath("app.jar");
+        final String aotConfigFile = "app.aotconfig";
+        final String aotCacheFile = "app.aot";
+        final String appClass = "ValueObjectMethodsClassApp";
+
+        ProcessBuilder pb;
+        OutputAnalyzer out;
+
+        // first make sure we have a valid aotConfigFile
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "--enable-preview",
+            "-XX:CompileThresholdScaling=0.01",
+            "-Xlog:aot",
+            "-XX:AOTMode=record",
+            "-XX:AOTConfiguration=" + aotConfigFile,
+            "-cp", appJar, appClass);
+
+        out = CDSTestUtils.executeAndLog(pb, "train");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "--enable-preview",
+            "-Xlog:aot",
+            "-XX:AOTMode=create",
+            "-XX:AOTConfiguration=" + aotConfigFile,
+            "-XX:AOTCache=" + aotCacheFile,
+            "-cp", appJar);
+
+        out = CDSTestUtils.executeAndLog(pb, "assemble");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "--enable-preview",
+            "-XX:CompileThresholdScaling=0.01",
+            "-XX:+DeoptimizeALot",
+            "-Xlog:aot",
+            "-XX:AOTCache=" + aotCacheFile,
+            "-cp", appJar, appClass);
+
+        out = CDSTestUtils.executeAndLog(pb, "production");
+        out.shouldHaveExitValue(0);
+    }
+}
+
+class ValueObjectMethodsClassApp {
+    private static int hash;
+
+    static value class Value {
+        private final int val;
+        Value(int i) {
+            val = i;
+        }
+    }
+
+    static int test(int i) {
+        return System.identityHashCode(new Value(i));
+    }
+
+    public static void main(String[] args) {
+        // 1000 iterations are enough since we use CompileThresholdScaling=0.01
+        for (int i = 0; i < 1000; i++) {
+            hash = test(i);
+        }
+        System.out.println("Hash: " + hash);
+    }
+}


### PR DESCRIPTION
Added missing `ValueObjectMethods` class initialization in `JVM_IHashCode()`. Similar initialization already exists in [InterpreterRuntime::is_substitutable()](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/interpreter/interpreterRuntime.cpp#L329)

Originally found when tested AOT code changes with `--enable-preview -XX:CompileThresholdScaling=0.01 -XX:+DeoptimizeALot` flags. But AOT compilation is disabled with Valhalla and I reproduced failure with latest JDK 28. 

It is easy to reproduce when using AOT caching so I created regression test with it.

testing: tier1-4,sh-comp-stress,hs-aot-stress, new regression test

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391022](https://bugs.openjdk.org/browse/JDK-8391022): [valhalla] Missed ValueObjectMethods class initialization in JVM_IHashCode() (**Bug** - P2)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32522/head:pull/32522` \
`$ git checkout pull/32522`

Update a local copy of the PR: \
`$ git checkout pull/32522` \
`$ git pull https://git.openjdk.org/jdk.git pull/32522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32522`

View PR using the GUI difftool: \
`$ git pr show -t 32522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32522.diff">https://git.openjdk.org/jdk/pull/32522.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32522#issuecomment-5412920132)
</details>
