### PR TITLE
8372389: Omit filler arrays from heap dump

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -29,6 +29,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/gcLocker.hpp"
 #include "gc/shared/gcVMOperations.hpp"
 #include "gc/shared/workerThread.hpp"
@@ -2199,6 +2200,10 @@ void HeapObjectDumper::do_object(oop o) {
   }
 
   if (DumperSupport::mask_dormant_archived_object(o, nullptr) == nullptr) {
+    return;
+  }
+
+  if (CollectedHeap::is_filler_object(o)) {
     return;
   }
 


### PR DESCRIPTION
Please review this simple change to remove filler arrays (and objects) from heap dumps. In the hprof format, they are not distinguishable from `int[]`, which can be confusing (where are these huge `int[]`s coming from in my application?), and they bloat the heap dump time and size.

(Note: I sent a request for comments [on the serviceability-dev mailing list](https://mail.openjdk.org/archives/list/serviceability-dev@openjdk.org/thread/USL6YYR2UW76Z4VFESN225ZASLL2DHYQ/) but got no response, so made a PR)

Using Eclipse MAT, before:
```
with-filler.hprof - 6.2GB

Class Name | Objects | Shallow Heap
=====================================
    byte[]    39,938   4,997,553,360
     int[]    45,839   1,140,524,000
```

After:
```
without-filler.hprof - 5.0GB

Class Name | Objects | Shallow Heap
=====================================
    byte[]    48,321    4,998,520,248
     int[]     4,995          951,088
```

([Test file](https://gist.github.com/olivergillespie/1661499afb9e1c708de30cf0bdfca30e))

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8372389](https://bugs.openjdk.org/browse/JDK-8372389): Omit filler arrays from heap dump (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32542/head:pull/32542` \
`$ git checkout pull/32542`

Update a local copy of the PR: \
`$ git checkout pull/32542` \
`$ git pull https://git.openjdk.org/jdk.git pull/32542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32542`

View PR using the GUI difftool: \
`$ git pr show -t 32542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32542.diff">https://git.openjdk.org/jdk/pull/32542.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32542#issuecomment-5426229735)
</details>
