### PR TITLE
8384133: StringTableCorruptionTest should keep Strings alive to reliably trigger

### DIFF
--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCorruptionTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCorruptionTest.java
@@ -34,8 +34,8 @@
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCorruptionTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCorruptionTest.java
@@ -34,11 +34,16 @@
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.ArrayList;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class StringTableCorruptionTest {
+    // Retain all Strings to make sure StringTable grows and keeps our corrupted String alive
+    static final List<String> RETAIN = new ArrayList<>();
+
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("--add-opens", "java.base/java.lang=ALL-UNNAMED",
@@ -51,9 +56,20 @@ public class StringTableCorruptionTest {
 
         Field f = String.class.getDeclaredField("value");
         f.setAccessible(true);
-        f.set("s1".intern(), f.get("s2"));
+
+        // Put a String into StringTable and corrupt it.
+        String s1 = "s1".intern();
+        f.set(s1, f.get("s2"));
+        RETAIN.add(s1);
+
+        // Fill in StringTable to trigger growth.
+        // Also do a few GCs to make sure test behavior does not depend to stray GCs.
         for (int i = 0; i < 4_000_000; i++) {
-            ("s_" + i).intern();
+            String s = ("s_" + i).intern();
+            RETAIN.add(s);
+            if (i % 100_000 == 0) {
+                System.gc();
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCorruptionTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCorruptionTest.java
@@ -63,7 +63,7 @@ public class StringTableCorruptionTest {
         RETAIN.add(s1);
 
         // Fill in StringTable to trigger growth.
-        // Also do a few GCs to make sure test behavior does not depend to stray GCs.
+        // Also do a few intentional GCs to make sure test behavior does not depend on accidental GCs.
         for (int i = 0; i < 4_000_000; i++) {
             String s = ("s_" + i).intern();
             RETAIN.add(s);


### PR DESCRIPTION
Caught this in my GHA runs. I took a brief look, and I think the mechanism is simple. Test allocates a string, interns it, deliberately corrupts it, and then does intern-s to grow the String table. The verification code which we want to trigger works on table grows, and verifies existing entries there. But G1 is apparently able to clean up the table before the growth happens, so we sometimes see no corrupted string, since it is dead. So the test intermittently fails.

This is a test bug: we need to retain strings to make sure G1 triggers the check reliably. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, affected test now passes, 100x repeats
 - [x] Linux x86_64 server fastdebug, affected test reliably fails without `RETAIN.add`-s

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384133](https://bugs.openjdk.org/browse/JDK-8384133): StringTableCorruptionTest should keep Strings alive to reliably trigger (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32557/head:pull/32557` \
`$ git checkout pull/32557`

Update a local copy of the PR: \
`$ git checkout pull/32557` \
`$ git pull https://git.openjdk.org/jdk.git pull/32557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32557`

View PR using the GUI difftool: \
`$ git pr show -t 32557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32557.diff">https://git.openjdk.org/jdk/pull/32557.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32557#issuecomment-5439051033)
</details>
