### PR TITLE
8391170: JLinkToolProviderTest fails after JDK-8390505 when using configure --enable-linkable-runtime

### DIFF
--- a/test/jdk/tools/jlink/JLinkToolProviderTest.java
+++ b/test/jdk/tools/jlink/JLinkToolProviderTest.java
@@ -34,7 +34,7 @@ import java.util.spi.ToolProvider;
 /*
  * @test
  * @modules jdk.jlink
- * @run main JLinkToolProviderTest
+ * @run main/othervm JLinkToolProviderTest
  */
 public class JLinkToolProviderTest {
     static final ToolProvider JLINK_TOOL = ToolProvider.findFirst("jlink")


### PR DESCRIPTION
Running `JLinkToolProviderTest` on a JDK built with `--enable-linkable-runtime` fails with the following error:
```
java.lang.AssertionError: 1:Error: jlink does not support linking from the run-time image when running on a patched runtime with --patch-module:
at JLinkToolProviderTest.checkConcurrentAccess(JLinkToolProviderTest.java:69)
at JLinkToolProviderTest.main(JLinkToolProviderTest.java:78)
...
```
The test invokes `jlink` through `ToolProvider`. Its default agent-VM execution runs on a patched runtime, which `jlink` does not support when linking from the run-time image.

The proposed fix changes the test’s jtreg action from `main` to `main/othervm`, so the `ToolProvider` invocation runs in a fresh, unpatched VM.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391170](https://bugs.openjdk.org/browse/JDK-8391170): JLinkToolProviderTest fails after JDK-8390505 when using configure --enable-linkable-runtime (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32531/head:pull/32531` \
`$ git checkout pull/32531`

Update a local copy of the PR: \
`$ git checkout pull/32531` \
`$ git pull https://git.openjdk.org/jdk.git pull/32531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32531`

View PR using the GUI difftool: \
`$ git pr show -t 32531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32531.diff">https://git.openjdk.org/jdk/pull/32531.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32531#issuecomment-5426630934)
</details>
