### PR TITLE
8354563: javap's -bootclasspath option is no longer respected

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -585,8 +585,14 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
         }
 
         try {
-            if (fileManager.handleOption(name, rest))
+            if (fileManager.handleOption(name, rest)) {
+                if (name.equals("-bootclasspath")
+                        || name.equals("--boot-class-path")
+                        || name.startsWith("--boot-class-path=")) {
+                    bootClassPathSpecified = true;
+                }
                 return;
+            }
         } catch (IllegalArgumentException e) {
             throw new BadArgs("err.invalid.use.of.option", name).showUsage(true);
         }
@@ -871,7 +877,7 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
             if (moduleLocation != null) {
                 fo = fileManager.getJavaFileForInput(moduleLocation, className, JavaFileObject.Kind.CLASS);
             } else {
-                if (className.indexOf('.') > 0 || className.indexOf('/') > 0) {
+                if (!bootClassPathSpecified && (className.indexOf('.') > 0 || className.indexOf('/') > 0)) {
                     //search for classes with a named package in the JDK modules specifed by --system option first
                     try {
                         for (Set<Location> locations: fileManager.listLocationsForModules(StandardLocation.SYSTEM_MODULES)) {
@@ -1082,6 +1088,7 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
     List<String> classes;
     Location moduleLocation;
     Options options;
+    boolean bootClassPathSpecified;
     //ResourceBundle bundle;
     Locale task_locale;
     Map<Locale, ResourceBundle> bundles;

--- a/test/langtools/tools/javap/BootClassPathTest.java
+++ b/test/langtools/tools/javap/BootClassPathTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Yunbo Zhang. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8354563
+ * @summary Verify javap honors -bootclasspath when resolving system classes
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.javap
+ * @build toolbox.JavacTask toolbox.JavapTask toolbox.ToolBox
+ * @run main BootClassPathTest
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import toolbox.JavacTask;
+import toolbox.JavapTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class BootClassPathTest {
+    public static void main(String... args) throws Exception {
+        ToolBox tb = new ToolBox();
+        Path src = Paths.get("src");
+        Path classes = Files.createDirectories(Paths.get("classes"));
+
+        tb.writeJavaFiles(src, """
+                package java.lang;
+
+                public class Object {
+                    public static final int TEST_FIELD = 0;
+                }
+                """);
+
+        new JavacTask(tb)
+                .options("--patch-module", "java.base=" + src)
+                .outdir(classes)
+                .files(tb.findJavaFiles(src))
+                .run()
+                .writeAll();
+
+        String testJdk = System.getProperty("test.jdk");
+        String bootClassPath = classes.toString();
+        String[][] optionSets = {
+                { "-bootclasspath", bootClassPath },
+                { "--boot-class-path", bootClassPath },
+                { "--boot-class-path=" + bootClassPath },
+                { "--system", testJdk, "-bootclasspath", bootClassPath },
+                { "-bootclasspath", bootClassPath, "--system", testJdk },
+                { "--system", testJdk, "--boot-class-path", bootClassPath },
+                { "--boot-class-path", bootClassPath, "--system", testJdk }
+        };
+
+        String[] classNames = {
+                "java.lang.Object",
+                "java/lang/Object"
+        };
+
+        for (String[] options : optionSets) {
+            for (String className : classNames) {
+                String output = new JavapTask(tb)
+                        .options(options)
+                        .classes(className)
+                        .run()
+                        .writeAll()
+                        .getOutput(Task.OutputKind.DIRECT);
+
+                if (!output.contains("TEST_FIELD")) {
+                    throw new AssertionError("javap ignored boot class path for " + className
+                            + " with options: " + String.join(" ", options) + "\n" + output);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Problem:

When `-bootclasspath` is specified, javap still searches `SYSTEM_MODULES` before `PLATFORM_CLASS_PATH`. Therefore, system classes such as `java.lang.Object` are loaded from the current JDK instead of the specified boot class path.

Fix:

When a boot class path is explicitly specified, skip the `SYSTEM_MODULES` lookup. The existing behavior remains unchanged otherwise.

Testing:

- Added regression coverage for all three boot class path option forms: `-bootclasspath`, `--boot-class-path`, and `--boot-class-path=<path>`.
- `make test TEST=test/langtools/tools/javap`: 87 passed, 1 excluded, 0 failed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8354563](https://bugs.openjdk.org/browse/JDK-8354563): javap's -bootclasspath option is no longer respected (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32554/head:pull/32554` \
`$ git checkout pull/32554`

Update a local copy of the PR: \
`$ git checkout pull/32554` \
`$ git pull https://git.openjdk.org/jdk.git pull/32554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32554`

View PR using the GUI difftool: \
`$ git pr show -t 32554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32554.diff">https://git.openjdk.org/jdk/pull/32554.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32554#issuecomment-5436369563)
</details>
