### PR TITLE
8391333: RISC-V: Use zext.h and zext.w for AndL with 16-bit and 32-bit mask

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2848,6 +2848,16 @@ operand immIpowerOf2() %{
   interface(CONST_INTER);
 %}
 
+// Long Immediate: low 16-bit mask
+operand immL_16bits()
+%{
+  predicate(n->get_long() == 0xFFFFL);
+  match(ConL);
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 // Long Immediate: low 32-bit mask
 operand immL_32bits()
 %{

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -183,7 +183,7 @@ instruct convI2UL_reg_reg_b(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %{
     __ zext_w(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
-  ins_pipe(ialu_reg_shift);
+  ins_pipe(ialu_reg);
 %}
 
 // And with a low 16-bit mask

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -186,6 +186,36 @@ instruct convI2UL_reg_reg_b(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %{
   ins_pipe(ialu_reg_shift);
 %}
 
+// And with a low 16-bit mask
+instruct andL_16bits_b(iRegLNoSp dst, iRegL src, immL_16bits mask) %{
+  predicate(UseZbb);
+  match(Set dst (AndL src mask));
+
+  format %{ "zext.h  $dst, $src\t#@andL_16bits_b" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// And with a low 32-bit mask
+instruct andL_32bits_b(iRegLNoSp dst, iRegL src, immL_32bits mask) %{
+  predicate(UseZba);
+  match(Set dst (AndL src mask));
+
+  format %{ "zext.w  $dst, $src\t#@andL_32bits_b" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_w(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
 // BSWAP instructions
 instruct bytes_reverse_int_b(iRegINoSp dst, iRegIorL2I src) %{
   match(Set dst (ReverseBytesI src));


### PR DESCRIPTION
Hi, please consider.
On RISC-V , And of a long with a 16-bit or 32-bit mask is compiled as a constant materialization followed by an and, even when Zbb or Zba is available:
```
x & 0xffffL

  0x00007f1e950757a2:   lui	t2,0x10
  0x00007f1e950757a4:   addiw	t2,t2,-1 # 0x000000000000ffff
  0x00007f1e950757a6:   and	a0,a1,t2                    ;*land {reexecute=0 rethrow=0 return_oop=0}
```

```
x & 0xffffffffL

  0x00007f1e950754a2:   li	t2,1
  0x00007f1e950754a4:   slli	t2,t2,0x20
  0x00007f1e950754a6:   addi	t2,t2,-1
  0x00007f1e950754a8:   and	a0,a1,t2                    ;*land {reexecute=0 rethrow=0 return_oop=0}
```

Both are a zero extension and can be done with a single zext.h or zext.w, which also frees the register that would otherwise hold the mask.


with this patch:
```
x & 0xffffL

  0x00007ff549075922:   .insn	4, 0x0805c53b               ;*land {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - TestZbbSelect::andL_16bits@4 (line 3)
```

```
x & 0xffffffffL

  0x00007ff549075622:   .insn	4, 0x0805853b               ;*land {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - TestZbbSelect::andL_32bits@4 (line 6)
```


```
   4:	0805c53b          	zext.h	a0,a1
   8:	0805853b          	add.uw	a0,a1,zero        	
```
By the way, `add.uw	a0,a1,zero` and `zext.w a0, a1 ` are equivalent instructions.

Opto log:
before this patch:
```
x & 0xffffL
022     mv R7, #65535	# long, #@loadConL
026 +   andr  R10, R11, R7	#@andL_reg_reg

x & 0xffffffffL
022     mv R7, #4294967295	# long, #@loadConL
028 +   andr  R10, R11, R7	#@andL_reg_reg
```

after this patch:
```
x & 0xffffL
022     zext.h  R10, R11	#@andL_16bits_b

x & 0xffffffffL
022     zext.w  R10, R11	#@andL_32bits_b
```


### Testing
- [x] Run tier1-tier3 test with release on SG2044

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391333](https://bugs.openjdk.org/browse/JDK-8391333): RISC-V: Use zext.h and zext.w for AndL with 16-bit and 32-bit mask (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32568/head:pull/32568` \
`$ git checkout pull/32568`

Update a local copy of the PR: \
`$ git checkout pull/32568` \
`$ git pull https://git.openjdk.org/jdk.git pull/32568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32568`

View PR using the GUI difftool: \
`$ git pr show -t 32568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32568.diff">https://git.openjdk.org/jdk/pull/32568.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32568#issuecomment-5449742924)
</details>
