### PR TITLE
8376668: Consolidate common logic in FieldLayoutBuilder field sorting methods

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -841,6 +841,64 @@ void FieldLayoutBuilder::prologue() {
   _root_group = new FieldGroup();
 }
 
+int FieldLayoutBuilder::add_field_to_group(FieldInfo fieldinfo, int idx, FieldGroup* group) {
+  BasicType type = Signature::basic_type(fieldinfo.signature(_constant_pool));
+  switch(type) {
+  case T_BYTE:
+  case T_CHAR:
+  case T_DOUBLE:
+  case T_FLOAT:
+  case T_INT:
+  case T_LONG:
+  case T_SHORT:
+  case T_BOOLEAN:
+    group->add_primitive_field(idx, type);
+    return type2aelembytes(type); // alignment == size for primitive types
+  case T_OBJECT:
+  case T_ARRAY:
+  {
+    const bool is_inline_class = _is_inline_type || _is_abstract_value;
+    // Atomic flat fields can always be used in identity classes.
+    // Use them only for inline classes if the container is itself atomic.
+    const bool use_atomic_flat = !is_inline_class || _must_be_atomic;
+    LayoutKind lk = field_layout_selection(fieldinfo, _inline_layout_info_array, use_atomic_flat);
+    lk = adjust_with_budget(fieldinfo, _inline_layout_info_array, lk, _flattening_budget);
+    if (field_is_inlineable(fieldinfo, lk, _inline_layout_info_array)) {
+      _has_inlineable_fields = true;
+    }
+
+    if (lk == LayoutKind::REFERENCE) {
+      if (group != _static_fields) {
+        _nonstatic_oopmap_count++;
+      }
+      group->add_oop_field(idx);
+      return type2aelembytes(type); // alignment == size for oops
+    }
+
+    assert(group != _static_fields, "Static fields are not flattened");
+    assert(lk != LayoutKind::BUFFERED && lk != LayoutKind::UNKNOWN,
+           "Invalid layout kind for flat field: %s", LayoutKindHelper::layout_kind_as_string(lk));
+
+    const int field_index = (int)fieldinfo.index();
+    assert(_inline_layout_info_array != nullptr, "Array must have been created");
+    assert(_inline_layout_info_array->adr_at(field_index)->klass() != nullptr, "Klass must have been set");
+    _has_inlined_fields = true;
+    InlineKlass* vk = _inline_layout_info_array->adr_at(field_index)->klass();
+    if (is_inline_class && !vk->is_naturally_atomic(LayoutKindHelper::is_null_free_flat(lk))) {
+      _has_non_naturally_atomic_fields = true;
+    }
+    group->add_flat_field(idx, vk, lk);
+    _inline_layout_info_array->adr_at(field_index)->set_kind(lk);
+    _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
+    _field_info->adr_at(idx)->field_flags_addr()->update_flat(true);
+    _field_info->adr_at(idx)->set_layout_kind(lk);
+    return vk->layout_alignment(lk);
+  }
+  default:
+    fatal("Unexpected BasicType");
+  }
+}
+
 // Field sorting for regular (non-inline) classes:
 //   - fields are sorted in static and non-static fields
 //   - non-static fields are also sorted according to their contention group
@@ -869,52 +927,7 @@ void FieldLayoutBuilder::regular_field_sorting() {
       }
     }
     assert(group != nullptr, "invariant");
-    BasicType type = Signature::basic_type(fieldinfo.signature(_constant_pool));
-    switch(type) {
-    case T_BYTE:
-    case T_CHAR:
-    case T_DOUBLE:
-    case T_FLOAT:
-    case T_INT:
-    case T_LONG:
-    case T_SHORT:
-    case T_BOOLEAN:
-      group->add_primitive_field(idx, type);
-      break;
-    case T_OBJECT:
-    case T_ARRAY:
-    {
-      LayoutKind lk = field_layout_selection(fieldinfo, _inline_layout_info_array, true);
-      lk = adjust_with_budget(fieldinfo, _inline_layout_info_array, lk, _flattening_budget);
-      if (field_is_inlineable(fieldinfo, lk, _inline_layout_info_array)) {
-        _has_inlineable_fields = true;
-      }
-
-      if (lk == LayoutKind::REFERENCE) {
-        if (group != _static_fields) _nonstatic_oopmap_count++;
-        group->add_oop_field(idx);
-      } else {
-        assert(group != _static_fields, "Static fields are not flattened");
-        assert(lk != LayoutKind::BUFFERED && lk != LayoutKind::UNKNOWN,
-               "Invalid layout kind for flat field: %s", LayoutKindHelper::layout_kind_as_string(lk));
-
-        const int field_index = (int)fieldinfo.index();
-        assert(_inline_layout_info_array != nullptr, "Array must have been created");
-        assert(_inline_layout_info_array->adr_at(field_index)->klass() != nullptr, "Klass must have been set");
-        _has_inlined_fields = true;
-        InlineKlass* vk = _inline_layout_info_array->adr_at(field_index)->klass();
-        group->add_flat_field(idx, vk, lk);
-        _inline_layout_info_array->adr_at(field_index)->set_kind(lk);
-        _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
-        _field_info->adr_at(idx)->field_flags_addr()->update_flat(true);
-        _field_info->adr_at(idx)->set_layout_kind(lk);
-        // no need to update _must_be_atomic if vk->must_be_atomic() is true because current class is not an inline class
-      }
-      break;
-    }
-    default:
-      fatal("Something wrong?");
-    }
+    add_field_to_group(fieldinfo, idx, group);
   }
   _root_group->sort_by_size();
   _static_fields->sort_by_size();
