### PR TITLE
8391236: RISC-V: Save a jump in string_indexof_char intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -576,10 +576,10 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1,
 
   bind(CH1_LOOP);
   ld(ch1, Address(str1));
-  addi(str1, str1, 8);
-  subi(cnt1, cnt1, 8);
   compute_match_mask(ch1, ch, match_mask, mask1, mask2);
   bnez(match_mask, HIT);
+  addi(str1, str1, 8);
+  subi(cnt1, cnt1, 8);
   bge(cnt1, loop_step, CH1_LOOP);
 
   beqz(cnt1, DONE);
@@ -604,7 +604,6 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1,
   // count bits of trailing zero chars
   ctzc_bits(trailing_chars, match_mask, isL, mask1, mask2);
   srli(trailing_chars, trailing_chars, 3);
-  addi(cnt1, cnt1, 8);
 
   // match case
   if (!isL) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -514,19 +514,20 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1,
                                             Register tmp3, Register tmp4,
                                             bool isL)
 {
-  Label CH1_LOOP, HIT, NOMATCH, DONE, SHORT;
+  Label CH1_LOOP, HIT, DONE, SHORT;
   Register ch1 = t0;
   Register orig_cnt = t1;
-  Register mask1 = tmp3;
+  Register mask1 = tmp1;
   Register mask2 = tmp2;
-  Register match_mask = tmp1;
+  Register match_mask = tmp3;
   Register loop_step = tmp4;
   Register trailing_chars = tmp4;
   Register unaligned_chars = tmp4;
   Register start_index = tmp4;
 
   BLOCK_COMMENT("string_indexof_char {");
-  beqz(cnt1, NOMATCH);
+  mv(result, -1);
+  beqz(cnt1, DONE);
 
   subi(t0, cnt1, isL ? 32 : 16);
   mv(start_index, zr);
@@ -581,7 +582,7 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1,
   bnez(match_mask, HIT);
   bge(cnt1, loop_step, CH1_LOOP);
 
-  beqz(cnt1, NOMATCH);
+  beqz(cnt1, DONE);
   if (!isL) {
     srli(cnt1, cnt1, 1);
   }
@@ -601,7 +602,7 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1,
 
   bind(HIT);
   // count bits of trailing zero chars
-  ctzc_bits(trailing_chars, match_mask, isL, ch1, result);
+  ctzc_bits(trailing_chars, match_mask, isL, mask1, mask2);
   srli(trailing_chars, trailing_chars, 3);
   addi(cnt1, cnt1, 8);
 
@@ -613,10 +614,6 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1,
 
   sub(result, orig_cnt, cnt1);
   add(result, result, trailing_chars);
-  j(DONE);
-
-  bind(NOMATCH);
-  mv(result, -1);
 
   bind(DONE);
   BLOCK_COMMENT("} string_indexof_char");


### PR DESCRIPTION
Hi, please consider.

C2_MacroAssembler::string_indexof_char() sets the no-match value -1 from a
dedicated NOMATCH block emitted just before DONE, so the matching (HIT) path
has to jump over that block to reach DONE.
 
Hoisting mv(result, -1) to the function entry removes the NOMATCH block
entirely: the HIT path then falls through to DONE, and the two
beqz(cnt1, NOMATCH) become beqz(cnt1, DONE). result is already -1 on every
path that reaches DONE without a match, since string_indexof_char_short()
sets it itself and compute_match_mask() does not touch it. The intrinsic ends
up one instruction shorter and the HIT path trades a taken jump for a
fall-through. Checked with -XX:+PrintAssembly: one instruction less for both
StringLatin1.indexOf and StringUTF16.indexOf, with and without UseZbb.
 
While here, stop passing result as a scratch register to ctzc_bits(). With
result now carrying the no-match value from the entry onwards, clobbering it
in the HIT block makes that invariant fragile. mask1/mask2 are dead by then,
so use those instead, and renumber the mask registers so that
mask1/mask2/match_mask map to tmp1/tmp2/tmp3.

### Testing on sg2042
- compiler/intrinsics/string 
- tier1 (fastdebug)
- micro:java.lang.StringIndexOfChar
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391236](https://bugs.openjdk.org/browse/JDK-8391236): RISC-V: Save a jump in string_indexof_char intrinsic (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author) Review applies to [6564fb1d](https://git.openjdk.org/jdk/pull/32550/files/6564fb1d019de9c6502cf16f6c31d0f16a02c7db)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32550/head:pull/32550` \
`$ git checkout pull/32550`

Update a local copy of the PR: \
`$ git checkout pull/32550` \
`$ git pull https://git.openjdk.org/jdk.git pull/32550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32550`

View PR using the GUI difftool: \
`$ git pr show -t 32550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32550.diff">https://git.openjdk.org/jdk/pull/32550.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32550#issuecomment-5433964911)
</details>
