### PR TITLE
8391222: Clarify the explanation of line terminator sequences in java.util.Properties.load(Reader)

### DIFF
--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -239,8 +239,8 @@ public class Properties extends Hashtable<Object,Object> {
      * Properties are processed in terms of lines. There are two
      * kinds of lines, <i>natural lines</i> and <i>logical lines</i>.
      * A natural line is defined as a line of
-     * characters that is terminated either by a set of line terminator
-     * characters ({@code \n} or {@code \r} or {@code \r\n})
+     * characters that is terminated either by a line terminator
+     * sequence ({@code \n}, {@code \r}, or {@code \r\n})
      * or by the end of the stream. A natural line may be either a blank line,
      * a comment line, or hold all or some of a key-element pair. A logical
      * line holds all the data of a key-element pair, which may be spread
@@ -265,9 +265,9 @@ public class Properties extends Hashtable<Object,Object> {
      *
      * <p>
      * If a logical line is spread across several natural lines, the
-     * backslash escaping the line terminator sequence and any white
-     * space at the start of the following line have no effect on the
-     * key or element values.
+     * backslash escaping the line terminator sequence, the line
+     * terminator sequence itself, and any white space at the start of the
+     * following line have no effect on the key or element values.
      * The remainder of the discussion of key and element parsing
      * (when loading) will assume all the characters constituting
      * the key and element appear on a single natural line after

--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,9 +265,9 @@ public class Properties extends Hashtable<Object,Object> {
      *
      * <p>
      * If a logical line is spread across several natural lines, the
-     * backslash escaping the line terminator sequence, the line
-     * terminator sequence, and any white space at the start of the
-     * following line have no effect on the key or element values.
+     * backslash escaping the line terminator sequence and any white
+     * space at the start of the following line have no effect on the
+     * key or element values.
      * The remainder of the discussion of key and element parsing
      * (when loading) will assume all the characters constituting
      * the key and element appear on a single natural line after


### PR DESCRIPTION
The current wording for line terminator explanation may be misleading and should be clarified.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391222](https://bugs.openjdk.org/browse/JDK-8391222): Clarify the explanation of line terminator sequences in java.util.Properties.load(Reader) (**Bug** - P5)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32547/head:pull/32547` \
`$ git checkout pull/32547`

Update a local copy of the PR: \
`$ git checkout pull/32547` \
`$ git pull https://git.openjdk.org/jdk.git pull/32547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32547`

View PR using the GUI difftool: \
`$ git pr show -t 32547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32547.diff">https://git.openjdk.org/jdk/pull/32547.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32547#issuecomment-5431940323)
</details>