@@ -952,60 +965,7 @@ void FieldLayoutBuilder::inline_class_field_sorting() {
       group = _root_group;
     }
     assert(group != nullptr, "invariant");
-    BasicType type = Signature::basic_type(fieldinfo.signature(_constant_pool));
-    switch(type) {
-    case T_BYTE:
-    case T_CHAR:
-    case T_DOUBLE:
-    case T_FLOAT:
-    case T_INT:
-    case T_LONG:
-    case T_SHORT:
-    case T_BOOLEAN:
-      if (group != _static_fields) {
-        field_alignment = type2aelembytes(type); // alignment == size for primitive types
-      }
-      group->add_primitive_field(idx, type);
-      break;
-    case T_OBJECT:
-    case T_ARRAY:
-    {
-      bool use_atomic_flat = _must_be_atomic; // flatten atomic fields only if the container is itself atomic
-      LayoutKind lk = field_layout_selection(fieldinfo, _inline_layout_info_array, use_atomic_flat);
-      lk = adjust_with_budget(fieldinfo, _inline_layout_info_array, lk, _flattening_budget);
-      if (field_is_inlineable(fieldinfo, lk, _inline_layout_info_array)) {
-        _has_inlineable_fields = true;
-      }
-
-      if (lk == LayoutKind::REFERENCE) {
-        if (group != _static_fields) {
-          _nonstatic_oopmap_count++;
-          field_alignment = type2aelembytes(type); // alignment == size for oops
-        }
-        group->add_oop_field(idx);
-      } else {
-        assert(group != _static_fields, "Static fields are not flattened");
-        assert(lk != LayoutKind::BUFFERED && lk != LayoutKind::UNKNOWN,
-               "Invalid layout kind for flat field: %s", LayoutKindHelper::layout_kind_as_string(lk));
-
-        const int field_index = (int)fieldinfo.index();
-        assert(_inline_layout_info_array != nullptr, "Array must have been created");
-        assert(_inline_layout_info_array->adr_at(field_index)->klass() != nullptr, "Klass must have been set");
-        _has_inlined_fields = true;
-        InlineKlass* vk = _inline_layout_info_array->adr_at(field_index)->klass();
-        if (!vk->is_naturally_atomic(LayoutKindHelper::is_null_free_flat(lk))) _has_non_naturally_atomic_fields = true;
-        group->add_flat_field(idx, vk, lk);
-        _inline_layout_info_array->adr_at(field_index)->set_kind(lk);
-        _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
-        field_alignment = vk->layout_alignment(lk);
-        _field_info->adr_at(idx)->field_flags_addr()->update_flat(true);
-        _field_info->adr_at(idx)->set_layout_kind(lk);
-      }
-      break;
-    }
-    default:
-      fatal("Unexpected BasicType");
-    }
+    field_alignment = add_field_to_group(fieldinfo, idx, group);
     if (!fieldinfo.access_flags().is_static() && field_alignment > alignment) alignment = field_alignment;
   }
   _root_group->sort_by_size();

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -341,6 +341,7 @@ class FieldLayoutBuilder : public ResourceObj {
  protected:
   void prologue();
   void epilogue();
+  int add_field_to_group(FieldInfo fieldinfo, int idx, FieldGroup* group);
   void regular_field_sorting();
   void inline_class_field_sorting();
   void add_flat_field_oopmap(OopMapBlocksBuilder* nonstatic_oop_map, InlineKlass* vk, int offset);


### PR DESCRIPTION
Hi everyone,

`FieldLayoutBuilder::regular_field_sorting` and `FieldLayoutBuilder::inline_class_field_sorting` are both large functions that contain almost the exact same logic with a lot of duplicated code. Both classify primitive, oop, and flat fields into field groups and perform some flattening and metadata bookkeeping. The main difference is that `FieldLayoutBuilder::regular_field_sorting` handles `@Contended` field groups, while `FieldLayoutBuilder::inline_class_field_sorting` tracks the number and alignment of non-static fields. One of the duplicated steps is adding a field to a field group. This logic is near identical, so I suggest extracting it into a separate function. This leaves leaves the contended specific grouping and sorting for the regular-class path, and the field count and alignment calculations in the inline-class path.

Testing:
 - Oracle tiers 1-3


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8376668](https://bugs.openjdk.org/browse/JDK-8376668): Consolidate common logic in FieldLayoutBuilder field sorting methods (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32575/head:pull/32575` \
`$ git checkout pull/32575`

Update a local copy of the PR: \
`$ git checkout pull/32575` \
`$ git pull https://git.openjdk.org/jdk.git pull/32575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32575`

View PR using the GUI difftool: \
`$ git pr show -t 32575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32575.diff">https://git.openjdk.org/jdk/pull/32575.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32575#issuecomment-5452396855)
</details>
