### PR TITLE
8391220: Rewriter has unused _invokedynamic_references_map

### DIFF
--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -255,14 +255,14 @@ void Rewriter::maybe_rewrite_invokehandle(address opc, int cp_index, int cache_i
             MethodHandles::is_signature_polymorphic_name(vmClasses::MethodHandle_klass(),
                                                          _pool->uncached_name_ref_at(cp_index))) {
           // we may need a resolved_refs entry for the appendix
-          int resolved_index = add_invokedynamic_resolved_references_entry(cp_index, cache_index);
+          int resolved_index = add_invokedynamic_resolved_references_entry(cp_index);
           _initialized_method_entries.at(cache_index).set_resolved_references_index((u2)resolved_index);
           status = +1;
         } else if (_pool->uncached_klass_ref_at_noresolve(cp_index) == vmSymbols::java_lang_invoke_VarHandle() &&
                    MethodHandles::is_signature_polymorphic_name(vmClasses::VarHandle_klass(),
                                                                 _pool->uncached_name_ref_at(cp_index))) {
           // we may need a resolved_refs entry for the appendix
-          int resolved_index = add_invokedynamic_resolved_references_entry(cp_index, cache_index);
+          int resolved_index = add_invokedynamic_resolved_references_entry(cp_index);
           _initialized_method_entries.at(cache_index).set_resolved_references_index((u2)resolved_index);
           status = +1;
         } else {
@@ -294,7 +294,7 @@ void Rewriter::rewrite_invokedynamic(address bcp, int offset, bool reverse) {
   assert(p[-1] == Bytecodes::_invokedynamic, "not invokedynamic bytecode");
   if (!reverse) {
     int cp_index = Bytes::get_Java_u2(p);
-    int resolved_index = add_invokedynamic_resolved_references_entry(cp_index, -1); // Indy no longer has a CPCE
+    int resolved_index = add_invokedynamic_resolved_references_entry(cp_index); // Indy no longer has a CPCE
     // Replace the trailing four bytes with an index to the array of
     // indy resolution information in the CPC. There is one entry for
     // each bytecode, even if they make the same call. In other words,

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -109,7 +109,7 @@ void Rewriter::make_constant_pool_cache(TRAPS) {
   assert(_field_entry_index == _initialized_field_entries.length(), "Field entry size mismatch");
   assert(_method_entry_index == _initialized_method_entries.length(), "Method entry size mismatch");
   ConstantPoolCache* cache =
-      ConstantPoolCache::allocate(loader_data, _invokedynamic_references_map,
+      ConstantPoolCache::allocate(loader_data,
                                   _initialized_indy_entries, _initialized_field_entries, _initialized_method_entries,
                                   CHECK);
 
@@ -584,7 +584,6 @@ Rewriter::Rewriter(InstanceKlass* klass, const constantPoolHandle& cpool, Array<
     _cp_map(cpool->length()),
     _reference_map(cpool->length()),
     _resolved_references_map(cpool->length() / 2),
-    _invokedynamic_references_map(cpool->length() / 2),
     _method_handle_invokers(cpool->length()),
     _invokedynamic_index(0),
     _field_entry_index(0),

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,9 @@ void Rewriter::make_constant_pool_cache(TRAPS) {
   assert(_method_entry_index == _initialized_method_entries.length(), "Method entry size mismatch");
   ConstantPoolCache* cache =
       ConstantPoolCache::allocate(loader_data,
-                                  _initialized_indy_entries, _initialized_field_entries, _initialized_method_entries,
+                                  _initialized_indy_entries,
+                                  _initialized_field_entries,
+                                  _initialized_method_entries,
                                   CHECK);
 
   // initialize object cache in constant pool

--- a/src/hotspot/share/interpreter/rewriter.hpp
+++ b/src/hotspot/share/interpreter/rewriter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/rewriter.hpp
+++ b/src/hotspot/share/interpreter/rewriter.hpp
@@ -99,7 +99,7 @@ class Rewriter: public StackObj {
   }
 
   // add a new entry to the resolved_references map (for invokedynamic and invokehandle only)
-  int add_invokedynamic_resolved_references_entry(int cp_index, int cache_index) {
+  int add_invokedynamic_resolved_references_entry(int cp_index) {
     assert(_resolved_reference_limit >= 0, "must add indy refs after first iteration");
     int ref_index = _resolved_references_map.append(cp_index);  // many-to-one
     assert(ref_index >= _resolved_reference_limit, "");

--- a/src/hotspot/share/interpreter/rewriter.hpp
+++ b/src/hotspot/share/interpreter/rewriter.hpp
@@ -43,7 +43,6 @@ class Rewriter: public StackObj {
   GrowableArray<int>  _cp_map;
   GrowableArray<int>  _reference_map; // maps from cp index to resolved_refs index (or -1)
   GrowableArray<int>  _resolved_references_map; // for strings, methodHandle, methodType
-  GrowableArray<int>  _invokedynamic_references_map; // for invokedynamic resolved refs
   GrowableArray<int>  _method_handle_invokers;
   int                 _resolved_reference_limit;
   int                 _invokedynamic_index;
@@ -68,7 +67,6 @@ class Rewriter: public StackObj {
 
     _method_handle_invokers.trunc_to(0);
     _resolved_references_map.trunc_to(0);
-    _invokedynamic_references_map.trunc_to(0);
     _resolved_reference_limit = -1;
   }
 
@@ -105,9 +103,6 @@ class Rewriter: public StackObj {
     assert(_resolved_reference_limit >= 0, "must add indy refs after first iteration");
     int ref_index = _resolved_references_map.append(cp_index);  // many-to-one
     assert(ref_index >= _resolved_reference_limit, "");
-    if (_pool->tag_at(cp_index).value() != JVM_CONSTANT_InvokeDynamic) {
-      _invokedynamic_references_map.at_put_grow(ref_index, cache_index, -1);
-    }
     return ref_index;
   }
 

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -376,7 +376,6 @@ Method* ConstantPoolCache::method_if_resolved(int method_index) const {
 }
 
 ConstantPoolCache* ConstantPoolCache::allocate(ClassLoaderData* loader_data,
-                                     const intStack& invokedynamic_map,
                                      const GrowableArray<ResolvedIndyEntry> indy_entries,
                                      const GrowableArray<ResolvedFieldEntry> field_entries,
                                      const GrowableArray<ResolvedMethodEntry> method_entries,
@@ -390,7 +389,7 @@ ConstantPoolCache* ConstantPoolCache::allocate(ClassLoaderData* loader_data,
   Array<ResolvedMethodEntry>* resolved_method_entries = initialize_resolved_entries_array(loader_data, method_entries, CHECK_NULL);
 
   return new (loader_data, size, MetaspaceObj::ConstantPoolCacheType, THREAD)
-              ConstantPoolCache(invokedynamic_map, resolved_indy_entries, resolved_field_entries, resolved_method_entries);
+              ConstantPoolCache(resolved_indy_entries, resolved_field_entries, resolved_method_entries);
 }
 
 // Record the GC marking cycle when redefined vs. when found in the loom stack chunks.

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -95,8 +95,6 @@ class ConstantPoolCache: public MetaspaceObj {
                     Array<ResolvedFieldEntry>* field_entries,
                     Array<ResolvedMethodEntry>* mehtod_entries);
 
-  // Initialization
-  void initialize(const intArray& invokedynamic_references_map);
  public:
   static ConstantPoolCache* allocate(ClassLoaderData* loader_data,
                                      const GrowableArray<ResolvedIndyEntry> indy_entries,

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -91,8 +91,7 @@ class ConstantPoolCache: public MetaspaceObj {
     };
 
   // Constructor
-  ConstantPoolCache(const intStack& invokedynamic_references_map,
-                    Array<ResolvedIndyEntry>* indy_info,
+  ConstantPoolCache(Array<ResolvedIndyEntry>* indy_info,
                     Array<ResolvedFieldEntry>* field_entries,
                     Array<ResolvedMethodEntry>* mehtod_entries);
 
@@ -100,7 +99,6 @@ class ConstantPoolCache: public MetaspaceObj {
   void initialize(const intArray& invokedynamic_references_map);
  public:
   static ConstantPoolCache* allocate(ClassLoaderData* loader_data,
-                                     const intStack& invokedynamic_references_map,
                                      const GrowableArray<ResolvedIndyEntry> indy_entries,
                                      const GrowableArray<ResolvedFieldEntry> field_entries,
                                      const GrowableArray<ResolvedMethodEntry> method_entries,

--- a/src/hotspot/share/oops/cpCache.inline.hpp
+++ b/src/hotspot/share/oops/cpCache.inline.hpp
@@ -35,8 +35,7 @@
 #include "runtime/atomicAccess.hpp"
 
 // Constructor
-inline ConstantPoolCache::ConstantPoolCache(const intStack& invokedynamic_references_map,
-                                            Array<ResolvedIndyEntry>* invokedynamic_info,
+inline ConstantPoolCache::ConstantPoolCache(Array<ResolvedIndyEntry>* invokedynamic_info,
                                             Array<ResolvedFieldEntry>* field_entries,
                                             Array<ResolvedMethodEntry>* method_entries) :
                                                   _constant_pool(nullptr),


### PR DESCRIPTION
Remove unused index map in the rewriter.
Tested with tier1 sanity.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391220](https://bugs.openjdk.org/browse/JDK-8391220): Rewriter has unused _invokedynamic_references_map (**Enhancement** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**) Review applies to [22a857ca](https://git.openjdk.org/jdk/pull/32546/files/22a857cab80cbb40405444760bf0317aa36ceef1)
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32546/head:pull/32546` \
`$ git checkout pull/32546`

Update a local copy of the PR: \
`$ git checkout pull/32546` \
`$ git pull https://git.openjdk.org/jdk.git pull/32546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32546`

View PR using the GUI difftool: \
`$ git pr show -t 32546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32546.diff">https://git.openjdk.org/jdk/pull/32546.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32546#issuecomment-5430389537)
</details>
