### PR TITLE
8391315: [BACKOUT] Not all --long-options accept space as seperator

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -727,8 +727,7 @@ IsModuleOption(const char* name) {
            JLI_StrCmp(name, "--add-exports") == 0 ||
            JLI_StrCmp(name, "--add-opens") == 0 ||
            JLI_StrCmp(name, "--add-reads") == 0 ||
-           JLI_StrCmp(name, "--patch-module") == 0 ||
-           JLI_StrCmp(name, "--enable-final-field-mutation") == 0;
+           JLI_StrCmp(name, "--patch-module") == 0;
 }
 
 static jboolean
@@ -740,21 +739,7 @@ IsLongFormModuleOption(const char* name) {
            JLI_StrCCmp(name, "--limit-modules=") == 0 ||
            JLI_StrCCmp(name, "--add-exports=") == 0 ||
            JLI_StrCCmp(name, "--add-reads=") == 0 ||
-           JLI_StrCCmp(name, "--patch-module=") == 0 ||
-           JLI_StrCCmp(name, "--enable-final-field-mutation=") == 0;
-}
-
-/*
- * Test if the given name is a non-module VM white-space option that
- * will be passed to the VM with its corresponding long-form option
- * name and "=" delimiter.
- */
-static jboolean
-IsNonModuleVMWhiteSpaceOption(const char* name) {
-    return JLI_StrCmp(name, "--illegal-native-access") == 0 ||
-           JLI_StrCmp(name, "--illegal-final-field-mutation") == 0 ||
-           JLI_StrCmp(name, "--sun-misc-unsafe-memory-access") == 0 ||
-           JLI_StrCmp(name, "--finalization") == 0;
+           JLI_StrCCmp(name, "--patch-module=") == 0;
 }
 
 /*
@@ -763,8 +748,7 @@ IsNonModuleVMWhiteSpaceOption(const char* name) {
 jboolean
 IsWhiteSpaceOption(const char* name) {
     return IsModuleOption(name) ||
-           IsLauncherOption(name) ||
-           IsNonModuleVMWhiteSpaceOption(name);
+           IsLauncherOption(name);
 }
 
 /*
@@ -1141,7 +1125,7 @@ GetOpt(int *pargc, char ***pargv, char **poption, char **pvalue) {
         }
         kind = IsLauncherMainOption(arg) ? LAUNCHER_MAIN_OPTION
                                          : LAUNCHER_OPTION_WITH_ARGUMENT;
-    } else if (IsModuleOption(arg) || IsNonModuleVMWhiteSpaceOption(arg)) {
+    } else if (IsModuleOption(arg)) {
         kind = VM_LONG_OPTION_WITH_ARGUMENT;
         if (has_arg) {
             value = *argv;
@@ -1255,12 +1239,6 @@ ParseArguments(int *pargc, char ***pargv,
             } else if (kind == VM_LONG_OPTION_WITH_ARGUMENT) {
                 AddLongFormOption(option, value);
             }
-        /*
-         * Normalize a missing argument to the equivalent "--option=" form
-         * and let the subsequent option validation handle the empty value.
-         */
-        } else if (!has_arg && IsNonModuleVMWhiteSpaceOption(arg)) {
-            AddLongFormOption(option, "");
 /*
  * Error missing argument
  */

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,6 @@ public class TestEnableNativeAccess extends TestEnableNativeAccessBase {
                 { "panama_no_unnamed_module_native_access", UNNAMED, successWithWarning("ALL-UNNAMED"), new String[]{} },
                 { "panama_all_unnamed_module_native_access", UNNAMED, successNoWarning(), new String[]{"--enable-native-access=ALL-UNNAMED"} },
                 { "panama_allow_unnamed_module_native_access", UNNAMED, successNoWarning(), new String[]{"--illegal-native-access=allow"} },
-                { "panama_allow_unnamed_module_native_access", UNNAMED, successNoWarning(), new String[]{"--illegal-native-access", "allow"} },
         };
     }
 
