### PR TITLE
8391351: G1: G1HeapRegionRemSet double counts code roots in mem_size()

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
@@ -162,7 +162,7 @@ public:
   // The actual # of bytes this hr_remset takes up. Also includes the code
   // root set.
   size_t mem_size() {
-    return sizeof(G1HeapRegionRemSet) + code_roots_mem_size();
+    return sizeof(G1HeapRegionRemSet) - sizeof(G1CodeRootSet) + code_roots_mem_size();
   }
 
   // Returns the memory occupancy of all static data structures associated


### PR DESCRIPTION
Hi all,

  please review this change that fixes double-counting of G1CodeRoots in G1HeapRegionRemSet::mem_size() because the called code_roots_mem_size() already contains the embedded G1CodeRootSet.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391351](https://bugs.openjdk.org/browse/JDK-8391351): G1: G1HeapRegionRemSet double counts code roots in mem_size() (**Bug** - P4)


### Reviewers
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32581/head:pull/32581` \
`$ git checkout pull/32581`

Update a local copy of the PR: \
`$ git checkout pull/32581` \
`$ git pull https://git.openjdk.org/jdk.git pull/32581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32581`

View PR using the GUI difftool: \
`$ git pr show -t 32581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32581.diff">https://git.openjdk.org/jdk/pull/32581.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32581#issuecomment-5454127178)
</details>
