### PR TITLE
8390782: TestExpressions.java does not correctly handle NaNs in Float16 reduction result

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestExpressions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestExpressions.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8359412 8370922 8369699
+ * @bug 8359412 8370922 8369699 8390782
  * @key randomness
  * @summary Demonstrate the use of Expressions from the Template Library.
  * @modules java.base/jdk.internal.misc
@@ -48,6 +48,7 @@ import static compiler.lib.template_framework.Template.scope;
 import static compiler.lib.template_framework.Template.let;
 import compiler.lib.template_framework.library.Expression;
 import compiler.lib.template_framework.library.Operations;
+import compiler.lib.template_framework.library.ShortCarriesFloat16Type;
 import compiler.lib.template_framework.library.TestFrameworkClass;
 
 public class TestExpressions {
@@ -88,6 +89,12 @@ public class TestExpressions {
             // precision results from some operators. We only compare the results if we know that the
             // result is deterministically the same.
             TemplateToken expressionToken = expression.asToken(expression.argumentTypes.stream().map(t -> t.con()).toList());
+            // Float16Vector lane()/reduceLanes() return a short carrier; box to Float16 so
+            // Verify.checkEQ canonicalizes NaN.
+            boolean float16CarrierResult = expression.returnType instanceof ShortCarriesFloat16Type;
+            List<Object> returnStmt = float16CarrierResult
+                ? List.of("return Float16.shortBitsToFloat16(", expressionToken, ");\n")
+                : List.of("return ", expressionToken, ";\n");
             return scope(
                 let("returnType", expression.returnType),
                 """
@@ -104,7 +111,7 @@ public class TestExpressions {
                 public static Object ${primitiveConTest}_compiled() {
                 try {
                 """,
-                    "return ", expressionToken, ";\n",
+                    returnStmt,
                     expression.info.exceptions.stream().map(exception ->
                         "} catch (" + exception + " e) { return e;\n"
                     ).toList(),
@@ -118,7 +125,7 @@ public class TestExpressions {
                 public static Object ${primitiveConTest}_reference() {
                 try {
                 """,
-                    "return ", expressionToken, ";\n",
+                    returnStmt,
                     expression.info.exceptions.stream().map(exception ->
                         "} catch (" + exception + " e) { return e;\n"
                     ).toList(),

--- a/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestExpressions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/template_framework/examples/TestExpressions.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8359412 8370922 8369699 8390782
+ * @bug 8359412 8370922 8369699
  * @key randomness
  * @summary Demonstrate the use of Expressions from the Template Library.
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Hi,

Patch fixes TestExpressions.java to box Float16Vector scalar results (short carriers from reduceLanes/lane) via Float16.shortBitsToFloat16() before Verify.checkEQ, so equivalent NaNs with different payloads compare correctly.

Kindly review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390782](https://bugs.openjdk.org/browse/JDK-8390782): TestExpressions.java does not correctly handle NaNs in Float16 reduction result (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32572/head:pull/32572` \
`$ git checkout pull/32572`

Update a local copy of the PR: \
`$ git checkout pull/32572` \
`$ git pull https://git.openjdk.org/jdk.git pull/32572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32572`

View PR using the GUI difftool: \
`$ git pr show -t 32572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32572.diff">https://git.openjdk.org/jdk/pull/32572.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32572#issuecomment-5450770107)
</details>
