### PR TITLE
8391295: Net.c and other native code cleanup

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -276,8 +276,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
      */
     if (domain == AF_INET6 && ipv4_available()) {
         int arg = 0;
-        if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&arg,
-                       sizeof(int)) < 0) {
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&arg, sizeof(int)) < 0) {
             JNU_ThrowByNameWithLastError(env,
                                          JNU_JAVANETPKG "SocketException",
                                          "Unable to set IPV6_V6ONLY");
@@ -288,8 +287,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
 
     if (reuse) {
         int arg = 1;
-        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&arg,
-                       sizeof(arg)) < 0) {
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, sizeof(arg)) < 0) {
             JNU_ThrowByNameWithLastError(env,
                                          JNU_JAVANETPKG "SocketException",
                                          "Unable to set SO_REUSEADDR");
@@ -418,7 +416,6 @@ Java_sun_nio_ch_Net_accept(JNIEnv *env, jclass clazz, jobject fdo, jobject newfd
         }
         /* ECONNABORTED => restart accept */
     }
-
     if (newfd < 0) {
         if (errno == EAGAIN || errno == EWOULDBLOCK)
             return IOS_UNAVAILABLE;
@@ -427,14 +424,18 @@ Java_sun_nio_ch_Net_accept(JNIEnv *env, jclass clazz, jobject fdo, jobject newfd
         JNU_ThrowIOExceptionWithLastError(env, "Accept failed");
         return IOS_THROWN;
     }
-
     setfdval(env, newfdo, newfd);
 
     remote_ia = NET_SockaddrToInetAddress(env, &sa, (int *)&remote_port);
-    CHECK_NULL_RETURN(remote_ia, IOS_THROWN);
-
+    if (remote_ia == NULL) {
+        close(newfd);
+        return IOS_THROWN;
+    }
     isa = (*env)->NewObject(env, isa_class, isa_ctorID, remote_ia, remote_port);
-    CHECK_NULL_RETURN(isa, IOS_THROWN);
+    if (isa == NULL) {
+        close(newfd);
+        return IOS_THROWN;
+    }
     (*env)->SetObjectArrayElement(env, isaa, 0, isa);
 
     return 1;

--- a/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,8 +172,10 @@ Java_sun_nio_ch_UnixDomainSockets_accept0(JNIEnv *env, jclass clazz, jobject fdo
     setfdval(env, newfdo, newfd);
 
     address = sockaddrToUnixAddressBytes(env, &sa, sa_len);
-    CHECK_NULL_RETURN(address, IOS_THROWN);
-
+    if (address == NULL) {
+        close(newfd);
+        return IOS_THROWN;
+    }
     (*env)->SetObjectArrayElement(env, array, 0, address);
 
     return 1;

--- a/src/java.base/unix/native/libnio/ch/UnixFileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/UnixFileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,9 +191,9 @@ Java_sun_nio_ch_UnixFileDispatcherImpl_available0(JNIEnv *env, jobject this, job
     if (fstat(fd, &fbuf) != -1) {
         int mode = fbuf.st_mode;
         if (S_ISCHR(mode) || S_ISFIFO(mode) || S_ISSOCK(mode)) {
-            int n = ioctl(fd, FIONREAD, &n);
-            if (n >= 0) {
-                return n;
+            int available;
+            if (ioctl(fd, FIONREAD, &available) >= 0) {
+                return available;
             }
         } else if (S_ISREG(mode)) {
             size = fbuf.st_size;

--- a/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,32 +435,36 @@ Java_sun_nio_ch_FileDispatcherImpl_isOther0(JNIEnv *env, jobject this, jobject f
     HANDLE handle = (HANDLE)(handleval(env, fdo));
 
     BY_HANDLE_FILE_INFORMATION finfo;
-    if (!GetFileInformationByHandle(handle, &finfo))
+    if (!GetFileInformationByHandle(handle, &finfo)) {
         JNU_ThrowIOExceptionWithLastError(env, "isOther failed");
-    DWORD fattr = finfo.dwFileAttributes;
+        return JNI_FALSE;
+    }
 
+    DWORD fattr = finfo.dwFileAttributes;
     if ((fattr & FILE_ATTRIBUTE_DEVICE) != 0)
         return (jboolean)JNI_TRUE;
 
     if ((fattr & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
         int size = MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
         void* lpOutBuffer = (void*)malloc(size*sizeof(char));
-        if (lpOutBuffer == NULL)
+        if (lpOutBuffer == NULL) {
             JNU_ThrowOutOfMemoryError(env, "isOther failed");
+            return JNI_FALSE;
+        }
 
         DWORD bytesReturned;
         if (!DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, NULL, 0,
                              lpOutBuffer, (DWORD)size, &bytesReturned, NULL)) {
             free(lpOutBuffer);
             JNU_ThrowIOExceptionWithLastError(env, "isOther failed");
+            return JNI_FALSE;
         }
         ULONG reparseTag = (*((PULONG)lpOutBuffer));
         free(lpOutBuffer);
-        return reparseTag == IO_REPARSE_TAG_SYMLINK ?
-            (jboolean)JNI_FALSE : (jboolean)JNI_TRUE;
+        return reparseTag == IO_REPARSE_TAG_SYMLINK ? JNI_FALSE : JNI_TRUE;
     }
 
-    return (jboolean)JNI_FALSE;
+    return JNI_FALSE;
 }
 
 JNIEXPORT jint JNICALL

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -158,25 +158,19 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
     int domain = (preferIPv6) ? AF_INET6 : AF_INET;
 
     s = socket(domain, (stream ? SOCK_STREAM : SOCK_DGRAM), 0);
-    if (s != INVALID_SOCKET) {
-        SetHandleInformation((HANDLE)s, HANDLE_FLAG_INHERIT, 0);
-
-        /* Attempt to disable IPV6_V6ONLY to ensure dual-socket support; ignore errors */
-        if (domain == AF_INET6) {
-            int opt = 0;
-            setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY,
-                       (const char *)&opt, sizeof(opt));
-        }
-
-        /* Disable WSAECONNRESET errors for initially unconnected UDP sockets */
-        if (!stream) {
-            setConnectionReset(s, FALSE);
-        }
-
-    } else {
+    if (s == INVALID_SOCKET) {
         NET_ThrowNew(env, WSAGetLastError(), "socket");
+        return IOS_THROWN;
+    }
+    SetHandleInformation((HANDLE)s, HANDLE_FLAG_INHERIT, 0);
+
+    /* Attempt to disable IPV6_V6ONLY to ensure dual-socket support; ignore errors */
+    if (domain == AF_INET6 && ipv4_available()) {
+        int opt = 0;
+        setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, (const char *)&opt, sizeof(opt));
     }
 
+    /* Enable SIO_LOOPBACK_FAST_PATH on TCP sockets if possible */
     if (stream && fastLoopback) {
         static int loopback_available = 1;
         if (loopback_available) {
@@ -186,9 +180,16 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
                     loopback_available = 0;
                 } else {
                     NET_ThrowNew(env, rv, "fastLoopback");
+                    closesocket(s);
+                    return IOS_THROWN;
                 }
             }
         }
+    }
+
+    /* Disable WSAECONNRESET errors for initially unconnected UDP sockets */
+    if (!stream) {
+        setConnectionReset(s, FALSE);
     }
 
     return (jint)s;
@@ -290,15 +291,19 @@ Java_sun_nio_ch_Net_accept(JNIEnv *env, jclass clazz, jobject fdo, jobject newfd
         JNU_ThrowIOExceptionWithLastError(env, "Accept failed");
         return IOS_THROWN;
     }
-
     SetHandleInformation((HANDLE)(UINT_PTR)newfd, HANDLE_FLAG_INHERIT, 0);
     setfdval(env, newfdo, newfd);
 
     remote_ia = NET_SockaddrToInetAddress(env, &sa, (int *)&remote_port);
-    CHECK_NULL_RETURN(remote_ia, IOS_THROWN);
-
+    if (remote_ia == NULL) {
+        closesocket(newfd);
+        return IOS_THROWN;
+    }
     isa = (*env)->NewObject(env, isa_class, isa_ctorID, remote_ia, remote_port);
-    CHECK_NULL_RETURN(isa, IOS_THROWN);
+    if (isa == NULL) {
+        closesocket(newfd);
+        return IOS_THROWN;
+    }
     (*env)->SetObjectArrayElement(env, isaa, 0, isa);
 
     return 1;

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,7 +237,10 @@ Java_sun_nio_ch_UnixDomainSockets_accept0(JNIEnv *env, jclass clazz, jobject fdo
     setfdval(env, newfdo, newfd);
 
     address = sockaddrToUnixAddressBytes(env, &sa, sa_len);
-    CHECK_NULL_RETURN(address, IOS_THROWN);
+    if (address == NULL) {
+        closesocket(newfd);
+        return IOS_THROWN;
+    }
     (*env)->SetObjectArrayElement(env, array, 0, address);
 
     return 1;

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -901,8 +901,8 @@ Java_sun_nio_fs_WindowsNativeDispatcher_LookupAccountSid0(JNIEnv* env,
 {
     WCHAR domain[255];
     WCHAR name[255];
-    DWORD domainLen = sizeof(domain);
-    DWORD nameLen = sizeof(name);
+    DWORD domainLen = (DWORD)(sizeof(domain) / sizeof(domain[0]));
+    DWORD nameLen = (DWORD)(sizeof(name) / sizeof(name[0]));
     SID_NAME_USE use;
     PSID sid = jlong_to_ptr(address);
     jstring s;
@@ -932,7 +932,7 @@ Java_sun_nio_fs_WindowsNativeDispatcher_LookupAccountName0(JNIEnv* env,
     LPCWSTR accountName = jlong_to_ptr(nameAddress);
     PSID sid = jlong_to_ptr(sidAddress);
     WCHAR domain[255];
-    DWORD domainLen = sizeof(domain);
+    DWORD domainLen = (DWORD)(sizeof(domain) / sizeof(domain[0]));
     SID_NAME_USE use;
 
     if (LookupAccountNameW(NULL, accountName, sid, (LPDWORD)&cbSid,


### PR DESCRIPTION
Some native code cleanups:

- Net.accept doesn't close the accepted socket if NET_SockaddrToInetAddress or NewObject fails
- UnixDomainSockets.accept0 doesn't close the accepted socket if sockaddrToUnixAddressBytes fails
- UnixFileDispatcherImpl.available ioctl(FIONREAD) isn't returning the returned "available"
- FileDispatcherImpl.isOther0 should return immediately after JNU_ThrowOutOfMemoryError
- WindowsNativeDispatcher_LookupAccountSid0 and WindowsNativeDispatcher_LookupAccountName0 doesn't compute domainLen correctly

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391295](https://bugs.openjdk.org/browse/JDK-8391295): Net.c and other native code cleanup (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32561/head:pull/32561` \
`$ git checkout pull/32561`

Update a local copy of the PR: \
`$ git checkout pull/32561` \
`$ git pull https://git.openjdk.org/jdk.git pull/32561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32561`

View PR using the GUI difftool: \
`$ git pr show -t 32561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32561.diff">https://git.openjdk.org/jdk/pull/32561.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32561#issuecomment-5450651938)
</details>
