### PR TITLE
8391169: (process) Stale comments after JDK-8357089

### DIFF
--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -369,10 +369,11 @@ JDK_execvpe(int mode, const char *file,
 }
 
 /**
- * Child process after a successful fork().
- * This function must not return, and must be prepared for either all
- * of its address space to be shared with its parent, or to be a copy.
- * It must not modify global variables such as "environ".
+ * Child process after a successful fork() or after posix_spawn() inside
+ * jspawnhelper.
+ * This function must not return. It will prepare the exec of the target
+ * binary, then exec the target binary. If an error occurs, it ends the
+ * process with _exit().
  */
 int
 childProcess(void *arg)


### PR DESCRIPTION
Trivial comment update. We remove the VFORK mode, so any reference to shared address space with the parent is not needed anymore.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391169](https://bugs.openjdk.org/browse/JDK-8391169): (process) Stale comments after JDK-8357089 (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32526/head:pull/32526` \
`$ git checkout pull/32526`

Update a local copy of the PR: \
`$ git checkout pull/32526` \
`$ git pull https://git.openjdk.org/jdk.git pull/32526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32526`

View PR using the GUI difftool: \
`$ git pr show -t 32526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32526.diff">https://git.openjdk.org/jdk/pull/32526.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32526#issuecomment-5481724709)
</details>
