### PR TITLE
8390759: Checked exception in switch guard is hidden

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -707,6 +707,7 @@ public class Flow {
                 for (JCCaseLabel pat : c.labels) {
                     scan(pat);
                 }
+                scan(c.guard);
                 scanStats(c.stats);
                 if (alive != Liveness.DEAD && c.caseKind == JCCase.RULE) {
                     scanSyntheticBreak(make, tree);
@@ -752,6 +753,7 @@ public class Flow {
                 for (JCCaseLabel pat : c.labels) {
                     scan(pat);
                 }
+                scan(c.guard);
                 scanStats(c.stats);
                 if (alive == Liveness.ALIVE) {
                     if (c.caseKind == JCCase.RULE) {
@@ -1225,6 +1227,7 @@ public class Flow {
             for (List<JCCase> l = cases; l.nonEmpty(); l = l.tail) {
                 JCCase c = l.head;
                 scan(c.labels);
+                scan(c.guard);
                 scan(c.stats);
             }
             if (tree.hasTag(SWITCH_EXPRESSION)) {

--- a/test/langtools/tools/javac/patterns/GuardsExceptions.java
+++ b/test/langtools/tools/javac/patterns/GuardsExceptions.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8390759
+ * @summary Check that exceptions thrown from a guard propagate out of the switch.
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run junit GuardsExceptions
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class GuardsExceptions {
+
+    Path base;
+    ToolBox tb = new ToolBox();
+
+    @Test
+    void testUnreportedExceptionReported() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics", "-nowarn")
+                .sources("""
+                         package test;
+
+                         import java.io.IOException;
+
+                         public class Test {
+                             private static boolean guard() throws IOException {
+                                 throw new IOException();
+                             }
+
+                             public static void test(Object o) {
+                                 switch (o) {
+                                     case String s when guard() -> {}
+                                     default -> {}
+                                 }
+                             }
+                         }
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:12:37: compiler.err.unreported.exception.need.to.catch.or.throw: java.io.IOException",
+                "1 error"));
+    }
+
+    @Test
+    void testThrownExceptionHandled() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics", "-nowarn")
+                .sources("""
+                         package test;
+
+                         import java.io.IOException;
+
+                         public class Test {
+                             private static boolean guard() throws IOException {
+                                 throw new IOException();
+                             }
+
+                             public static void test(Object o) {
+                                 try {
+                                     switch (o) {
+                                         case String s when guard() -> {}
+                                         default -> {}
+                                     }
+                                 } catch (IOException e) {}
+                             }
+                         }
+                         """)
+                .run()
+                .writeAll();
+    }
+
+    @Test
+    void testUnreachableStatementReported() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics", "-nowarn")
+                .sources("""
+                         package test;
+
+                         import java.io.IOException;
+
+                         public class Test {
+                             public static void test(Object o) {
+                                 switch (o) {
+                                     case String s when switch(s.length()) {
+                                         case 0 -> { yield false; System.out.println(); }
+                                         default -> true;
+                                     } -> {}
+                                     default -> {}
+                                 }
+                             }
+                         }
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:9:42: compiler.err.unreachable.stmt",
+                "1 error"));
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo info) {
+        base = Paths.get(".")
+                    .resolve(info.getTestMethod()
+                                 .orElseThrow()
+                                 .getName());
+    }
+}

--- a/test/langtools/tools/javac/patterns/GuardsExceptions.java
+++ b/test/langtools/tools/javac/patterns/GuardsExceptions.java
@@ -143,6 +143,37 @@ public class GuardsExceptions {
                 "1 error"));
     }
 
+    @Test
+    void testUnreachableStatementReportedFromSwitchExpression() throws Exception {
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        List<String> out = new JavacTask(tb)
+                .options("-d", classes.toString(), "-XDrawDiagnostics", "-nowarn")
+                .sources("""
+                         package test;
+
+                         import java.io.IOException;
+
+                         public class Test {
+                             public static int test(Object o) {
+                                 return switch (o) {
+                                     case String s when switch(s.length()) {
+                                         case 0 -> { yield false; System.out.println(); }
+                                         default -> true;
+                                     } -> 1;
+                                     default -> 0;
+                                 };
+                             }
+                         }
+                         """)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        tb.checkEqual(out, List.of(
+                "Test.java:9:42: compiler.err.unreachable.stmt",
+                "1 error"));
+    }
+
     @BeforeEach
     public void setUp(TestInfo info) {
         base = Paths.get(".")


### PR DESCRIPTION
Consider the following source code:
```
 public class Test {
     private static boolean guard() throws IOException {
         throw new IOException();
     }

     public static void test(Object o) {
         switch (o) {
             case String s when guard() -> {}
             default -> {}
         }
     }
 }
```
When compiling this class, javac accepts the checked exception thrown from the guard even though it is neither caught nor declared. Moreover, javac rejects an attempt to add an exact catch clause as unnecessary. This is a regression introduced in JDK 21ea+24.

The problem is that some of javac's flow analyzers do not visit switch guards. Guards were originally stored in `JCPatternCaseLabel` and were visited while scanning case labels. They were later moved to `JCCase`, but the custom switch traversal in `FlowAnalyzer `continued to scan only the case labels and statements. A similar problem exists in `AliveAnalyzer`.

The proposed fix modifies `FlowAnalyzer` and `AliveAnalyzer` to include switch guards in their switch traversal.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Change requires CSR request [JDK-8391610](https://bugs.openjdk.org/browse/JDK-8391610) to be approved
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8390759](https://bugs.openjdk.org/browse/JDK-8390759): Checked exception in switch guard is hidden (**Bug** - P3)
 * [JDK-8391610](https://bugs.openjdk.org/browse/JDK-8391610): Checked exception in switch guard is hidden (**CSR**)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32600/head:pull/32600` \
`$ git checkout pull/32600`

Update a local copy of the PR: \
`$ git checkout pull/32600` \
`$ git pull https://git.openjdk.org/jdk.git pull/32600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32600`

View PR using the GUI difftool: \
`$ git pr show -t 32600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32600.diff">https://git.openjdk.org/jdk/pull/32600.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32600#issuecomment-5476905315)
</details>
