### PR TITLE
8391311: GenShen: Avoid double region iteration in final mark

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,17 +258,12 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
   {
     ShenandoahGCPhase phase(concurrent ? ShenandoahPhaseTimings::final_update_region_states :
                             ShenandoahPhaseTimings::degen_gc_final_update_region_states);
-    ShenandoahFinalMarkUpdateRegionStateClosure cl(complete_marking_context());
-    parallel_heap_region_iterate(&cl);
-
-    if (is_young()) {
-      // We always need to update the watermark for old regions. If there
-      // are mixed collections pending, we also need to synchronize the
-      // pinned status for old regions. Since we are already visiting every
-      // old region here, go ahead and sync the pin status too.
-      ShenandoahFinalMarkUpdateRegionStateClosure old_cl(nullptr);
-      heap->old_generation()->parallel_heap_region_iterate(&old_cl);
-    }
+    // Update region state for every active region, but only update the liveness data for
+    // the generation we marked. We always need to update the watermark for old regions.
+    // If there are mixed collections pending, we also need to synchronize the pinned status
+    // for old regions.
+    ShenandoahFinalMarkUpdateRegionStateClosure cl(complete_marking_context(), this);
+    heap->global_generation()->parallel_heap_region_iterate(&cl);
   }
 
   // Tally the census counts and compute the adaptive tenuring threshold

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.cpp
@@ -55,18 +55,24 @@ void ShenandoahSynchronizePinnedRegionStates::synchronize_pin_count(ShenandoahHe
   }
 }
 
