### PR TITLE
8391298: JFR: Overscoping JfrEpochShift_lock

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -38,7 +38,6 @@
 #include "jfr/recorder/storage/jfrMemorySpace.inline.hpp"
 #include "jfr/recorder/storage/jfrReferenceCountedStorage.hpp"
 #include "jfr/recorder/storage/jfrStorageUtils.inline.hpp"
-#include "jfr/recorder/stringpool/jfrStringPool.hpp"
 #include "jfr/support/jfrDeprecationManager.hpp"
 #include "jfr/support/jfrKlassUnloading.hpp"
 #include "jfr/support/jfrThreadLocal.hpp"
@@ -507,7 +506,6 @@ void JfrCheckpointManager::shift_epoch() {
   DEBUG_ONLY(const u1 current_epoch = JfrTraceIdEpoch::current();)
   JfrTraceIdEpoch::shift_epoch();
   assert(current_epoch != JfrTraceIdEpoch::current(), "invariant");
-  JfrStringPool::on_epoch_shift();
 }
 
 size_t JfrCheckpointManager::write() {

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -467,12 +467,15 @@ void JfrRecorderService::safepoint_clear() {
   _checkpoint_manager.notify_threads(true);
   JfrDeprecationManager::on_safepoint_clear();
   JfrStackTraceRepository::clear();
-  // Ensure that non-Java threads cannot perform tagging, enqueuing,
-  // or event writing that interleaves with the epoch shift.
-  ConditionalMutexLocker lock(JfrEpochShift_lock, UseShenandoahGC || UseZGC, Mutex::_no_safepoint_check_flag);
-  _storage.clear();
-  _chunkwriter.set_time_stamp();
-  _checkpoint_manager.shift_epoch();
+  {
+    // Ensure that non-Java threads cannot perform tagging, enqueuing,
+    // or event writing that interleaves with the epoch shift.
+    ConditionalMutexLocker lock(JfrEpochShift_lock, UseShenandoahGC || UseZGC, Mutex::_no_safepoint_check_flag);
+    _storage.clear();
+    _chunkwriter.set_time_stamp();
+    _checkpoint_manager.shift_epoch();
+  }
+  JfrStringPool::on_epoch_shift();
 }
 
 void JfrRecorderService::post_safepoint_clear() {
@@ -581,12 +584,15 @@ void JfrRecorderService::safepoint_write() {
   _checkpoint_manager.on_rotation();
   JfrDeprecationManager::on_safepoint_write();
   write_stacktrace(_stack_trace_repository, _chunkwriter, true);
-  // Ensure that non-Java threads cannot perform tagging, enqueuing,
-  // or event writing that interleaves with the epoch shift.
-  ConditionalMutexLocker lock(JfrEpochShift_lock, UseShenandoahGC || UseZGC, Mutex::_no_safepoint_check_flag);
-  _storage.write_at_safepoint();
-  _chunkwriter.set_time_stamp();
-  _checkpoint_manager.shift_epoch();
+  {
+    // Ensure that non-Java threads cannot perform tagging, enqueuing,
+    // or event writing that interleaves with the epoch shift.
+    ConditionalMutexLocker lock(JfrEpochShift_lock, UseShenandoahGC || UseZGC, Mutex::_no_safepoint_check_flag);
+    _storage.write_at_safepoint();
+    _chunkwriter.set_time_stamp();
+    _checkpoint_manager.shift_epoch();
+  }
+  JfrStringPool::on_epoch_shift();
 }
 
 void JfrRecorderService::post_safepoint_write() {


### PR DESCRIPTION
Greetings,

JfrEpochShift_lock is held while notifying JfrStringPool::on_epoch_shift(), which touches an oop.

It can lock-invert against NmtVirtualMemoryLocker when updating the new epoch generation.

Testing: jdk_jfr

Cheers
Markus

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391298](https://bugs.openjdk.org/browse/JDK-8391298): JFR: Overscoping JfrEpochShift_lock (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32562/head:pull/32562` \
`$ git checkout pull/32562`

Update a local copy of the PR: \
`$ git checkout pull/32562` \
`$ git pull https://git.openjdk.org/jdk.git pull/32562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32562`

View PR using the GUI difftool: \
`$ git pr show -t 32562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32562.diff">https://git.openjdk.org/jdk/pull/32562.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32562#issuecomment-5442645149)
</details>
