### PR TITLE
8389730: [Valhalla] Fix two masked inverted conditions in LibraryCallKit::should_bail_out_on_non_ref_arrays()

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5369,7 +5369,7 @@ bool LibraryCallKit::should_bail_out_on_non_ref_arrays(const TypeAryPtr* src_typ
     return true;
   }
 
-  if (UseArrayFlattening) {
+  if (!UseArrayFlattening) {
     // The remaining checks revolve around array flatness. Without array flatness, we don't need the stronger non-ref
     // runtime check excluding flat arrays.
     return false;
@@ -5391,7 +5391,7 @@ bool LibraryCallKit::should_bail_out_on_non_ref_arrays(const TypeAryPtr* src_typ
   // TODO 8251971: Optimize for the case when flat src/dst are later found to not contain
   //               oops (i.e., move this check to the macro expansion phase).
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  if (bs->array_copy_requires_gc_barriers(true, T_OBJECT, false, false, BarrierSetC2::Parsing)) {
+  if (!bs->array_copy_requires_gc_barriers(true, T_OBJECT, false, false, BarrierSetC2::Parsing)) {
     // No barriers required.
     return false;
   }


### PR DESCRIPTION
There are two inverted conditions in `LibraryCallKit::should_bail_out_on_non_ref_arrays()` added with [JDK-8382226](https://bugs.openjdk.org/browse/JDK-8382226) that should be fixed. These are masked because we currently bail out on flat arrays anyways with `flat_array_test()` until [JDK-8251971](https://bugs.openjdk.org/browse/JDK-8251971) is fixed.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389730](https://bugs.openjdk.org/browse/JDK-8389730): [Valhalla] Fix two masked inverted conditions in LibraryCallKit::should_bail_out_on_non_ref_arrays() (**Bug** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32603/head:pull/32603` \
`$ git checkout pull/32603`

Update a local copy of the PR: \
`$ git checkout pull/32603` \
`$ git pull https://git.openjdk.org/jdk.git pull/32603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32603`

View PR using the GUI difftool: \
`$ git pr show -t 32603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32603.diff">https://git.openjdk.org/jdk/pull/32603.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32603#issuecomment-5478118061)
</details>
