### PR TITLE
8391075: 'jfr assemble' doesn't handle unfinished files

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,10 @@ import jdk.jfr.internal.MetadataDescriptor;
 
 public final class ChunkHeader {
     public static final long HEADER_SIZE = 68;
-    static final byte UPDATING_CHUNK_HEADER = (byte) 255;
+    public static final byte UPDATING_CHUNK_HEADER = (byte) 255;
     public static final long CHUNK_SIZE_POSITION = 8;
     static final long DURATION_NANOS_POSITION = 40;
-    static final long FILE_STATE_POSITION = 64;
+    public static final long FILE_STATE_POSITION = 64;
     static final long FLAG_BYTE_POSITION = 67;
     static final long METADATA_TYPE_ID = 0;
     static final byte[] FILE_MAGIC = { 'F', 'L', 'R', '\0' };

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RecordingInput.java
@@ -98,7 +98,7 @@ public final class RecordingInput implements DataInput, AutoCloseable {
         this(f, DEFAULT_BLOCK_SIZE);
     }
 
-    void positionPhysical(long position) throws IOException {
+    public void positionPhysical(long position) throws IOException {
         file.seek(position);
     }
 
@@ -110,7 +110,7 @@ public final class RecordingInput implements DataInput, AutoCloseable {
         return file.readLong();
     }
 
-    void readPhysicalFully(byte[] dest, int offset, int length) throws IOException {
+    public void readPhysicalFully(byte[] dest, int offset, int length) throws IOException {
         file.readFully(dest, offset, length);
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Assemble.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Assemble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,16 +28,20 @@ package jdk.jfr.internal.tool;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 
+import jdk.jfr.internal.consumer.ChunkHeader;
+import jdk.jfr.internal.consumer.RecordingInput;
 import jdk.jfr.internal.util.UserDataException;
 import jdk.jfr.internal.util.UserSyntaxException;
 
@@ -111,14 +115,36 @@ final class Assemble extends Command {
     }
 
     private void transferTo(List<Path> sourceFiles, Path output, FileChannel out) throws UserDataException {
-        long pos = 0;
         for (Path p : sourceFiles) {
+            long pos = 0;
+            long rem = 0;
+            try (RecordingInput input = new RecordingInput(p.toFile())) {
+                HeaderData hd = HeaderData.read(input);
+                if (hd == null) {
+                    println("Skipping recording chunk that is being updated " + p );
+                    continue;
+                }
+                if (hd.finished()) {
+                    rem = Files.size(p);
+                } else {
+                    hd.markFinished();
+                    hd.write(out);
+                    println("Truncating unfinished recording chunk  " + p);
+                    rem = hd.size() - ChunkHeader.HEADER_SIZE;
+                    pos = ChunkHeader.HEADER_SIZE;
+                }
+            } catch (IOException e) {
+                println("Skipping recording chunk  " + p + " due to: " + e.getMessage());
+                continue;
+            }
             println(" " + p.toString());
             try (FileChannel sourceChannel = FileChannel.open(p)) {
-                long rem = Files.size(p);
                 while (rem > 0) {
                     long n = Math.min(rem, 1024 * 1024);
-                    long w = out.transferFrom(sourceChannel, pos, n);
+                    long w = sourceChannel.transferTo(pos, n, out);
+                    if (w == 0) {
+                        throw new IOException("Could not transfer remaining bytes");
+                    }
                     pos += w;
                     rem -= w;
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/HeaderData.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/HeaderData.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.internal.tool;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.ByteBuffer;
+import jdk.jfr.internal.consumer.ChunkHeader;
+import jdk.jfr.internal.consumer.RecordingInput;
+
+final class HeaderData {
+    private static int FILE_STATE_POSITION = (int) ChunkHeader.FILE_STATE_POSITION;
+    private static int CHUNK_SIZE_POSITION = (int) ChunkHeader.CHUNK_SIZE_POSITION;
+    private static int HEADER_SIZE = (int) ChunkHeader.HEADER_SIZE;
+
+    private final ByteBuffer buffer;
+
+    HeaderData(byte[] bytes) {
+        buffer = ByteBuffer.wrap(bytes);
+    }
+
+    boolean finished() {
+        return buffer.get(FILE_STATE_POSITION) == 0;
+    }
+
+    long size() {
+        return buffer.getLong(CHUNK_SIZE_POSITION);
+    }
+
+    void markFinished() {
+        buffer.put(FILE_STATE_POSITION, (byte) 0);
+    }
+
+    void write(FileChannel out) throws IOException {
+        while (buffer.hasRemaining()) {
+            out.write(buffer);
+        }
+    }
+
+    static HeaderData read(RecordingInput input) throws IOException {
+        byte[] first = new byte[HEADER_SIZE];
+        byte[] second = new byte[HEADER_SIZE];
+        while (true) {
+            while (true) {
+                input.positionPhysical(0);
+                input.readPhysicalFully(first, 0, first.length);
+                if (first[FILE_STATE_POSITION] != ChunkHeader.UPDATING_CHUNK_HEADER) {
+                    break;
+                }
+                try {
+                    input.pollWait();
+                } catch (IOException ioe) {
+                    return null;
+                }
+            }
+            input.positionPhysical(0);
+            input.readPhysicalFully(second, 0, second.length);
+            if (first[FILE_STATE_POSITION] == second[FILE_STATE_POSITION]) {
+                return new HeaderData(first);
+            }
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/tool/TestAssemble.java
+++ b/test/jdk/jdk/jfr/tool/TestAssemble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,11 @@ package jdk.jfr.tool;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 import jdk.jfr.Event;
 import jdk.jfr.Name;
@@ -69,14 +71,16 @@ public class TestAssemble {
             r.stop();
             recordings[i] = r;
         }
-        Path dir = Paths.get("reconstruction-parts");
+        Path dir = Paths.get("reconstruction-parts").toAbsolutePath();
         Files.createDirectories(dir);
 
         long expectedCount = 0;
+        Path[] files = new Path[RECORDING_COUNT];
         for (int i = 0; i < RECORDING_COUNT; i++) {
-            Path tmp = dir.resolve("chunk-part-" + i + ".jfr");
-            recordings[i].dump(tmp);
-            expectedCount += countEventInRecording(tmp);
+            Path file = dir.resolve("chunk-part-" + i + ".jfr");
+            recordings[i].dump(file);
+            expectedCount += countEventInRecording(file);
+            files[i] = file;
         }
 
         Path repository = Repository.getRepository().getRepositoryPath();
@@ -112,13 +116,48 @@ public class TestAssemble {
         output = ExecuteHelper.jfr("assemble", directory, destination);
         System.out.println(output.getOutput());
         output.shouldContain("Finished.");
-
         long reconstructedCount = countEventInRecording(destinationPath);
         Asserts.assertEquals(expectedCount, reconstructedCount);
+        Files.delete(destinationPath);
+
+        // Test unfinished and updated
+        writeUnfinished(files[1]);
+        writeUpdating(files[2]);
+        output = ExecuteHelper.jfr("assemble", dir.toString(), destination);
+        System.out.println(output.getOutput());
+        output.shouldContain("Skipping");
+        output.shouldContain("Truncating");
+        reconstructedCount = countEventInRecording(destinationPath);
+        Asserts.assertEquals(RECORDING_COUNT - 1L, reconstructedCount);
+        Files.delete(destinationPath);
+
         // Cleanup
         for (int i = 0; i < RECORDING_COUNT; i++) {
             recordings[i].close();
         }
+    }
+
+    private static void writeUpdating(Path path) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(path.toFile(), "rw")) {
+            raf.seek(64); // file state position
+            raf.write(255); // means the JVM is currently modifying header
+            appendJunk(raf);
+        }
+    }
+
+    private static void writeUnfinished(Path path) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(path.toFile(), "rw")) {
+            raf.seek(64); // file state position
+            raf.write(42); // generation 42 (not finished)
+            appendJunk(raf);
+        }
+    }
+
+    private static void appendJunk(RandomAccessFile raf) throws IOException {
+        byte[] junk = new byte[131072];
+        Arrays.fill(junk, (byte)42);
+        raf.seek(raf.length());
+        raf.write(junk);
     }
 
     private static long countEventInRecording(Path file) throws IOException {


### PR DESCRIPTION
Could I have a review of a PR that makes the `jfr assemble` command work against unfinished files?

**Problem**
Users copy chunk files from the JFR repository while the JVM is running. It's not supported, but it happens anyway. This means the last chunk is typically in an unfinished state, or it might even be updating the chunk header.The JDK parser does check if a file is being written to, but `jfr assemble` doesn't, so the output file may become unparsable. 

My plan is to update ChunkHeader to take a byte[], but that's a larger change. I created the HeaderData class for this PR so the fix can safely be backported.

This fix also allows `jfr assemble` to repair unfinished files so they can be read by the JMC parser. 

Testing: test/jdk/jdk/jfr/tool/TestAssemble.java

Thanks
Erik


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391075](https://bugs.openjdk.org/browse/JDK-8391075): 'jfr assemble' doesn't handle unfinished files (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32563/head:pull/32563` \
`$ git checkout pull/32563`

Update a local copy of the PR: \
`$ git checkout pull/32563` \
`$ git pull https://git.openjdk.org/jdk.git pull/32563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32563`

View PR using the GUI difftool: \
`$ git pr show -t 32563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32563.diff">https://git.openjdk.org/jdk/pull/32563.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32563#issuecomment-5443906780)
</details>
