### PR TITLE
8391423: jpackage DEB packaging tests fail on RPM-based Linux

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
@@ -973,15 +973,19 @@ public final class LinuxHelper {
         static final PackageType VALUE;
 
         private static boolean isDebian() {
-            // we are just going to run "dpkg -s coreutils" and assume Debian
-            // or derivative if no error is returned.
-            return Result.of(Executor.of("dpkg", "-s", "coreutils")::execute).hasValue();
+            // Run "dpkg -s coreutils" command and assume this is native Debian-based Linux if it succeeds.
+            // If it fails to execute (command not found) or exits with an error (non-zero exit code), we assume the opposite.
+            return Result.of(Executor.of("dpkg", "-s", "coreutils")::executeWithoutExitCodeCheck).value().filter(result -> {
+                return result.getExitCode() == 0;
+            }).isPresent();
         }
 
         private static boolean isRpm() {
-            // we are just going to run "rpm -q rpm" and assume RPM
-            // or derivative if no error is returned.
-            return Result.of(Executor.of("rpm", "-q", "rpm")::execute).hasValue();
+            // Run "rpm -q rpm" command and assume this is native RPM-based Linux if it succeeds.
+            // If it fails to execute (command not found) or exits with an error (non-zero exit code), we assume the opposite.
+            return Result.of(Executor.of("rpm", "-q", "rpm")::executeWithoutExitCodeCheck).value().filter(result -> {
+                return result.getExitCode() == 0;
+            }).isPresent();
         }
 
         static {

--- a/test/jdk/tools/jpackage/linux/LinuxResourceTest.java
+++ b/test/jdk/tools/jpackage/linux/LinuxResourceTest.java
@@ -78,10 +78,13 @@ public class LinuxResourceTest {
                     "Maintainer: APPLICATION_MAINTAINER",
                     "Priority: optional",
                     archProp.format(),
-                    "Provides: dont-install-me",
                     "Description: APPLICATION_DESCRIPTION",
                     "Installed-Size: APPLICATION_INSTALLED_SIZE",
-                    "Depends: PACKAGE_DEFAULT_DEPENDENCIES"
+                    "Depends: PACKAGE_DEFAULT_DEPENDENCIES",
+                    // The value of the last field must not be an empty string.
+                    // Otherwise newer versions of dpkg-deb fails with
+                    // "end of file before value of field 'Depends' (missing final newline)" error
+                    "Provides: dont-install-me"
             ));
 
             cmd.excludeStandardAsserts(StandardAssert.LINUX_PACKAGE_ARCH);


### PR DESCRIPTION
Fix testing of jpackage's Debian packaging on RPM-based Linux distros.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8391423: jpackage DEB packaging tests fail on RPM-based Linux`

### Issue
 * [JDK-8391423](https://bugs.openjdk.org/browse/JDK-8391423): jpackage DEB packaging tests fail on RPM-based Linux (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32589/head:pull/32589` \
`$ git checkout pull/32589`

Update a local copy of the PR: \
`$ git checkout pull/32589` \
`$ git pull https://git.openjdk.org/jdk.git pull/32589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32589`

View PR using the GUI difftool: \
`$ git pr show -t 32589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32589.diff">https://git.openjdk.org/jdk/pull/32589.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32589#issuecomment-5459127680)
</details>
