### PR TITLE
8391160: C2 uses a raw base for an oop arraycopy destination

### DIFF
--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1418,10 +1418,6 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
       if (ac->_dest_type != TypeOopPtr::BOTTOM) {
         adr_type = ac->_dest_type->add_offset(Type::OffsetBot)->is_ptr();
       }
-      if (ac->_src_type != ac->_dest_type) {
-        adr_type = TypeRawPtr::BOTTOM;
-        raw_base = true;
-      }
     }
     merge_mem = MergeMemNode::make(mem);
     transform_later(merge_mem);

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestCopyOfBrokenAntiDependency.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestCopyOfBrokenAntiDependency.java
@@ -30,6 +30,8 @@
  * @run main/othervm -Xbatch -XX:-ReduceInitialCardMarks -XX:-ReduceBulkZeroing ${test.main.class}
  */
 
+package compiler.escapeAnalysis;
+
 import java.util.Arrays;
 
 public class TestCopyOfBrokenAntiDependency {

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestCopyOfBrokenAntiDependency.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestCopyOfBrokenAntiDependency.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +24,10 @@
 
 /**
  * @test
- * @bug 8238384
- * @summary CTW: C2 compilation fails with "assert(store != load->find_exact_control(load->in(0))) failed: dependence cycle found"
- *
- * @run main/othervm -XX:-BackgroundCompilation TestCopyOfBrokenAntiDependency
- *
+ * @bug 8238384 8391160
+ * @summary Test that Arrays.copyOf with non-escaping allocations and distinct memory slices compiles without assertion failures
+ * @run main/othervm -Xbatch ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-ReduceInitialCardMarks -XX:-ReduceBulkZeroing ${test.main.class}
  */
 
 import java.util.Arrays;


### PR DESCRIPTION
This fixes an old merge conflict from Valhalla that made it's way into mainline with the recent integration with [JDK-8389219](https://bugs.openjdk.org/browse/JDK-8389219). In 2018, this code got removed by [JDK-8210887](https://bugs.openjdk.org/browse/JDK-8210887) when arraycopy calls moved to MergeMem destination slices:
https://github.com/openjdk/jdk/commit/ce59b4b472dd1680a46d6d0d7cb504ec46518332#diff-25d831b18a6331eb1400cbd9af71194225c556e16def16280d8c62f1590c82cbL1130

Earlier that year, Valhalla code was updated to support arraycopy/copyOf/clone for flat arrays and moved that exact code into an else branch:
https://github.com/openjdk/valhalla/commit/09f099cab74c483c4aee3e927f2bc3c41ad784c9#diff-25d831b18a6331eb1400cbd9af71194225c556e16def16280d8c62f1590c82cbR1226

As a result, this removal was probably missed when [JDK-8210887](https://bugs.openjdk.org/browse/JDK-8210887) got merged into Valhalla. Let's remove it now, 8 years later :slightly_smiling_face: 

Gory details:
In the test, EA gives non-escaping and independent `dst` and `dst2` different heap memory slices and the old code treats this as evidence that the destination is raw memory, setting `raw_base = true`. This produces an invalid `AddP(top, oop, offset)` which triggers an assert later.

I extended an existing test to cover this.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391160](https://bugs.openjdk.org/browse/JDK-8391160): C2 uses a raw base for an oop arraycopy destination (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32530/head:pull/32530` \
`$ git checkout pull/32530`

Update a local copy of the PR: \
`$ git checkout pull/32530` \
`$ git pull https://git.openjdk.org/jdk.git pull/32530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32530`

View PR using the GUI difftool: \
`$ git pr show -t 32530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32530.diff">https://git.openjdk.org/jdk/pull/32530.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32530#issuecomment-5426660043)
</details>
