### PR TITLE
8390354: Inconsistent stackmap frames VerifyError after negated nested pattern match

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -2323,6 +2323,8 @@ public class Code {
         int prevNextReg = nextreg;
         nextreg = first;
         for (int i = nextreg; i < prevNextReg; i++) endScope(i);
+        //make sure variables for which we ended the scopes here are
+        //not defined in the state of the pendingJumps:
         undefineVariablesInChain(pendingJumps, first);
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -2323,6 +2323,14 @@ public class Code {
         int prevNextReg = nextreg;
         nextreg = first;
         for (int i = nextreg; i < prevNextReg; i++) endScope(i);
+        undefineVariablesInChain(pendingJumps, first);
+    }
+
+    public void undefineVariablesInChain(Chain toClear, int limit) {
+        while (toClear != null) {
+            toClear.state.defined.excludeFrom(limit);
+            toClear = toClear.next;
+        }
     }
 
 /* ************************************************************************

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -773,12 +773,13 @@ public class Gen extends JCTree.Visitor {
                 code.setLetExprStackPos(prevLetExprStart);
             }
             CondItem result = genCond(tree.expr, markBranches);
+            Assert.checkNull(code.pendingJumps);
             code.endScopes(limit);
             //make sure variables defined in the let expression are not included
             //in the defined variables for jumps that go outside of this let
             //expression:
-            undefineVariablesInChain(result.falseJumps, limit);
-            undefineVariablesInChain(result.trueJumps, limit);
+            code.undefineVariablesInChain(result.falseJumps, limit);
+            code.undefineVariablesInChain(result.trueJumps, limit);
             return result;
         } else {
             CondItem result = genExpr(_tree, syms.booleanType).mkCond();
@@ -786,13 +787,6 @@ public class Gen extends JCTree.Visitor {
             return result;
         }
     }
-        //where:
-        private void undefineVariablesInChain(Chain toClear, int limit) {
-            while (toClear != null) {
-                toClear.state.defined.excludeFrom(limit);
-                toClear = toClear.next;
-            }
-        }
 
     public Code getCode() {
         return code;

--- a/test/langtools/tools/javac/stackmap/StackMapCornerCases.java
+++ b/test/langtools/tools/javac/stackmap/StackMapCornerCases.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390354
+ * @summary Verify correct StackMapTable is created in corner case scenarios
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit StackMapCornerCases
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import toolbox.JavaTask;
+import toolbox.JavacTask;
+import toolbox.Task.OutputKind;
+import toolbox.ToolBox;
+
+public class StackMapCornerCases {
+    Path base;
+    ToolBox tb = new ToolBox();
+
+    @Test
+    void testWrongDefinedInBlockPendingOutgoingBranch() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         public class Test {
+                             private int switchValue;
+                             private void handle(Object tuple) {
+                                 {
+                                     Test t;
+                                     if (!(tuple instanceof Test && (t = ((Test) tuple)) != null)) {
+                                         return;
+                                     }
+                                 }
+
+                                 switch (switchValue) {
+                                     case 0:
+                                         int msg = 0;
+                                         System.out.println(msg);
+                                         break;
+                                     default:
+                                         System.out.println("default");
+                                         break;
+                                 }
+                             }
+                             void main() {
+                                 switchValue = 0;
+                                 handle(this);
+                                 switchValue = 1;
+                                 handle(this);
+                             }
+                         }
+                         """)
+                .run()
+                .writeAll();
+
+        List<String> out =
+            new JavaTask(tb)
+                .classpath(classes.toString())
+                .className("Test")
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.STDOUT);
+
+        Assertions.assertEquals(List.of("0", "default"),
+                                out);
+    }
+
+    @Test
+    void testWrongDefinedAfterPatternMatching() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         public class Test {
+                             record Box(Object object) {}
+                             record Tuple(Object a, Object b) {}
+
+                             class BrokenClass {
+
+                                 public static void handle(Object tuple) {
+                                     if (!(tuple instanceof Tuple(Box(var foo), Box(var bar)))) {
+                                         System.out.println("-1");
+                                         return;
+                                     }
+
+                                     switch ("string") {
+                                         case String msg when msg.isBlank() -> {
+                                             System.out.println("0");
+                                         }
+                                         default -> {
+                                             System.out.println("default");
+                                         }
+                                     }
+                                 }
+                             }
+
+
+                             void main() {
+                                 BrokenClass.handle(new Tuple("foo", "bar"));
+                                 BrokenClass.handle(new Tuple(new Box("foo"), new Box("bar")));
+                             }
+                         }
+                         """)
+                .run()
+                .writeAll();
+
+        List<String> out =
+            new JavaTask(tb)
+                .classpath(classes.toString())
+                .className("Test")
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.STDOUT);
+
+        Assertions.assertEquals(List.of("-1", "default"),
+                                out);
+    }
+
+    @Test
+    void testCanReuseVariablesInSwitch() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         public class Test {
+                             private int switchValue;
+                             private void handle(Object tuple) {
+                                 {
+                                     Test t;
+                                     if (!(tuple instanceof Test && (t = ((Test) tuple)) != null)) {
+                                         return;
+                                     }
+                                 }
+
+                                 switch (switchValue) {
+                                     case 0:
+                                         int msg = 0;
+                                         System.out.println(msg);
+                                         break;
+                                     default:
+                                         msg = 1;
+                                         System.out.println(msg);
+                                         break;
+                                 }
+                             }
+                             void main() {
+                                 switchValue = 0;
+                                 handle(this);
+                                 switchValue = 1;
+                                 handle(this);
+                             }
+                         }
+                         """)
+                .run()
+                .writeAll();
+
+        List<String> out =
+            new JavaTask(tb)
+                .classpath(classes.toString())
+                .className("Test")
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.STDOUT);
+
+        Assertions.assertEquals(List.of("0", "1"),
+                                out);
+    }
+
+    @Test
+    void testCanReuseVariablesInSwitchExtraVariable() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString())
+                .sources("""
+                         public class Test {
+                             private int switchValue;
+                             private void handle(Object tuple) {
+                                 {
+                                     Test t;
+                                     if (!(tuple instanceof Test && (t = ((Test) tuple)) != null)) {
+                                         return;
+                                     }
+                                 }
+
+                                 switch (switchValue) {
+                                     case 0:
+                                         int msg = 0;
+                                         System.out.println(msg);
+                                         break;
+                                     default:
+                                         msg = 1;
+                                         String value = "default";
+                                         System.out.println(msg);
+                                         System.out.println(value);
+                                         break;
+                                 }
+                             }
+                             void main() {
+                                 switchValue = 0;
+                                 handle(this);
+                                 switchValue = 1;
+                                 handle(this);
+                             }
+                         }
+                         """)
+                .run()
+                .writeAll();
+
+        List<String> out =
+            new JavaTask(tb)
+                .classpath(classes.toString())
+                .className("Test")
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.STDOUT);
+
+        Assertions.assertEquals(List.of("0", "1", "default"),
+                                out);
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}


### PR DESCRIPTION
Consider this code:
```
public class JDK_8390354 {
    public static void handle(Object tuple) {
        {
            JDK_8390354 t;
            if (!(tuple instanceof JDK_8390354 && (t = ((JDK_8390354) tuple)) != null)) {
                return;
            }
        }

        switch (0) {
            case 0:
                int msg = 0;
                System.err.println(msg);
                break;
            default:
                System.err.println("asdf");
                break;
        }
    }
...
}
```

There is a jump for the if's condition, when the condition is false. This is implemented in javac using a `Chain`, which is basically a pending jump. The chain also holds the bitmap of defined variables, so that these can be merged in at the jump target.

When the block enclosing the if ends, the scope of the `t` variable ends, but the else jump for the if is still recorded in `Code.pendingJumps`, and is still keeping the `t` variable as defined.

Inside the `switch`, the "register" number originally used for `t` is reused for `msg`, and `msg` is assigned inside `case 0`. This still works.

But, when working on `default`, javac will reuse the original state from the jump from the `if`, i.e. will consider the variable/register that now represents `msg` existing and defined, even though it obviously is not. This will then fail verifier:
```
$ java JDK_8390354.java
Exception in thread "main" java.lang.VerifyError: Inconsistent stackmap frames at branch target 48
Exception Details:
  Location:
    JDK_8390354.handle(Ljava/lang/Object;)V @48: getstatic
  Reason:
    Type top (current frame, locals[1]) is not assignable to integer (stack map, locals[1])
  Current Frame:
    bci: @18
    flags: { }
    locals: { 'java/lang/Object' }
    stack: { integer }
  Stackmap Frame:
    bci: @48
    flags: { }
    locals: { 'java/lang/Object', integer }
    stack: { }
  Bytecode:
    0000000: 2ac1 0007 9900 0c2a c000 0759 4cc7 0004
    0000010: b103 ab00 0000 001e 0000 0001 0000 0000
    0000020: 0000 0012 033c b200 091b b600 0fa7 000b
    0000030: b200 0912 15b6 0017 b1                 
  Stackmap Table:
    same_frame(@16)
    same_frame(@17)
    same_frame(@36)
    append_frame(@48,Integer)
    chop_frame(@56,1)

        at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
        at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3010)
        at java.base/java.lang.Class.getMethodsRecursive(Class.java:3146)
        at java.base/java.lang.Class.findMethod(Class.java:2463)
        at java.base/java.lang.System$1.findMethod(System.java:2003)
        at java.base/jdk.internal.misc.MethodFinder.findMainMethod(MethodFinder.java:84)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.execute(SourceLauncher.java:194)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.run(SourceLauncher.java:138)
        at jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher.main(SourceLauncher.java:76)
```

This is very similar to https://github.com/openjdk/jdk/pull/25849 / https://bugs.openjdk.org/browse/JDK-8358801, which related to LetExpr in condition position.

The proposal herein is to enhance the solution for JDK-8358801, and mask out variables going out of the scope in the defined set in the `Code.pendingJumps`. We need to keep the existing code for LetExpr in `genCond`, as the chains there are not `pendingJumps`, but separate `true`/`false` chains. (Added an assert to make sure there are no `pendingJumps`
 while handling the conditional chains/jumps.)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390354](https://bugs.openjdk.org/browse/JDK-8390354): Inconsistent stackmap frames VerifyError after negated nested pattern match (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32541/head:pull/32541` \
`$ git checkout pull/32541`

Update a local copy of the PR: \
`$ git checkout pull/32541` \
`$ git pull https://git.openjdk.org/jdk.git pull/32541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32541`

View PR using the GUI difftool: \
`$ git pr show -t 32541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32541.diff">https://git.openjdk.org/jdk/pull/32541.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32541#issuecomment-5426064566)
</details>
