### PR TITLE
8390617: [REDO] C2: Fix the memory around some intrinsics nodes

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -46,14 +46,17 @@
 #include "opto/intrinsicnode.hpp"
 #include "opto/locknode.hpp"
 #include "opto/machnode.hpp"
+#include "opto/memnode.hpp"
 #include "opto/multnode.hpp"
 #include "opto/narrowptrnode.hpp"
 #include "opto/opaquenode.hpp"
+#include "opto/opcodes.hpp"
 #include "opto/parse.hpp"
 #include "opto/reachability.hpp"
 #include "opto/rootnode.hpp"
 #include "opto/runtime.hpp"
 #include "opto/subtypenode.hpp"
+#include "opto/type.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -4871,51 +4874,81 @@ void GraphKit::store_String_coder(Node* str, Node* value) {
                   value, TypeInt::BYTE, T_BYTE, IN_HEAP | MO_UNORDERED);
 }
 
-// Capture src and dst memory state with a MergeMemNode
-Node* GraphKit::capture_memory(const TypePtr* src_type, const TypePtr* dst_type) {
+// If input and output memory types differ, capture the whole memory to preserve
+// the dependency between preceding and subsequent loads/stores.
+// For example, the following program:
+//  StoreB
+//  compress_string
+//  LoadB
+// has this memory graph (use->def):
+//  LoadB -> compress_string -> CharMem
+//             ... -> StoreB -> ByteMem
+// The intrinsic hides the dependency between LoadB and StoreB, causing
+// the load to read from memory not containing the result of the StoreB.
+// The correct memory graph should look like this:
+//  LoadB -> compress_string -> MergeMem -> StoreB
+Node* GraphKit::capture_memory(const TypePtr*& combined_type, const TypePtr* src_type, const TypePtr* dst_type) {
   if (src_type == dst_type) {
     // Types are equal, we don't need a MergeMemNode
+    combined_type = src_type;
     return memory(src_type);
   }
-  MergeMemNode* merge = MergeMemNode::make(map()->memory());
-  record_for_igvn(merge); // fold it up later, if possible
-  int src_idx = C->get_alias_index(src_type);
-  int dst_idx = C->get_alias_index(dst_type);
-  merge->set_memory_at(src_idx, memory(src_idx));
-  merge->set_memory_at(dst_idx, memory(dst_idx));
-  return merge;
+  Node* mem = reset_memory();
+  set_all_memory(mem);
+  combined_type = TypePtr::BOTTOM;
+  return mem;
+}
+
+// If dst_type and src_type are different, str may have an anti-dependency with another node
+// consuming src_type.
+// For example:
+//  compress_string
+//  StoreC
+// has this memory graph (use->def):
+//  compress_string -> MergeMem -> CharMem
+//                       StoreC
+// The scheduler needs to ensure that compress_string is not executed after StoreC, or it will read
+// the wrong memory. For normal loads, the scheduler computes its anti-dependencies to ensure the
+// memory it reads from is not killed. Since we do not compute anti-dependencies for
+// StrCompressedCopyNode, manually insert a MemBar so the anti-dependency becomes use-def
+// dependency:
+//  StoreC -> MemBar -> MergeMem -> compress_string -> MergeMem -> CharMem
+//                               -------------------------------->
+void GraphKit::memory_effect(Node* res_mem, const TypePtr* src_type, const TypePtr* dst_type) {
+  set_memory(res_mem, dst_type);
+  if (src_type != dst_type) {
+    Node* all_mem = reset_memory();
+    set_all_memory(all_mem);
+    Node* membar = new MemBarCPUOrderNode(C, C->get_alias_index(src_type), nullptr);
+    membar->init_req(TypeFunc::Control, control());
+    membar->init_req(TypeFunc::Memory, all_mem);
+    membar = _gvn.transform(membar);
+    set_control(_gvn.transform(new ProjNode(membar, TypeFunc::Control)));
+    set_memory(_gvn.transform(new ProjNode(membar, TypeFunc::Memory)), src_type);
+  }
 }
 
 Node* GraphKit::compress_string(Node* src, const TypeAryPtr* src_type, Node* dst, Node* count) {
   assert(Matcher::match_rule_supported(Op_StrCompressedCopy), "Intrinsic not supported");
   assert(src_type == TypeAryPtr::BYTES || src_type == TypeAryPtr::CHARS, "invalid source type");
-  // If input and output memory types differ, capture both states to preserve
-  // the dependency between preceding and subsequent loads/stores.
-  // For example, the following program:
-  //  StoreB
-  //  compress_string
-  //  LoadB
-  // has this memory graph (use->def):
-  //  LoadB -> compress_string -> CharMem
-  //             ... -> StoreB -> ByteMem
-  // The intrinsic hides the dependency between LoadB and StoreB, causing
-  // the load to read from memory not containing the result of the StoreB.
-  // The correct memory graph should look like this:
-  //  LoadB -> compress_string -> MergeMem(CharMem, StoreB(ByteMem))
-  Node* mem = capture_memory(src_type, TypeAryPtr::BYTES);
-  StrCompressedCopyNode* str = new StrCompressedCopyNode(control(), mem, src, dst, count);
+  const TypePtr* dst_type = TypeAryPtr::BYTES;
+  const TypePtr* adr_type;
+  Node* mem = capture_memory(adr_type, src_type, dst_type);
+  StrCompressedCopyNode* str = new StrCompressedCopyNode(control(), mem, adr_type, src, dst, count);
   Node* res_mem = _gvn.transform(new SCMemProjNode(_gvn.transform(str)));
-  set_memory(res_mem, TypeAryPtr::BYTES);
+  memory_effect(res_mem, src_type, dst_type);
   return str;
 }
 
 void GraphKit::inflate_string(Node* src, Node* dst, const TypeAryPtr* dst_type, Node* count) {
   assert(Matcher::match_rule_supported(Op_StrInflatedCopy), "Intrinsic not supported");
   assert(dst_type == TypeAryPtr::BYTES || dst_type == TypeAryPtr::CHARS, "invalid dest type");
-  // Capture src and dst memory (see comment in 'compress_string').
-  Node* mem = capture_memory(TypeAryPtr::BYTES, dst_type);
-  StrInflatedCopyNode* str = new StrInflatedCopyNode(control(), mem, src, dst, count);
-  set_memory(_gvn.transform(str), dst_type);
+  const TypePtr* src_type = TypeAryPtr::BYTES;
+  const TypePtr* adr_type;
+  Node* mem = capture_memory(adr_type, src_type, dst_type);
+  StrInflatedCopyNode* str = new StrInflatedCopyNode(control(), mem, adr_type, src, dst, count);
+  Node* res_mem = _gvn.transform(str);
+  memory_effect(res_mem, src_type, dst_type);
 }
 
 void GraphKit::inflate_string_slow(Node* src, Node* dst, Node* start, Node* count) {

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -886,7 +886,8 @@ class GraphKit : public Phase {
   Node* load_String_coder(Node* str, bool set_ctrl);
   void store_String_value(Node* str, Node* value);
   void store_String_coder(Node* str, Node* value);
-  Node* capture_memory(const TypePtr* src_type, const TypePtr* dst_type);
+  Node* capture_memory(const TypePtr*& combined_type, const TypePtr* src_type, const TypePtr* dst_type);
+  void memory_effect(Node* res_mem, const TypePtr* src_type, const TypePtr* dst_type);
   Node* compress_string(Node* src, const TypeAryPtr* src_type, Node* dst, Node* count);
   void inflate_string(Node* src, Node* dst, const TypeAryPtr* dst_type, Node* count);
   void inflate_string_slow(Node* src, Node* dst, Node* start, Node* count);

--- a/src/hotspot/share/opto/intrinsicnode.cpp
+++ b/src/hotspot/share/opto/intrinsicnode.cpp
@@ -63,8 +63,6 @@ const Type* StrIntrinsicNode::Value(PhaseGVN* phase) const {
   return bottom_type();
 }
 
-uint StrIntrinsicNode::size_of() const { return sizeof(*this); }
-
 //=============================================================================
 //------------------------------Ideal------------------------------------------
 // Return a node which is more "ideal" than the current node.  Strip out

--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -48,7 +48,7 @@ private:
 
 //------------------------------StrIntrinsic-------------------------------
 // Base class for Ideal nodes used in String intrinsic code.
-class StrIntrinsicNode: public Node {
+class StrIntrinsicNode : public Node {
  public:
   // Possible encodings of the parameters passed to the string intrinsic.
   // 'L' stands for Latin1 and 'U' stands for UTF16. For example, 'LU' means that
@@ -59,7 +59,11 @@ class StrIntrinsicNode: public Node {
  protected:
   // Encoding of strings. Used to select the right version of the intrinsic.
   const ArgEncoding _encoding;
-  virtual uint size_of() const;
+  virtual uint size_of() const override { return sizeof(StrIntrinsicNode); }
+  virtual uint hash() const override { return Node::hash() + _encoding; }
+  virtual bool cmp(const Node& n) const override {
+    return Node::cmp(n) && _encoding == static_cast<const StrIntrinsicNode&>(n)._encoding;
+  }
 
  public:
   StrIntrinsicNode(Node* control, Node* char_array_mem,
@@ -77,141 +81,189 @@ class StrIntrinsicNode: public Node {
   Node(control, char_array_mem, s1, s2), _encoding(encoding) {
   }
 
-  virtual const TypePtr* adr_type() const { return TypeAryPtr::BYTES; }
-  virtual uint match_edge(uint idx) const;
-  virtual uint ideal_reg() const { return Op_RegI; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
-  virtual const Type* Value(PhaseGVN* phase) const;
+  virtual const TypePtr* adr_type() const override = 0;
+  virtual uint match_edge(uint idx) const override;
+  virtual uint ideal_reg() const override { return Op_RegI; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
+  virtual const Type* Value(PhaseGVN* phase) const override;
   ArgEncoding encoding() const { return _encoding; }
 
 private:
-  virtual bool depends_only_on_test_impl() const { return false; }
+  virtual bool depends_only_on_test_impl() const override { return false; }
 };
 
 //------------------------------StrComp-------------------------------------
-class StrCompNode: public StrIntrinsicNode {
+class StrCompNode final : public StrIntrinsicNode {
  public:
   StrCompNode(Node* control, Node* char_array_mem,
               Node* s1, Node* c1, Node* s2, Node* c2, ArgEncoding encoding):
   StrIntrinsicNode(control, char_array_mem, s1, c1, s2, c2, encoding) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::INT; }
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::INT; }
+  virtual const TypePtr* adr_type() const override { return TypeAryPtr::BYTES; }
 };
 
 //------------------------------StrEquals-------------------------------------
-class StrEqualsNode: public StrIntrinsicNode {
+class StrEqualsNode final : public StrIntrinsicNode {
  public:
   StrEqualsNode(Node* control, Node* char_array_mem,
                 Node* s1, Node* s2, Node* c, ArgEncoding encoding):
   StrIntrinsicNode(control, char_array_mem, s1, s2, c, encoding) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::BOOL; }
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::BOOL; }
+  virtual const TypePtr* adr_type() const override { return TypeAryPtr::BYTES; }
 };
 
 //------------------------------StrIndexOf-------------------------------------
-class StrIndexOfNode: public StrIntrinsicNode {
+class StrIndexOfNode final : public StrIntrinsicNode {
  public:
   StrIndexOfNode(Node* control, Node* char_array_mem,
                  Node* s1, Node* c1, Node* s2, Node* c2, ArgEncoding encoding):
   StrIntrinsicNode(control, char_array_mem, s1, c1, s2, c2, encoding) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::INT; }
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::INT; }
+  virtual const TypePtr* adr_type() const override { return TypeAryPtr::BYTES; }
 };
 
 //------------------------------StrIndexOfChar-------------------------------------
-class StrIndexOfCharNode: public StrIntrinsicNode {
+class StrIndexOfCharNode final : public StrIntrinsicNode {
  public:
   StrIndexOfCharNode(Node* control, Node* char_array_mem,
                      Node* s1, Node* c1, Node* c, ArgEncoding encoding):
   StrIntrinsicNode(control, char_array_mem, s1, c1, c, encoding) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::INT; }
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::INT; }
+  virtual const TypePtr* adr_type() const override { return TypeAryPtr::BYTES; }
 };
 
 //--------------------------StrCompressedCopy-------------------------------
-class StrCompressedCopyNode: public StrIntrinsicNode {
- public:
-  StrCompressedCopyNode(Node* control, Node* arymem,
+class StrCompressedCopyNode final : public StrIntrinsicNode {
+private:
+  const TypePtr* const _adr_type;
+
+public:
+  StrCompressedCopyNode(Node* control, Node* arymem, const TypePtr* adr_type,
                         Node* s1, Node* s2, Node* c):
-  StrIntrinsicNode(control, arymem, s1, s2, c, none) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::INT; }
-  virtual const TypePtr* adr_type() const { return TypePtr::BOTTOM; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
+  StrIntrinsicNode(control, arymem, s1, s2, c, none), _adr_type(adr_type) {};
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::INT; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
+
+private:
+  virtual uint size_of() const override { return sizeof(StrCompressedCopyNode); }
+  virtual uint hash() const override { return StrIntrinsicNode::hash() + (uint)(uintptr_t) _adr_type; }
+  virtual bool cmp(const Node& n) const override {
+    return StrIntrinsicNode::cmp(n) && _adr_type == static_cast<const StrCompressedCopyNode&>(n)._adr_type;
+  }
+  virtual const TypePtr* adr_type() const override { return _adr_type; }
 };
 
 //--------------------------StrInflatedCopy---------------------------------
-class StrInflatedCopyNode: public StrIntrinsicNode {
- public:
-  StrInflatedCopyNode(Node* control, Node* arymem,
+class StrInflatedCopyNode final : public StrIntrinsicNode {
+private:
+  const TypePtr* const _adr_type;
+
+public:
+  StrInflatedCopyNode(Node* control, Node* arymem, const TypePtr* adr_type,
                       Node* s1, Node* s2, Node* c):
-  StrIntrinsicNode(control, arymem, s1, s2, c, none) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return Type::MEMORY; }
-  virtual const TypePtr* adr_type() const { return TypePtr::BOTTOM; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
+  StrIntrinsicNode(control, arymem, s1, s2, c, none), _adr_type(adr_type) {};
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return Type::MEMORY; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
+
+private:
+  virtual uint size_of() const override { return sizeof(StrInflatedCopyNode); }
+  virtual uint hash() const override { return StrIntrinsicNode::hash() + (uint)(uintptr_t) _adr_type; }
+  virtual bool cmp(const Node& n) const override {
+    return StrIntrinsicNode::cmp(n) && _adr_type == static_cast<const StrInflatedCopyNode&>(n)._adr_type;
+  }
+  virtual const TypePtr* adr_type() const override { return _adr_type; }
 };
 
 //------------------------------AryEq---------------------------------------
-class AryEqNode: public StrIntrinsicNode {
- public:
-  AryEqNode(Node* control, Node* char_array_mem,
+class AryEqNode final : public StrIntrinsicNode {
+private:
+  const TypeAryPtr* const _in_adr_type;
+
+public:
+  AryEqNode(Node* control, Node* char_array_mem, const TypeAryPtr* in_adr_type,
             Node* s1, Node* s2, ArgEncoding encoding):
-  StrIntrinsicNode(control, char_array_mem, s1, s2, encoding) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::BOOL; }
+  StrIntrinsicNode(control, char_array_mem, s1, s2, encoding), _in_adr_type(in_adr_type) {};
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::BOOL; }
+
+private:
+  virtual uint size_of() const override { return sizeof(AryEqNode); }
+  virtual uint hash() const override { return StrIntrinsicNode::hash() + (uint)(uintptr_t) _in_adr_type; }
+  virtual bool cmp(const Node& n) const override {
+    return StrIntrinsicNode::cmp(n) && _in_adr_type == static_cast<const AryEqNode&>(n)._in_adr_type;
+  }
+  virtual const TypePtr* adr_type() const override { return _in_adr_type; }
 };
 
 //------------------------------CountPositives------------------------------
-class CountPositivesNode: public StrIntrinsicNode {
+class CountPositivesNode final : public StrIntrinsicNode {
  public:
   CountPositivesNode(Node* control, Node* char_array_mem, Node* s1, Node* c1):
   StrIntrinsicNode(control, char_array_mem, s1, c1, none) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::POS; }
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::POS; }
+  virtual const TypePtr* adr_type() const override { return TypeAryPtr::BYTES; }
 };
 
 //------------------------------VectorizedHashCodeNode----------------------
-class VectorizedHashCodeNode: public Node {
- public:
-  VectorizedHashCodeNode(Node* control, Node* ary_mem, Node* arg1, Node* cnt1, Node* result, Node* basic_type)
-    : Node(control, ary_mem, arg1, cnt1, result, basic_type) {};
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::INT; }
-  virtual const TypePtr* adr_type() const { return TypePtr::BOTTOM; }
-  virtual uint match_edge(uint idx) const;
-  virtual uint ideal_reg() const { return Op_RegI; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
-  virtual const Type* Value(PhaseGVN* phase) const;
+class VectorizedHashCodeNode final : public Node {
+private:
+  const TypeAryPtr* const _in_adr_type;
+
+public:
+  VectorizedHashCodeNode(Node* control, Node* ary_mem, const TypeAryPtr* in_adr_type, Node* arg1, Node* cnt1, Node* result, Node* basic_type)
+    : Node(control, ary_mem, arg1, cnt1, result, basic_type), _in_adr_type(in_adr_type) {};
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::INT; }
+  virtual uint match_edge(uint idx) const override;
+  virtual uint ideal_reg() const override { return Op_RegI; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
+  virtual const Type* Value(PhaseGVN* phase) const override;
 
 private:
-  virtual bool depends_only_on_test_impl() const { return false; }
+  virtual uint size_of() const override { return sizeof(VectorizedHashCodeNode); }
+  virtual uint hash() const override { return Node::hash() + (uint)(uintptr_t) _in_adr_type; }
+  virtual bool cmp(const Node& n) const override {
+    return Node::cmp(n) && _in_adr_type == static_cast<const VectorizedHashCodeNode&>(n)._in_adr_type;
+  }
+  virtual const TypePtr* adr_type() const override { return _in_adr_type; }
+  virtual bool depends_only_on_test_impl() const override { return false; }
 };
 
 //------------------------------EncodeISOArray--------------------------------
 // encode char[] to byte[] in ISO_8859_1 or ASCII
-class EncodeISOArrayNode: public Node {
+class EncodeISOArrayNode final : public Node {
+private:
+  const TypePtr* const _adr_type;
   bool _ascii;
- public:
-  EncodeISOArrayNode(Node* control, Node* arymem, Node* s1, Node* s2, Node* c, bool ascii)
-    : Node(control, arymem, s1, s2, c), _ascii(ascii) {}
+
+public:
+  EncodeISOArrayNode(Node* control, Node* arymem, const TypePtr* adr_type, Node* s1, Node* s2, Node* c, bool ascii)
+    : Node(control, arymem, s1, s2, c), _adr_type(adr_type), _ascii(ascii) {}
 
   bool is_ascii() { return _ascii; }
-  virtual int Opcode() const;
-  virtual const Type* bottom_type() const { return TypeInt::INT; }
-  virtual const TypePtr* adr_type() const { return TypePtr::BOTTOM; }
-  virtual uint match_edge(uint idx) const;
-  virtual uint ideal_reg() const { return Op_RegI; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
-  virtual const Type* Value(PhaseGVN* phase) const;
-  virtual uint size_of() const { return sizeof(EncodeISOArrayNode); }
-  virtual uint hash() const { return Node::hash() + _ascii; }
-  virtual bool cmp(const Node& n) const {
-    return Node::cmp(n) && _ascii == ((EncodeISOArrayNode&)n).is_ascii();
-  }
+  virtual int Opcode() const override;
+  virtual const Type* bottom_type() const override { return TypeInt::INT; }
+  virtual uint match_edge(uint idx) const override;
+  virtual uint ideal_reg() const override { return Op_RegI; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
+  virtual const Type* Value(PhaseGVN* phase) const override;
 
 private:
-  virtual bool depends_only_on_test_impl() const { return false; }
+  virtual uint size_of() const override { return sizeof(EncodeISOArrayNode); }
+  virtual uint hash() const override { return Node::hash() + (uint)(uintptr_t) _adr_type + _ascii; }
+  virtual bool cmp(const Node& n) const override {
+    const EncodeISOArrayNode& e = static_cast<const EncodeISOArrayNode&>(n);
+    return Node::cmp(n) && _ascii == e._ascii && _adr_type == e._adr_type;
+  }
+  virtual const TypePtr* adr_type() const override { return _adr_type; }
+  virtual bool depends_only_on_test_impl() const override { return false; }
 };
 
 //-------------------------------DigitNode----------------------------------------

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -7255,12 +7255,16 @@ bool LibraryCallKit::inline_encodeISOArray(bool ascii) {
   // 'dst_start' points to dst array + scaled offset
 
   // See GraphKit::compress_string
+  const TypePtr* src_adr_type = TypeAryPtr::get_array_body_type(src_elem);
+  const TypePtr* dst_adr_type = TypeAryPtr::get_array_body_type(dst_elem);
+  assert(src_adr_type == TypeAryPtr::BYTES || src_adr_type == TypeAryPtr::CHARS, "unexpected src_adr_type");
+  assert(dst_adr_type == TypeAryPtr::BYTES, "unexpected dst_adr_type");
   const TypePtr* adr_type;
-  Node* mem = capture_memory(adr_type, src_type, dst_type);
+  Node* mem = capture_memory(adr_type, src_adr_type, dst_adr_type);
   Node* enc = new EncodeISOArrayNode(control(), mem, adr_type, src_start, dst_start, length, ascii);
   enc = _gvn.transform(enc);
   Node* res_mem = _gvn.transform(new SCMemProjNode(enc));
-  memory_effect(res_mem, src_type, dst_type);
+  memory_effect(res_mem, src_adr_type, dst_adr_type);
 
   set_result(enc);
   clear_upper_avx();

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1162,7 +1162,7 @@ bool LibraryCallKit::inline_array_equals(StrIntrinsicNode::ArgEnc ae) {
   Node* arg2 = argument(1);
 
   const TypeAryPtr* mtype = (ae == StrIntrinsicNode::UU) ? TypeAryPtr::CHARS : TypeAryPtr::BYTES;
-  set_result(_gvn.transform(new AryEqNode(control(), memory(mtype), arg1, arg2, ae)));
+  set_result(_gvn.transform(new AryEqNode(control(), memory(mtype), mtype, arg1, arg2, ae)));
   clear_upper_avx();
 
   return true;
@@ -7254,11 +7254,14 @@ bool LibraryCallKit::inline_encodeISOArray(bool ascii) {
   // 'src_start' points to src array + scaled offset
   // 'dst_start' points to dst array + scaled offset
 
-  const TypeAryPtr* mtype = TypeAryPtr::BYTES;
-  Node* enc = new EncodeISOArrayNode(control(), memory(mtype), src_start, dst_start, length, ascii);
+  // See GraphKit::compress_string
+  const TypePtr* adr_type;
+  Node* mem = capture_memory(adr_type, src_type, dst_type);
+  Node* enc = new EncodeISOArrayNode(control(), mem, adr_type, src_start, dst_start, length, ascii);
   enc = _gvn.transform(enc);
   Node* res_mem = _gvn.transform(new SCMemProjNode(enc));
-  set_memory(res_mem, mtype);
+  memory_effect(res_mem, src_type, dst_type);
+
   set_result(enc);
   clear_upper_avx();
 
@@ -7737,7 +7740,8 @@ bool LibraryCallKit::inline_vectorizedHashCode() {
   // Resolve address of first element
   Node* array_start = array_element_address(array, offset, bt);
 
-  set_result(_gvn.transform(new VectorizedHashCodeNode(control(), memory(TypeAryPtr::get_array_body_type(bt)),
+  const TypeAryPtr* in_adr_type = TypeAryPtr::get_array_body_type(bt);
+  set_result(_gvn.transform(new VectorizedHashCodeNode(control(), memory(in_adr_type), in_adr_type,
     array_start, length, initialValue, basic_type)));
   clear_upper_avx();
 

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestAntiDependency.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestAntiDependency.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.intrinsics.string;
+
+import compiler.lib.ir_framework.DontInline;
+import compiler.lib.ir_framework.Run;
+import compiler.lib.ir_framework.Test;
+import compiler.lib.ir_framework.TestFramework;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8373591
+ * @summary Verify that StringLatin1::inflate, StringUTF16::compress, and
+ *          StringCoding::implEncodeAsciiArray are scheduled properly
+ * @library /test/lib /
+ * @modules java.base/java.lang:+open
+ * @run driver ${test.main.class}
+ */
+public class TestAntiDependency {
+    static final MethodHandle COMPRESS_HANDLE;
+    static final MethodHandle INFLATE_HANDLE;
+    static final MethodHandle ENCODE_ISO_HANDLE;
+    static {
+        try {
+            var currentLookup = MethodHandles.lookup();
+            var stringLookup = MethodHandles.privateLookupIn(String.class, currentLookup);
+            Class<?> stringUtf16Class = stringLookup.findClass("java.lang.StringUTF16");
+            var stringUtf16Lookup = MethodHandles.privateLookupIn(stringUtf16Class, currentLookup);
+            COMPRESS_HANDLE = stringUtf16Lookup.findStatic(stringUtf16Class, "compress0",
+                    MethodType.methodType(int.class, char[].class, int.class, byte[].class, int.class, int.class));
+            Class<?> stringLatin1Class = stringLookup.findClass("java.lang.StringLatin1");
+            var stringLatin1Lookup = MethodHandles.privateLookupIn(stringLatin1Class, currentLookup);
+            INFLATE_HANDLE = stringLatin1Lookup.findStatic(stringLatin1Class, "inflate0",
+                    MethodType.methodType(void.class, byte[].class, int.class, char[].class, int.class, int.class));
+            Class<?> stringCodingClass = stringLookup.findClass("java.lang.StringCoding");
+            ENCODE_ISO_HANDLE = stringLookup.findStatic(stringCodingClass, "encodeAsciiArray0",
+                    MethodType.methodType(int.class, char[].class, int.class, byte[].class, int.class, int.class));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        var testFramework = new TestFramework();
+        testFramework.setDefaultWarmup(1);
+        testFramework.addFlags("--add-opens=java.base/java.lang=ALL-UNNAMED");
+        testFramework.start();
+    }
+
+    @DontInline
+    static void consume(Object o1, Object o2) {}
+
+    @Test
+    static int testStringCompress() throws Throwable {
+        byte[] dst = new byte[4];
+        char[] src = new char[4];
+        consume(dst, src);
+
+        // The compiler must not schedule this after the store to src, either by having
+        // StringCompressedCopyNode kill the whole memory, or by taking into consideration the
+        // anti-dependency between 2 nodes
+        int _ = (int) COMPRESS_HANDLE.invokeExact(src, 0, dst, 0, 4);
+        src[0] = 1;
+        return dst[0];
+    }
+
+    @Test
+    static int testStringInflate() throws Throwable {
+        char[] dst = new char[4];
+        byte[] src = new byte[4];
+        consume(dst, src);
+
+        // The compiler must not schedule this after the store to src, either by having
+        // StringInflatedCopyNode kill the whole memory, or by taking into consideration the
+        // anti-dependency between 2 nodes
+        INFLATE_HANDLE.invokeExact(src, 0, dst, 0, 4);
+        src[0] = 1;
+        return dst[0];
+    }
+
+    @Test
+    static int testEncodeISO() throws Throwable {
+        byte[] dst = new byte[4];
+        char[] src = new char[4];
+        consume(dst, src);
+
+        // The compiler must not schedule this after the store to src, either by having
+        // EncodeISOArrayNode kill the whole memory, or by taking into consideration the
+        // anti-dependency between 2 nodes
+        int _ = (int) ENCODE_ISO_HANDLE.invokeExact(src, 0, dst, 0, 4);
+        src[0] = 1;
+        return dst[0];
+    }
+
+    @Run(test = {"testStringCompress", "testStringInflate", "testEncodeISO"})
+    public void run() throws Throwable {
+        Asserts.assertEQ(0, testStringCompress());
+        Asserts.assertEQ(0, testStringInflate());
+        Asserts.assertEQ(0, testEncodeISO());
+    }
+}

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestAntiDependency.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestAntiDependency.java
@@ -82,6 +82,7 @@ public class TestAntiDependency {
         byte[] dst = new byte[4];
         char[] src = new char[4];
         consume(dst, src);
+        dst[0] = (byte) -1;
 
         // The compiler must not schedule this after the store to src, either by having
         // StringCompressedCopyNode kill the whole memory, or by taking into consideration the
@@ -96,6 +97,7 @@ public class TestAntiDependency {
         char[] dst = new char[4];
         byte[] src = new byte[4];
         consume(dst, src);
+        dst[0] = (char) -1;
 
         // The compiler must not schedule this after the store to src, either by having
         // StringInflatedCopyNode kill the whole memory, or by taking into consideration the
@@ -110,6 +112,7 @@ public class TestAntiDependency {
         byte[] dst = new byte[4];
         char[] src = new char[4];
         consume(dst, src);
+        dst[0] = (byte) -1;
 
         // The compiler must not schedule this after the store to src, either by having
         // EncodeISOArrayNode kill the whole memory, or by taking into consideration the


### PR DESCRIPTION
Hi,

This PR redoes [JDK-8373591](https://bugs.openjdk.org/browse/JDK-8373591) after it has been backed out by [JDK-8390590](https://bugs.openjdk.org/browse/JDK-8390590). The first commit just reverts the backout, the second commit fixes the issue, that is the intrinsic node incorrectly captures the memories corresponding to the header of the arguments instead of their bodies. [JDK-8390591](https://bugs.openjdk.org/browse/JDK-8390591) has added regression test for the issue, I also modified the test in this PR to catch the same issue, thanks to the suggestion by @TobiHartmann.

Testing:

- [x] tier1-4,hs-comp-stress

Please take a look and leave your review, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390617](https://bugs.openjdk.org/browse/JDK-8390617): [REDO] C2: Fix the memory around some intrinsics nodes (**Bug** - P3)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32527/head:pull/32527` \
`$ git checkout pull/32527`

Update a local copy of the PR: \
`$ git checkout pull/32527` \
`$ git pull https://git.openjdk.org/jdk.git pull/32527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32527`

View PR using the GUI difftool: \
`$ git pr show -t 32527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32527.diff">https://git.openjdk.org/jdk/pull/32527.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32527#issuecomment-5426460412)
</details>
