### PR TITLE
8391450: Aarch64: Remove the movk narrowKlass mode

### DIFF
--- a/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
@@ -98,25 +98,6 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
     result = reserve_at_eor_compatible_address(size, aslr);
   }
 
-  // Movk-compatible reservation via probing.
-  if (result == nullptr) {
-    result = reserve_address_space_for_16bit_move(size, aslr);
-  }
-
-  // Movk-compatible reservation via overallocation.
-  // If that failed, attempt to allocate at any 4G-aligned address. Let the system decide where. For ASLR,
-  // we now rely on the system.
-  // Compared with the probing done above, this has two disadvantages:
-  // - on a kernel with 52-bit address space we may get an address that has bits set between [48, 52).
-  //   In that case, we may need two movk moves (not yet implemented).
-  // - this technique leads to temporary over-reservation of address space; it will spike the vsize of
-  //   the process. Therefore it may fail if a vsize limit is in place (e.g. ulimit -v).
-  if (result == nullptr) {
-    constexpr size_t alignment = nth_bit(32);
-    log_debug(metaspace, map)("Trying to reserve at a 32-bit-aligned address");
-    result = os::reserve_memory_aligned(size, alignment, mtNone);
-  }
-
   return result;
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5494,12 +5494,6 @@ MacroAssembler::KlassDecodeMode  MacroAssembler::klass_decode_mode(address base,
     }
   }
 
-  const uint64_t shifted_base =
-    (uint64_t)base >> shift;
-  if ((shifted_base & 0xffff0000ffffffff) == 0) {
-    return KlassDecodeMovk;
-  }
-
   return KlassDecodeFallback;
 }
 
@@ -5543,14 +5537,6 @@ void MacroAssembler::emit_encode_klass_not_null(Register dst, Register src, Regi
   case KlassDecodeXor:
     eor(dst, src, (uint64_t)base);
     lsr(dst, dst, shift);
-    break;
-
-  case KlassDecodeMovk:
-    if (shift != 0) {
-      ubfx(dst, src, shift, 32);
-    } else {
-      movw(dst, src);
-    }
     break;
 
   case KlassDecodeFallback: {
@@ -5608,16 +5594,6 @@ void MacroAssembler::emit_decode_klass_not_null(Register dst, Register src, Regi
     lsl(dst, src, shift);
     eor(dst, dst, (uint64_t)base);
     break;
-
-  case KlassDecodeMovk: { // 1-3 instructions
-    const uint64_t shifted_base =
-      (uint64_t)base >> shift;
-
-    if (dst != src) movw(dst, src);
-    movk(dst, shifted_base >> 32, 32);
-    lsl(dst, dst, shift);
-    break;
-  }
 
   case KlassDecodeFallback: { // 3-4 instructions
     mov(tmp, base);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -104,7 +104,6 @@ class MacroAssembler: public Assembler {
     KlassDecodeNone,
     KlassDecodeZero,
     KlassDecodeXor,
-    KlassDecodeMovk,
     KlassDecodeFallback
   };
 

--- a/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
+++ b/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
@@ -622,15 +622,20 @@ struct GtestFriendToMacroAssembler {
       build_and_run_encode_decode_klass((address)(right_n_bits(highest_xor_base_bit - lowest_xor_base_bit) << lowest_xor_base_bit),
           shift, MA::KlassDecodeXor);
 
-      // test movk-based
-      // Only bits in the third quadrant and not a valid immediate
-      build_and_run_encode_decode_klass((address)0x0000'A000'0000'0000ULL, 0, MA::KlassDecodeMovk);
-
       // test Fallback mode.
-      // base has low bits that intersect with nKlass, no other mode would work
-      build_and_run_encode_decode_klass((address)(0x5'0000'0000ULL + os::vm_page_size()),
+      // We take fallback mode if base has low bits that intersect with nKlass, and/or if it is not a
+      // valid logical immediate
+
+      // Not a logical immediate
+      build_and_run_encode_decode_klass((address)0x0000'A000'0000'0000ULL,
                                         shift, MA::KlassDecodeFallback);
-      build_and_run_encode_decode_klass((address)(0x5'0000'0000ULL - os::vm_page_size()),
+      build_and_run_encode_decode_klass((address)0x0000'0005'0000'0000ULL,
+                                        shift, MA::KlassDecodeFallback);
+
+      // Base spills into lower bits
+      build_and_run_encode_decode_klass((address)(0x2'0000'0000ULL + os::vm_page_size()),
+                                        shift, MA::KlassDecodeFallback);
+      build_and_run_encode_decode_klass((address)(0x2'0000'0000ULL - os::vm_page_size()),
                                         shift, MA::KlassDecodeFallback);
 
       // a base that has ones in all four quadrants to trigger the full movz+3*movk path

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -84,7 +84,6 @@ public class CompressedCPUSpecificClassSpaceReservation {
             }
             output.shouldContain("Trying to reserve at an EOR-compatible address");
             output.shouldNotContain(tryReserveForZeroBased);
-            output.shouldMatch(tryReserveFor16bitMoveIntoQ3Regex);
         } else if (Platform.isPPC()) {
             if (CDS) {
                 output.shouldNotContain(tryReserveForUnscaled);


### PR DESCRIPTION
See the full ratio in JBS.
See also discussion here: https://github.com/openjdk/jdk/pull/32520

In short: With the introduction of the narrowKlass fallback decode mode with [JDK-8387652](https://bugs.openjdk.org/browse/JDK-8387652), movk mode became redundant. We no longer need it to cover the few cases where zero-based or XOR mode would not work. It's almost never used in production, only in our tests when deliberately triggered. That means test coverage is weak, which explains how old bugs like [JDK-8387962](https://bugs.openjdk.org/browse/JDK-8387962) could go undetected.

Better to just remove it.

tests: hotspot tier1, 2 on macos aarch64, selected tests on linux aarch64 (Raspberry with small address space), and GHAs


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391450](https://bugs.openjdk.org/browse/JDK-8391450): Aarch64: Remove the movk narrowKlass mode (**Bug** - P3)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32596/head:pull/32596` \
`$ git checkout pull/32596`

Update a local copy of the PR: \
`$ git checkout pull/32596` \
`$ git pull https://git.openjdk.org/jdk.git pull/32596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32596`

View PR using the GUI difftool: \
`$ git pr show -t 32596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32596.diff">https://git.openjdk.org/jdk/pull/32596.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32596#issuecomment-5478856840)
</details>
