### PR TITLE
8380647: ASAN: heap-buffer-overflow in ArchiveBuilder::make_shallow_copy

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -639,7 +639,10 @@ void ArchiveBuilder::make_shallow_copies(DumpRegion *dump_region,
 
 void ArchiveBuilder::make_shallow_copy(DumpRegion *dump_region, SourceObjInfo* src_info) {
   address src = src_info->source_addr();
-  int bytes = src_info->size_in_bytes();
+  // Symbols may be allocated in C-heap with a size smaller than src_info->size_in_bytes(), so
+  // copy the exact number of bytes to avoid triggering ASAN error.
+  int bytes = (src_info->type() == MetaspaceClosureType::SymbolType) ?
+              ((Symbol*)src)->byte_size() : src_info->size_in_bytes();
   char* dest = dump_region->allocate_metaspace_obj(bytes, src, src_info->type(),
                                                    src_info->read_only(), &_alloc_stats);
 


### PR DESCRIPTION
Please review this small fix:

Symbols may be allocated in C-heap with a size smaller than `src_info->size_in_bytes()`. We should copy the exact number of bytes to avoid triggering ASAN error.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380647](https://bugs.openjdk.org/browse/JDK-8380647): ASAN: heap-buffer-overflow in ArchiveBuilder::make_shallow_copy (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32594/head:pull/32594` \
`$ git checkout pull/32594`

Update a local copy of the PR: \
`$ git checkout pull/32594` \
`$ git pull https://git.openjdk.org/jdk.git pull/32594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32594`

View PR using the GUI difftool: \
`$ git pr show -t 32594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32594.diff">https://git.openjdk.org/jdk/pull/32594.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32594#issuecomment-5472031147)
</details>
