### PR TITLE
8353495: tools/launcher/ExecutionEnvironment.java fails on RISC-V when run by qemu

### DIFF
--- a/test/jdk/tools/launcher/ExecutionEnvironment.java
+++ b/test/jdk/tools/launcher/ExecutionEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/launcher/ExecutionEnvironment.java
+++ b/test/jdk/tools/launcher/ExecutionEnvironment.java
@@ -23,9 +23,10 @@
 
 /*
  * @test
- * @bug 4780570 4731671 6354700 6367077 6670965 4882974
+ * @bug 4780570 4731671 6354700 6367077 6670965 4882974 8353495
  * @summary Checks for LD_LIBRARY_PATH and execution on *nixes
  * @requires os.family != "windows"
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @modules jdk.compiler
  *          jdk.zipfs

--- a/test/jdk/tools/launcher/ExecutionEnvironment.java
+++ b/test/jdk/tools/launcher/ExecutionEnvironment.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4780570 4731671 6354700 6367077 6670965 4882974 8353495
+ * @bug 4780570 4731671 6354700 6367077 6670965 4882974
  * @summary Checks for LD_LIBRARY_PATH and execution on *nixes
  * @requires os.family != "windows"
  * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")

--- a/test/jdk/tools/launcher/Test7029048.java
+++ b/test/jdk/tools/launcher/Test7029048.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Ensure that the launcher defends against user settings of the
  *          LD_LIBRARY_PATH environment variable on Unixes
  * @requires os.family != "windows" & os.family != "mac"
+ * @requires os.arch != "riscv64" | !(vm.cpu.features ~= ".*qemu.*")
  * @library /test/lib
  * @compile ExecutionEnvironment.java Test7029048.java
  * @run main/othervm Test7029048


### PR DESCRIPTION
`ExecutionEnvironment` verifies that the JDK launcher preserves `LD_LIBRARY_PATH` when starting a child VM. A RISC-V QEMU launcher wrapper needs to set this variable to locate the target libraries, so the wrapper overwrites the sentinel value before the child VM starts. The test therefore cannot verify its intended launcher property in this environment.

This change excludes only RISC-V running under QEMU, using the same `vm.cpu.features` condition already used by other tests. Native RISC-V and all other supported Unix platforms continue to run the test.

Testing:

- Reproduced the original failure under `qemu-riscv64-static`: `FAIL: did not get <LD_LIBRARY_PATH=/Bridge/On/The/River/Kwai>`.
- Verified that the test is not selected when `os.arch=riscv64` and `vm.cpu.features=qemu`.
- Verified `test/jdk/tools/launcher/ExecutionEnvironment.java` passes on Linux x86_64 (`passed: 1`).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8353495](https://bugs.openjdk.org/browse/JDK-8353495): tools/launcher/ExecutionEnvironment.java fails on RISC-V when run by qemu (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer) Review applies to [c0a57a80](https://git.openjdk.org/jdk/pull/32553/files/c0a57a80995c268ef6aa1a8337f7f5283c202df3)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32553/head:pull/32553` \
`$ git checkout pull/32553`

Update a local copy of the PR: \
`$ git checkout pull/32553` \
`$ git pull https://git.openjdk.org/jdk.git pull/32553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32553`

View PR using the GUI difftool: \
`$ git pr show -t 32553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32553.diff">https://git.openjdk.org/jdk/pull/32553.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32553#issuecomment-5436076969)
</details>
