### PR TITLE
8348737: PlatformProperties always triggers rebuild when cross compiling

### DIFF
--- a/make/modules/java.base/gensrc/GensrcMisc.gmk
+++ b/make/modules/java.base/gensrc/GensrcMisc.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ else
   OPENJDK_TARGET_OS_CANONICAL := $(OPENJDK_TARGET_OS)
 endif
 
-$(eval $(call SetupTextFileProcessing, BUILD_PLATFORMPROPERTIES_JAVA, \
+$(eval $(call SetupTextFileProcessing, BUILD_PLATFORMPROPERTIES_JAVA_$(OPENJDK_TARGET_OS)_$(OPENJDK_TARGET_CPU), \
     SOURCE_FILES := $(TOPDIR)/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template, \
     OUTPUT_FILE := $(SUPPORT_OUTPUTDIR)/gensrc/java.base/jdk/internal/util/PlatformProps.java, \
     REPLACEMENTS := \
@@ -82,7 +82,8 @@ $(eval $(call SetupTextFileProcessing, BUILD_PLATFORMPROPERTIES_JAVA, \
         @@OPENJDK_TARGET_CPU_BITS@@ => $(OPENJDK_TARGET_CPU_BITS), \
 ))
 
-TARGETS += $(BUILD_VERSION_JAVA) $(BUILD_PLATFORMPROPERTIES_JAVA)
+TARGETS += $(BUILD_VERSION_JAVA) \
+    $(BUILD_PLATFORMPROPERTIES_JAVA_$(OPENJDK_TARGET_OS)_$(OPENJDK_TARGET_CPU))
 ################################################################################
 
 ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )


### PR DESCRIPTION
**Problem:**

When cross-compiling, `PlatformProps.java` is regenerated during every incremental `make images` build, even when no source files have changed. This causes `java.base` and the JDK image to be rebuilt unnecessarily, increasing the build time.

The second build produced output such as:

```bash
make CONF=linux-x86_64-server-release LOG=debug images > build.log 2>&1
rg -n 'Processing PlatformProps.java|Compiling up to .* files for java.base|Creating jdk image' build.log
```

```text
Processing PlatformProps.java
[buildjdk] Processing PlatformProps.java
Compiling up to 3396 files for java.base
[buildjdk] Compiling up to 3396 files for java.base
Creating jdk image
```

**Fix:**

Include the target OS and CPU in the name of `BUILD_PLATFORMPROPERTIES_JAVA`, so that the build JDK and target JDK use separate variable-dependency files and do not overwrite each other’s build state.

**Testing:**

Ran `make images` again without modifying any source files. The second build completed in about two seconds and no longer processed `PlatformProps.java`, rebuilt `java.base`, or recreated the JDK image.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8348737](https://bugs.openjdk.org/browse/JDK-8348737): PlatformProperties always triggers rebuild when cross compiling (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32593/head:pull/32593` \
`$ git checkout pull/32593`

Update a local copy of the PR: \
`$ git checkout pull/32593` \
`$ git pull https://git.openjdk.org/jdk.git pull/32593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32593`

View PR using the GUI difftool: \
`$ git pr show -t 32593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32593.diff">https://git.openjdk.org/jdk/pull/32593.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32593#issuecomment-5470505362)
</details>
