### PR TITLE
8391186: Avoid unused variables in libjsound

### DIFF
--- a/make/modules/java.desktop/Lib.gmk
+++ b/make/modules/java.desktop/Lib.gmk
@@ -64,10 +64,8 @@ ifeq ($(ENABLE_JSOUND), true)
         EXTRA_HEADER_DIRS := java.base:libjava, \
         CFLAGS := $(LIBJSOUND_CFLAGS), \
         CXXFLAGS := $(LIBJSOUND_CFLAGS), \
-        DISABLED_WARNINGS_gcc := undef unused-variable, \
-        DISABLED_WARNINGS_clang := undef unused-variable, \
-        DISABLED_WARNINGS_clang_PLATFORM_API_MacOSX_MidiUtils.c := \
-            unused-but-set-variable, \
+        DISABLED_WARNINGS_gcc := undef, \
+        DISABLED_WARNINGS_clang := undef, \
         DISABLED_WARNINGS_clang_DirectAudioDevice.c := unused-function, \
         LIBS_linux := $(ALSA_LIBS), \
         LIBS_macosx := \

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiOut.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_MidiOut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,8 +120,6 @@ INT32 MIDI_OUT_SendShortMessage(MidiDeviceHandle* handle, UINT32 packedMsg,
                                 UINT32 timestamp) {
     int err;
     int status;
-    int data1;
-    int data2;
     char buffer[3];
 
     TRACE2("> MIDI_OUT_SendShortMessage() %x, time: %u\n", packedMsg, (unsigned int) timestamp);

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_PCM.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_PCM.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -412,13 +412,14 @@ int setSWParams(AlsaPcmInfo* info) {
     return TRUE;
 }
 
+#ifdef USE_TRACE
 static snd_output_t* ALSA_OUTPUT = NULL;
+#endif
 
 void* DAUDIO_Open(INT32 mixerIndex, INT32 deviceID, int isSource,
                   int encoding, float sampleRate, int sampleSizeInBits,
                   int frameSize, int channels,
                   int isSigned, int isBigEndian, int bufferSizeInBytes) {
-    snd_pcm_format_mask_t* formatMask;
     snd_pcm_format_t format;
     int dir;
     int ret = 0;
@@ -888,7 +889,6 @@ INT64 DAUDIO_GetBytePosition(void* id, int isSource, INT64 javaBytePos) {
 
     if (!info->isFlushed && state != SND_PCM_STATE_XRUN) {
 #ifdef GET_POSITION_METHOD2
-        snd_timestamp_t* ts;
         snd_pcm_uframes_t framesAvail;
 
         // note: slight race condition if this is called simultaneously from 2 threads

--- a/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_Ports.c
+++ b/src/java.desktop/linux/native/libjsound/PLATFORM_API_LinuxOS_ALSA_Ports.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -532,7 +532,6 @@ INT32 PORT_GetIntValue(void* controlIDV) {
 
 void PORT_SetIntValue(void* controlIDV, INT32 value) {
     PortControl* portControl = (PortControl*) controlIDV;
-    snd_mixer_selem_channel_id_t channel;
 
     if (portControl != NULL) {
         if (portControl->controlType == CONTROL_TYPE_MUTE) {

--- a/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_MidiUtils.c
+++ b/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_MidiUtils.c
@@ -542,8 +542,9 @@ INT32 MIDI_Utils_CloseDevice(MacMidiDeviceHandle* handle) {
 
 
 INT32 MIDI_Utils_StartDevice(MacMidiDeviceHandle* handle) {
+#ifdef USE_ERROR
     OSStatus err = noErr;
-
+#endif
     if (!handle || !handle->h.deviceHandle) {
         ERROR0("ERROR: MIDI_Utils_StartDevice: handle or native is NULL\n");
         return MIDI_INVALID_HANDLE;
@@ -565,10 +566,16 @@ INT32 MIDI_Utils_StartDevice(MacMidiDeviceHandle* handle) {
             // Similarly, handle->h.queue is used in the CoreMDID's callback
             // to dispatch the incoming messages to the appropriate queue.
             //
-            err = MIDIPortConnectSource(inPort, (MIDIEndpointRef) (intptr_t) (handle->h.deviceHandle), (void*) handle);
+#ifdef USE_ERROR
+            err =
+#endif
+            MIDIPortConnectSource(inPort, (MIDIEndpointRef) (intptr_t) (handle->h.deviceHandle), (void*) handle);
         } else if (handle->direction == MIDI_OUT) {
             // Unschedules previous-sent packets.
-            err = MIDIFlushOutput((MIDIEndpointRef) (intptr_t) handle->h.deviceHandle);
+#ifdef USE_ERROR
+            err =
+#endif
+            MIDIFlushOutput((MIDIEndpointRef) (intptr_t) handle->h.deviceHandle);
         }
 
         MIDI_CHECK_ERROR;
@@ -578,8 +585,9 @@ INT32 MIDI_Utils_StartDevice(MacMidiDeviceHandle* handle) {
 
 
 INT32 MIDI_Utils_StopDevice(MacMidiDeviceHandle* handle) {
+#ifdef USE_ERROR
     OSStatus err = noErr;
-
+#endif
     if (!handle || !handle->h.deviceHandle) {
         ERROR0("ERROR: MIDI_Utils_StopDevice: handle or native handle is NULL\n");
         return MIDI_INVALID_HANDLE;
@@ -590,10 +598,16 @@ INT32 MIDI_Utils_StopDevice(MacMidiDeviceHandle* handle) {
         handle->isStarted = FALSE;
 
         if (handle->direction == MIDI_IN) {
-            err = MIDIPortDisconnectSource(inPort, (MIDIEndpointRef) (intptr_t) (handle->h.deviceHandle));
+#ifdef USE_ERROR
+            err =
+#endif
+            MIDIPortDisconnectSource(inPort, (MIDIEndpointRef) (intptr_t) (handle->h.deviceHandle));
         } else if (handle->direction == MIDI_OUT) {
             // Unschedules previously-sent packets.
-            err = MIDIFlushOutput((MIDIEndpointRef) (intptr_t) handle->h.deviceHandle);
+#ifdef USE_ERROR
+            err =
+#endif
+            MIDIFlushOutput((MIDIEndpointRef) (intptr_t) handle->h.deviceHandle);
         }
 
         MIDI_CHECK_ERROR;

--- a/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_PCM.cpp
+++ b/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_PCM.cpp
@@ -764,10 +764,16 @@ static OSStatus InputCallback(void                          *inRefCon,
             }
             device->lastWrittenSampleTime = sampleTime + inNumberFrames;
 
-            int bytesWritten = device->resampler->Process(abl.mBuffers[0].mData, (int)abl.mBuffers[0].mDataByteSize, &device->ringBuffer);
+#ifdef USE_TRACE
+            int bytesWritten =
+#endif
+            device->resampler->Process(abl.mBuffers[0].mData, (int)abl.mBuffers[0].mDataByteSize, &device->ringBuffer);
             TRACE2("<<InputCallback (RESAMPLED, saved %d bytes of %d)\n", bytesWritten, (int)abl.mBuffers[0].mDataByteSize);
         } else {
-            int bytesWritten = device->ringBuffer.Write(abl.mBuffers[0].mData, (int)abl.mBuffers[0].mDataByteSize, false);
+#ifdef USE_TRACE
+            int bytesWritten =
+#endif
+            device->ringBuffer.Write(abl.mBuffers[0].mData, (int)abl.mBuffers[0].mDataByteSize, false);
             TRACE2("<<InputCallback (saved %d bytes of %d)\n", bytesWritten, (int)abl.mBuffers[0].mDataByteSize);
         }
     }

--- a/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Utils.cpp
+++ b/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Utils.cpp
@@ -158,8 +158,6 @@ void DeviceList::Free() {
 OSStatus DeviceList::NotificationCallback(AudioObjectID inObjectID,
     UInt32 inNumberAddresses, const AudioObjectPropertyAddress inAddresses[], void *inClientData)
 {
-    DeviceList *pThis = (DeviceList *)inClientData;
-
     for (UInt32 i=0; i<inNumberAddresses; i++) {
         switch (inAddresses[i].mSelector) {
         case kAudioHardwarePropertyDevices:


### PR DESCRIPTION
Currently we disable unused variable warnings when building libjsound.
This should be avoided.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391186](https://bugs.openjdk.org/browse/JDK-8391186): Avoid unused variables in libjsound (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32543/head:pull/32543` \
`$ git checkout pull/32543`

Update a local copy of the PR: \
`$ git checkout pull/32543` \
`$ git pull https://git.openjdk.org/jdk.git pull/32543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32543`

View PR using the GUI difftool: \
`$ git pr show -t 32543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32543.diff">https://git.openjdk.org/jdk/pull/32543.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32543#issuecomment-5427007924)
</details>
