### PR TITLE
8391431: RISC-V: AOTCodeTest.java fails after JDK-8388288 with fastdebug

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1240,8 +1240,8 @@ class StubGenerator: public StubCodeGenerator {
   void verify_oop_array(size_t size, Register a, Register count, Register temp) {
     Label loop, end;
     __ mv(t1, zr);
-    __ slli(t0, count, exact_log2(size));
     __ bind(loop);
+    __ slli(t0, count, exact_log2(size));
     __ bgeu(t1, t0, end);
 
     __ add(temp, a, t1);


### PR DESCRIPTION
Hi, I ran `make test TEST="runtime/cds/appcds/aotCode/AOTCodeTest.java#g1"` on RISC-V K3 with fastdebug model, and the test failed. 
In stubGenerator_riscv.cpp, verify_oop_array uses t0 to hold the loop bound computed once before the loop:
```
    __ mv(t1, zr);
    __ slli(t0, count, exact_log2(size));
    __ bind(loop);
    __ bgeu(t1, t0, end);
```
In PR https://github.com/openjdk/jdk/pull/31923, a UseZicond branch was added, which clobbers t0 here, causing the test to fail.
https://github.com/openjdk/jdk/blob/7353d1725b93d6caade70440f177e07178d48906/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L4069-L4080
The fix moves the slli that computes the loop bound from before the loop to inside the loop body, so t0 is recomputed each iteration. Since count is invariant across iterations, this produces the same value every time. The verify_oop_array is a verification code path, so it does not affect release performance.

### Testing
- [x] Run tier1test with fastdebug on RISC-V K3

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391431](https://bugs.openjdk.org/browse/JDK-8391431): RISC-V: AOTCodeTest.java fails after JDK-8388288 with fastdebug (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32592/head:pull/32592` \
`$ git checkout pull/32592`

Update a local copy of the PR: \
`$ git checkout pull/32592` \
`$ git pull https://git.openjdk.org/jdk.git pull/32592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32592`

View PR using the GUI difftool: \
`$ git pr show -t 32592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32592.diff">https://git.openjdk.org/jdk/pull/32592.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32592#issuecomment-5468178114)
</details>
