### PR TITLE
8387971: Minor comment typos "successfull"

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -670,7 +670,7 @@ bool CgroupSubsystem::active_processor_count(int (*cpu_bound_func)(), double& va
  *
  * return:
  *    false if retrieving the value failed
- *    true if retrieving the value was successfull and the value was
+ *    true if retrieving the value was successful and the value was
  *    set in the 'value' reference.
  */
 bool CgroupSubsystem::memory_limit_in_bytes(physical_memory_size_type upper_bound,

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2135,7 +2135,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
       // goal without. In that case, we optimize probing by sorting the attach
       // points: We attempt outermost points first, then work ourselves up to
       // the middle. That reduces address space fragmentation. We also alternate
-      // hemispheres, which increases the chance of successfull mappings if the
+      // hemispheres, which increases the chance of successful mappings if the
       // previous mapping had been blocked by large maps.
       hemi_split(points, num_attempts);
     }


### PR DESCRIPTION
Hi everyone,

Trivial comment fix correcting a couple misspellings. Was `successfull` but should be `successful`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8387971](https://bugs.openjdk.org/browse/JDK-8387971): Minor comment typos "successfull" (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32579/head:pull/32579` \
`$ git checkout pull/32579`

Update a local copy of the PR: \
`$ git checkout pull/32579` \
`$ git pull https://git.openjdk.org/jdk.git pull/32579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32579`

View PR using the GUI difftool: \
`$ git pr show -t 32579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32579.diff">https://git.openjdk.org/jdk/pull/32579.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32579#issuecomment-5453093587)
</details>
