### PR TITLE
8390064: Test sun/net/www/http/HttpClient/IsAvailable.java fails intermittently with AssertionFailedError: Connection over closed socket should not be available ==> expected: <false> but was: <true>

### DIFF
--- a/test/jdk/sun/net/www/http/HttpClient/IsAvailable.java
+++ b/test/jdk/sun/net/www/http/HttpClient/IsAvailable.java
@@ -118,11 +118,13 @@ class IsAvailable {
             // Verify that closing the socket removes the availability
             LOGGER.info("Closing the socket...");
             infra.clientSocket.close();
-            // Closing the peer socket does not guarantee that EOF is immediately observable
-            // on the client side. This test sends no application data, so observing EOF does
-            // not consume data needed by the assertion.
-            assertEquals(-1, infra.readFromHttpClientSocket(),
-                    "Expected EOF after closing the peer socket");
+            // Closing the server socket may not immediately be observable by
+            // the client. Read from the client's _internal_ socket to ensure
+            // that EOF, which is necessary for the `HttpClient::available`
+            // verification, has arrived.
+            assertEquals(
+                    -1, infra.readFromHttpClientSocket(),
+                    "Expected EOF after closing the server socket");
             LOGGER.info("Checking the connection (#2)...");
             assertFalse(infra.available(), "Connection over closed socket should not be available");
             assertEquals(readTimeout, infra.httpClient.getReadTimeout(), "Read-timeout should be restored");
@@ -148,10 +150,13 @@ class IsAvailable {
                 clientSocketOutputStream.write("unexpected data".getBytes(US_ASCII));
             }
 
-            // The raw read consumes one byte; the payload must leave data for the
-            // `HttpClient::available` probe below.
-            assertTrue(infra.readFromHttpClientSocket() >= 0,
-                    "Expected unexpected data on the client socket");
+            // Writing to the server socket may not immediately be observable
+            // by the client. Read from the client's _internal_ socket to ensure
+            // that the data, which is necessary for the `HttpClient::available`
+            // verification, has arrived.
+            assertTrue(
+                    infra.readFromHttpClientSocket() >= 0,
+                    "Unexpected data should have arrived to the client socket");
 
             // Verify that the presence of stale data on the socket removes the availability
             LOGGER.info("Checking the connection (#2)...");

--- a/test/jdk/sun/net/www/http/HttpClient/IsAvailable.java
+++ b/test/jdk/sun/net/www/http/HttpClient/IsAvailable.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import sun.net.www.http.HttpClient;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
@@ -117,6 +118,11 @@ class IsAvailable {
             // Verify that closing the socket removes the availability
             LOGGER.info("Closing the socket...");
             infra.clientSocket.close();
+            // Closing the peer socket does not guarantee that EOF is immediately observable
+            // on the client side. This test sends no application data, so observing EOF does
+            // not consume data needed by the assertion.
+            assertEquals(-1, infra.readFromHttpClientSocket(),
+                    "Expected EOF after closing the peer socket");
             LOGGER.info("Checking the connection (#2)...");
             assertFalse(infra.available(), "Connection over closed socket should not be available");
             assertEquals(readTimeout, infra.httpClient.getReadTimeout(), "Read-timeout should be restored");
@@ -142,10 +148,10 @@ class IsAvailable {
                 clientSocketOutputStream.write("unexpected data".getBytes(US_ASCII));
             }
 
-            // Writing to the socket on the server side may not make the data
-            // immediately visible to the client side. Make sure we wait long
-            // enough for the data to get delivered.
-            Thread.sleep(adjustTimeout(500));
+            // The raw read consumes one byte; the payload must leave data for the
+            // `HttpClient::available` probe below.
+            assertTrue(infra.readFromHttpClientSocket() >= 0,
+                    "Expected unexpected data on the client socket");
 
             // Verify that the presence of stale data on the socket removes the availability
             LOGGER.info("Checking the connection (#2)...");
@@ -161,6 +167,8 @@ class IsAvailable {
 
         private static final Predicate<HttpClient> AVAILABLE_ACCESSOR = findAvailableAccessor();
 
+        private static final Function<HttpClient, Socket> SERVER_SOCKET_ACCESSOR = findServerSocketAccessor();
+
         private static Predicate<HttpClient> findAvailableAccessor() {
             final MethodHandle availableMH;
             try {
@@ -173,6 +181,24 @@ class IsAvailable {
             return httpClient -> {
                 try {
                     return (boolean) availableMH.invoke(httpClient);
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            };
+        }
+
+        private static Function<HttpClient, Socket> findServerSocketAccessor() {
+            final MethodHandle serverSocketMH;
+            try {
+                serverSocketMH = MethodHandles
+                        .privateLookupIn(HttpClient.class, MethodHandles.lookup())
+                        .findGetter(HttpClient.class, "serverSocket", Socket.class);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+            return httpClient -> {
+                try {
+                    return (Socket) serverSocketMH.invoke(httpClient);
                 } catch (Throwable e) {
                     throw new RuntimeException(e);
                 }
@@ -208,6 +234,17 @@ class IsAvailable {
 
         private boolean available() {
             return AVAILABLE_ACCESSOR.test(httpClient);
+        }
+
+        private int readFromHttpClientSocket() throws IOException {
+            Socket socket = SERVER_SOCKET_ACCESSOR.apply(httpClient);
+            int timeout = socket.getSoTimeout();
+            try {
+                socket.setSoTimeout((int) adjustTimeout(5000));
+                return socket.getInputStream().read();
+            } finally {
+                socket.setSoTimeout(timeout);
+            }
         }
 
         @Override


### PR DESCRIPTION
Replaces the fixed delay in `IsAvailable.java` with reads from the socket used by `HttpClient::available`.
The tests wait for EOF or data on that socket before invoking the existing `HttpClient::available` assertion.

No production code is changed.

Testing:
- `make test TEST='test/jdk/sun/net/www/http/HttpClient/IsAvailable.java' JTREG='REPEAT_COUNT=200;VERBOSE=summary;RETAIN=fail'` (200/200 passed)
- `make test TEST='test/jdk/sun/net/www/http/HttpClient/IsAvailable.java' JTREG='VERBOSE=summary;RETAIN=fail;VM_OPTIONS=-Dsun.net.client.defaultReadTimeout=200'` (passed)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390064](https://bugs.openjdk.org/browse/JDK-8390064): Test sun/net/www/http/HttpClient/IsAvailable.java fails intermittently with AssertionFailedError: Connection over closed socket should not be available ==&gt; expected: &lt;false&gt; but was: &lt;true&gt; (**Bug** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32539/head:pull/32539` \
`$ git checkout pull/32539`

Update a local copy of the PR: \
`$ git checkout pull/32539` \
`$ git pull https://git.openjdk.org/jdk.git pull/32539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32539`

View PR using the GUI difftool: \
`$ git pr show -t 32539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32539.diff">https://git.openjdk.org/jdk/pull/32539.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32539#issuecomment-5426466415)
</details>
