### PR TITLE
8388369: C2: VectorAPI: Potential null pointer dereference in LibraryCallKit::inline_vector_test

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1681,6 +1681,7 @@ bool LibraryCallKit::inline_vector_test() {
 
   Node* opd1 = unbox_vector(argument(4), vbox_type, elem_bt, num_elem);
   if (opd1 == nullptr) {
+    log_if_needed("  ** unbox failed m1=%s", argument(4)->Name());
     return false;
   }
 
@@ -1688,11 +1689,12 @@ bool LibraryCallKit::inline_vector_test() {
   if (Matcher::vectortest_needs_second_argument(booltest == BoolTest::overflow,
                                                 opd1->bottom_type()->isa_pvectmask())) {
     opd2 = unbox_vector(argument(5), vbox_type, elem_bt, num_elem);
+    if (opd2 == nullptr) {
+      log_if_needed("  ** unbox failed m2=%s", argument(5)->Name());
+      return false;
+    }
   } else {
     opd2 = opd1;
-  }
-  if (opd2 == nullptr) {
-    return false;
   }
 
   Node* cmp = gvn().transform(trace_vector(new VectorTestNode(opd1, opd2, booltest)));

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1680,6 +1680,10 @@ bool LibraryCallKit::inline_vector_test() {
   }
 
   Node* opd1 = unbox_vector(argument(4), vbox_type, elem_bt, num_elem);
+  if (opd1 == nullptr) {
+    return false;
+  }
+
   Node* opd2;
   if (Matcher::vectortest_needs_second_argument(booltest == BoolTest::overflow,
                                                 opd1->bottom_type()->isa_pvectmask())) {
@@ -1687,8 +1691,8 @@ bool LibraryCallKit::inline_vector_test() {
   } else {
     opd2 = opd1;
   }
-  if (opd1 == nullptr || opd2 == nullptr) {
-    return false; // operand unboxing failed
+  if (opd2 == nullptr) {
+    return false;
   }
 
   Node* cmp = gvn().transform(trace_vector(new VectorTestNode(opd1, opd2, booltest)));

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1681,7 +1681,7 @@ bool LibraryCallKit::inline_vector_test() {
 
   Node* opd1 = unbox_vector(argument(4), vbox_type, elem_bt, num_elem);
   if (opd1 == nullptr) {
-    log_if_needed("  ** unbox failed m1=%s", argument(4)->Name());
+    log_if_needed("  ** unbox failed m1=%s", NodeClassNames[argument(4)->Opcode()]);
     return false;
   }
 
@@ -1690,7 +1690,7 @@ bool LibraryCallKit::inline_vector_test() {
                                                 opd1->bottom_type()->isa_pvectmask())) {
     opd2 = unbox_vector(argument(5), vbox_type, elem_bt, num_elem);
     if (opd2 == nullptr) {
-      log_if_needed("  ** unbox failed m2=%s", argument(5)->Name());
+      log_if_needed("  ** unbox failed m2=%s", NodeClassNames[argument(5)->Opcode()]);
       return false;
     }
   } else {


### PR DESCRIPTION
Hi,

This PR addresses a possible issue reported by parfait. The issue is that we check `opd1 == nullptr` after performing the access `opd1->bottom_type()`, which may result in SIGSEGV when `opd1` is `nullptr`. It is not an issue in practice, because the intrinsic is an internal API, and the argument is `this`, which means that it is always null-free, as well as has the correct type. For example, we have:

    @Override
    @ForceInline
    public boolean ByteVector512::ByteMask512::anyTrue() {
        return VectorSupport.test(BT_ne, ByteMask512.class, LANEBITS_TYPE_ORDINAL, VLENGTH,
                                     this, VSPECIES.maskAll(true),
                                     (m, _) -> anyTrueHelper(((ByteMask512)m).getBits()));
    }

So, `this` is statically determined to be a non-null `ByteVector512::ByteMask512`, which is a final class.

Please take a look and leave your reviews, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388369](https://bugs.openjdk.org/browse/JDK-8388369): C2: VectorAPI: Potential null pointer dereference in LibraryCallKit::inline_vector_test (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer) Review applies to [a437a19a](https://git.openjdk.org/jdk/pull/32532/files/a437a19a4e0ba7e458cbe060197032863e98641b)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32532/head:pull/32532` \
`$ git checkout pull/32532`

Update a local copy of the PR: \
`$ git checkout pull/32532` \
`$ git pull https://git.openjdk.org/jdk.git pull/32532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32532`

View PR using the GUI difftool: \
`$ git pr show -t 32532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32532.diff">https://git.openjdk.org/jdk/pull/32532.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32532#issuecomment-5426633841)
</details>