-ShenandoahFinalMarkUpdateRegionStateClosure::ShenandoahFinalMarkUpdateRegionStateClosure(ShenandoahMarkingContext *ctx, ShenandoahGeneration* generation) :
-        _ctx(ctx), _generation(generation) { }
+ShenandoahFinalMarkUpdateRegionStateClosure::ShenandoahFinalMarkUpdateRegionStateClosure(ShenandoahMarkingContext* ctx, ShenandoahGeneration* generation) :
+    _ctx(ctx), _generation(generation) {
+  assert(_ctx != nullptr, "Marking context is required");
+  assert(_generation != nullptr, "Generation is required");
+}
 
 void ShenandoahFinalMarkUpdateRegionStateClosure::heap_region_do(ShenandoahHeapRegion* r) {
   // Region data can only be adjusted for regions in the generation this cycle marked.
+  // For old regions during a young cycle, we only sync the pin status and update
+  // the watermark. We cannot reset the TAMS for old regions because we rely on
+  // that to keep promoted objects alive after old marking is complete.
   const bool in_marked_generation = _generation->contains(r);
   if (r->is_active()) {
     if (in_marked_generation) {
       // All allocations past TAMS are implicitly live, adjust the region data.
       // Bitmaps/TAMS are swapped at this point, so we need to poll complete bitmap.
-      HeapWord *tams = _ctx->top_at_mark_start(r);
-      HeapWord *top = r->top();
+      HeapWord* tams = _ctx->top_at_mark_start(r);
+      HeapWord* top = r->top();
       if (top > tams) {
         r->increase_live_data_alloc_words(pointer_delta(top, tams));
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
  *
  */
 
+#include "gc/shenandoah/shenandoahGeneration.hpp"
 #include "gc/shenandoah/shenandoahHeapRegionClosures.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
@@ -54,17 +55,14 @@ void ShenandoahSynchronizePinnedRegionStates::synchronize_pin_count(ShenandoahHe
   }
 }
 
-ShenandoahFinalMarkUpdateRegionStateClosure::ShenandoahFinalMarkUpdateRegionStateClosure(ShenandoahMarkingContext *ctx) :
-        _ctx(ctx) { }
+ShenandoahFinalMarkUpdateRegionStateClosure::ShenandoahFinalMarkUpdateRegionStateClosure(ShenandoahMarkingContext *ctx, ShenandoahGeneration* generation) :
+        _ctx(ctx), _generation(generation) { }
 
 void ShenandoahFinalMarkUpdateRegionStateClosure::heap_region_do(ShenandoahHeapRegion* r) {
+  // Region data can only be adjusted for regions in the generation this cycle marked.
+  const bool in_marked_generation = _generation->contains(r);
   if (r->is_active()) {
-    if (_ctx != nullptr) {
-      // _ctx may be null when this closure is used to sync only the pin status
-      // update the watermark of old regions. For old regions we cannot reset
-      // the TAMS because we rely on that to keep promoted objects alive after
-      // old marking is complete.
-
+    if (in_marked_generation) {
       // All allocations past TAMS are implicitly live, adjust the region data.
       // Bitmaps/TAMS are swapped at this point, so we need to poll complete bitmap.
       HeapWord *tams = _ctx->top_at_mark_start(r);
@@ -89,7 +87,7 @@ void ShenandoahFinalMarkUpdateRegionStateClosure::heap_region_do(ShenandoahHeapR
     }
   } else {
     assert(!r->has_live(), "Region %zu should have no live data", r->index());
-    assert(_ctx == nullptr || _ctx->top_at_mark_start(r) == r->top(),
+    assert(!in_marked_generation || _ctx->top_at_mark_start(r) == r->top(),
            "Region %zu should have correct TAMS", r->index());
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.hpp
@@ -96,14 +96,15 @@ public:
 class ShenandoahMarkingContext;
 class ShenandoahGeneration;
 
-// Synchronizes region pinned status, sets update watermark and adjust live data tally for regions
+// Synchronizes region pinned status, sets update watermark and adjusts live data tally for regions.
+// Live data tally is only adjusted for regions in the given generation.
 class ShenandoahFinalMarkUpdateRegionStateClosure : public ShenandoahHeapRegionClosure {
 private:
   ShenandoahMarkingContext* const _ctx;
   ShenandoahGeneration* const _generation;
   ShenandoahSynchronizePinnedRegionStates _pins;
 public:
-  ShenandoahFinalMarkUpdateRegionStateClosure(ShenandoahMarkingContext* ctx, ShenandoahGeneration* generation);
+  explicit ShenandoahFinalMarkUpdateRegionStateClosure(ShenandoahMarkingContext* ctx, ShenandoahGeneration* generation);
 
   void heap_region_do(ShenandoahHeapRegion* r) override;
   bool is_thread_safe() override { return true; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionClosures.hpp
@@ -94,14 +94,16 @@ public:
 };
 
 class ShenandoahMarkingContext;
+class ShenandoahGeneration;
 
 // Synchronizes region pinned status, sets update watermark and adjust live data tally for regions
 class ShenandoahFinalMarkUpdateRegionStateClosure : public ShenandoahHeapRegionClosure {
 private:
   ShenandoahMarkingContext* const _ctx;
+  ShenandoahGeneration* const _generation;
   ShenandoahSynchronizePinnedRegionStates _pins;
 public:
-  explicit ShenandoahFinalMarkUpdateRegionStateClosure(ShenandoahMarkingContext* ctx);
+  ShenandoahFinalMarkUpdateRegionStateClosure(ShenandoahMarkingContext* ctx, ShenandoahGeneration* generation);
 
   void heap_region_do(ShenandoahHeapRegion* r) override;
   bool is_thread_safe() override { return true; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -452,7 +452,7 @@ void ShenandoahOldGeneration::prepare_regions_and_collection_set(bool concurrent
     ShenandoahGCPhase phase(concurrent ?
         ShenandoahPhaseTimings::final_update_region_states :
         ShenandoahPhaseTimings::degen_gc_final_update_region_states);
-    ShenandoahFinalMarkUpdateRegionStateClosure cl(complete_marking_context());
+    ShenandoahFinalMarkUpdateRegionStateClosure cl(complete_marking_context(), this);
 
     parallel_heap_region_iterate(&cl);
     heap->assert_pinned_region_status(this);


### PR DESCRIPTION
During final mark for a young cycle, we iterate through young and old regions in two separate loops. We can optimize this by iterating both generations in one loop. We'll only adjust the region data if the region is in the generation that was marked, but we'll always update the watermark and pin status for every active region regardless of the generation.

### Testing
- `hotspot_gc_shenandoah` with `linux-x86_64-server-fastdebug`
- Internal CI pipeline

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391311](https://bugs.openjdk.org/browse/JDK-8391311): GenShen: Avoid double region iteration in final mark (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32587/head:pull/32587` \
`$ git checkout pull/32587`

Update a local copy of the PR: \
`$ git checkout pull/32587` \
`$ git pull https://git.openjdk.org/jdk.git pull/32587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32587`

View PR using the GUI difftool: \
`$ git pr show -t 32587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32587.diff">https://git.openjdk.org/jdk/pull/32587.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32587#issuecomment-5485472620)
</details>
