### PR TITLE
8390935: G1: Retained regions do not get an efficiency assigned

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -345,6 +345,7 @@ void G1CollectionSetCandidates::add_retained_region_unsorted(G1HeapRegion* r) {
 
   G1CSetCandidateGroup* gr = new G1CSetCandidateGroup();
   gr->add(r);
+  gr->calculate_efficiency();
 
   _retained_groups.append(gr);
 }


### PR DESCRIPTION
Hi all,

  please review this change to fix calculation of region efficiency for retained regions: they were not calculated at all, e.g. 0.0. This means that when sorting, they would be taken by evacuation in some order determined by insertion order.

This could cause hiccups with pause time as g1 would take them in that order.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390935](https://bugs.openjdk.org/browse/JDK-8390935): G1: Retained regions do not get an efficiency assigned (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32534/head:pull/32534` \
`$ git checkout pull/32534`

Update a local copy of the PR: \
`$ git checkout pull/32534` \
`$ git pull https://git.openjdk.org/jdk.git pull/32534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32534`

View PR using the GUI difftool: \
`$ git pr show -t 32534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32534.diff">https://git.openjdk.org/jdk/pull/32534.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32534#issuecomment-5437105216)
</details>
