### PR TITLE
8390121: C2: StressBailout and VerifyIterativeGVN lead to nullptr push to igvn worklist

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3089,7 +3089,9 @@ void Compile::Optimize() {
   }
   assert(!has_vbox_nodes(), "sanity");
 
-  if (failing())  return;
+  if (failing()) {
+    return;
+  }
 
   if (RenumberLiveNodes && live_nodes() + NodeLimitFudgeFactor < unique()) {
     Compile::TracePhase tp(_t_renumberLive);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3089,7 +3089,9 @@ void Compile::Optimize() {
   }
   assert(!has_vbox_nodes(), "sanity");
 
-  if (!failing() && RenumberLiveNodes && live_nodes() + NodeLimitFudgeFactor < unique()) {
+  if (failing())  return;
+
+  if (RenumberLiveNodes && live_nodes() + NodeLimitFudgeFactor < unique()) {
     Compile::TracePhase tp(_t_renumberLive);
     igvn_worklist()->ensure_empty(); // should be done with igvn
     {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3089,10 +3089,6 @@ void Compile::Optimize() {
   }
   assert(!has_vbox_nodes(), "sanity");
 
-  if (failing()) {
-    return;
-  }
-
   if (RenumberLiveNodes && live_nodes() + NodeLimitFudgeFactor < unique()) {
     Compile::TracePhase tp(_t_renumberLive);
     igvn_worklist()->ensure_empty(); // should be done with igvn

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1117,7 +1117,9 @@ bool PhaseIterGVN::drain_worklist() {
     }
     loop_count++;
   }
-  return false;
+  // A bailout in the last transformation would otherwise reach verification
+  // with the graph flushed.
+  return C->failing();
 }
 
 void PhaseIterGVN::push_deep_revisit_candidates() {
@@ -1195,6 +1197,11 @@ bool PhaseIterGVN::deep_revisit() {
 }
 
 void PhaseIterGVN::optimize(bool deep) {
+  if (C->failing()) {
+    // A failure in a previous phase flushed the graph (record_failure sets the
+    // root to null); there is nothing left to optimize or verify.
+    return;
+  }
   bool deep_revisit_converged = false;
   DEBUG_ONLY(_num_processed = 0;)
   NOT_PRODUCT(init_verifyPhaseIterGVN();)
@@ -1222,6 +1229,7 @@ void PhaseIterGVN::optimize(bool deep) {
 
 #ifdef ASSERT
 void PhaseIterGVN::verify_optimize(bool deep_revisit_converged) {
+  assert(!C->failing_internal(), "should not verify a failed compilation");
   assert(_worklist.size() == 0, "igvn worklist must be empty before verify");
 
   if (is_verify_Value() ||

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1195,11 +1195,9 @@ bool PhaseIterGVN::deep_revisit() {
 }
 
 void PhaseIterGVN::optimize(bool deep) {
-  if (C->failing()) {
-    // A failure in a previous phase flushed the graph (record_failure sets the
-    // root to null); there is nothing left to optimize or verify.
-    return;
-  }
+  // A correctly handled failure returns at the failing() call that raised it, so
+  // the compilation must never get here failed, with the graph already flushed.
+  assert(!C->failing_internal(), "should not run IGVN on a failed compilation");
   bool deep_revisit_converged = false;
   DEBUG_ONLY(_num_processed = 0;)
   NOT_PRODUCT(init_verifyPhaseIterGVN();)
@@ -1227,7 +1225,6 @@ void PhaseIterGVN::optimize(bool deep) {
 
 #ifdef ASSERT
 void PhaseIterGVN::verify_optimize(bool deep_revisit_converged) {
-  assert(!C->failing_internal(), "should not verify a failed compilation");
   assert(_worklist.size() == 0, "igvn worklist must be empty before verify");
 
   if (is_verify_Value() ||

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1117,9 +1117,7 @@ bool PhaseIterGVN::drain_worklist() {
     }
     loop_count++;
   }
-  // A bailout in the last transformation would otherwise reach verification
-  // with the graph flushed.
-  return C->failing();
+  return false;
 }
 
 void PhaseIterGVN::push_deep_revisit_candidates() {

--- a/test/hotspot/jtreg/compiler/debug/TestStressBailout.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressBailout.java
@@ -50,6 +50,16 @@ import jdk.test.lib.Utils;
  * @run main compiler.debug.TestStressBailout -XX:VerifyIterativeGVN=1111
  */
 
+/*
+ * @test
+ * @key stress randomness
+ * @bug 8390121
+ * @requires vm.debug == true & vm.compiler2.enabled & (vm.opt.AbortVMOnCompilationFailure == "null" | !vm.opt.AbortVMOnCompilationFailure)
+ * @summary Bailouts between optimization phases must not reach IGVN verification
+ * @library /test/lib /
+ * @run main compiler.debug.TestStressBailout -XX:VerifyIterativeGVN=1110 -XX:+StressIGVN -XX:+StressIncrementalInlining
+ */
+
 public class TestStressBailout {
 
     static void runTest(int invprob, Stream<String> vmArgs) throws Exception {

--- a/test/hotspot/jtreg/compiler/debug/TestStressBailout.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressBailout.java
@@ -57,7 +57,7 @@ import jdk.test.lib.Utils;
  * @requires vm.debug == true & vm.compiler2.enabled & (vm.opt.AbortVMOnCompilationFailure == "null" | !vm.opt.AbortVMOnCompilationFailure)
  * @summary Bailouts between optimization phases must not reach IGVN verification
  * @library /test/lib /
- * @run main compiler.debug.TestStressBailout -XX:VerifyIterativeGVN=1110 -XX:+StressIGVN -XX:+StressIncrementalInlining
+ * @run main ${test.main.class} -XX:VerifyIterativeGVN=1110 -XX:+StressIGVN -XX:+StressIncrementalInlining
  */
 
 public class TestStressBailout {


### PR DESCRIPTION
With StressBailout any `failing()` call can be the one that fails the compilation, and `record_failure` nulls the root. The `!failing()` in `Compile::Optimize`'s `RenumberLiveNodes` condition swallows a failure raised by the call itself: nothing returns, `process_inline_types` runs `igvn.optimize()`, and verification pushes the null root, the SIGSEGV from the report. The check predates StressBailout.

It is now a separate `if (failing()) return;`. `PhaseIterGVN::optimize` also returns early on a failed compilation, and `drain_worklist` reports a failure in its last transformation, so no caller can reach verification with a flushed graph; `verify_optimize` asserts that.

Testing:
- new `TestStressBailout` run with the flag combination from the report
- forcing the stress failure onto each `failing()` call adjacent to an IGVN pass: before the fix this crashes at the renumber condition, after it nowhere
- `compiler/debug` and tier1 compiler jtreg on macos-aarch64 fastdebug

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390121](https://bugs.openjdk.org/browse/JDK-8390121): C2: StressBailout and VerifyIterativeGVN lead to nullptr push to igvn worklist (**Bug** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Daniel Skantz](https://openjdk.org/census#dskantz) (@danielogh - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32601/head:pull/32601` \
`$ git checkout pull/32601`

Update a local copy of the PR: \
`$ git checkout pull/32601` \
`$ git pull https://git.openjdk.org/jdk.git pull/32601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32601`

View PR using the GUI difftool: \
`$ git pr show -t 32601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32601.diff">https://git.openjdk.org/jdk/pull/32601.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32601#issuecomment-5477550255)
</details>
