### PR TITLE
8390825: C1: -XX:-GenerateArrayStoreCheck is unsafe and should be removed

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1964,7 +1964,7 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
     }
   }
 
-  if (GenerateArrayStoreCheck && needs_store_check) {
+  if (needs_store_check) {
     CodeEmitInfo* store_check_info = new CodeEmitInfo(range_check_info);
     array_store_check(value.result(), array.result(), store_check_info, x->profiled_method(), x->profiled_bci());
   }

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,9 +237,6 @@
                                                                             \
   develop(bool, UseSlowPath, false,                                         \
           "For debugging: test slow cases by always using them")            \
-                                                                            \
-  develop(bool, GenerateArrayStoreCheck, true,                              \
-          "Generates code for array store checks")                          \
                                                                             \
   develop(bool, PrintBailouts, false,                                       \
           "Print bailout and its reason")                                   \


### PR DESCRIPTION
Please review this change, thanks.

**Description:**

GenerateArraayStoreCheck is a develop flag that allows C1 to omit required runtime array store checks.  Since disabling this check is unsafe, remove the flag for cleanup.  The default behavior is unchanged.

**Test:**
1. GHA
2. Linux Fedora 44 x86_64 with no regression:
- test/hotspot/jtreg/compiler/c1




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390825](https://bugs.openjdk.org/browse/JDK-8390825): C1: -XX:-GenerateArrayStoreCheck is unsafe and should be removed (**Bug** - P4)


### Reviewers
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32538/head:pull/32538` \
`$ git checkout pull/32538`

Update a local copy of the PR: \
`$ git checkout pull/32538` \
`$ git pull https://git.openjdk.org/jdk.git pull/32538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32538`

View PR using the GUI difftool: \
`$ git pr show -t 32538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32538.diff">https://git.openjdk.org/jdk/pull/32538.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32538#issuecomment-5426917934)
</details>
