### PR TITLE
8390921: RISC-V: Enable arraycopy partial inlining with RVV

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -247,6 +247,15 @@ void VM_Version::c2_initialize() {
     }
   }
 
+  intx max_inline_size = MIN2(MaxVectorSize, (intx)256);
+  if (FLAG_IS_DEFAULT(ArrayOperationPartialInlineSize)) {
+    FLAG_SET_DEFAULT(ArrayOperationPartialInlineSize, UseRVV ? max_inline_size : 0);
+  }
+  if (ArrayOperationPartialInlineSize > max_inline_size) {
+    warning("Setting ArrayOperationPartialInlineSize to %d", (int)max_inline_size);
+    ArrayOperationPartialInlineSize = max_inline_size;
+  }
+
   if (FLAG_IS_DEFAULT(AlignVector)) {
     FLAG_SET_DEFAULT(AlignVector,
       unaligned_vector.value() != MISALIGNED_VECTOR_FAST);


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8390921](https://bugs.openjdk.org/browse/JDK-8390921): RISC-V: Enable arraycopy partial inlining with RVV (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32569/head:pull/32569` \
`$ git checkout pull/32569`

Update a local copy of the PR: \
`$ git checkout pull/32569` \
`$ git pull https://git.openjdk.org/jdk.git pull/32569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32569`

View PR using the GUI difftool: \
`$ git pr show -t 32569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32569.diff">https://git.openjdk.org/jdk/pull/32569.diff</a>

</details>
