### PR TITLE
8389968: revert checking ENOPROTOOPT when trying to set IP_MULTICAST_ALL in Net.c

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -300,7 +300,8 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
     /* IPv4 or IPv6 datagram socket: disable IP_MULTICAST_ALL (Linux 2.6.31) */
     if (type == SOCK_DGRAM && ipv4_available()) {
         int arg = 0;
-        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0)) {
+        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0) &&
+            (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
                                          JNU_JAVANETPKG "SocketException",
                                          "Unable to set IP_MULTICAST_ALL");


### PR DESCRIPTION
prior 28, the flag was checked and did not threw anything if it got back no-proto-opt from setsockopt ip_multicast_all on regular unicast sockets during new socket()... in 28 that ipv4 part was refactored ( https://github.com/AlanBateman/jdk/commit/3dcc9e750b68f9e841a9ac1ce70d13dce1ce10f8 ) and the check fallen off somehow, whereas for ipv6 sockets right below the code i'm touching here, its still there.... this small patch just readds that missing check...

this missing check prevents openjdk running on freebsd and netbsd (probably others) in their linux emulation mode, see below the daily iso from freebsd + debians' openjdk mix from freertr.org passes through the interface detection part (two short lived jvm runs) but fails to start up properly when it cannot open the socket for the detected interfaces' javas' sides of the socat udp: interface:  .....




```
starting
mount: /usr/src: No such file or directory
net.inet6.ip6.auto_linklocal: 1 -> 0
linux: jid 0 pid 25 (java): unsupported madvise behav 23
linux: jid 0 pid 25 (java): unsupported madvise behav 102
linux: jid 0 pid 25 (C1 Comp..hread0): syscall fchmodat2 not implemented
% detecting hardware
% iface=1 line=1 cross=0 tuntap=0 mem=384m
error cfgInit.stopRouter:cfgInit.java:1373 shutdown code=18 reason=finished
linux: jid 0 pid 29 (java): unsupported madvise behav 23
linux: jid 0 pid 29 (java): unsupported madvise behav 102
linux: jid 0 pid 29 (C1 Comp..hread0): syscall fchmodat2 not implemented
% redetecting hardware
% detected=1 needed=1 changed=0
error cfgInit.stopRouter:cfgInit.java:1373 shutdown code=18 reason=finished
lo0: link state changed to UP
starting interfaces.
starting lines.
starting main.
linux: jid 0 pid 34 (modem.bin): unsupported madvise behav 102
linux: jid 0 pid 39 (ttyLin.bin): unsupported madvise behav 102
linux: jid 0 pid 40 (java): unsupported madvise behav 23
linux: jid 0 pid 40 (java): unsupported madvise behav 102
debugnet_any_ifnet_update: Bad dn_init result from vtnet0 (ifp 0xfffff8000368fc00), ignoring.
vtnet0: link state changed to UP
vtnet0: promiscuous mode enabled
linux: jid 0 pid 40 (C1 Comp..hread0): syscall fchmodat2 not implemented
linux: jid 0 pid 40 (GC Thread#1): unsupported IPv4 socket option IP_MULTICAST_ALL (49), your linux program will not see all multicast groups joined by the entire system, only those the program joined itself on this socket
linux: jid 0 pid 48 (java): unsupported madvise behav 23
linux: jid 0 pid 48 (java): unsupported madvise behav 102
linux: jid 0 pid 48 (C1 Comp..hread0): syscall fchmodat2 not implemented
linux: jid 0 pid 48 (GC Thread#1): unsupported IPv4 socket option IP_MULTICAST_ALL (49), your linux program will not see all multicast groups joined by the entire system, only those the program joined itself on this socket
```


---------
[x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8389968](https://bugs.openjdk.org/browse/JDK-8389968)

### Issue
 * [JDK-8389968](https://bugs.openjdk.org/browse/JDK-8389968): (dc) DatagramChannel.open() attempts to disable IPPROTO_IPV6/IP_MULTICAST_ALL (lnx) (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32591/head:pull/32591` \
`$ git checkout pull/32591`

Update a local copy of the PR: \
`$ git checkout pull/32591` \
`$ git pull https://git.openjdk.org/jdk.git pull/32591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32591`

View PR using the GUI difftool: \
`$ git pr show -t 32591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32591.diff">https://git.openjdk.org/jdk/pull/32591.diff</a>

</details>
