### PR TITLE
8380310: Remove Finalizers from remaining security components

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -232,8 +232,10 @@ module java.base {
     exports jdk.internal.ref to
         java.desktop,
         java.net.http,
+        java.security.sasl,
         java.smartcardio,
-        jdk.naming.dns;
+        jdk.naming.dns,
+        jdk.security.jgss;
     exports jdk.internal.reflect to
         java.logging,
         java.sql,

--- a/src/java.base/share/classes/sun/security/util/KeyUtil.java
+++ b/src/java.base/share/classes/sun/security/util/KeyUtil.java
@@ -26,6 +26,7 @@
 package sun.security.util;
 
 import java.io.IOException;
+import java.lang.ref.Cleaner;
 import java.math.BigInteger;
 import java.security.*;
 import java.security.interfaces.*;
@@ -41,6 +42,7 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.DestroyFailedException;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.ref.CleanerFactory;
 
 import com.sun.crypto.provider.PBKDF2KeyImpl;
 import sun.security.jca.JCAUtil;
@@ -551,6 +553,14 @@ public final class KeyUtil {
 
         }
         throw new IOException("No algorithm detected");
+    }
+
+    // methods for generating cleanables which clears arrays
+    public static Cleaner.Cleanable getCleanable(Object obj, byte[] b) {
+        return CleanerFactory.cleaner().register(obj,
+                ()->{
+                    Arrays.fill(b, (byte) 0);
+                });
     }
 
     // Generic method for zeroing arrays and objects

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/ClientFactoryImpl.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/ClientFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import sun.security.util.PBEUtil;
 
 /**
  * Client factory for EXTERNAL, CRAM-MD5, PLAIN.
@@ -143,7 +143,7 @@ public final class ClientFactoryImpl implements SaslClientFactory {
             String authId;
 
             if (pw != null) {
-                bytepw = new String(pw).getBytes(UTF_8);
+                bytepw = PBEUtil.encodePassword(pw);
                 pcb.clearPassword();
             } else {
                 bytepw = null;

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Base.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Base.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,6 @@ import java.util.logging.Logger;
 abstract class CramMD5Base {
     protected boolean completed = false;
     protected boolean aborted = false;
-    protected byte[] pw;
 
     protected CramMD5Base() {
         initLogger();
@@ -122,25 +121,6 @@ abstract class CramMD5Base {
         }
     }
 
-    public void dispose() throws SaslException {
-        clearPassword();
-    }
-
-    protected void clearPassword() {
-        if (pw != null) {
-            // zero out password
-            for (int i = 0; i < pw.length; i++) {
-                pw[i] = (byte)0;
-            }
-            pw = null;
-        }
-    }
-
-    @SuppressWarnings("removal")
-    protected void finalize() {
-        clearPassword();
-    }
-
     private static final int MD5_BLOCKSIZE = 64;
     /**
      * Hashes its input arguments according to HMAC-MD5 (RFC 2104)
@@ -161,9 +141,8 @@ abstract class CramMD5Base {
         MessageDigest md5 = MessageDigest.getInstance("MD5");
 
         /* digest the key if longer than 64 bytes */
-        if (key.length > MD5_BLOCKSIZE) {
-            key = md5.digest(key);
-        }
+        key = (key.length > MD5_BLOCKSIZE ?
+                md5.digest(key) : key.clone());
 
         byte[] ipad = new byte[MD5_BLOCKSIZE];  /* inner padding */
         byte[] opad = new byte[MD5_BLOCKSIZE];  /* outer padding */
@@ -181,35 +160,36 @@ abstract class CramMD5Base {
             ipad[i] ^= 0x36;
             opad[i] ^= 0x5c;
         }
