### PR TITLE
8388484: RFC 9846-style Supported Group Selection

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -868,7 +868,8 @@ public class SSLParameters {
      * This method returns the most recent value passed to
      * {@link #setNamedGroups} if that method has been called and otherwise
      * returns the default named groups for connection populated objects,
-     * or {@code null} for pre-populated objects.
+     * or {@code null} for pre-populated objects. Any prefixed asterisk
+     * is retained.
      *
      * @apiNote
      * Note that a provider may not have been updated to support this method
@@ -916,6 +917,13 @@ public class SSLParameters {
      * array and the underlying provider-specific default named groups.
      * See {@link #getNamedGroups} for specific details on how the
      * parameters are used in SSL/TLS/DTLS connections.
+     * <p>
+     * In TLS 1.3, the ClientHello message can include a list of pre-calculated
+     * key shares. If a group name is prefixed with an asterisk ("*"), a key
+     * share for the named group will be included in the message. If none
+     * of the names have the prefix or these names are not available, the
+     * implementation determines which key shares to include in the message.
+     * The prefix is ignored on the server side.
      *
      * @apiNote
      * Note that a provider may not have been updated to support this method
@@ -931,8 +939,9 @@ public class SSLParameters {
      *        SSL/TLS/DTLS connections.
      * @spec security/standard-names.html Java Security Standard Algorithm Names
      * @throws IllegalArgumentException if any element in the
-     *        {@code namedGroups} array is a duplicate, {@code null} or
-     *        {@linkplain String#isBlank() blank}.
+     *        {@code namedGroups} array is a duplicate, {@code null},
+     *        {@linkplain String#isBlank() blank}, or starts with two
+     *        asterisks ("**").
      *
      * @see #getNamedGroups
      *
@@ -945,11 +954,22 @@ public class SSLParameters {
             tempGroups = namedGroups.clone();
             Set<String> groupsSet = new HashSet<>();
             for (String namedGroup : tempGroups) {
-                if (namedGroup == null || namedGroup.isBlank()) {
+                if (namedGroup == null) {
                     throw new IllegalArgumentException(
-                        "An element of namedGroups is null or blank");
+                        "An element of namedGroups is null");
                 }
-
+                // Avoid "name" and "*name" both specified.
+                if (namedGroup.startsWith("*")) {
+                    namedGroup = namedGroup.substring(1);
+                    if (namedGroup.startsWith("*")) {
+                        throw new IllegalArgumentException(
+                                "Multiple asterisks");
+                    }
+                }
+                if (namedGroup.isBlank()) {
+                    throw new IllegalArgumentException(
+                            "An element of namedGroups is blank");
+                }
                 if (groupsSet.contains(namedGroup)) {
                     throw new IllegalArgumentException(
                         "Duplicate element of namedGroups: " + namedGroup);

--- a/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
@@ -142,6 +142,9 @@ abstract class HandshakeContext implements ConnectionContext {
     // SupportedGroups
     List<NamedGroup>                        clientRequestedNamedGroups;
 
+    // Groups for initial key share
+    List<NamedGroup>                        clientInitialKeyShareGroups;
+
     // HelloRetryRequest
     NamedGroup                              serverSelectedNamedGroup;
 

--- a/src/java.base/share/classes/sun/security/ssl/KeyShareExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/KeyShareExtension.java
@@ -235,37 +235,61 @@ final class KeyShareExtension {
             }
 
             List<NamedGroup> namedGroups;
+            boolean exactList;
             if (chc.serverSelectedNamedGroup != null) {
                 // Response to HelloRetryRequest
                 namedGroups = List.of(chc.serverSelectedNamedGroup);
+                exactList = true;
             } else {
-                namedGroups = chc.clientRequestedNamedGroups;
-                if (namedGroups == null || namedGroups.isEmpty()) {
+                if (chc.clientRequestedNamedGroups == null
+                        || chc.clientRequestedNamedGroups.isEmpty()) {
                     // No supported groups.
                     if (SSLLogger.isOn() &&
                             SSLLogger.isOn(SSLLogger.Opt.HANDSHAKE)) {
                         SSLLogger.warning(
-                            "Ignore key_share extension, no supported groups");
+                                "Ignore key_share extension, no supported groups");
                     }
                     return null;
                 }
+                if (chc.clientInitialKeyShareGroups != null) {
+                    namedGroups = chc.clientInitialKeyShareGroups;
+                    exactList = true;
+                } else {
+                    namedGroups = chc.clientRequestedNamedGroups;
+                    exactList = false;
+                }
             }
 
-            // Go through the named groups and take the most-preferred
-            // group from two categories (i.e. XDH and ECDHE).  Once we have
-            // the most preferred group from two types we can exit the loop.
             List<KeyShareEntry> keyShares = new LinkedList<>();
-            EnumSet<NamedGroupSpec> ngTypes =
-                    EnumSet.noneOf(NamedGroupSpec.class);
             byte[] keyExchangeData;
-            for (NamedGroup ng : namedGroups) {
-                if (!ngTypes.contains(ng.spec)) {
+
+            if (exactList) {
+                // Has preferred groups: either after HRR or have starred
+                for (NamedGroup ng : namedGroups) {
                     if ((keyExchangeData = getShare(chc, ng)) != null) {
                         keyShares.add(new KeyShareEntry(ng.id,
                                 keyExchangeData));
-                        ngTypes.add(ng.spec);
-                        if (ngTypes.size() == 2) {
-                            break;
+                    }
+                }
+            }
+
+            // Cannot create keyshare for preferred groups. Fallback to
+            // automatic selection unless this is after HRR.
+            if (keyShares.isEmpty() && chc.serverSelectedNamedGroup == null) {
+                // Go through the named groups and take the most-preferred
+                // group from two categories (e.g. XDH and ECDHE).  Once we have
+                // the most preferred group from two types we can exit the loop.
+                EnumSet<NamedGroupSpec> ngTypes =
+                        EnumSet.noneOf(NamedGroupSpec.class);
+                for (NamedGroup ng : chc.clientRequestedNamedGroups) {
+                    if (!ngTypes.contains(ng.spec)) {
+                        if ((keyExchangeData = getShare(chc, ng)) != null) {
+                            keyShares.add(new KeyShareEntry(ng.id,
+                                    keyExchangeData));
+                            ngTypes.add(ng.spec);
+                            if (ngTypes.size() == 2) {
+                                break;
+                            }
                         }
                     }
                 }
@@ -350,13 +374,31 @@ final class KeyShareExtension {
                 return;     // ignore the extension
             }
 
+            if (shc.clientRequestedNamedGroups == null) {
+                throw shc.conContext.fatal(Alert.MISSING_EXTENSION,
+                        "No supported_groups extension");
+            }
+
+            NamedGroup mutual = null;
+            for (var clientng : shc.clientRequestedNamedGroups) {
+                if (NamedGroup.isActivatable(shc.sslConfig,
+                        shc.algorithmConstraints, clientng)) {
+                    mutual = clientng;
+                    break;
+                }
+            }
+
+            if (mutual == null) {
+                throw shc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
+                        "No common named group");
+            }
+
             // Parse the extension
             CHKeyShareSpec spec = new CHKeyShareSpec(shc, buffer);
             List<SSLCredentials> credentials = new LinkedList<>();
             for (KeyShareEntry entry : spec.clientShares) {
                 NamedGroup ng = NamedGroup.valueOf(entry.namedGroupId);
-                if (ng == null || !NamedGroup.isActivatable(shc.sslConfig,
-                        shc.algorithmConstraints, ng)) {
+                if (ng == null) {
                     if (SSLLogger.isOn() &&
                             SSLLogger.isOn(SSLLogger.Opt.HANDSHAKE)) {
                         SSLLogger.fine(
@@ -365,7 +407,9 @@ final class KeyShareExtension {
                     }
                     continue;
                 }
-
+                if (ng.id != mutual.id) {
+                    continue;
+                }
                 try {
                     SSLCredentials kaCred =
                         ng.decodeCredentials(entry.keyExchange);
@@ -806,7 +850,7 @@ final class KeyShareExtension {
         @Override
         public String toString() {
             MessageFormat messageFormat = new MessageFormat(
-                "\"selected group\": '['{0}']'", Locale.ENGLISH);
+                "\"selected group\": {0}", Locale.ENGLISH);
 
             Object[] messageFields = {
                     NamedGroup.nameOf(selectedGroup)

--- a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
+++ b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
@@ -49,6 +49,7 @@ import sun.security.util.CurveDB;
  * required functions (e.g. encoding/decoding).
  */
 enum NamedGroup {
+
     // Elliptic Curves (RFC 4492)
     //
     // See sun.security.util.CurveDB for the OIDs
@@ -261,6 +262,24 @@ enum NamedGroup {
             ProtocolVersion.PROTOCOLS_TO_12,
             null);
 
+    record PreferredGroup(boolean preferred, NamedGroup ng) {
+        @Override
+        public String toString() {
+            return (preferred ? "*" : "") + ng.name;
+        }
+        static PreferredGroup of(String name) {
+            boolean preferred;
+            if (name.startsWith("*")) {
+                preferred = true;
+                name = name.substring(1);
+            } else {
+                preferred = false;
+            }
+            NamedGroup ng = nameOf(name);
+            return ng == null ? null : new PreferredGroup(preferred, ng);
+        }
+    }
+
     final int id;               // hash + signature
     final String name;          // literal name
     final NamedGroupSpec spec;  // group type
@@ -467,10 +486,10 @@ enum NamedGroup {
             AlgorithmConstraints constraints, NamedGroupSpec type) {
 
         boolean hasFFDHEGroups = false;
-        for (NamedGroup namedGroup :
+        for (PreferredGroup preferredGroup :
                 SupportedGroups.getGroupsFromConfig(sslConfig)) {
-            if (namedGroup.isAvailable && namedGroup.spec == type) {
-                if (namedGroup.isPermitted(constraints)) {
+            if (preferredGroup.ng.isAvailable && preferredGroup.ng.spec == type) {
+                if (preferredGroup.ng.isPermitted(constraints)) {
                     return true;
                 }
 
@@ -504,8 +523,8 @@ enum NamedGroup {
     // Is the named group supported?
     static boolean isEnabled(SSLConfiguration sslConfig,
                              NamedGroup namedGroup) {
-        for (NamedGroup ng : SupportedGroups.getGroupsFromConfig(sslConfig)) {
-            if (namedGroup.equals(ng)) {
+        for (PreferredGroup pg : SupportedGroups.getGroupsFromConfig(sslConfig)) {
+            if (namedGroup.equals(pg.ng)) {
                 return true;
             }
         }
@@ -519,14 +538,13 @@ enum NamedGroup {
             SSLConfiguration sslConfig,
             ProtocolVersion negotiatedProtocol,
             AlgorithmConstraints constraints, NamedGroupSpec[] types) {
-        for (NamedGroup ng : SupportedGroups.getGroupsFromConfig(sslConfig)) {
-            if (ng.isAvailable && NamedGroupSpec.arrayContains(types, ng.spec)
-                    && ng.isAvailable(negotiatedProtocol)
-                    && ng.isPermitted(constraints)) {
-                return ng;
+        for (PreferredGroup pg : SupportedGroups.getGroupsFromConfig(sslConfig)) {
+            if (pg.ng.isAvailable && NamedGroupSpec.arrayContains(types, pg.ng.spec)
+                    && pg.ng.isAvailable(negotiatedProtocol)
+                    && pg.ng.isPermitted(constraints)) {
+                return pg.ng;
             }
         }
-
         return null;
     }
 
@@ -862,25 +880,25 @@ enum NamedGroup {
     static final class SupportedGroups {
 
         // Default named groups.
-        private static final NamedGroup[] defaultGroups = new NamedGroup[]{
+        private static final PreferredGroup[] defaultGroups = new PreferredGroup[]{
                 // Hybrid key agreement
-                X25519MLKEM768,
+                new PreferredGroup(true, X25519MLKEM768),
 
                 // Primary XDH (RFC 7748) curves
-                X25519,
+                new PreferredGroup(true, X25519),
 
                 // Primary NIST Suite B curves
-                SECP256_R1,
-                SECP384_R1,
-                SECP521_R1,
+                new PreferredGroup(false, SECP256_R1),
+                new PreferredGroup(false, SECP384_R1),
+                new PreferredGroup(false, SECP521_R1),
 
                 // Secondary XDH curves
-                X448,
+                new PreferredGroup(false, X448),
 
                 // FFDHE (RFC 7919)
-                FFDHE_2048,
-                FFDHE_3072,
-                FFDHE_4096
+                new PreferredGroup(false, FFDHE_2048),
+                new PreferredGroup(false, FFDHE_3072),
+                new PreferredGroup(false, FFDHE_4096)
         };
 
         // Filter default groups names against default constraints.
@@ -888,12 +906,12 @@ enum NamedGroup {
         // "java -XshowSettings:security:tls" command.
         private static final String[] defaultNames = Arrays.stream(
                         defaultGroups)
-                .filter(ng -> ng.isAvailable)
-                .filter(ng -> ng.isPermitted(SSLAlgorithmConstraints.DEFAULT))
-                .map(ng -> ng.name)
+                .filter(pg -> pg.ng.isAvailable)
+                .filter(pg -> pg.ng.isPermitted(SSLAlgorithmConstraints.DEFAULT))
+                .map(pg -> pg.toString())
                 .toArray(String[]::new);
 
-        private static final NamedGroup[] customizedGroups =
+        private static final PreferredGroup[] customizedGroups =
                 getCustomizedNamedGroups();
 
         // Note: user-passed groups are not being filtered against default
@@ -901,7 +919,7 @@ enum NamedGroup {
         private static final String[] customizedNames =
                 customizedGroups == null ?
                         null : Arrays.stream(customizedGroups)
-                        .map(ng -> ng.name)
+                        .map(pg -> pg.toString())
                         .toArray(String[]::new);
 
         // Named group names for SSLConfiguration.
@@ -920,27 +938,28 @@ enum NamedGroup {
         }
 
         // Avoid the group lookup for default and customized groups.
-        static NamedGroup[] getGroupsFromConfig(SSLConfiguration sslConfig) {
+        static PreferredGroup[] getGroupsFromConfig(SSLConfiguration sslConfig) {
             if (sslConfig.namedGroups == defaultNames) {
                 return defaultGroups;
             } else if (sslConfig.namedGroups == customizedNames) {
                 return customizedGroups;
             } else {
                 return Arrays.stream(sslConfig.namedGroups)
-                        .map(NamedGroup::nameOf)
+                        .map(PreferredGroup::of)
                         .filter(Objects::nonNull)
-                        .toArray(NamedGroup[]::new);
+                        .toArray(PreferredGroup[]::new);
             }
         }
 
         // The value of the System Property defines a list of enabled named
-        // groups in preference order, separated with comma.  For example:
+        // groups in preference order and optionally what key shares should be
+        // sent in CH, separated with comma.  For example:
         //
-        //      jdk.tls.namedGroups="secp521r1, secp256r1, ffdhe2048"
+        //      jdk.tls.namedGroups="*secp521r1, secp256r1, ffdhe2048"
         //
         // If the System Property is not defined or the value is empty, the
         // default groups and preferences will be used.
-        private static NamedGroup[] getCustomizedNamedGroups() {
+        static PreferredGroup[] getCustomizedNamedGroups() {
             String property = System.getProperty("jdk.tls.namedGroups");
 
             if (property != null && !property.isEmpty()) {
@@ -952,12 +971,17 @@ enum NamedGroup {
             }
 
             if (property != null && !property.isEmpty()) {
-                NamedGroup[] ret = Arrays.stream(property.split(","))
-                        .map(String::trim)
-                        .map(NamedGroup::nameOf)
-                        .filter(Objects::nonNull)
-                        .filter(ng -> ng.isAvailable)
-                        .toArray(NamedGroup[]::new);
+                List<PreferredGroup> list = new ArrayList<>();
+                for (String s : property.split(",")) {
+                    String name = s.trim();
+                    PreferredGroup pg = PreferredGroup.of(name);
+                    if (pg != null) {
+                        if (pg.ng.isAvailable) {
+                            list.add(pg);
+                        }
+                    }
+                }
+                PreferredGroup[] ret = list.toArray(new PreferredGroup[0]);
 
                 if (ret.length == 0) {
                     throw new IllegalArgumentException(
@@ -965,10 +989,8 @@ enum NamedGroup {
                                     property
                                     + ") contains no supported named groups");
                 }
-
                 return ret;
             }
-
             return null;
         }
     }

--- a/src/java.base/share/classes/sun/security/ssl/SupportedGroupsExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SupportedGroupsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,9 +175,11 @@ final class SupportedGroupsExtension {
             // Produce the extension.
             ArrayList<NamedGroup> namedGroups =
                     new ArrayList<>(chc.sslConfig.namedGroups.length);
+            ArrayList<NamedGroup> preferredGroups =
+                    new ArrayList<>(chc.sslConfig.namedGroups.length);
             for (String name : chc.sslConfig.namedGroups) {
-                NamedGroup ng = NamedGroup.nameOf(name);
-                if (ng == null) {
+                NamedGroup.PreferredGroup pg = NamedGroup.PreferredGroup.of(name);
+                if (pg == null) {
                     if (SSLLogger.isOn() &&
                             SSLLogger.isOn(SSLLogger.Opt.HANDSHAKE)) {
                         SSLLogger.fine(
@@ -187,18 +189,19 @@ final class SupportedGroupsExtension {
                 }
 
                 if ((!SSLConfiguration.enableFFDHE) &&
-                    (ng.spec == NamedGroupSpec.NAMED_GROUP_FFDHE)) {
+                    (pg.ng().spec == NamedGroupSpec.NAMED_GROUP_FFDHE)) {
                     continue;
                 }
 
-                if (ng.isAvailable(chc.activeProtocols) &&
-                        ng.isSupported(chc.activeCipherSuites) &&
-                        ng.isPermitted(chc.algorithmConstraints)) {
-                    namedGroups.add(ng);
+                if (pg.ng().isAvailable(chc.activeProtocols) &&
+                        pg.ng().isSupported(chc.activeCipherSuites) &&
+                        pg.ng().isPermitted(chc.algorithmConstraints)) {
+                    namedGroups.add(pg.ng());
+                    if (pg.preferred()) preferredGroups.add(pg.ng());
                 } else if (SSLLogger.isOn() &&
                         SSLLogger.isOn(SSLLogger.Opt.HANDSHAKE)) {
                     SSLLogger.fine(
-                        "Ignore inactive or disabled named group: " + ng.name);
+                        "Ignore inactive or disabled named group: " + pg.ng().name);
                 }
             }
 
@@ -222,6 +225,12 @@ final class SupportedGroupsExtension {
             // Update the context.
             chc.clientRequestedNamedGroups =
                     Collections.unmodifiableList(namedGroups);
+            // If no preferred is chosen, set clientInitialKeyShareGroups
+            // to null and JSSE will pick one or two; otherwise, send their
+            // keyshares.
+            chc.clientInitialKeyShareGroups =
+                    preferredGroups.isEmpty() ? null :
+                            Collections.unmodifiableList(preferredGroups);
             chc.handshakeExtensions.put(CH_SUPPORTED_GROUPS,
                     new SupportedGroupsSpec(namedGroups));
 
@@ -339,8 +348,8 @@ final class SupportedGroupsExtension {
             ArrayList<NamedGroup> namedGroups = new ArrayList<>(
                     shc.sslConfig.namedGroups.length);
             for (String name : shc.sslConfig.namedGroups) {
-                NamedGroup ng = NamedGroup.nameOf(name);
-                if (ng == null) {
+                NamedGroup.PreferredGroup pg = NamedGroup.PreferredGroup.of(name);
+                if (pg == null) {
                     if (SSLLogger.isOn() &&
                             SSLLogger.isOn(SSLLogger.Opt.HANDSHAKE)) {
                         SSLLogger.fine(
@@ -349,6 +358,7 @@ final class SupportedGroupsExtension {
                     continue;
                 }
 
+                NamedGroup ng = pg.ng();
                 if ((!SSLConfiguration.enableFFDHE) &&
                     (ng.spec == NamedGroupSpec.NAMED_GROUP_FFDHE)) {
                     continue;

--- a/test/jdk/javax/net/ssl/SSLParameters/NamedGroupSettings.java
+++ b/test/jdk/javax/net/ssl/SSLParameters/NamedGroupSettings.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8388484
+ * @library /test/lib
+ * @summary Test all combinations of named group settings
+ * @run main/othervm NamedGroupSettings
+ */
+
+import jdk.test.lib.Asserts;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLParameters;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.StringJoiner;
+
+public class NamedGroupSettings {
+    private static final boolean DEBUG = System.getProperty("debug") != null;
+
+    // TestCase including client/server settings and expected message fields.
+    // When a field is missing it will be null. To show a case on one line,
+    // group names are abbreviated:
+    // A = x25519
+    // B = x448
+    // C = secp256r1
+    // D = secp384r1
+    // X/Y/Z = unknown group names
+    record TestCase(
+            String clientSetting,
+            String serverSetting,
+            String chGroups, // expected supported_group in CH1
+            String chKeyShares, // expected key_share in CH1
+            String serverResponse, // expected server response to CH1
+            String serverChoice, // expected server selected group
+            String ch2Groups, // expected supported_group in CH2
+            String ch2KeyShares, // expected key_share in CH2
+            String err) {
+
+        static TestCase of(String clientSetting, String serverSetting,
+                String chGroups, String chKeyShares,
+                String serverResponse, String serverChoice,
+                String ch2Groups, String ch2KeyShares) {
+            return of(clientSetting, serverSetting,
+                    chGroups, chKeyShares,
+                    serverResponse, serverChoice,
+                    ch2Groups, ch2KeyShares, null);
+        }
+
+        static TestCase of(String clientSetting, String serverSetting,
+                String chGroups, String chKeyShares,
+                String serverResponse, String serverChoice,
+                String ch2Groups, String ch2KeyShares, String comment) {
+            return new TestCase(clientSetting, serverSetting,
+                    chGroups, chKeyShares,
+                    serverResponse, serverChoice,
+                    ch2Groups, ch2KeyShares, comment);
+        }
+
+        static String expand(String s) {
+            return s.replace("A", "x25519")
+                    .replace("B", "x448")
+                    .replace("C", "secp256r1")
+                    .replace("D", "secp384r1");
+        }
+
+        static String shrink(String s) {
+            return s.replace("x25519", "A")
+                    .replace("x448", "B")
+                    .replace("secp256r1", "C")
+                    .replace("secp384r1", "D");
+        }
+
+        public void check(Result result) {
+            Asserts.assertEquals(chGroups, enc(result.chGroups));
+            Asserts.assertEquals(chKeyShares, enc(result.chKeyShares));
+            Asserts.assertEquals(serverResponse, result.serverResponse);
+            Asserts.assertEquals(serverChoice, enc(result.serverChoice));
+            Asserts.assertEquals(ch2Groups, enc(result.ch2Groups));
+            Asserts.assertEquals(ch2KeyShares, enc(result.ch2KeyShares));
+            if (err != null) {
+                // only compare failures, result.err could be something else
+                Asserts.assertEquals(err, result.err);
+            }
+        }
+    }
+
+    // Expected behavior:
+    // - If any "*" exists, CH1 key_share contains all starred enabled groups.
+    // - If no "*" exists, CH1 key_share follows old JSSE automatic selection.
+    // - Server chooses first mutually supported group in CH1 supported_groups.
+    // - If key_share for that group exists, SH; otherwise HRR.
+
+    static final List<TestCase> TEST_CASES = List.of(
+            // Negotiable
+            TestCase.of("*A,*B,*C", "A,B,C", "A,B,C", "A,B,C", "SH", "A", null, null), // first mutual A has share
+            TestCase.of("*A,*B,*C", "B,A,C", "A,B,C", "A,B,C", "SH", "A", null, null), // server order ignored; client first mutual A has share
+            TestCase.of("*A,*B,*C", "B,C", "A,B,C", "A,B,C", "SH", "B", null, null), // A unsupported by server; first mutual B has share
+            TestCase.of("*A,*B,*C", "C", "A,B,C", "A,B,C", "SH", "C", null, null), // only C mutual and has share
+            TestCase.of("A,*B,*C", "A,B,C", "A,B,C", "B,C", "HRR", "A", "A,B,C", "A"), // first mutual A has no share
+            TestCase.of("A,*B,*C", "B,A,C", "A,B,C", "B,C", "HRR", "A", "A,B,C", "A"), // server order ignored; first mutual A has no share
+            TestCase.of("A,*B,*C", "B,C", "A,B,C", "B,C", "SH", "B", null, null), // first mutual B has share
+            TestCase.of("A,*B,*C", "C,B", "A,B,C", "B,C", "SH", "B", null, null), // server order ignored; first mutual B has share
+            TestCase.of("A,*B,*C", "C", "A,B,C", "B,C", "SH", "C", null, null), // first mutual C has share
+            TestCase.of("A,*B,*C", "A", "A,B,C", "B,C", "HRR", "A", "A,B,C", "A"), // only mutual A has no share
+            TestCase.of("A,B,*C", "A,B,C", "A,B,C", "C", "HRR", "A", "A,B,C", "A"), // first mutual A has no share
+            TestCase.of("A,B,*C", "B,A,C", "A,B,C", "C", "HRR", "A", "A,B,C", "A"), // server order ignored; first mutual A has no share
+            TestCase.of("A,B,*C", "B,C", "A,B,C", "C", "HRR", "B", "A,B,C", "B"), // first mutual B has no share
+            TestCase.of("A,B,*C", "C,B", "A,B,C", "C", "HRR", "B", "A,B,C", "B"), // server order ignored; first mutual B has no share
+            TestCase.of("A,B,*C", "C", "A,B,C", "C", "SH", "C", null, null), // first mutual C has share
+            TestCase.of("B,A,*C", "A,B,C", "B,A,C", "C", "HRR", "B", "B,A,C", "B"), // client order makes B first mutual
+            TestCase.of("*B,A,*C", "A,B,C", "B,A,C", "B,C", "SH", "B", null, null), // client order makes B first mutual and has share
+            TestCase.of("*C,*B,A", "A,B,C", "C,B,A", "C,B", "SH", "C", null, null), // client order makes C first mutual and has share
+            TestCase.of("A,B,C", "A,B,C", "A,B,C", "A,C", "SH", "A", null, null), // no star: old default shares include A
+            TestCase.of("A,B,C", "B,C", "A,B,C", "A,C", "HRR", "B", "A,B,C", "B"), // no star: first mutual B not in default shares
+            TestCase.of("A,B,C", "C", "A,B,C", "A,C", "SH", "C", null, null), // no star: first mutual C in default shares
+            TestCase.of("B,A,C", "A,B,C", "B,A,C", "B,C", "SH", "B", null, null), // no star: client first mutual B has default share
+            TestCase.of("C,A,B", "A,B,C", "C,A,B", "C,A", "SH", "C", null, null), // no star: client first mutual C has default share
+            TestCase.of("X,A,*B,*C", "A,B,C", "A,B,C", "B,C", "HRR", "A", "A,B,C", "A"), // unknown client group X ignored
+            TestCase.of("A,*X,*B,*C", "A,B,C", "A,B,C", "B,C", "HRR", "A", "A,B,C", "A"), // unknown starred client group X ignored
+            TestCase.of("A,*B,*C", "X,B,C", "A,B,C", "B,C", "SH", "B", null, null), // unknown server group X ignored; first mutual B
+            TestCase.of("A,*B,*C", "X,Y,C", "A,B,C", "B,C", "SH", "C", null, null), // unknown server groups ignored; first mutual C
+            TestCase.of("X,A,*Y,*B,*C", "Y,X,B,C", "A,B,C", "B,C", "SH", "B", null, null), // unknown groups ignored on both sides
+            TestCase.of("X,A,Y,B,Z,C", "A,B,C", "A,B,C", "A,C", "SH", "A", null, null), // unknown unstarred groups ignored; no-star default shares
+            TestCase.of("X,A,Y,B,Z,C", "B,C", "A,B,C", "A,C", "HRR", "B", "A,B,C", "B"), // unknown ignored; first mutual B lacks default share
+            TestCase.of("X,*A,Y,*B,Z,*C", "A,B,C", "A,B,C", "A,B,C", "SH", "A", null, null), // unknown ignored; all known starred shares sent
+            TestCase.of("A,B,*X", "A,B,C", "A,B", "A", "SH", "A", null, null), // unknown starred ignored; default keyshare!
+
+            // No group negotiated
+            TestCase.of("A,*B,*C", "D", "A,B,C", "B,C", null, null, null, null, "(handshake_failure) No common named group"),
+            TestCase.of("A,*B,*C", "X,Y,Z", "A,B,C", "B,C", null, null, null, null, "(handshake_failure) No common named group"),
+            TestCase.of("A,B,C", "D", "A,B,C", "A,C", null, null, null, null, "(handshake_failure) No common named group"),
+            TestCase.of("A,B,*C", "D", "A,B,C", "C", null, null, null, null, "(handshake_failure) No common named group"),
+
+            // Syntax error
+            TestCase.of("**A", "A", null, null, null, null, null, null, "Multiple asterisks"),
+            TestCase.of("*A,*A", "A", null, null, null, null, null, null, "Duplicate element of namedGroups: x25519"),
+            TestCase.of("A,*A", "A", null, null, null, null, null, null, "Duplicate element of namedGroups: x25519"),
+            TestCase.of("A,,B", "A", null, null, null, null, null, null, "An element of namedGroups is blank"),
+            TestCase.of("*", "A", null, null, null, null, null, null, "An element of namedGroups is blank"),
+            TestCase.of("A,*", "A", null, null, null, null, null, null, "An element of namedGroups is blank"),
+            TestCase.of("X,Y,Z", "A,B,C", null, null, null, null, null, null,
+                    "(missing_extension) No supported_groups or signature_algorithms extension when pre_shared_key extension is not present"),
+            TestCase.of("*X,*Y", "A,B,C", null, null, null, null, null, null,
+                    "(missing_extension) No supported_groups or signature_algorithms extension when pre_shared_key extension is not present")
+    );
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 0) {
+            // Manual play
+            System.out.println(test(
+                    args[0].equals("null") ? null : TestCase.expand(args[0]),
+                    args[1].equals("null") ? null : TestCase.expand(args[1])));
+        } else {
+            for (TestCase c : TEST_CASES) {
+                System.out.println(c.clientSetting + " - " + c.serverSetting);
+                Result result = test(TestCase.expand(c.clientSetting), TestCase.expand(c.serverSetting));
+                c.check(result);
+            }
+        }
+    }
+
+    // encode one group name using TextCase.shrink
+    static String enc(String s) {
+        if (s == null) return null;
+        return TestCase.shrink(s);
+    }
+
+    // encode a list of group names using TextCase.shrink
+    static String enc(Collection<String> ss) {
+        if (ss == null || ss.isEmpty()) return null;
+        var sj = new StringJoiner(",");
+        for (String s : ss) {
+            sj.add(s);
+        }
+        return TestCase.shrink(sj.toString());
+    }
+
+    // Observed result from debug output
+    static class Result {
+        public List<String> chGroups = new ArrayList<>();
+        public List<String> chKeyShares = new ArrayList<>();
+        public String serverResponse;
+        public String serverChoice;
+        public List<String> ch2Groups = new ArrayList<>();
+        public List<String> ch2KeyShares = new ArrayList<>();
+        public String err;
+
+        enum Phase {
+            BEFORE_CH1,
+            IN_CH1,
+            WAIT_SERVER,
+            IN_SH,
+            IN_HRR,
+            IN_CH2
+        }
+
+        private Phase phase = Phase.BEFORE_CH1;
+
+        void consume(String line) {
+
+            if (DEBUG) {
+                System.out.println(line);
+            }
+
+            if (line.contains(".java")) {
+                return;
+            }
+
+            if (line.contains("SSLHandshakeException")) {
+                err = line.substring(line.indexOf(':') + 1).trim();
+            }
+
+            switch (phase) {
+                case BEFORE_CH1 -> {
+                    if (has(line, "ClientHello")) {
+                        phase = Phase.IN_CH1;
+                    }
+                }
+                case IN_CH1 -> {
+                    readClientHelloLine(line, chGroups, chKeyShares);
+                    if (has(line, "ClientHello")) {
+                        phase = Phase.WAIT_SERVER;
+                    }
+                }
+                case WAIT_SERVER -> {
+                    if (has(line, "HelloRetryRequest")) {
+                        serverResponse = "HRR";
+                        phase = Phase.IN_HRR;
+                    } else if (has(line, "ServerHello")) {
+                        serverResponse = "SH";
+                        phase = Phase.IN_SH;
+                    }
+                }
+                case IN_SH -> {
+                    if (has(line, "named group")) {
+                        serverChoice = parseOne(line);
+                    }
+                }
+                case IN_HRR -> {
+                    if (has(line, "selected group")) {
+                        serverChoice = parseOne(line);
+                    } else if (has(line, "ClientHello")) {
+                        phase = Phase.IN_CH2;
+                    }
+                }
+                case IN_CH2 -> readClientHelloLine(line, ch2Groups, ch2KeyShares);
+            }
+        }
+
+        private static void readClientHelloLine(String line,
+                List<String> groups, List<String> shares) {
+            if (has(line, "named groups")) {
+                groups.addAll(parseList(line));
+            } else if (has(line, "named group")) {
+                shares.add(parseOne(line));
+            }
+        }
+    }
+
+    static boolean has(String in, String key) {
+        return in.contains('"' + key + '"');
+    }
+
+    static String parseOne(String line) {
+        String value = line.substring(line.indexOf(':') + 1).trim();
+        if (value.startsWith("[") && value.endsWith("]")) {
+            value = value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    static List<String> parseList(String in) {
+        return Arrays.stream(in.split("[\\[\\]]")[1].split(",\\s*")).toList();
+    }
+
+    static Result test(String clientSetting, String serverSetting) throws Exception {
+        System.setProperty("javax.net.debug", "ssl,handshake");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream oldErr = System.err;
+        System.setErr(new PrintStream(baos));
+        Exception exception = null;
+        try {
+            SSLContext sc = SSLContext.getDefault();
+            SSLEngine client = sc.createSSLEngine("someone", 8080);
+            client.setUseClientMode(true);
+            if (clientSetting != null) {
+                SSLParameters cp = client.getSSLParameters();
+                cp.setNamedGroups(clientSetting.split(","));
+                client.setSSLParameters(cp);
+            }
+            client.beginHandshake();
+
+            SSLEngine server = sc.createSSLEngine();
+            server.setUseClientMode(false);
+            if (serverSetting != null) {
+                SSLParameters sp = server.getSSLParameters();
+                sp.setNamedGroups(serverSetting.split(","));
+                server.setSSLParameters(sp);
+            }
+            server.beginHandshake();
+
+
+            ByteBuffer clientToServer =
+                    ByteBuffer.allocate(client.getSession().getPacketBufferSize());
+            ByteBuffer serverToClient =
+                    ByteBuffer.allocate(server.getSession().getPacketBufferSize());
+            ByteBuffer app =
+                    ByteBuffer.allocate(server.getSession().getApplicationBufferSize());
+
+            client.wrap(ByteBuffer.allocate(0), clientToServer);
+            clientToServer.flip();
+
+            server.unwrap(clientToServer, app);
+
+            while (server.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                Runnable task;
+                while ((task = server.getDelegatedTask()) != null) {
+                    task.run();
+                }
+            }
+
+            // If SH has been sent, the next call might fail because
+            // authentication has not been configured at all. Otherwise,
+            // we will record HRR and CH2 messages.
+            // The error is recorded but will not be used in comparison.
+            server.wrap(ByteBuffer.allocate(0), serverToClient);
+            serverToClient.flip();
+
+            client.unwrap(serverToClient, app);
+            while (client.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_TASK) {
+                Runnable task;
+                while ((task = client.getDelegatedTask()) != null) {
+                    task.run();
+                }
+            }
+        } catch (Exception e) {
+            exception = e; // handshake errors
+        } finally {
+            System.clearProperty("javax.net.debug");
+            System.setErr(oldErr);
+        }
+        Result info = new Result();
+        new String(baos.toByteArray(), StandardCharsets.UTF_8).lines()
+                .forEach(info::consume);
+        if (info.err == null && exception != null) {
+            info.err = exception.getMessage(); // parsing errors
+        }
+        return info;
+    }
+}

--- a/test/jdk/sun/security/pkcs11/tls/fips/FipsModeTLS.java
+++ b/test/jdk/sun/security/pkcs11/tls/fips/FipsModeTLS.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, Red Hat, Inc.
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -431,7 +431,9 @@ public final class FipsModeTLS extends SecmodTest {
                 throw new RuntimeException("No ECDHE named groups available");
             }
             // remove XDH named groups - not available in PKCS11
-            namedGroups = Arrays.stream(namedGroups).filter(s-> !s.startsWith("x")).toArray(String[]::new);
+            namedGroups = Arrays.stream(namedGroups)
+                    .filter(s -> !s.startsWith("x") && !s.startsWith("*x"))
+                    .toArray(String[]::new);
             sslParameters.setNamedGroups(namedGroups);
             ssle.setSSLParameters(sslParameters);
 

--- a/test/jdk/sun/security/ssl/CipherSuite/DefaultNamedGroups.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/DefaultNamedGroups.java
@@ -32,7 +32,7 @@ import jdk.test.lib.security.SecurityUtils;
 
 /*
  * @test
- * @bug 8370885
+ * @bug 8370885 8388484
  * @summary Default namedGroups values are not being filtered against
  *          algorithm constraints
  * @library /javax/net/ssl/templates
@@ -44,8 +44,8 @@ public class DefaultNamedGroups extends SSLEngineTemplate {
 
     protected static final String DISABLED_NG = "secp256r1";
     protected static final List<String> REFERENCE_NG = Stream.of(
-                    "X25519MLKEM768",
-                    "x25519",
+                    "*X25519MLKEM768",
+                    "*x25519",
                     "secp256r1",
                     "secp384r1",
                     "secp521r1",

--- a/test/jdk/sun/security/ssl/NamedGroups/SystemProperty.java
+++ b/test/jdk/sun/security/ssl/NamedGroups/SystemProperty.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8388484
+ * @library /test/lib
+ * @summary check system property on group names
+ * @run main/othervm -Djdk.tls.namedGroups=secp256r1,secp384r1 SystemProperty secp256r1
+ * @run main/othervm -Djdk.tls.namedGroups=secp256r1,*secp384r1 SystemProperty secp384r1
+ * @run main/othervm -Djdk.tls.namedGroups=secp256r1,*unknown SystemProperty secp256r1
+ */
+
+import jdk.test.lib.Asserts;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SystemProperty {
+
+    private static final boolean DEBUG = System.getProperty("debug") != null;
+
+    // Observed result from debug output
+    static class Result {
+        public List<String> cshares = new ArrayList<>();
+        public String err;
+
+        enum Phase {
+            BEFORE_CH1,
+            IN_CH1,
+            WAIT_SERVER,
+        }
+
+        private Phase phase = Phase.BEFORE_CH1;
+
+        void consume(String line) {
+
+            if (DEBUG) {
+                System.out.println(line);
+            }
+
+            if (line.contains(".java")) { // titles
+                return;
+            }
+
+            if (line.contains("SSLHandshakeException")) {
+                err = line.substring(line.indexOf(':') + 1).trim();
+            }
+
+            switch (phase) {
+                case BEFORE_CH1 -> {
+                    if (has(line, "ClientHello")) {
+                        phase = Phase.IN_CH1;
+                    }
+                }
+                case IN_CH1 -> {
+                    readClientHelloLine(line, cshares);
+                    if (has(line, "ClientHello")) {
+                        phase = Phase.WAIT_SERVER;
+                    }
+                }
+            }
+        }
+
+        private static void readClientHelloLine(String line, List<String> shares) {
+            if (has(line, "named group")) {
+                shares.add(parseOne(line));
+            }
+        }
+    }
+
+    static boolean has(String in, String key) {
+        return in.contains('"' + key + '"');
+    }
+
+    static String parseOne(String line) {
+        String value = line.substring(line.indexOf(':') + 1).trim();
+        if (value.startsWith("[") && value.endsWith("]")) {
+            value = value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty("javax.net.debug", "ssl,handshake");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream oldErr = System.err;
+        System.setErr(new PrintStream(baos));
+        Exception exception = null;
+        try {
+            SSLContext sc = SSLContext.getDefault();
+            SSLEngine client = sc.createSSLEngine("someone", 8080);
+            client.setUseClientMode(true);
+            client.beginHandshake();
+
+            ByteBuffer clientToServer =
+                    ByteBuffer.allocate(client.getSession().getPacketBufferSize());
+
+            client.wrap(ByteBuffer.allocate(0), clientToServer);
+            clientToServer.flip();
+        } catch (Exception e) {
+            exception = e; // handshake errors
+        } finally {
+            System.clearProperty("javax.net.debug");
+            System.setErr(oldErr);
+        }
+        Result result = new Result();
+        new String(baos.toByteArray(), StandardCharsets.UTF_8).lines()
+                .forEach(result::consume);
+        if (result.err == null && exception != null) {
+            result.err = exception.getMessage(); // parsing errors
+        }
+        Asserts.assertEquals(List.of(args[0]), result.cshares);
+    }
+}

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
@@ -45,8 +46,10 @@ public class SSLEngineDecodeBadPoint {
             "040305030603080708080804080508060809080a080b040105010601" +
             "02030201002b0003020304002d000201010032002200200403050306" +
             "03080708080804080508060809080a080b0401050106010203020100" +
-            "33006b0069001d00209a4d13131f83cc4c5be46520f0b4d7a6f1d3f6" +
-            "ca7118e6dd115125090da6e044" +
+            "33006b0069" +
+            // X25519 key share, valid
+            "001d00209a4d13131f83cc4c5be46520f0b4d7a6f1d3f6ca7118e6dd" +
+            "115125090da6e044" +
             // ECDHE key share, 5th byte changed from 04 to (invalid) 05
             "0017004105d8c3734b9c729f6a9851" +
             "5049543ec5a9bb6c19b8c02ca0bdc3b20a77c44acdab226b6329b7c5" +
@@ -55,6 +58,13 @@ public class SSLEngineDecodeBadPoint {
     public static void main(String[] args) throws NoSuchAlgorithmException, SSLException {
         SSLContext ctx = SSLContext.getDefault();
         SSLEngine eng = ctx.createSSLEngine();
+
+        // After 8388484, server side no longer check all key shares.
+        // Therefore, restrict server to only accept the invalid key share.
+        SSLParameters params = eng.getSSLParameters();
+        params.setNamedGroups(new String[] {"secp256r1"});
+        eng.setSSLParameters(params);
+
         eng.setUseClientMode(false);
         eng.beginHandshake();
         ByteBuffer hello = ByteBuffer.wrap(clientHello);


### PR DESCRIPTION
The enhancement implements the new RFC 9846-style support group selection on the server side (first mutual group matters) and change the supported-groups format. Specifically:

1. `SSLParameters.setNamedGroups` and the `jdk.tls.namedGroups` system property now recognize a *-prefix on a group name.
2. The prefix does not change the supported_groups extension.
3. On a TLS 1.3 client, usable starred groups determine the initial key_share entries. If no usable starred group remains, JSSE falls back to its existing automatic key-share selection.
4. SunJSSE’s default parameters contains 2 starred groups, which can be observed by `getNamedGroups`.
5. The server ignores the marker in its own configuration.
6. Server group selection now follows RFC 9846: choose the first mutually supported group according to the client’s supported_groups order, then sends ServerHello if its key share is present or HelloRetryRequest if not.

No new API or system property defined for the new format. The existing methods and system property are already called a lot by both JSSE itself and an application. The default value of the system property is empty which gives each provider the chance to define it itself.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388484](https://bugs.openjdk.org/browse/JDK-8388484): RFC 9846-style Supported Group Selection (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32586/head:pull/32586` \
`$ git checkout pull/32586`

Update a local copy of the PR: \
`$ git checkout pull/32586` \
`$ git pull https://git.openjdk.org/jdk.git pull/32586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32586`

View PR using the GUI difftool: \
`$ git pr show -t 32586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32586.diff">https://git.openjdk.org/jdk/pull/32586.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32586#issuecomment-5664199992)
</details>
