### PR TITLE
8387799: Infinite attempts of post-parse call devirtualization on nullable receiver

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1560,6 +1560,9 @@ Node* CallDynamicJavaNode::Ideal(PhaseGVN* phase, bool can_reshape) {
       assert(IncrementalInlineVirtual, "required");
       assert(cg->call_node() == this, "mismatch");
 
+      Node* receiver_node = in(TypeFunc::Parms);
+      const TypeOopPtr* receiver_type = phase->type(receiver_node)->isa_oopptr();
+
       if (cg->callee_method() == nullptr) {
         // Recover symbolic info for method resolution.
         ciMethod* caller = jvms()->method();
@@ -1578,9 +1581,6 @@ Node* CallDynamicJavaNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
         ciInstanceKlass* klass = ciEnv::get_instance_klass_for_declared_method_holder(holder);
 
-        Node* receiver_node = in(TypeFunc::Parms);
-        const TypeOopPtr* receiver_type = phase->type(receiver_node)->isa_oopptr();
-
         int  not_used3;
         bool call_does_dispatch;
         ciMethod* callee = phase->C->optimize_virtual_call(caller, klass, holder, orig_callee, receiver_type, true /*is_virtual*/,
@@ -1589,8 +1589,9 @@ Node* CallDynamicJavaNode::Ideal(PhaseGVN* phase, bool can_reshape) {
           cg->set_callee_method(callee);
         }
       }
-      if (cg->callee_method() != nullptr) {
-        // Register for late inlining.
+      if (cg->callee_method() != nullptr && receiver_type != nullptr && !receiver_type->maybe_null()) {
+        // Only register for late inlining if the receiver is null-free because
+        // LateInlineVirtualCallGenerator::do_late_inline_check() rejects nullable receivers.
         register_for_late_inline(); // MH late inlining prepends to the list, so do the same
       }
     } else {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1909,23 +1909,6 @@ void PhaseIterGVN::verify_Ideal_for(Node* n, bool can_reshape, bool deep_revisit
     //   test/jdk/jdk/incubator/vector/VectorRuns.java
     //   -XX:VerifyIterativeGVN=1110
 
-    // CallDynamicJavaNode::Ideal, and I think also for CallStaticJavaNode::Ideal
-    //  and possibly their subclasses.
-    // During late inlining it can call CallJavaNode::register_for_late_inline
-    // That means we do more rounds of late inlining, but might fail.
-    // Then we do IGVN again, and register the node again for late inlining.
-    // This creates an endless cycle. Everytime we try late inlining, we
-    // are also creating more nodes, especially SafePoint and MergeMem.
-    // These nodes are immediately rejected when the inlining fails in the
-    // do_late_inline_check, but they still grow the memory, until we hit
-    // the MemLimit and crash.
-    // The assumption here seems that CallDynamicJavaNode::Ideal does not get
-    // called repeatedly, and eventually we terminate. I fear this is not
-    // a great assumption to make. We should investigate more.
-    //
-    // Found with:
-    //   compiler/loopopts/superword/TestDependencyOffsets.java#vanilla-U
-    //   -XX:+IgnoreUnrecognizedVMOptions -XX:VerifyIterativeGVN=1110
     return;
   }
 

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInlineNullableReceiver.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInlineNullableReceiver.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8387799
+ * @summary Test that a nullable receiver is not endlessly retried for virtual late inlining
+ * @modules jdk.incubator.vector
+ * @library /test/lib
+ * @requires vm.compiler2.enabled
+ * @run main ${test.main.class}
+ * @run main/othervm -Xcomp
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:CompileCommand=delayinline,${test.main.class}::lateInlined
+ *                   ${test.main.class}
+ */
+
+package compiler.inlining;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.test.lib.Asserts;
+
+public class TestLateInlineNullableReceiver {
+    static final VectorMask<Float> MASK = FloatVector.SPECIES_128.maskAll(true);
+    // Another (unused) mask to prevent dervirtualization of the 'trueCount' call
+    static final VectorMask<Float> OTHER_MASK = FloatVector.SPECIES_64.maskAll(true);
+
+    static VectorMask<?> lateInlined(Object value) {
+        return (VectorMask<?>) MASK.getClass().cast(value);
+    }
+
+    static int test(Object value) {
+        // XOR a vector and make sure it's live at below virtual call
+        IntVector vector = IntVector.fromArray(IntVector.SPECIES_128, new int[4], 0).lanewise(VectorOperators.XOR, 0);
+
+        // After late inlining, 'value' is exact but still nullable. C2 will then
+        // attempt to strength reduce the 'trueCount' virtual call to a static call.
+        int result = lateInlined(value).trueCount();
+
+        return result + vector.lane(0); // Keep the vector live
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 200; i++) {
+            Asserts.assertEquals(test(MASK), 4);
+        }
+    }
+}
+


### PR DESCRIPTION
We hit test or compilation timeouts because C2 tries indefinitely to strength-reduce a virtual call with a nullable receiver to a static call.

Gory details:
`TestLateInlineNullableReceiver` is a heavily reduced version of the original generated test (Kudos once again to Emanuel's `VectorExpressionFuzzer.java`): Vector box `vector` is live at virtual call `trueCount()`and vector box scalarization then wires the `XorV`value directly into the safepoint debug information:
https://github.com/openjdk/jdk/blob/9096e2917a410f0964c5e788ee393b946f5a23ab/src/hotspot/share/opto/vector.cpp#L294-L296 

C2 then incrementally inlines the method `lateInlined` which leads to `value`, the receiver of the `trueCount` call, becoming exact but still nullable. C2 then attempts to strength-reduce the `trueCount()` virtual call to a static call but fails because the receiver is nullable (see [JDK-8273165](https://bugs.openjdk.org/browse/JDK-8273165) for details around this bailout):
https://github.com/openjdk/jdk/blob/caf2c84d4717fa91bb078bdabd8ce10f110ac0e3/src/hotspot/share/opto/callGenerator.cpp#L566-L569

Next, `inline_incrementally_one()` restores the generator because no progress was made: 
https://github.com/openjdk/jdk/blob/caf2c84d4717fa91bb078bdabd8ce10f110ac0e3/src/hotspot/share/opto/compile.cpp#L2807

and `process_late_inline_calls_no_inline()` calls
https://github.com/openjdk/jdk/blob/caf2c84d4717fa91bb078bdabd8ce10f110ac0e3/src/hotspot/share/opto/compile.cpp#L2959

which calls

https://github.com/openjdk/jdk/blob/caf2c84d4717fa91bb078bdabd8ce10f110ac0e3/src/hotspot/share/opto/compile.cpp#L2830-L2834

During `PhaseRemoveUseless`, `disconnect_useless_nodes()` executes this for every useful node:
https://github.com/openjdk/jdk/blob/caf2c84d4717fa91bb078bdabd8ce10f110ac0e3/src/hotspot/share/opto/compile.cpp#L468-L470

In this case, `n` is our `vector` `LoadVector` with unique user `XorV` and since [JDK-8354242](https://bugs.openjdk.org/browse/JDK-8354242), `XorV` is treated specially there
https://github.com/openjdk/jdk/blob/caf2c84d4717fa91bb078bdabd8ce10f110ac0e3/src/hotspot/share/opto/node.cpp#L1255-L1257

Our virtual call user that just failed strength reduction, is enqueued for IGVN again and everything starts over.

The fix is to check if the receiver is null-free before registering a virtual call for strength-reduction.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387799](https://bugs.openjdk.org/browse/JDK-8387799): Infinite attempts of post-parse call devirtualization on nullable receiver (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32574/head:pull/32574` \
`$ git checkout pull/32574`

Update a local copy of the PR: \
`$ git checkout pull/32574` \
`$ git pull https://git.openjdk.org/jdk.git pull/32574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32574`

View PR using the GUI difftool: \
`$ git pr show -t 32574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32574.diff">https://git.openjdk.org/jdk/pull/32574.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32574#issuecomment-5452233486)
</details>
