### PR TITLE
8354467: Several problems with TestDwarf.java

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -82,9 +82,9 @@ public class TestDwarf {
                     Asserts.fail("Should crash in crashNativeMultipleMethods()");
                     crashNativeMultipleMethods(4);
                 }
-                case "nativeDereferenceNull" -> {
-                    crashNativeDereferenceNull();
-                    Asserts.fail("Should crash in crashNativeDereferenceNull()");
+                case "nativeStoreToNull" -> {
+                    crashNativeStoreToNull();
+                    Asserts.fail("Should crash in crashNativeStoreToNull()");
                 }
             }
         } else {
@@ -109,19 +109,13 @@ public class TestDwarf {
         if (Platform.isX64() || Platform.isX86()) {
             // Not all platforms raise SIGFPE but x86_32 and x86_64 do.
             runAndCheck(new Flags(TestDwarf.class.getCanonicalName(), "nativeDivByZero"),
-                        new DwarfConstraint(0, "Java_TestDwarf_crashNativeDivByZero", "libTestDwarf.c", 62));
+                        new DwarfConstraint(0, "Java_TestDwarf_crashNativeDivByZero", "libTestDwarf.c", 64));
             runAndCheck(new Flags(TestDwarf.class.getCanonicalName(), "nativeMultipleMethods"),
-                        new DwarfConstraint(0, "foo", "libTestDwarf.c", 45),
-                        new DwarfConstraint(1, "Java_TestDwarf_crashNativeMultipleMethods", "libTestDwarf.c", 73));
+                        new DwarfConstraint(0, "foo", "libTestDwarf.c", 47),
+                        new DwarfConstraint(1, "Java_TestDwarf_crashNativeMultipleMethods", "libTestDwarf.c", 75));
         }
-        // Null pointer dereferences exhibit different behaviour depending on if GCC or Clang is used.
-        // When using GCC, the VM will crash gracefully and generate a hs_err which can be parsed.
-        // On the contrary, with Clang the process exits immediately without hs_err.
-        // Since runAndCheck needs an hs_err file, we have to skip this subtest.
-        if (!isUsingClang()) {
-            runAndCheck(new Flags(TestDwarf.class.getCanonicalName(), "nativeDereferenceNull"),
-                        new DwarfConstraint(0, "dereference_null", "libTestDwarfHelper.h", 49));
-        }
+        runAndCheck(new Flags(TestDwarf.class.getCanonicalName(), "nativeStoreToNull"),
+                    new DwarfConstraint(0, "store_to_null", "libTestDwarfHelper.h", 49));
     }
 
     // A full pattern could check for lines like:
@@ -245,9 +239,8 @@ public class TestDwarf {
     }
 
     private static native void crashNativeDivByZero();
-    private static native void crashNativeDereferenceNull();
+    private static native void crashNativeStoreToNull();
     private static native void crashNativeMultipleMethods(int x);
-    private static native boolean isUsingClang();
 }
 
 class UnsupportedDwarfVersionException extends RuntimeException { }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/libTestDwarf.c
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/libTestDwarf.c
@@ -24,12 +24,14 @@
 #include "libTestDwarfHelper.h"
 #include <stdio.h>
 
-int zero = 0;
+volatile int zero = 0;
 int result = 0;
 int limit = 20;
 
-// Explicitly don't inline. foo needs complexity so GCC/Clang don't optimize it away.
-#if !defined(_MSC_VER)
+// Explicitly don't inline.
+#if defined(_MSC_VER)
+__declspec(noinline)
+#else
 __attribute__((noinline))
 #endif
 void foo(int x) {
@@ -62,8 +64,8 @@ JNIEXPORT void JNICALL Java_TestDwarf_crashNativeDivByZero(JNIEnv* env, jclass j
   foo(34 / zero); // Crash
 }
 
-JNIEXPORT void JNICALL Java_TestDwarf_crashNativeDereferenceNull(JNIEnv* env, jclass jclazz) {
-  dereference_null();
+JNIEXPORT void JNICALL Java_TestDwarf_crashNativeStoreToNull(JNIEnv* env, jclass jclazz) {
+  store_to_null();
 }
 
 JNIEXPORT void JNICALL Java_TestDwarf_crashNativeMultipleMethods(JNIEnv* env, jclass jclazz, jint x) {
@@ -78,13 +80,3 @@ JNIEXPORT void JNICALL Java_TestDwarf_crashNativeMultipleMethods(JNIEnv* env, jc
     result += zero + i;
   }
 }
-
-// Need to tell if Clang was used to build libTestDwarf.
-JNIEXPORT jboolean JNICALL Java_TestDwarf_isUsingClang(JNIEnv* env, jobject obj) {
-#if defined(__clang__)
-    return JNI_TRUE;
-#else
-    return JNI_FALSE;
-#endif
-}
-

--- a/test/hotspot/jtreg/runtime/ErrorHandling/libTestDwarfHelper.h
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/libTestDwarfHelper.h
@@ -44,7 +44,7 @@ void unused5() {
 #if !defined(_MSC_VER)
 __attribute__((noinline))
 #endif
-EXPORT void dereference_null() {
-  int* x = (int*)0;
+EXPORT void store_to_null() {
+  volatile int* x = (volatile int*)0;
   *x = 34; // Crash
 }


### PR DESCRIPTION
TestDwarf.java has supporting native code in libTestDwarf.c and libTestDwarfHelper.h that contained undefined behavior in the form of a store to a null pointer and several divisions by zero. 

Compilers, particularly Clang, can detect and optimize these away, causing the expected crashes to not occur and the test to fail on clang/linux. Additionally, a helper function relied on an unreliable size-based heuristic to prevent inlining, and a crash function was poorly named.

This fix eliminates the undefined behavior so crashes occur reliably regardless of compiler and optimization level, renames the misnamed function to accurately reflect its behavior, replaces the inlining heuristic with an explicit compiler directive, and removes the isUsingClang() workaround that was skipping the affected subtest on Clang builds.

JDK Issue: [JDK-8354467](https://bugs.openjdk.org/browse/JDK-8354467)


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8354467](https://bugs.openjdk.org/browse/JDK-8354467): Several problems with TestDwarf.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32580/head:pull/32580` \
`$ git checkout pull/32580`

Update a local copy of the PR: \
`$ git checkout pull/32580` \
`$ git pull https://git.openjdk.org/jdk.git pull/32580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32580`

View PR using the GUI difftool: \
`$ git pr show -t 32580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32580.diff">https://git.openjdk.org/jdk/pull/32580.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32580#issuecomment-5505216832)
</details>
