### PR TITLE
8391235: Zero build fails due to GCC-15.2.0 stringop-overflow warning after JDK-8390310

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.cpp
@@ -26,11 +26,19 @@
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
 #include "gc/shenandoah/shenandoahGenerationalHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 #include "gc/shenandoah/shenandoahInPlacePromoter.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahScanRemembered.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
+
+void ShenandoahInPlacePromotionPlanner::RegionPromotionStats::update(ShenandoahHeapRegion* region) {
+  count++;
+  usage += region->get_live_data_bytes();
+  free += region->free();
+  garbage += region->garbage();
+}
 
 ShenandoahInPlacePromotionPlanner::ShenandoahInPlacePromotionPlanner(const ShenandoahGenerationalHeap* heap)
   : _old_garbage_threshold(ShenandoahHeapRegion::region_size_bytes() * heap->old_generation()->heuristics()->get_old_garbage_threshold() / 100)

--- a/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInPlacePromoter.hpp
@@ -26,7 +26,6 @@
 #define SHARE_GC_SHENANDOAH_SHENANDOAHINPLACEPROMOTER_HPP
 
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
-#include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 #include "gc/shenandoah/shenandoahSimpleBitMap.hpp"
 
 class ShenandoahMarkingContext;
@@ -82,12 +81,7 @@ class ShenandoahInPlacePromotionPlanner {
     size_t garbage;
 
     RegionPromotionStats() : count(0), usage(0), free(0), garbage(0) {}
-    void update(ShenandoahHeapRegion* region) {
-      count++;
-      usage += region->get_live_data_bytes();
-      free += region->free();
-      garbage += region->garbage();
-    }
+    void update(ShenandoahHeapRegion* region);
   };
 
   const size_t _old_garbage_threshold;


### PR DESCRIPTION
Move implementation out of header, fix includes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391235](https://bugs.openjdk.org/browse/JDK-8391235): Zero build fails due to GCC-15.2.0 stringop-overflow warning after JDK-8390310 (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32564/head:pull/32564` \
`$ git checkout pull/32564`

Update a local copy of the PR: \
`$ git checkout pull/32564` \
`$ git pull https://git.openjdk.org/jdk.git pull/32564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32564`

View PR using the GUI difftool: \
`$ git pr show -t 32564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32564.diff">https://git.openjdk.org/jdk/pull/32564.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32564#issuecomment-5445685124)
</details>
