### PR TITLE
8375639: C2: transformation to counted loop in Stemmer.java fails with StressIncrementalInlining

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1880,6 +1880,17 @@ Node* IfNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   Node* prev_dom = search_identical(dist, igvn);
 
   if (prev_dom != nullptr) {
+    Node* true_proj = proj_out(1);
+    Node* false_proj = proj_out(0);
+
+    Node* head = true_proj->find_out_with(Op_Loop);
+    if (head == nullptr) {
+      head = false_proj->find_out_with(Op_Loop);
+    }
+    if (head != nullptr && head->as_Loop()->is_loop_nest_inner_loop()) {
+      return nullptr;
+    }
+
     // Dominating CountedLoopEnd (left over from some now dead loop) will become the new loop exit. Outer strip mined
     // loop will go away. Mark this loop as no longer strip mined.
     if (is_CountedLoopEnd()) {
@@ -1945,9 +1956,6 @@ Node* IfNode::dominated_by(Node* prev_dom, PhaseIterGVN* igvn, bool prev_dom_not
         // For Regions it may not be in slot 0.
         uint l;
         for (l = 0; s->in(l) != ifp; l++) { }
-        if (s->is_Loop() && s->as_Loop()->is_loop_nest_inner_loop() && l == LoopNode::LoopBackControl) {
-          s->as_Loop()->clear_loop_nest_inner_loop();
-        }
         igvn->replace_input_of(s, l, ctrl_target);
       }
     } // End for each child of a projection

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1888,6 +1888,8 @@ Node* IfNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       head = false_proj->find_out_with(Op_Loop);
     }
     if (head != nullptr && head->as_Loop()->is_loop_nest_inner_loop()) {
+      // Exit test for a loop that's in the process of being transformed into a counted loop: do not remove that exit
+      // test so the counted loop transformation happens.
       return nullptr;
     }
 

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1945,6 +1945,9 @@ Node* IfNode::dominated_by(Node* prev_dom, PhaseIterGVN* igvn, bool prev_dom_not
         // For Regions it may not be in slot 0.
         uint l;
         for (l = 0; s->in(l) != ifp; l++) { }
+        if (s->is_Loop() && s->as_Loop()->is_loop_nest_inner_loop() && l == LoopNode::LoopBackControl) {
+          s->as_Loop()->clear_loop_nest_inner_loop();
+        }
         igvn->replace_input_of(s, l, ctrl_target);
       }
     } // End for each child of a projection

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1880,8 +1880,8 @@ Node* IfNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   Node* prev_dom = search_identical(dist, igvn);
 
   if (prev_dom != nullptr) {
-    Node* true_proj = proj_out(1);
-    Node* false_proj = proj_out(0);
+    Node* true_proj = this->true_proj();
+    Node* false_proj = this->false_proj();
 
     Node* head = true_proj->find_out_with(Op_Loop);
     if (head == nullptr) {

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -123,7 +123,6 @@ public:
   void mark_profile_trip_failed() { _loop_flags |= ProfileTripFailed; }
   void mark_subword_loop() { _loop_flags |= SubwordLoop; }
   void mark_loop_nest_inner_loop() { _loop_flags |= LoopNestInnerLoop; }
-  void clear_loop_nest_inner_loop() { _loop_flags &= ~LoopNestInnerLoop; }
   void mark_loop_nest_outer_loop() { _loop_flags |= LoopNestLongOuterLoop; }
   void mark_flat_arrays() { _loop_flags |= FlatArrays; }
 

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -123,6 +123,7 @@ public:
   void mark_profile_trip_failed() { _loop_flags |= ProfileTripFailed; }
   void mark_subword_loop() { _loop_flags |= SubwordLoop; }
   void mark_loop_nest_inner_loop() { _loop_flags |= LoopNestInnerLoop; }
+  void clear_loop_nest_inner_loop() { _loop_flags &= ~LoopNestInnerLoop; }
   void mark_loop_nest_outer_loop() { _loop_flags |= LoopNestLongOuterLoop; }
   void mark_flat_arrays() { _loop_flags |= FlatArrays; }
 

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestInnerLoopConstantFoldedExitTest.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestInnerLoopConstantFoldedExitTest.java
@@ -29,6 +29,7 @@
  * @run main ${test.main.class}
  */
 
+package compiler.longcountedloops;
 
 public class TestInnerLoopConstantFoldedExitTest {
     static int offset = 1;

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestInnerLoopConstantFoldedExitTest.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestInnerLoopConstantFoldedExitTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8375639
+  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:StressLongCountedLoop=1 -XX:+AlwaysIncrementalInline
+ *                   -Xbatch -XX:CompileCommand=compileonly,${test.main.class}::test ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+
+public class TestInnerLoopConstantFoldedExitTest {
+    static int offset = 1;
+    static final char[] array = {'a', 'b'};
+
+    static void loop(String s, int off) {
+        for (int i = 0; i < 2; i++) {
+            if (array[off + i] != s.charAt(i)) {
+                return;
+            }
+        }
+    }
+
+    static void test() {
+        int start = offset - 1;
+        loop("cd", start);
+        loop("ab", start);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; i++) {
+            test();
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestInnerLoopConstantFoldedExitTest.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestInnerLoopConstantFoldedExitTest.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8375639
-  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:StressLongCountedLoop=1 -XX:+AlwaysIncrementalInline
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:StressLongCountedLoop=1 -XX:+AlwaysIncrementalInline
  *                   -Xbatch -XX:CompileCommand=compileonly,${test.main.class}::test ${test.main.class}
  * @run main ${test.main.class}
  */


### PR DESCRIPTION
A `LongCountedLoop` is transformed into a loop nest with an inner
`CountedLoop`. That happens in 2 passes of loop opts: first the loop
nest is created and then the inner loop is transformed into a counted
loop. The assert that fails catches cases where a transformation
happens between the 2 passes that causes the shape of the inner loop
to change so that it's not recognized as a counted loop, i.e. c2
somehow fails at transforming the inner loop into a counted loop.

In this particular case, the exit condition of the inner loop is
constant folded because a dominating `If` with an identical condition
is found by igvn. The fix I propose, is to not constant fold the exit
condition in that case. That allows the counted loop transformation to
proceed and a pass of loop opts to run. The exit condition is likely
constant folded next time igvn runs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8375639](https://bugs.openjdk.org/browse/JDK-8375639): C2: transformation to counted loop in Stemmer.java fails with StressIncrementalInlining (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32552/head:pull/32552` \
`$ git checkout pull/32552`

Update a local copy of the PR: \
`$ git checkout pull/32552` \
`$ git pull https://git.openjdk.org/jdk.git pull/32552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32552`

View PR using the GUI difftool: \
`$ git pr show -t 32552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32552.diff">https://git.openjdk.org/jdk/pull/32552.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32552#issuecomment-5435987470)
</details>