+        try {
+            /* inner MD5 */
+            md5.update(ipad);
+            md5.update(text);
+            digest = md5.digest();
 
-        /* inner MD5 */
-        md5.update(ipad);
-        md5.update(text);
-        digest = md5.digest();
+            /* outer MD5 */
+            md5.update(opad);
+            md5.update(digest);
+            digest = md5.digest();
 
-        /* outer MD5 */
-        md5.update(opad);
-        md5.update(digest);
-        digest = md5.digest();
+            // Get character representation of digest
+            StringBuilder digestString = new StringBuilder();
 
-        // Get character representation of digest
-        StringBuilder digestString = new StringBuilder();
-
-        for (i = 0; i < digest.length; i++) {
-            if ((digest[i] & 0x000000ff) < 0x10) {
-                digestString.append('0').append(Integer.toHexString(digest[i] & 0x000000ff));
-            } else {
-                digestString.append(
-                    Integer.toHexString(digest[i] & 0x000000ff));
+            for (i = 0; i < digest.length; i++) {
+                if ((digest[i] & 0x000000ff) < 0x10) {
+                    digestString.append('0').append(Integer.toHexString(digest[i] & 0x000000ff));
+                } else {
+                    digestString.append(
+                        Integer.toHexString(digest[i] & 0x000000ff));
+                }
             }
+            return (digestString.toString());
+        } finally {
+            Arrays.fill(ipad, (byte)0);
+            Arrays.fill(opad, (byte)0);
+            ipad = null;
+            opad = null;
+            Arrays.fill(key, (byte)0);
         }
-
-        Arrays.fill(ipad, (byte)0);
-        Arrays.fill(opad, (byte)0);
-        ipad = null;
-        opad = null;
-
-        return (digestString.toString());
     }
 
     /**

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Client.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,14 @@
 
 package com.sun.security.sasl;
 
-import javax.security.sasl.*;
+import java.lang.ref.Cleaner;
+import java.lang.ref.Reference;
 import java.security.NoSuchAlgorithmException;
-
+import java.util.Arrays;
 import java.util.logging.Logger;
 import java.util.logging.Level;
+import javax.security.sasl.*;
+import sun.security.util.KeyUtil;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -47,6 +50,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 final class CramMD5Client extends CramMD5Base implements SaslClient {
     private String username;
 
+    private final byte[] pw;
+    private Cleaner.Cleanable cleanable;
+
     /**
      * Creates a SASL mechanism with client credentials that it needs
      * to participate in CRAM-MD5 authentication exchange with the server.
@@ -54,7 +60,7 @@ final class CramMD5Client extends CramMD5Base implements SaslClient {
      * @param authID A  non-null string representing the principal
      * being authenticated.
      *
-     * @param pw A non-null String or byte[]
+     * @param pw A non-null byte[]
      * containing the password. If it is an array, it is first cloned.
      */
     CramMD5Client(String authID, byte[] pw) throws SaslException {
@@ -65,11 +71,13 @@ final class CramMD5Client extends CramMD5Base implements SaslClient {
 
         username = authID;
         this.pw = pw;  // caller should have already cloned
+        this.cleanable = KeyUtil.getCleanable(this, pw);
     }
 
     /**
      * CRAM-MD5 has no initial response.
      */
+    @Override
     public boolean hasInitialResponse() {
         return false;
     }
@@ -87,6 +95,7 @@ final class CramMD5Client extends CramMD5Base implements SaslClient {
      * @throws SaslException if platform does not have MD5 support
      * @throws IllegalStateException if this method is invoked more than once.
      */
+    @Override
     public byte[] evaluateChallenge(byte[] challengeData)
         throws SaslException {
 
@@ -101,6 +110,11 @@ final class CramMD5Client extends CramMD5Base implements SaslClient {
                 "CRAM-MD5 authentication previously aborted due to error");
         }
 
+        if (cleanable == null) {
+            throw new IllegalStateException(
+                "CRAM-MD5 authentication already disposed");
+        }
+
         // generate a keyed-MD5 digest from the user's password and challenge.
         try {
             if (logger.isLoggable(Level.FINE)) {
@@ -110,20 +124,31 @@ final class CramMD5Client extends CramMD5Base implements SaslClient {
 
             String digest = HMAC_MD5(pw, challengeData);
 
-            // clear it when we no longer need it
-            clearPassword();
-
             // response is username + " " + digest
             String resp = username + " " + digest;
-
             logger.log(Level.FINE, "CRAMCLNT02:Sending response: {0}", resp);
-
             completed = true;
 
             return resp.getBytes(UTF_8);
         } catch (java.security.NoSuchAlgorithmException e) {
             aborted = true;
             throw new SaslException("MD5 algorithm not available on platform", e);
+        } finally {
+            // clear it when we no longer need it
+            clearPassword();
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    @Override
+    public void dispose() throws SaslException {
+        clearPassword();
+    }
+
+    private void clearPassword() {
+        if (cleanable != null) {
+            cleanable.clean();
+            cleanable = null;
         }
     }
 }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Server.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,17 @@
 
 package com.sun.security.sasl;
 
-import sun.security.jca.JCAUtil;
-
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.Map;
 import javax.security.sasl.*;
 import javax.security.auth.callback.*;
+
+import sun.security.jca.JCAUtil;
+import sun.security.util.PBEUtil;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -96,6 +98,7 @@ final class CramMD5Server extends CramMD5Base implements SaslServer {
      *        the client for the first call; null when 2nd call is successful.
      * @throws SaslException If authentication fails.
      */
+    @Override
     public byte[] evaluateResponse(byte[] responseData)
         throws SaslException {
 
@@ -178,21 +181,20 @@ final class CramMD5Server extends CramMD5Base implements SaslServer {
                         "CRAM-MD5: username not found: " + username);
                 }
                 pcb.clearPassword();
-                String pwStr = new String(pwChars);
-                for (int i = 0; i < pwChars.length; i++) {
-                    pwChars[i] = 0;
+                byte[] pw = PBEUtil.encodePassword(pwChars);
+                String digest;
+                try {
+                    // Generate a keyed-MD5 digest from the user's password and
+                    // original challenge.
+                    digest = HMAC_MD5(pw, challengeData);
+
+                    logger.log(Level.FINE,
+                        "CRAMSRV04:Expecting digest: {0}", digest);
+                } finally {
+                    // clear pw when we no longer need it
+                    Arrays.fill(pwChars, '0');
+                    Arrays.fill(pw, (byte)0);
                 }
-                pw = pwStr.getBytes(UTF_8);
-
-                // Generate a keyed-MD5 digest from the user's password and
-                // original challenge.
-                String digest = HMAC_MD5(pw, challengeData);
-
-                logger.log(Level.FINE,
-                    "CRAMSRV04:Expecting digest: {0}", digest);
-
-                // clear pw when we no longer need it
-                clearPassword();
 
                 // Check whether digest is as expected
                 byte[] expectedDigest = digest.getBytes(UTF_8);
@@ -238,6 +240,7 @@ final class CramMD5Server extends CramMD5Base implements SaslServer {
         }
     }
 
+    @Override
     public String getAuthorizationID() {
         if (completed) {
             return authzid;
@@ -245,5 +248,9 @@ final class CramMD5Server extends CramMD5Base implements SaslServer {
             throw new IllegalStateException(
                 "CRAM-MD5 authentication not completed");
         }
+    }
+
+    @Override
+    public void dispose() throws SaslException {
     }
 }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/PlainClient.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/PlainClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,10 @@
 
 package com.sun.security.sasl;
 
+import java.lang.ref.Cleaner;
+import java.lang.ref.Reference;
 import javax.security.sasl.*;
+import sun.security.util.KeyUtil;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -39,6 +42,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 final class PlainClient implements SaslClient {
     private boolean completed = false;
     private byte[] pw;
+    private Cleaner.Cleanable cleanable;
     private String authorizationID;
     private String authenticationID;
     private static byte SEP = 0; // US-ASCII <NUL>
@@ -64,6 +68,7 @@ final class PlainClient implements SaslClient {
         this.authorizationID = authorizationID;
         this.authenticationID = authenticationID;
         this.pw = pw;  // caller should have already cloned
+        this.cleanable = KeyUtil.getCleanable(this, pw);
     }
 
     /**
@@ -72,14 +77,17 @@ final class PlainClient implements SaslClient {
      *
      * @return  The string "PLAIN".
      */
+    @Override
     public String getMechanismName() {
         return "PLAIN";
     }
 
+    @Override
     public boolean hasInitialResponse() {
         return true;
     }
 
+    @Override
     public void dispose() throws SaslException {
         clearPassword();
     }
@@ -93,35 +101,44 @@ final class PlainClient implements SaslClient {
      * @return A non-null byte array containing the response to be sent to the server.
      * @throws IllegalStateException if authentication already completed
      */
+    @Override
     public byte[] evaluateChallenge(byte[] challengeData) {
         if (completed) {
             throw new IllegalStateException(
-                "PLAIN authentication already completed");
+                    "PLAIN authentication already completed");
         }
-        completed = true;
-        byte[] authz = (authorizationID != null)
-            ? authorizationID.getBytes(UTF_8)
-            : null;
-        byte[] auth = authenticationID.getBytes(UTF_8);
-
-        byte[] answer = new byte[pw.length + auth.length + 2 +
-                (authz == null ? 0 : authz.length)];
-
-        int pos = 0;
-        if (authz != null) {
-            System.arraycopy(authz, 0, answer, 0, authz.length);
-            pos = authz.length;
+        if (pw == null) {
+            throw new IllegalStateException(
+                    "PLAIN authentication already disposed");
         }
-        answer[pos++] = SEP;
-        System.arraycopy(auth, 0, answer, pos, auth.length);
+        try {
+            completed = true;
+            byte[] authz = (authorizationID != null)
+                ? authorizationID.getBytes(UTF_8)
+                : null;
+            byte[] auth = authenticationID.getBytes(UTF_8);
 
-        pos += auth.length;
-        answer[pos++] = SEP;
+            byte[] answer = new byte[pw.length + auth.length + 2 +
+                    (authz == null ? 0 : authz.length)];
 
-        System.arraycopy(pw, 0, answer, pos, pw.length);
+            int pos = 0;
+            if (authz != null) {
+                System.arraycopy(authz, 0, answer, 0, authz.length);
+                pos = authz.length;
+            }
+            answer[pos++] = SEP;
+            System.arraycopy(auth, 0, answer, pos, auth.length);
 
-        clearPassword();
-        return answer;
+            pos += auth.length;
+            answer[pos++] = SEP;
+
+            System.arraycopy(pw, 0, answer, pos, pw.length);
+
+            return answer;
+        } finally {
+            clearPassword();
+            Reference.reachabilityFence(this);
+        }
     }
 
     /**
@@ -130,6 +147,7 @@ final class PlainClient implements SaslClient {
      *
      * @return true if has completed; false otherwise;
      */
+    @Override
     public boolean isComplete() {
         return completed;
     }
@@ -139,6 +157,7 @@ final class PlainClient implements SaslClient {
      *
      * @throws SaslException Not applicable to this mechanism.
      */
+    @Override
     public byte[] unwrap(byte[] incoming, int offset, int len)
         throws SaslException {
         if (completed) {
@@ -154,6 +173,7 @@ final class PlainClient implements SaslClient {
      *
      * @throws SaslException Not applicable to this mechanism.
      */
+    @Override
     public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
         if (completed) {
             throw new SaslException(
@@ -173,6 +193,7 @@ final class PlainClient implements SaslClient {
      * @exception IllegalStateException if this authentication exchange
      *     has not completed
      */
+    @Override
     public Object getNegotiatedProperty(String propName) {
         if (completed) {
             if (propName.equals(Sasl.QOP)) {
@@ -187,16 +208,8 @@ final class PlainClient implements SaslClient {
 
     private void clearPassword() {
         if (pw != null) {
-            // zero out password
-            for (int i = 0; i < pw.length; i++) {
-                pw[i] = (byte)0;
-            }
+            cleanable.clean();
             pw = null;
         }
-    }
-
-    @SuppressWarnings("removal")
-    protected void finalize() {
-        clearPassword();
     }
 }

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Base.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Base.java
@@ -186,8 +186,14 @@ abstract class GssKrb5Base extends AbstractSaslImpl {
 
     public void dispose() throws SaslException {
         if (secCtx != null) {
-            cleanable.clean();
-            secCtx = null;
+            try {
+                cleanable.clean();
+            } catch (RuntimeException re) {
+                throw new SaslException("Problem disposing GSS context",
+                        re.getCause());
+            } finally {
+                secCtx = null;
+            }
         }
     }
 

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Base.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Base.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,14 +26,17 @@
 
 package com.sun.security.sasl.gsskerb;
 
+import java.lang.ref.Cleaner;
+import java.lang.ref.Reference;
 import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import javax.security.sasl.*;
-import com.sun.security.sasl.util.AbstractSaslImpl;
-import org.ietf.jgss.*;
+import jdk.internal.ref.CleanerFactory;
 import com.sun.security.jgss.ExtendedGSSContext;
 import com.sun.security.jgss.InquireType;
+import com.sun.security.sasl.util.AbstractSaslImpl;
+import org.ietf.jgss.*;
 
 abstract class GssKrb5Base extends AbstractSaslImpl {
 
@@ -47,12 +50,42 @@ abstract class GssKrb5Base extends AbstractSaslImpl {
         } catch (GSSException ignore) {}
     }
 
+    private static Cleaner.Cleanable registerCleaner(Object obj,
+            GSSContext ctx) {
+        return CleanerFactory.cleaner().register(obj,
+                ()->{
+                    try {
+                        ctx.dispose();
+                    } catch (GSSException e) {
+                        // Cleaner cleanup is best-effort; checked
+                        // exceptions cannot be thrown
+                        // To preserve the behavior for dispose(), we
+                        // wrap it with a RuntimeException
+                        throw new RuntimeException
+                                ("Problem disposing GSS context", e);
+                    }});
+    }
+
+    private Cleaner.Cleanable cleanable = null;
+
+    // must be set through updateSecCtx(...) method so the private 'cleanable'
+    // field is set for cleanup
     protected GSSContext secCtx = null;
+
     protected static final int JGSS_QOP = 0;    // unrelated to SASL QOP mask
 
     protected GssKrb5Base(Map<String, ?> props, String className)
         throws SaslException {
         super(props, className);
+    }
+
+    protected void updateSecCtx(GSSContext secCtx) throws SaslException {
+        if (this.secCtx == null) {
+            this.secCtx = secCtx;
+            this.cleanable = registerCleaner(this, secCtx);
+        } else {
+            throw new SaslException("GSS Context already exists!");
+        }
     }
 
     /**
@@ -153,18 +186,9 @@ abstract class GssKrb5Base extends AbstractSaslImpl {
 
     public void dispose() throws SaslException {
         if (secCtx != null) {
-            try {
-                secCtx.dispose();
-            } catch (GSSException e) {
-                throw new SaslException("Problem disposing GSS context", e);
-            }
+            cleanable.clean();
             secCtx = null;
         }
-    }
-
-    @SuppressWarnings("removal")
-    protected void finalize() throws Throwable {
-        dispose();
     }
 
     void checkMessageProp(String label, MessageProp msgProp)

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Client.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,10 +121,10 @@ final class GssKrb5Client extends GssKrb5Base implements SaslClient {
             }
 
             // Create a context using credentials for Krb5 mech
-            secCtx = mgr.createContext(acceptorName,
+            updateSecCtx(mgr.createContext(acceptorName,
                 KRB5_OID,   /* mechanism */
                 credentials, /* credentials */
-                GSSContext.INDEFINITE_LIFETIME);
+                GSSContext.INDEFINITE_LIFETIME));
 
             // Request credential delegation when credentials have been supplied
             if (credentials != null) {
@@ -175,6 +175,7 @@ final class GssKrb5Client extends GssKrb5Base implements SaslClient {
         }
     }
 
+    @Override
     public boolean hasInitialResponse() {
         return true;
     }
@@ -193,6 +194,7 @@ final class GssKrb5Client extends GssKrb5Base implements SaslClient {
      * @return A non-null byte array containing the response to be
      * sent to the server.
      */
+    @Override
     public byte[] evaluateChallenge(byte[] challengeData) throws SaslException {
         if (completed) {
             throw new IllegalStateException(

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Server.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ final class GssKrb5Server extends GssKrb5Base implements SaslServer {
                 KRB5_OID, GSSCredential.ACCEPT_ONLY);
 
             // Create a context using the server's credentials
-            secCtx = mgr.createContext(cred);
+            updateSecCtx(mgr.createContext(cred));
 
             if ((allQop&INTEGRITY_ONLY_PROTECTION) != 0) {
                 // Might need integrity
@@ -144,6 +144,7 @@ final class GssKrb5Server extends GssKrb5Base implements SaslServer {
      * @return A non-null byte array containing the challenge to be
      * sent to the client, or null when no more data is to be sent.
      */
+    @Override
     public byte[] evaluateResponse(byte[] responseData) throws SaslException {
         if (completed) {
             throw new SaslException(
@@ -332,6 +333,7 @@ final class GssKrb5Server extends GssKrb5Base implements SaslServer {
         }
     }
 
+    @Override
     public String getAuthorizationID() {
         if (completed) {
             return authzid;
@@ -340,6 +342,7 @@ final class GssKrb5Server extends GssKrb5Base implements SaslServer {
         }
     }
 
+    @Override
     public Object getNegotiatedProperty(String propName) {
         if (!completed) {
             throw new IllegalStateException("Authentication incomplete");

--- a/test/jdk/com/sun/security/sasl/ClientCleaner.java
+++ b/test/jdk/com/sun/security/sasl/ClientCleaner.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8380310
+ * @summary Ensure that the password in CramMD5Client and PlainClient is cleared
+ * @modules java.security.sasl/com.sun.security.sasl
+ * @compile --patch-module java.security.sasl=${test.src} ClientCleaner.java
+ * @run main/othervm --patch-module java.security.sasl=${test.classes}
+ *      com.sun.security.sasl.ClientCleaner
+ */
+
+package com.sun.security.sasl;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+
+public final class ClientCleaner {
+
+    public static void main(String[] args) throws Exception {
+        String[] types = { "CramMD5", "Plaint" };
+        for (String t : types) {
+            System.out.println("Testing " + t);
+            autoClean(t);
+            callDispose(t);
+            System.out.println("=> Done");
+        }
+    }
+
+    private static void autoClean(String type) throws Exception {
+        byte[] pw = { 'c', 'l', 'e', 'a', 'n', 'e', 'r' };
+        ReferenceQueue<Object> queue = new ReferenceQueue<>();
+        WeakReference<Object> ref = newClient(type, queue, pw, false);
+
+        // run GC and verify that 'pw' is cleared
+        check(ref, queue, pw, (byte)0, type +
+                ": Cleaner did not clear password");
+    }
+
+    private static void callDispose(String type) throws Exception {
+        byte[] pw = { 'd', 'i', 's', 'p', 'o', 's', 'e' };
+        ReferenceQueue<Object> queue = new ReferenceQueue<>();
+        WeakReference<Object> ref = newClient(type, queue, pw, true);
+
+        // 'pw' should be cleared by the dispose() call
+        if (!isFilled(pw, (byte)0)) {
+            throw new AssertionError(type +
+                    ": dispose() did not clear password");
+        }
+
+        // now set 'pw' to nonzero values and see if it's cleared again
+        Arrays.fill(pw, (byte)'x');
+        check(ref, queue, pw, (byte)'x', type +
+                ": Cleaner ran again after dispose()");
+    }
+
+    private static WeakReference<Object> newClient(String type,
+            ReferenceQueue<Object> queue, byte[] password,
+            boolean dispose) throws Exception {
+        Object obj;
+        switch (type) {
+            case "CramMD5" ->{
+                obj = new CramMD5Client("user", password);
+                if (dispose) {
+                    ((CramMD5Client)obj).dispose();
+                }
+            }
+            case "Plaint" ->{
+                obj = new PlainClient(null, "user", password);
+                if (dispose) {
+                    ((PlainClient)obj).dispose();
+                }
+            }
+            default -> throw new RuntimeException("Error: Unsupported type " +
+                               type);
+        }
+        return new WeakReference<>(obj, queue);
+    }
+
+    private static void check(WeakReference<Object> ref,
+            ReferenceQueue<Object> queue, byte[] password, byte val,
+            String message)
+            throws InterruptedException {
+        boolean found = false;
+        for (int i = 0; i < 100; i++) {
+            System.gc();
+
+            if (queue.remove(100) == ref) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            throw new AssertionError(
+                    "not collected; cleaner action may retain it");
+        }
+        for (int i = 0; i < 100; i++) {
+            if (isFilled(password, val)) {
+                return;
+            }
+            System.gc();
+            Thread.sleep(100);
+        }
+        throw new AssertionError(message);
+    }
+
+    private static boolean isFilled(byte[] password, byte expected) {
+        for (byte b : password) {
+            if (b != expected) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/test/jdk/com/sun/security/sasl/ClientCleaner.java
+++ b/test/jdk/com/sun/security/sasl/ClientCleaner.java
@@ -35,7 +35,6 @@ package com.sun.security.sasl;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.util.Arrays;
 
 public final class ClientCleaner {
 
@@ -69,11 +68,6 @@ public final class ClientCleaner {
             throw new AssertionError(type +
                     ": dispose() did not clear password");
         }
-
-        // now set 'pw' to nonzero values and see if it's cleared again
-        Arrays.fill(pw, (byte)'x');
-        check(ref, queue, pw, (byte)'x', type +
-                ": Cleaner ran again after dispose()");
     }
 
     private static WeakReference<Object> newClient(String type,


### PR DESCRIPTION
This PR removes the finalize() methods from the SASL modules and replace them with Cleaner. Also did some minor refactoring so the sensitive info is only kept wherever necessary.

I am still working on a regression test for the GssKrb5 classes, just want to get the source changes out while I work on it so there is more time for review.

Thanks in advance for the review~

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8380310](https://bugs.openjdk.org/browse/JDK-8380310): Remove Finalizers from remaining security components (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32551/head:pull/32551` \
`$ git checkout pull/32551`

Update a local copy of the PR: \
`$ git checkout pull/32551` \
`$ git pull https://git.openjdk.org/jdk.git pull/32551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32551`

View PR using the GUI difftool: \
`$ git pr show -t 32551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32551.diff">https://git.openjdk.org/jdk/pull/32551.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32551#issuecomment-5434592040)
</details>
