### PR TITLE
8391178: TypeAryPtr::narrow_size_type returns incorrect type for flat arrays

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4656,8 +4656,7 @@ Node* GraphKit::new_array(Node* klass_node,     // array klass (maybe variable)
 
   Node* valid_length_test = _gvn.intcon(1);
   if (ary_type->isa_aryptr()) {
-    BasicType bt = ary_type->isa_aryptr()->elem()->array_element_basic_type();
-    jint max = TypeAryPtr::max_array_length(bt);
+    jint max = ary_type->is_aryptr()->max_array_length();
     Node* valid_length_cmp  = _gvn.transform(new CmpUNode(length, intcon(max)));
     valid_length_test = _gvn.transform(new BoolNode(valid_length_cmp, BoolTest::le));
   }

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4697,18 +4697,26 @@ const TypeAryPtr* TypeAryPtr::cast_to_instance_id(int instance_id) const {
 
 //-----------------------------max_array_length-------------------------------
 // A wrapper around arrayOopDesc::max_array_length(etype) with some input normalization.
-jint TypeAryPtr::max_array_length(BasicType etype) {
-  if (!is_java_primitive(etype) && !::is_reference_type(etype)) {
-    if (etype == T_NARROWOOP) {
-      etype = T_OBJECT;
-    } else if (etype == T_ILLEGAL) { // bottom[]
-      etype = T_BYTE; // will produce conservatively high value
-    } else {
-      fatal("not an element type: %s", type2name(etype));
+jint TypeAryPtr::max_array_length() const {
+  if (is_not_flat()) {
+    BasicType etype = elem()->array_element_basic_type();
+    if (!is_java_primitive(etype) && !::is_reference_type(etype)) {
+      if (etype == T_NARROWOOP) {
+        etype = T_OBJECT;
+      } else if (etype == T_ILLEGAL) { // bottom[]
+        etype = T_BYTE; // will produce conservatively high value
+      } else {
+        fatal("not an element type: %s", type2name(etype));
+      }
     }
+    return arrayOopDesc::max_array_length(etype);
+  } else {
+    // A flat array's maximum length depends on its layout. If the layout
+    // is not known, max_jint is the only conservative upper bound.
+    return is_flat() && klass_is_exact() ? max_flat_elements() : max_jint;
   }
-  return arrayOopDesc::max_array_length(etype);
 }
+
 
 //-----------------------------narrow_size_type-------------------------------
 // Narrow the given size type to the index range for the given array base type.
@@ -4717,7 +4725,7 @@ const TypeInt* TypeAryPtr::narrow_size_type(const TypeInt* size) const {
   jint hi = size->_hi;
   jint lo = size->_lo;
   jint min_lo = 0;
-  jint max_hi = max_array_length(elem()->array_element_basic_type());
+  jint max_hi = max_array_length();
   //if (index_not_size)  --max_hi;     // type of a valid array index, FTR
   bool chg = false;
   if (lo < min_lo) {

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4717,7 +4717,6 @@ jint TypeAryPtr::max_array_length() const {
   }
 }
 
-
 //-----------------------------narrow_size_type-------------------------------
 // Narrow the given size type to the index range for the given array base type.
 // Return null if the resulting int type becomes empty.

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1818,7 +1818,7 @@ public:
 
   const TypeAryPtr* cast_to_autobox_cache() const;
 
-  static jint max_array_length(BasicType etype);
+  jint max_array_length() const;
 
   int flat_offset() const;
   const Offset field_offset() const { return _field_offset; }

--- a/test/hotspot/jtreg/resourcehogs/compiler/arrays/TestFlatArrayMaximumLength.java
+++ b/test/hotspot/jtreg/resourcehogs/compiler/arrays/TestFlatArrayMaximumLength.java
@@ -28,8 +28,8 @@ package compiler.arrays;
  * @bug 8391178
  * @summary Test correctness of C2's type for the length of large flat arrays
  * @enablePreview
- * @requires vm.compiler2.enabled & os.maxMemory >= 4G
- * @run main/othervm -Xmx3g -Xcomp -XX:-TieredCompilation
+ * @requires vm.compiler2.enabled & os.maxMemory > 4G
+ * @run main/othervm -Xmx4g -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+UseArrayFlattening -XX:+UseNullableAtomicValueFlattening
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
  *                   ${test.main.class}

--- a/test/hotspot/jtreg/resourcehogs/compiler/arrays/TestFlatArrayMaximumLength.java
+++ b/test/hotspot/jtreg/resourcehogs/compiler/arrays/TestFlatArrayMaximumLength.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arrays;
+
+/**
+ * @test
+ * @bug 8391178
+ * @summary Test correctness of C2's type for the length of large flat arrays
+ * @enablePreview
+ * @requires vm.compiler2.enabled & os.maxMemory >= 4G
+ * @run main/othervm -Xmx3g -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+UseArrayFlattening -XX:+UseNullableAtomicValueFlattening
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   ${test.main.class}
+ */
+public class TestFlatArrayMaximumLength {
+
+    static value class EmptyValue { }
+    static final int[] smallArray = new int[2];
+    static EmptyValue[] largeArray;
+
+    static int test1() {
+        // C2 must preserve the normal return from this legal allocation
+        EmptyValue[] array = new EmptyValue[Integer.MAX_VALUE];
+        largeArray = array;
+        return array.length;
+    }
+
+    static void test2(int length) {
+        // The type of array.length is set to [0..Integer.MAX_VALUE-2]
+        // while it should be [0..Integer.MAX_VALUE] for a flat array.
+        EmptyValue[] array = new EmptyValue[length];
+        // The range of index is therefore [0..1] but should be [0..2].
+        int index = (array.length + 2) >>> 30;
+        // The range of index is still [0..1] but should be [0..4] now.
+        index = index * index;
+        // The range check will be removed here because [0..1] is always
+        // in range but that's incorrect because [0..4] is not in range.
+        // With length == Integer.MAX_VALUE, index is 4 and we fail to
+        // throw an exception and write beyond the end of the array.
+        smallArray[index] = 42;
+    }
+
+    public static void main(String[] args) {
+        // Make sure that class is loaded
+        EmptyValue tmp = new EmptyValue();
+
+        if (test1() != Integer.MAX_VALUE) {
+            throw new RuntimeException("Incorrect array length");
+        }
+        largeArray = null;
+        System.gc();
+
+        for (int i = 0; i < 30_000; i++) {
+            test2(1);
+        }
+
+        try {
+            test2(Integer.MAX_VALUE);
+            throw new RuntimeException("No IndexOutOfBoundsException thrown!");
+        } catch (IndexOutOfBoundsException expected) {
+            // Expected
+        }
+    }
+}
+


### PR DESCRIPTION
`TypeAryPtr::narrow_size_type()` derives the maximum length of an array from its element basic type. For a flat array it returns the maximum length of a reference array (`max_jint - 2` on my machine with default arguments). The runtime instead uses the layout specific `FlatArrayKlass::max_elements()` and `EmptyValue[]` can therefore contain up to `Integer.MAX_VALUE` elements, i.e. more than expected.

New `TestFlatArrayMaximumLength::test2` demonstrates that this is problematic because a too narrow type on the array length can lead to array bounds checks being incorrectly eliminated and thus enabling out of bounds accesses.

The fix is to check if the array is known flat and then use `FlatArrayKlass::max_elements()` or if it might be flat and then fall back to the conservative `max_jint` upper bound on the array length.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391178](https://bugs.openjdk.org/browse/JDK-8391178): TypeAryPtr::narrow_size_type returns incorrect type for flat arrays (**Bug** - P2)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32537/head:pull/32537` \
`$ git checkout pull/32537`

Update a local copy of the PR: \
`$ git checkout pull/32537` \
`$ git pull https://git.openjdk.org/jdk.git pull/32537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32537`

View PR using the GUI difftool: \
`$ git pr show -t 32537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32537.diff">https://git.openjdk.org/jdk/pull/32537.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32537#issuecomment-5426019804)
</details>
