### PR TITLE
8391174: Simplify `identity_hash` after UseObjectMonitorTable removal

### DIFF
--- a/src/hotspot/share/cds/aotMappedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapWriter.cpp
@@ -725,39 +725,26 @@ template <typename T> void AOTMappedHeapWriter::mark_oop_pointer(T* buffered_add
   oopmap->set_bit(idx);
 }
 
-void AOTMappedHeapWriter::update_header_for_requested_obj(oop requested_obj, oop src_obj,  Klass* src_klass) {
+void AOTMappedHeapWriter::update_header_for_requested_obj(oop requested_obj, oop src_obj, Klass* src_klass) {
   narrowKlass nk = ArchiveBuilder::current()->get_requested_narrow_klass(src_klass);
   address buffered_addr = requested_addr_to_buffered_addr(cast_from_oop<address>(requested_obj));
 
-  oop fake_oop = cast_to_oop(buffered_addr);
-  if (UseCompactObjectHeaders) {
-    markWord prototype_header = src_klass->prototype_header().set_narrow_klass(nk);
-    fake_oop->set_mark(prototype_header);
-  } else {
-    fake_oop->set_narrow_klass(nk);
-  }
+  markWord mw = Arguments::enable_preview() ? src_klass->prototype_header() : markWord::prototype();
+  oopDesc* fake_oop = (oopDesc*)buffered_addr;
 
-  if (src_obj == nullptr) {
-    return;
-  }
   // We need to retain the identity_hash, because it may have been used by some hashtables
   // in the shared heap.
-  if (!src_obj->is_inline_type() && src_obj->has_identity_hash()) {
+  if (src_obj != nullptr && !src_obj->is_inline_type() && src_obj->has_identity_hash()) {
     intptr_t src_hash = src_obj->identity_hash();
-    if (UseCompactObjectHeaders) {
-      fake_oop->set_mark(fake_oop->mark().copy_set_hash(src_hash));
-    } else if (Arguments::is_valhalla_enabled()) {
-      fake_oop->set_mark(src_klass->prototype_header().copy_set_hash(src_hash));
-    } else {
-      fake_oop->set_mark(markWord::prototype().copy_set_hash(src_hash));
-    }
-    assert(fake_oop->mark().is_unlocked(), "sanity");
-
-    DEBUG_ONLY(intptr_t archived_hash = fake_oop->identity_hash());
-    assert(src_hash == archived_hash, "Different hash codes: original " INTPTR_FORMAT ", archived " INTPTR_FORMAT, src_hash, archived_hash);
+    mw = mw.copy_set_hash(src_hash);
   }
-  // Strip age bits.
-  fake_oop->set_mark(fake_oop->mark().set_age(0));
+
+  if (UseCompactObjectHeaders) {
+    fake_oop->set_mark(mw.set_narrow_klass(nk));
+  } else {
+    fake_oop->set_mark(mw);
+    fake_oop->set_narrow_klass(nk);
+  }
 }
 
 class AOTMappedHeapWriter::EmbeddedOopRelocator: public BasicOopIterateClosure {

--- a/src/hotspot/share/cds/aotMappedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapWriter.cpp
@@ -742,7 +742,7 @@ void AOTMappedHeapWriter::update_header_for_requested_obj(oop requested_obj, oop
   }
   // We need to retain the identity_hash, because it may have been used by some hashtables
   // in the shared heap.
-  if (!src_obj->fast_no_hash_check() && (!(Arguments::is_valhalla_enabled() && src_obj->mark().is_inline_type()))) {
+  if (src_obj->has_identity_hash() && (!(Arguments::is_valhalla_enabled() && src_obj->mark().is_inline_type()))) {
     intptr_t src_hash = src_obj->identity_hash();
     if (UseCompactObjectHeaders) {
       fake_oop->set_mark(fake_oop->mark().copy_set_hash(src_hash));

--- a/src/hotspot/share/cds/aotMappedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapWriter.cpp
@@ -742,7 +742,7 @@ void AOTMappedHeapWriter::update_header_for_requested_obj(oop requested_obj, oop
   }
   // We need to retain the identity_hash, because it may have been used by some hashtables
   // in the shared heap.
-  if (src_obj->has_identity_hash() && (!(Arguments::is_valhalla_enabled() && src_obj->mark().is_inline_type()))) {
+  if (!src_obj->is_inline_type() && src_obj->has_identity_hash()) {
     intptr_t src_hash = src_obj->identity_hash();
     if (UseCompactObjectHeaders) {
       fake_oop->set_mark(fake_oop->mark().copy_set_hash(src_hash));

--- a/src/hotspot/share/cds/aotMappedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapWriter.cpp
@@ -729,7 +729,7 @@ void AOTMappedHeapWriter::update_header_for_requested_obj(oop requested_obj, oop
   narrowKlass nk = ArchiveBuilder::current()->get_requested_narrow_klass(src_klass);
   address buffered_addr = requested_addr_to_buffered_addr(cast_from_oop<address>(requested_obj));
 
-  markWord mw = Arguments::enable_preview() ? src_klass->prototype_header() : markWord::prototype();
+  markWord mw = Arguments::is_valhalla_enabled() ? src_klass->prototype_header() : markWord::prototype();
   oopDesc* fake_oop = (oopDesc*)buffered_addr;
 
   // We need to retain the identity_hash, because it may have been used by some hashtables

--- a/src/hotspot/share/cds/aotStreamedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotStreamedHeapWriter.cpp
@@ -371,7 +371,7 @@ template <typename T> void AOTStreamedHeapWriter::map_oop_field_in_buffer(oop ob
 void AOTStreamedHeapWriter::update_header_for_buffered_addr(address buffered_addr, oop src_obj,  Klass* src_klass) {
   narrowKlass nk = ArchiveBuilder::current()->get_requested_narrow_klass(src_klass);
 
-  markWord mw = Arguments::enable_preview() ? src_klass->prototype_header() : markWord::prototype();
+  markWord mw = Arguments::is_valhalla_enabled() ? src_klass->prototype_header() : markWord::prototype();
   oopDesc* fake_oop = (oopDesc*)buffered_addr;
 
   // We need to retain the identity_hash, because it may have been used by some hashtables

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -909,7 +909,7 @@ void HeapShared::copy_and_rescan_aot_inited_mirror(InstanceKlass* ik) {
 void HeapShared::copy_java_mirror(oop orig_mirror, oop scratch_m) {
   // We need to retain the identity_hash, because it may have been used by some hashtables
   // in the shared heap.
-  if (!orig_mirror->fast_no_hash_check()) {
+  if (orig_mirror->has_identity_hash()) {
     intptr_t src_hash = orig_mirror->identity_hash();
     if (UseCompactObjectHeaders) {
       narrowKlass nk = CompressedKlassPointers::encode(orig_mirror->klass());

--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -48,10 +48,10 @@ void markWord::print_on(outputStream* st) const {
   if (is_inline_type()) {
     st->print(" inline_type");
   }
-  if (has_no_hash()) {
-    st->print(" no_hash");
-  } else {
+  if (has_hash()) {
     st->print(" hash=" INTPTR_FORMAT, hash());
+  } else {
+    st->print(" no_hash");
   }
 #ifdef _LP64 // 64 bit encodings have array information
   // flat or null-free do not imply each other

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -74,8 +74,9 @@
 //    * valhalla reserved: Reserved for future use
 //
 //    Inline types cannot be locked.
-//    They have a deterministic hash based on the immutable payload and class,
-//    which may be cached in the markWord.
+//
+//    Inline types have a deterministic hash based on the immutable payload
+//    and class, which may be cached in the markWord.
 //
 //  - hash - contains the hash value: largest value is 31 bits, see
 //    os::random().  Also, 64-bit VMs require a hash value no bigger than 32

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -74,7 +74,7 @@
 //    * valhalla reserved: Reserved for future use
 //
 //    Inline types cannot be locked and have a deterministic identity hash based
-//    on the immutable payload, which may be cached in the markWord.
+//    on the immutable payload and class, which may be cached in the markWord.
 //
 //  - hash - contains the identity hash value: largest value is 31 bits, see
 //    os::random().  Also, 64-bit VMs require a hash value no bigger than 32

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -73,10 +73,11 @@
 //    * null-free arrays:  An array instance without null elements
 //    * valhalla reserved: Reserved for future use
 //
-//    Inline types cannot be locked and have a deterministic identity hash based
-//    on the immutable payload and class, which may be cached in the markWord.
+//    Inline types cannot be locked.
+//    They have a deterministic hash based on the immutable payload and class,
+//    which may be cached in the markWord.
 //
-//  - hash - contains the identity hash value: largest value is 31 bits, see
+//  - hash - contains the hash value: largest value is 31 bits, see
 //    os::random().  Also, 64-bit VMs require a hash value no bigger than 32
 //    bits because they will not properly generate a mask larger than that:
 //    see library_call.cpp

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -73,7 +73,8 @@
 //    * null-free arrays:  An array instance without null elements
 //    * valhalla reserved: Reserved for future use
 //
-//    Inline types cannot be locked and do not have an identity hash.
+//    Inline types cannot be locked and have a deterministic identity hash based
+//    on the immutable payload, which may be cached in the markWord.
 //
 //  - hash - contains the identity hash value: largest value is 31 bits, see
 //    os::random().  Also, 64-bit VMs require a hash value no bigger than 32
@@ -228,7 +229,7 @@ class markWord {
     // The reserved bits are only guaranteed to be unset if the mark word is "unlocked"
     LP64_ONLY(assert(!is_unlocked() || mask_bits(value(),  valhalla_reserved_bit_in_place) == 0,
                      "Reserved bits should not be used. _value: " PTR_FORMAT, _value));
-    return !is_unlocked() || !has_no_hash();
+    return !is_unlocked() || has_hash();
   }
 
   // WARNING: The following routines are used EXCLUSIVELY by
@@ -269,11 +270,13 @@ class markWord {
 
   // hash operations
   intptr_t hash() const {
+    precond(!is_marked());
     return mask_bits(value() >> hash_shift, hash_mask);
   }
 
-  bool has_no_hash() const {
-    return hash() == no_hash;
+  bool has_hash() const {
+    precond(!is_marked());
+    return hash() != no_hash;
   }
 
   bool is_flat_array() const {

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -115,10 +115,30 @@ void oopDesc::verify(oopDesc* oop_desc) {
   verify_on(tty, oop_desc);
 }
 
-intptr_t oopDesc::slow_identity_hash() {
-  // slow case; we have to acquire the micro lock in order to locate the header
-  Thread* current = Thread::current();
-  return ObjectSynchronizer::FastHashCode(current, this);
+intptr_t oopDesc::slow_identity_hash(markWord mark, Thread* current) {
+  precond(!mark.has_hash());
+
+  // VM should be calling bootstrap method.
+  assert(!klass()->is_inline_klass(), "slow_identity_hash should not be called for inline classes");
+
+  // Calculate the new hash
+  const intptr_t new_hash = ObjectSynchronizer::get_next_hash(current, this);  // get a new hash
+
+  while (true) {
+    const markWord old_mark = mark;
+    const markWord new_mark = mark.copy_set_hash(new_hash);
+
+    // Try to install the hash
+    mark = cas_set_mark(new_mark, old_mark, memory_order_relaxed);
+    if (old_mark == mark) {
+      // CAS succeded, return the installed hash
+      return new_hash;
+    } else if (mark.has_hash()) {
+      // Another thread installed a hash, return the installed hash
+      return mark.hash();
+    }
+    // CAS failed, retry
+  }
 }
 
 // used only for asserts and guarantees

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -118,11 +118,10 @@ void oopDesc::verify(oopDesc* oop_desc) {
 intptr_t oopDesc::slow_identity_hash(markWord mark, Thread* current) {
   precond(!mark.has_hash());
 
-  // VM should be calling bootstrap method.
-  assert(!klass()->is_inline_klass(), "slow_identity_hash should not be called for inline classes");
+  assert(!is_inline(), "slow_identity_hash should not be called for value objects");
 
   // Calculate the new hash
-  const intptr_t new_hash = ObjectSynchronizer::get_next_hash(current, this);  // get a new hash
+  const intptr_t new_hash = ObjectSynchronizer::get_next_hash(current, this);
 
   while (true) {
     const markWord old_mark = mark;

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -115,14 +115,15 @@ void oopDesc::verify(oopDesc* oop_desc) {
   verify_on(tty, oop_desc);
 }
 
-intptr_t oopDesc::slow_identity_hash(markWord mark, Thread* current) {
-  precond(!mark.has_hash());
+intptr_t oopDesc::slow_identity_hash(markWord current_mark, Thread* current) {
+  precond(!current_mark.has_hash());
 
   assert(!is_inline(), "slow_identity_hash should not be called for value objects");
 
   // Calculate the new hash
   const intptr_t new_hash = ObjectSynchronizer::get_next_hash(current, this);
 
+  markWord mark = current_mark;
   while (true) {
     const markWord old_mark = mark;
     const markWord new_mark = mark.copy_set_hash(new_hash);

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -316,10 +316,13 @@ class oopDesc {
   inline static bool is_instanceof_or_null(oop obj, Klass* klass);
 
   // identity hash; returns the identity hash key (computes it if necessary)
-  inline intptr_t identity_hash();
-  intptr_t slow_identity_hash();
-  inline bool fast_no_hash_check();
+  inline intptr_t identity_hash(Thread* current = nullptr);
+  inline bool has_identity_hash();
 
+private:
+  intptr_t slow_identity_hash(markWord mark, Thread* current);
+
+public:
   // Checks if the mark word needs to be preserved
   inline bool mark_must_be_preserved() const;
   inline bool mark_must_be_preserved(markWord m) const;

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -320,7 +320,7 @@ class oopDesc {
   inline bool has_identity_hash();
 
 private:
-  intptr_t slow_identity_hash(markWord mark, Thread* current);
+  intptr_t slow_identity_hash(markWord current_mark, Thread* current);
 
 public:
   // Checks if the mark word needs to be preserved

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -404,25 +404,21 @@ bool oopDesc::is_instanceof_or_null(oop obj, Klass* klass) {
   return obj == nullptr || obj->klass()->is_subtype_of(klass);
 }
 
-intptr_t oopDesc::identity_hash() {
-  // Fast case; if the object is unlocked and the hash value is set, no locking is needed
+intptr_t oopDesc::identity_hash(Thread* current) {
   // Note: The mark must be read into local variable to avoid concurrent updates.
   markWord mrk = mark();
-  if (mrk.is_unlocked() && !mrk.has_no_hash()) {
+  assert(!mrk.is_marked(), "should never be marked");
+
+  if (mrk.has_hash()) {
     return mrk.hash();
-  } else if (mrk.is_marked()) {
-    return mrk.hash();
-  } else {
-    return slow_identity_hash();
   }
+
+  return slow_identity_hash(mrk, current == nullptr ? Thread::current() : current);
 }
 
-// This checks fast simple case of whether the oop has_no_hash,
-// to optimize JVMTI table lookup.
-bool oopDesc::fast_no_hash_check() {
+bool oopDesc::has_identity_hash() {
   markWord mrk = mark_acquire();
-  assert(!mrk.is_marked(), "should never be marked");
-  return mrk.is_unlocked() && mrk.has_no_hash();
+  return mrk.has_hash();
 }
 
 bool oopDesc::mark_must_be_preserved() const {

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -825,7 +825,7 @@ JVM_ENTRY(jint, JVM_IHashCode(JNIEnv* env, jobject handle))
       current_mark = ho->mark();
       new_mark = current_mark.copy_set_hash(identity_hash);
       old_mark = ho->cas_set_mark(new_mark, current_mark);
-      assert(old_mark.has_no_hash() || old_mark.hash() == new_mark.hash(),
+      assert(!old_mark.has_hash() || old_mark.hash() == new_mark.hash(),
             "CAS identity hash invariant violated, expected=" INTPTR_FORMAT " actual=" INTPTR_FORMAT,
             new_mark.hash(),
             old_mark.hash());
@@ -833,7 +833,7 @@ JVM_ENTRY(jint, JVM_IHashCode(JNIEnv* env, jobject handle))
 
     return checked_cast<jint>(new_mark.hash());
   } else {
-    return checked_cast<jint>(ObjectSynchronizer::FastHashCode(THREAD, obj));
+    return checked_cast<jint>(obj->identity_hash(THREAD));
   }
 JVM_END
 

--- a/src/hotspot/share/prims/jvmtiTagMapTable.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.cpp
@@ -244,11 +244,9 @@ jlong* JvmtiTagMapTable::lookup(const JvmtiHeapwalkObject& obj) const {
     return nullptr;
   }
 
-  if (!obj.is_value()) {
-    if (obj.obj()->fast_no_hash_check()) {
-      // Objects in the table all have a hashcode, unless inlined types.
-      return nullptr;
-    }
+  if (!obj.is_value() && !obj.obj()->has_identity_hash()) {
+    // Objects in the table all have a hashcode, unless inlined types.
+    return nullptr;
   }
   JvmtiTagMapKey entry(&obj);
   jlong* found = _table.get(entry);
@@ -265,7 +263,7 @@ void JvmtiTagMapTable::add(const JvmtiHeapwalkObject& obj, jlong tag) {
   assert(!obj.is_flat(), "Cannot add flat object to JvmtiTagMapTable");
   JvmtiTagMapKey new_entry(&obj);
   bool is_added;
-  if (!obj.is_value() && obj.obj()->fast_no_hash_check()) {
+  if (!obj.is_value() && !obj.obj()->has_identity_hash()) {
     // Can't be in the table so add it fast.
     is_added = _table.put_when_absent(new_entry, tag);
   } else {

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -635,7 +635,7 @@ static SharedGlobals GVars;
 //   There are simple ways to "diffuse" the middle address bits over the
 //   generated hashCode values:
 
-static intptr_t get_next_hash(Thread* current, oop obj) {
+intptr_t ObjectSynchronizer::get_next_hash(Thread* current, oop obj) {
   intptr_t value = 0;
   if (hashCode == 0) {
     // This form uses global Park-Miller RNG.
@@ -673,30 +673,6 @@ static intptr_t get_next_hash(Thread* current, oop obj) {
   if (value == 0) value = 0xBAD;
   assert(value != markWord::no_hash, "invariant");
   return value;
-}
-
-intptr_t ObjectSynchronizer::FastHashCode(Thread* current, oop obj) {
-  // VM should be calling bootstrap method.
-  assert(!obj->klass()->is_inline_klass(), "FastHashCode should not be called for inline classes");
-
-  while (true) {
-    markWord temp, test;
-    intptr_t hash;
-    markWord mark = obj->mark_acquire();
-    // The hash is located in the object header.
-    hash = mark.hash();
-    if (hash != 0) {                     // if it has a hash, just return it
-      return hash;
-    }
-    hash = get_next_hash(current, obj);  // get a new hash
-    temp = mark.copy_set_hash(hash);     // merge the hash into header
-    // try to install the hash
-    test = obj->cas_set_mark(temp, mark);
-    if (test == mark) {                  // if the hash was installed, return it
-      return hash;
-    }
-    // CAS failed, retry
-  }
 }
 
 bool ObjectSynchronizer::current_thread_holds_lock(JavaThread* current,
@@ -1506,7 +1482,7 @@ void ObjectSynchronizer::remove_monitor(ObjectMonitor* monitor, oop obj) {
 
 void ObjectSynchronizer::deflate_mark_word(oop obj) {
   markWord mark = obj->mark_acquire();
-  assert(!mark.has_no_hash(), "obj with inflated monitor must have had a hash");
+  assert(mark.has_hash(), "obj with inflated monitor must have had a hash");
 
   while (mark.has_monitor()) {
     const markWord new_mark = mark.clear_lock_bits().set_unlocked();
@@ -1887,7 +1863,7 @@ ObjectMonitor* ObjectSynchronizer::inflate_fast_locked_object(oop object, Object
   ObjectMonitor* monitor;
 
   // Inflating requires a hash code
-  ObjectSynchronizer::FastHashCode(current, object);
+  (void)object->identity_hash(current);
 
   markWord mark = object->mark_acquire();
   assert(!mark.is_unlocked(), "Cannot be unlocked");
@@ -1952,7 +1928,7 @@ ObjectMonitor* ObjectSynchronizer::inflate_and_enter(oop object, BasicLock* lock
   // Get or create the monitor
   if (monitor == nullptr) {
     // Lightweight monitors require that hash codes are installed first
-    ObjectSynchronizer::FastHashCode(locking_thread, object);
+    (void)object->identity_hash(locking_thread);
     monitor = get_or_insert_monitor(object, current, cause);
   }
 

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -127,9 +127,7 @@ public:
 
   static ObjectMonitor* read_monitor(oop obj);
 
-  // Returns the identity hash value for an oop
-  // NOTE: It may cause monitor inflation
-  static intptr_t FastHashCode(Thread* current, oop obj);
+  static intptr_t get_next_hash(Thread* current, oop obj);
 
   // java.lang.Thread support
   static bool current_thread_holds_lock(JavaThread* current, Handle h_obj);

--- a/src/hotspot/share/services/finalizerService.cpp
+++ b/src/hotspot/share/services/finalizerService.cpp
@@ -299,7 +299,7 @@ static FinalizerEntry* get_entry(oop finalizee, Thread* thread) {
 
 static void log_registered(oop finalizee, Thread* thread) {
   ResourceMark rm(thread);
-  const intptr_t identity_hash = ObjectSynchronizer::FastHashCode(thread, finalizee);
+  const intptr_t identity_hash = finalizee->identity_hash(thread);
   log_info(finalizer)("Registered object (" INTPTR_FORMAT ") of class %s as finalizable", identity_hash, finalizee->klass()->external_name());
 }
 
@@ -314,7 +314,7 @@ void FinalizerService::on_register(oop finalizee, Thread* thread) {
 
 static void log_completed(oop finalizee, Thread* thread) {
   ResourceMark rm(thread);
-  const intptr_t identity_hash = ObjectSynchronizer::FastHashCode(thread, finalizee);
+  const intptr_t identity_hash = finalizee->identity_hash(thread);
   log_info(finalizer)("Finalizer was run for object (" INTPTR_FORMAT ") of class %s", identity_hash, finalizee->klass()->external_name());
 }
 

--- a/test/hotspot/gtest/oops/test_markWord.cpp
+++ b/test/hotspot/gtest/oops/test_markWord.cpp
@@ -123,10 +123,10 @@ static void assert_unlocked_state(markWord mark) {
 
 static void assert_copy_set_hash(markWord mark) {
   const intptr_t hash = 4711;
-  EXPECT_TRUE(mark.has_no_hash());
+  EXPECT_FALSE(mark.has_hash());
   markWord copy = mark.copy_set_hash(hash);
   EXPECT_EQ(hash, copy.hash());
-  EXPECT_FALSE(copy.has_no_hash());
+  EXPECT_TRUE(copy.has_hash());
 }
 
 static void assert_type(markWord mark) {
@@ -141,7 +141,7 @@ TEST_VM(markWord, prototype) {
 
   assert_type(mark);
 
-  EXPECT_TRUE(mark.has_no_hash());
+  EXPECT_FALSE(mark.has_hash());
   EXPECT_FALSE(mark.is_marked());
 
   assert_copy_set_hash(mark);
@@ -162,7 +162,7 @@ TEST_VM(markWord, inline_type_prototype) {
 
   assert_inline_type(mark);
 
-  EXPECT_TRUE(mark.has_no_hash());
+  EXPECT_FALSE(mark.has_hash());
   EXPECT_FALSE(mark.is_marked());
 }
 
@@ -181,7 +181,7 @@ TEST_VM(markWord, null_free_flat_array_prototype) {
   assert_flat_array_type(mark);
   EXPECT_TRUE(mark.is_null_free_array());
 
-  EXPECT_TRUE(mark.has_no_hash());
+  EXPECT_FALSE(mark.has_hash());
   EXPECT_FALSE(mark.is_marked());
 
   assert_copy_set_hash(mark);
@@ -199,7 +199,7 @@ TEST_VM(markWord, nullable_flat_array_prototype) {
   assert_flat_array_type(mark);
   EXPECT_FALSE(mark.is_null_free_array());
 
-  EXPECT_TRUE(mark.has_no_hash());
+  EXPECT_FALSE(mark.has_hash());
   EXPECT_FALSE(mark.is_marked());
 
   assert_copy_set_hash(mark);
@@ -222,7 +222,7 @@ TEST_VM(markWord, null_free_array_prototype) {
 
   assert_null_free_array_type(mark);
 
-  EXPECT_TRUE(mark.has_no_hash());
+  EXPECT_FALSE(mark.has_hash());
   EXPECT_FALSE(mark.is_marked());
 
   assert_copy_set_hash(mark);


### PR DESCRIPTION
Historically we have had displaced markWord's because locking (stack locks, and inflated monitors).

After the `UseObjectMonitorTable` removal there are no more need to protect against displaced markWords.

I suggest we simplify this logic and clean up the interface w.r.t. `identity_hash`.

Changes the `fast_no_hash_check` and `has_no_hash` into `has_identity_hash` and `has_hash` checks. 
As before it is invalid to read the hash on marked objects, added asserts to ensure this.
Rewrote `oopDesc::slow_identity_hash` to not regenerate a new hash every time it transiently fails to install the hash in the markWord due to some other header change.

There are a few places which right now calls `identity_hash` from develop logging / introspection printing `InstanceStackChunkKlass::print_chunk` and `Continuation::print`. It is a bit unfortunate that we have these side-effects in debug VMs. But think we should handle these in a future RFE.

Testing (in progress):
* Tier 1-3 Oracle supported platforms
* GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391174](https://bugs.openjdk.org/browse/JDK-8391174): Simplify `identity_hash` after UseObjectMonitorTable removal (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32535/head:pull/32535` \
`$ git checkout pull/32535`

Update a local copy of the PR: \
`$ git checkout pull/32535` \
`$ git pull https://git.openjdk.org/jdk.git pull/32535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32535`

View PR using the GUI difftool: \
`$ git pr show -t 32535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32535.diff">https://git.openjdk.org/jdk/pull/32535.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32535#issuecomment-5426834779)
</details>