@@ -142,8 +141,7 @@ public class TestEnableNativeAccess extends TestEnableNativeAccessBase {
     }
 
     /**
-     * Tests invalid values for --enable-native-access and invalid or missing
-     * values for --illegal-native-access.
+     * Specifies bad value to --enable-native-access.
      */
     @Test
     public void testBadValue() throws Exception {
@@ -165,17 +163,6 @@ public class TestEnableNativeAccess extends TestEnableNativeAccessBase {
         run("panama_deny_no_module_jni", PANAMA_JNI,
                 failWithError("module panama_jni_load_module"),
                 "--illegal-native-access=deny");
-        run("panama_deny_no_module_jni", PANAMA_JNI,
-                failWithError("module panama_jni_load_module"),
-                "--illegal-native-access", "deny");
-        // Missing value.
-        run("panama_enable_native_access", PANAMA_MAIN,
-                failWithError("Value specified to --illegal-native-access not recognized"),
-                "--illegal-native-access");
-        // Invalid value.
-        run("panama_enable_native_access", PANAMA_MAIN,
-                failWithError("Value specified to --illegal-native-access not recognized"),
-                "--illegal-native-access", "bad");
     }
 
     @Test

--- a/test/jdk/java/lang/Object/FinalizationOption.java
+++ b/test/jdk/java/lang/Object/FinalizationOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,12 @@
 
 /*
  * @test
- * @bug 8276422 8387729
+ * @bug 8276422
  * @summary add command-line option to disable finalization
- * @library /test/lib
- * @run main FinalizationOption enabled  default
- * @run main FinalizationOption enabled  equals
- * @run main FinalizationOption enabled  whitespace
- * @run main FinalizationOption disabled equals
- * @run main FinalizationOption disabled whitespace
+ * @run main/othervm                         FinalizationOption yes
+ * @run main/othervm --finalization=enabled  FinalizationOption yes
+ * @run main/othervm --finalization=disabled FinalizationOption no
  */
-
-import jdk.test.lib.process.ProcessTools;
-
 public class FinalizationOption {
     static volatile boolean finalizerWasCalled = false;
 
@@ -110,54 +104,13 @@ public class FinalizationOption {
         return passed;
     }
 
-    /*
-     * Each @run invocation enters main() twice:
-     *
-     * 1. jtreg invokes main() with two arguments. This calls launch()
-     *    to start a test process.
-     *
-     * 2. The launched test process invokes main() with one argument and
-     *    performs the actual test.
-     */
-    public static void main(String[] args) throws Exception {
-        switch (args.length) {
-            case 2:
-                launch(args[0], args[1]);
-                return;
-            case 1:
-                test(args[0]);
-                return;
-            default:
-                throw new AssertionError(
-                    "expected one or two arguments");
-        }
-    }
-
-    /**
-     * Launch a test process with the given command-line option form.
-     */
-    static void launch(String option, String form) throws Exception {
-        String[] javaArgs = switch (form) {
-            case "default"    -> new String[] {"FinalizationOption", option};
-            case "equals"     -> new String[] {"--finalization=" + option,
-                                               "FinalizationOption", option};
-            case "whitespace" -> new String[] {"--finalization", option,
-                                               "FinalizationOption", option};
-            default -> throw new AssertionError("Unexpected option form: " + form);
-        };
-
-        ProcessTools.executeTestJava(javaArgs).shouldHaveExitValue(0);
-    }
-
-    /**
-     * Perform the actual finalization test.
-     */
-    static void test(String option) throws Exception {
-        boolean finalizationEnabled = switch (option) {
-            case "enabled"  -> true;
-            case "disabled" -> false;
-            default -> throw new AssertionError(
-                "usage: FinalizationOption enabled|disabled");
+    public static void main(String[] args) {
+        boolean finalizationEnabled = switch (args[0]) {
+            case "yes" -> true;
+            case "no"  -> false;
+            default -> {
+                throw new AssertionError("usage: FinalizationOption yes|no");
+            }
         };
 
         boolean threadPass = checkFinalizerThread(finalizationEnabled);

--- a/test/jdk/java/lang/Object/InvalidFinalizationOption.java
+++ b/test/jdk/java/lang/Object/InvalidFinalizationOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8276422 8387729
+ * @bug 8276422
  * @summary Invalid/missing values for the finalization option should be rejected
  * @library /test/lib
  * @run driver InvalidFinalizationOption
@@ -34,17 +34,12 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class InvalidFinalizationOption {
     public static void main(String[] args) throws Exception {
-        record TestData(String[] arg, String expected) { }
+        record TestData(String arg, String expected) { }
 
         TestData[] testData = {
-            new TestData(new String[] { "--finalization" },
-                         "Invalid finalization value"),
-            new TestData(new String[] { "--finalization=" },
-                         "Invalid finalization value"),
-            new TestData(new String[] { "--finalization=azerty" },
-                         "Invalid finalization value"),
-            new TestData(new String[] { "--finalization", "azerty" },
-                         "Invalid finalization value")
+            new TestData("--finalization",        "Unrecognized option"),
+            new TestData("--finalization=",       "Invalid finalization value"),
+            new TestData("--finalization=azerty", "Invalid finalization value")
         };
 
         for (var data : testData) {

--- a/test/jdk/java/lang/reflect/Field/mutateFinals/cli/CommandLineTest.java
+++ b/test/jdk/java/lang/reflect/Field/mutateFinals/cli/CommandLineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8353835 8387729
+ * @bug 8353835
  * @summary Test the command line option --enable-final-field-mutation
  * @library /test/lib
  * @build CommandLineTestHelper
@@ -84,27 +84,18 @@ class CommandLineTest {
      */
     @Test
     void testAllow() throws Exception {
-        for (String[] opt : optionForms("--illegal-final-field-mutation", "allow")) {
-            test("testFieldSetInt", opt)
-                .shouldNotContain(WARNING_LINE1)
-                .shouldNotContain(WARNING_MUTATED)
-                .shouldHaveExitValue(0);
-        }
-
-        for (String[] opt : optionForms("--enable-final-field-mutation", "ALL-UNNAMED")) {
-            test("testFieldSetInt", opt)
-                .shouldNotContain(WARNING_LINE1)
-                .shouldNotContain(WARNING_MUTATED)
-                .shouldHaveExitValue(0);
-        }
-
-        // allow ALL-UNNAMED, deny by default
-        test("testFieldSetInt", "--enable-final-field-mutation=ALL-UNNAMED", "--illegal-final-field-mutation=deny")
+        test("testFieldSetInt", "--illegal-final-field-mutation=allow")
             .shouldNotContain(WARNING_LINE1)
             .shouldNotContain(WARNING_MUTATED)
             .shouldHaveExitValue(0);
 
-        test("testFieldSetInt", "--enable-final-field-mutation", "ALL-UNNAMED", "--illegal-final-field-mutation", "deny")
+        test("testFieldSetInt", "--enable-final-field-mutation=ALL-UNNAMED")
+            .shouldNotContain(WARNING_LINE1)
+            .shouldNotContain(WARNING_MUTATED)
+            .shouldHaveExitValue(0);
+
+        // allow ALL-UNNAMED, deny by default
+        test("testFieldSetInt", "--enable-final-field-mutation=ALL-UNNAMED", "--illegal-final-field-mutation=deny")
             .shouldNotContain(WARNING_LINE1)
             .shouldNotContain(WARNING_MUTATED)
             .shouldHaveExitValue(0);
@@ -131,14 +122,12 @@ class CommandLineTest {
      */
     @Test
     void testWarn() throws Exception {
-        for (String[] opt : optionForms("--illegal-final-field-mutation", "warn")) {
-            test("testFieldSetInt", opt)
-                .shouldContain(WARNING_LINE1)
-                .shouldContain(WARNING_MUTATED)
-                .shouldContain(WARNING_LINE3)
-                .shouldContain(WARNING_LINE4)
-                .shouldHaveExitValue(0);
-        }
+        test("testFieldSetInt", "--illegal-final-field-mutation=warn")
+            .shouldContain(WARNING_LINE1)
+            .shouldContain(WARNING_MUTATED)
+            .shouldContain(WARNING_LINE3)
+            .shouldContain(WARNING_LINE4)
+            .shouldHaveExitValue(0);
 
         test("testUnreflectSetter", "--illegal-final-field-mutation=warn")
             .shouldContain(WARNING_LINE1)
@@ -173,15 +162,13 @@ class CommandLineTest {
      */
     @Test
     void testDebug() throws Exception {
-        for (String[] opt : optionForms("--illegal-final-field-mutation", "debug")) {
-            test("testFieldSetInt+testUnreflectSetter", opt)
-                .shouldContain("Final field value in class " + HELPER)
-                .shouldContain(WARNING_MUTATED)
-                .shouldContain("java.lang.reflect.Field.setInt")
-                .shouldContain(WARNING_UNREFLECTED)
-                .shouldContain("java.lang.invoke.MethodHandles$Lookup.unreflectSetter")
-                .shouldHaveExitValue(0);
-        }
+        test("testFieldSetInt+testUnreflectSetter", "--illegal-final-field-mutation=debug")
+            .shouldContain("Final field value in class " + HELPER)
+            .shouldContain(WARNING_MUTATED)
+            .shouldContain("java.lang.reflect.Field.setInt")
+            .shouldContain(WARNING_UNREFLECTED)
+            .shouldContain("java.lang.invoke.MethodHandles$Lookup.unreflectSetter")
+            .shouldHaveExitValue(0);
 
         test("testUnreflectSetter+testFieldSetInt", "--illegal-final-field-mutation=debug")
             .shouldContain("Final field value in class " + HELPER)
@@ -197,13 +184,11 @@ class CommandLineTest {
      */
     @Test
     void testDeny() throws Exception {
-        for (String[] opt : optionForms("--illegal-final-field-mutation", "deny")) {
-            test("testFieldSetInt", opt)
-                .shouldNotContain(WARNING_LINE1)
-                .shouldNotContain(WARNING_MUTATED)
-                .shouldContain("java.lang.IllegalAccessException")
-                .shouldNotHaveExitValue(0);
-        }
+        test("testFieldSetInt", "--illegal-final-field-mutation=deny")
+            .shouldNotContain(WARNING_LINE1)
+            .shouldNotContain(WARNING_MUTATED)
+            .shouldContain("java.lang.IllegalAccessException")
+            .shouldNotHaveExitValue(0);
 
         test("testUnreflectSetter", "--illegal-final-field-mutation=deny")
             .shouldNotContain(WARNING_LINE1)
@@ -217,17 +202,7 @@ class CommandLineTest {
      */
     @Test
     void testLastOneWins() throws Exception {
-        test("testFieldSetInt",
-             "--illegal-final-field-mutation=allow",
-             "--illegal-final-field-mutation=deny")
-            .shouldNotContain(WARNING_LINE1)
-            .shouldNotContain(WARNING_MUTATED)
-            .shouldContain("java.lang.IllegalAccessException")
-            .shouldNotHaveExitValue(0);
-
-        test("testFieldSetInt",
-             "--illegal-final-field-mutation", "allow",
-             "--illegal-final-field-mutation", "deny")
+        test("testFieldSetInt", "--illegal-final-field-mutation=allow", "--illegal-final-field-mutation=deny")
             .shouldNotContain(WARNING_LINE1)
             .shouldNotContain(WARNING_MUTATED)
             .shouldContain("java.lang.IllegalAccessException")
@@ -245,11 +220,9 @@ class CommandLineTest {
     @ParameterizedTest
     @ValueSource(strings = { "", "bad" })
     void testInvalidValues(String value) throws Exception {
-        for (String[] opt : optionForms("--illegal-final-field-mutation", value)) {
-            test("testFieldSetInt", opt)
-                .shouldContain("Value specified to --illegal-final-field-mutation not recognized")
-                .shouldNotHaveExitValue(0);
-        }
+        test("testFieldSetInt", "--illegal-final-field-mutation=" + value)
+            .shouldContain("Value specified to --illegal-final-field-mutation not recognized")
+            .shouldNotHaveExitValue(0);
     }
 
     /**
@@ -317,15 +290,5 @@ class CommandLineTest {
      */
     private int countStrings(String input, String substring) {
         return input.split(Pattern.quote(substring)).length - 1;
-    }
-
-    /**
-     * Returns the given option in both supported argument forms.
-     */
-    private String[][] optionForms(String option, String value) {
-        return new String[][] {
-            { option + "=" + value },
-            { option, value }
-        };
     }
 }

--- a/test/jdk/sun/misc/UnsafeMemoryAccessWarnings.java
+++ b/test/jdk/sun/misc/UnsafeMemoryAccessWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8331670 8338383 8387729
+ * @bug 8331670 8338383
  * @summary Basic test for --sun-misc-unsafe-memory-access=<value>
  * @library /test/lib
  * @compile TryUnsafeMemoryAccess.java
@@ -59,17 +59,16 @@ class UnsafeMemoryAccessWarnings {
      */
     @Test
     void testAllow() throws Exception {
-        for (String[] opt : optionForms("--sun-misc-unsafe-memory-access", "allow")) {
-            test("allocateMemory+freeMemory+objectFieldOffset+putLong+getLong+invokeCleaner", opt)
-                .shouldHaveExitValue(0)
-                .shouldNotContain("WARNING: A terminally deprecated method in sun.misc.Unsafe has been called")
-                .shouldNotContain("WARNING: sun.misc.Unsafe::allocateMemory")
-                .shouldNotContain("WARNING: sun.misc.Unsafe::freeMemory")
-                .shouldNotContain("WARNING: sun.misc.Unsafe::objectFieldOffset")
-                .shouldNotContain("WARNING: sun.misc.Unsafe::putLong")
-                .shouldNotContain("WARNING: sun.misc.Unsafe::getLong")
-                .shouldNotContain("WARNING: sun.misc.Unsafe::invokeCleaner");
-        }
+        test("allocateMemory+freeMemory+objectFieldOffset+putLong+getLong+invokeCleaner",
+                "--sun-misc-unsafe-memory-access=allow")
+            .shouldHaveExitValue(0)
+            .shouldNotContain("WARNING: A terminally deprecated method in sun.misc.Unsafe has been called")
+            .shouldNotContain("WARNING: sun.misc.Unsafe::allocateMemory")
+            .shouldNotContain("WARNING: sun.misc.Unsafe::freeMemory")
+            .shouldNotContain("WARNING: sun.misc.Unsafe::objectFieldOffset")
+            .shouldNotContain("WARNING: sun.misc.Unsafe::putLong")
+            .shouldNotContain("WARNING: sun.misc.Unsafe::getLong")
+            .shouldNotContain("WARNING: sun.misc.Unsafe::invokeCleaner");
     }
 
     /**
@@ -81,9 +80,7 @@ class UnsafeMemoryAccessWarnings {
             "objectFieldOffset+putLong+getLong"
     })
     void testWarn(String input) throws Exception {
-        for (String[] opt : optionForms("--sun-misc-unsafe-memory-access", "warn")) {
-            testOneWarning(input, opt);
-        }
+        testOneWarning(input, "--sun-misc-unsafe-memory-access=warn");
     }
 
     /**
@@ -116,16 +113,15 @@ class UnsafeMemoryAccessWarnings {
      */
     @Test
     void testDebug() throws Exception {
-        for (String[] opt : optionForms("--sun-misc-unsafe-memory-access", "debug")) {
-            test("allocateMemory+freeMemory+objectFieldOffset+putLong+getLong+invokeCleaner", opt)
-                .shouldHaveExitValue(0)
-                .shouldContain("WARNING: sun.misc.Unsafe::allocateMemory called")
-                .shouldContain("WARNING: sun.misc.Unsafe::freeMemory called")
-                .shouldContain("WARNING: sun.misc.Unsafe::objectFieldOffset called")
-                .shouldContain("WARNING: sun.misc.Unsafe::putLong called")
-                .shouldContain("WARNING: sun.misc.Unsafe::getLong called")
-                .shouldContain("WARNING: sun.misc.Unsafe::invokeCleaner called");
-        }
+        test("allocateMemory+freeMemory+objectFieldOffset+putLong+getLong+invokeCleaner",
+                "--sun-misc-unsafe-memory-access=debug")
+            .shouldHaveExitValue(0)
+            .shouldContain("WARNING: sun.misc.Unsafe::allocateMemory called")
+            .shouldContain("WARNING: sun.misc.Unsafe::freeMemory called")
+            .shouldContain("WARNING: sun.misc.Unsafe::objectFieldOffset called")
+            .shouldContain("WARNING: sun.misc.Unsafe::putLong called")
+            .shouldContain("WARNING: sun.misc.Unsafe::getLong called")
+            .shouldContain("WARNING: sun.misc.Unsafe::invokeCleaner called");
     }
 
     /**
@@ -133,13 +129,11 @@ class UnsafeMemoryAccessWarnings {
      */
     @Test
     void testDeny() throws Exception {
-        for (String[] opt : optionForms("--sun-misc-unsafe-memory-access", "deny")) {
-            test("allocateMemory+objectFieldOffset+invokeCleaner", opt)
-                .shouldHaveExitValue(0)
-                .shouldContain("java.lang.UnsupportedOperationException: allocateMemory")
-                .shouldContain("java.lang.UnsupportedOperationException: objectFieldOffset")
-                .shouldContain("java.lang.UnsupportedOperationException: invokeCleaner");
-        }
+        test("allocateMemory+objectFieldOffset+invokeCleaner", "--sun-misc-unsafe-memory-access=deny")
+            .shouldHaveExitValue(0)
+            .shouldContain("java.lang.UnsupportedOperationException: allocateMemory")
+            .shouldContain("java.lang.UnsupportedOperationException: objectFieldOffset")
+            .shouldContain("java.lang.UnsupportedOperationException: invokeCleaner");
     }
 
     /**
@@ -177,16 +171,8 @@ class UnsafeMemoryAccessWarnings {
     @Test
     void testLastOneWins() throws Exception {
         test("allocateMemory+objectFieldOffset+invokeCleaner",
-             "--sun-misc-unsafe-memory-access=allow",
-             "--sun-misc-unsafe-memory-access=deny")
-            .shouldHaveExitValue(0)
-            .shouldContain("java.lang.UnsupportedOperationException: allocateMemory")
-            .shouldContain("java.lang.UnsupportedOperationException: objectFieldOffset")
-            .shouldContain("java.lang.UnsupportedOperationException: invokeCleaner");
-
-        test("allocateMemory+objectFieldOffset+invokeCleaner",
-              "--sun-misc-unsafe-memory-access", "allow",
-              "--sun-misc-unsafe-memory-access", "deny")
+                "--sun-misc-unsafe-memory-access=allow",
+                "--sun-misc-unsafe-memory-access=deny")
             .shouldHaveExitValue(0)
             .shouldContain("java.lang.UnsupportedOperationException: allocateMemory")
             .shouldContain("java.lang.UnsupportedOperationException: objectFieldOffset")
@@ -199,11 +185,9 @@ class UnsafeMemoryAccessWarnings {
     @ParameterizedTest
     @ValueSource(strings = { "", "bad" })
     void testInvalidValues(String value) throws Exception {
-        for (String[] opt : optionForms("--sun-misc-unsafe-memory-access", value)) {
-            test("allocateMemory", opt)
-                .shouldNotHaveExitValue(0)
-                .shouldContain("Value specified to --sun-misc-unsafe-memory-access not recognized: '" + value);
-        }
+        test("allocateMemory", "--sun-misc-unsafe-memory-access=" + value)
+            .shouldNotHaveExitValue(0)
+            .shouldContain("Value specified to --sun-misc-unsafe-memory-access not recognized: '" + value);
     }
 
     /**
@@ -229,15 +213,5 @@ class UnsafeMemoryAccessWarnings {
                 .outputTo(System.err)
                 .errorTo(System.err);
         return outputAnalyzer;
-    }
-
-    /**
-     * Returns the given option in both supported argument forms.
-     */
-    private String[][] optionForms(String option, String value) {
-        return new String[][] {
-            { option + "=" + value },
-            { option, value }
-        };
     }
 }


### PR DESCRIPTION
Can I please get a review of this backout which backs out the change integrated in https://bugs.openjdk.org/browse/JDK-8387729? 

As noted in https://bugs.openjdk.org/browse/JDK-8391315, that change has caused several tests to fail when the tests are launched using a `Virtual` `-testThreadFactory` (https://github.com/openjdk/jdk/blob/master/doc/testing.md#test_thread_factory). Initial analysis suggests that the fix would require changes to the `ProcessTools` test library in the JDK. Given that that class is used in multiple different tests in various different ways, a fix to it will require running much more extensive testing in the CI. Until then, this PR proposes to backout the change done in JDK-8387729.

The backout was done using `git revert aa8af37164be6072a496f9e4ddd00bfe8d9ef95a`. I have initiated a CI run to verify this change and will integrate this PR once that completes normally.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391315](https://bugs.openjdk.org/browse/JDK-8391315): [BACKOUT] Not all --long-options accept space as seperator (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32566/head:pull/32566` \
`$ git checkout pull/32566`

Update a local copy of the PR: \
`$ git checkout pull/32566` \
`$ git pull https://git.openjdk.org/jdk.git pull/32566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32566`

View PR using the GUI difftool: \
`$ git pr show -t 32566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32566.diff">https://git.openjdk.org/jdk/pull/32566.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32566#issuecomment-5448678980)
</details>
