### PR TITLE
8390471: [Valhalla] "assert(_sig_cc == nullptr) failed: Already initialized" with -XX:+TestAOTAdapterLinkFailure

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3336,13 +3336,17 @@ bool AdapterHandlerLibrary::generate_adapter_code(AdapterHandlerEntry* handler,
                                          allocate_code_blob);
 
   if (ces.has_scalarized_args()) {
-    // Save a C heap allocated version of the scalarized signature and store it in the adapter
-    GrowableArray<SigEntry>* heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc()->length(), mtCode);
-    heap_sig->appendAll(ces.sig_cc());
-    handler->set_sig_cc(heap_sig);
-    heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc_ro()->length(), mtCode);
-    heap_sig->appendAll(ces.sig_cc_ro());
-    handler->set_sig_cc_ro(heap_sig);
+    assert((handler->get_sig_cc() == nullptr) == (handler->get_sig_cc_ro() == nullptr), "Inconsistency");
+    // Check if scalarized signatures have to be initialized
+    if (handler->get_sig_cc() == nullptr) {
+      // Save a C heap allocated version of the scalarized signature and store it in the adapter
+      GrowableArray<SigEntry>* heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc()->length(), mtCode);
+      heap_sig->appendAll(ces.sig_cc());
+      handler->set_sig_cc(heap_sig);
+      heap_sig = new (mtCode) GrowableArray<SigEntry>(ces.sig_cc_ro()->length(), mtCode);
+      heap_sig->appendAll(ces.sig_cc_ro());
+      handler->set_sig_cc_ro(heap_sig);
+    }
   }
   // On zero there is no code to save and no need to create a blob and
   // or relocate the handler.

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCacheSupportForCustomLoaders.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCacheSupportForCustomLoaders.java
@@ -25,8 +25,9 @@
 /*
  * @test
  * @summary Test AOT cache support for array classes in custom class loaders.
- * @bug 8353298 8356838
+ * @bug 8353298 8356838 8390471
  * @requires vm.cds.supports.aot.class.linking
+ * @enablePreview
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build ReturnIntegerAsString
  * @build AOTCacheSupportForCustomLoaders
@@ -60,12 +61,23 @@ public class AOTCacheSupportForCustomLoaders {
         String modulePath = modulePackager.getOutputDir().toString();
         modulePackager.createModularJar("com.test");
 
-        SimpleCDSAppTester.of("AOTCacheSupportForCustomLoaders")
+        test(modulePath, false);
+        test(modulePath, true); // Test case for JDK-8390471
+    }
+
+    static void test(String modulePath, boolean preview) throws Exception {
+        SimpleCDSAppTester tester =  SimpleCDSAppTester.of("AOTCacheSupportForCustomLoaders")
             .classpath("app.jar")
             .addVmArgs("-Xlog:aot+class=debug", "-Xlog:aot", "-Xlog:cds",
                        "--module-path=" + modulePath,
-                       "--add-modules=com.test")
-            .appCommandLine("AppWithCustomLoaders", modulePath)
+                       "--add-modules=com.test");
+            if (preview) {
+            // Test case for JDK-8390471
+            tester.addVmArgs("--enable-preview",
+                             "-XX:+IgnoreUnrecognizedVMOptions",
+                             "-XX:+TestAOTAdapterLinkFailure"); // TestAOTAdapterLinkFailure is a developer flag
+            }
+            tester.appCommandLine("AppWithCustomLoaders", modulePath)
             .setTrainingChecker((OutputAnalyzer out) -> {
                     out.shouldContain("Skipping AppWithCustomLoaders$MyLoadeeC: Not loaded from \"file:\" code source")
                        .shouldContain("Skipping AppWithCustomLoaders$MyLoadeeD: super AppWithCustomLoaders$MyLoadeeC is excluded")


### PR DESCRIPTION
Simple fix to prevent double initialization of calling conventions signatures in adapter handlers.
Thanks to Ioi for his help to adjust the test.

Tested with Mach5, tier 1 to 3.

Thanks,

Fred

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390471](https://bugs.openjdk.org/browse/JDK-8390471): [Valhalla] "assert(_sig_cc == nullptr) failed: Already initialized" with -XX:+TestAOTAdapterLinkFailure (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32584/head:pull/32584` \
`$ git checkout pull/32584`

Update a local copy of the PR: \
`$ git checkout pull/32584` \
`$ git pull https://git.openjdk.org/jdk.git pull/32584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32584`

View PR using the GUI difftool: \
`$ git pr show -t 32584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32584.diff">https://git.openjdk.org/jdk/pull/32584.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32584#issuecomment-5453659953)
</details>
