### PR TITLE
8391467: Show InstallationType in Windows System info

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2010,7 +2010,32 @@ void os::print_os_info(outputStream* st) {
   VM_Version::print_platform_virtualization_info(st);
 }
 
-bool getWindowsInstallationType(char* buffer, int bufferSize);
+static bool getWindowsInstallationType(char* buffer, int bufferSize) {
+  HKEY hKey;
+  const char* subKey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
+  const char* valueName = "InstallationType";
+
+  DWORD valueLength = bufferSize;
+
+  // Initialize buffer with empty string
+  buffer[0] = '\0';
+
+  // Open the registry key
+  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, subKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
+    // Return empty buffer if key cannot be opened
+    return false;
+  }
+
+  // Query the value
+  if (RegQueryValueExA(hKey, valueName, nullptr, nullptr, (LPBYTE)buffer, &valueLength) != ERROR_SUCCESS) {
+    RegCloseKey(hKey);
+    buffer[0] = '\0';
+    return false;
+  }
+
+  RegCloseKey(hKey);
+  return true;
+}
 
 void os::win32::print_windows_version(outputStream* st) {
   bool is_workstation = !IsWindowsServer();
@@ -2102,9 +2127,8 @@ void os::win32::print_windows_version(outputStream* st) {
   // InstallationType (e.g. Server Core, Nano server)
   const int BUFFER_SIZE = 256;
   char installationType[BUFFER_SIZE];
-  bool res = getWindowsInstallationType(installationType, BUFFER_SIZE);
-  if (res) {
-    st->print(" InstallationType %s", installationType);
+  if (getWindowsInstallationType(installationType, BUFFER_SIZE)) {
+    st->print(" InstallationType: \"%s\"", installationType);
   }
   st->cr();
 }
@@ -4311,7 +4335,7 @@ bool getWindowsInstallationType(char* buffer, int bufferSize) {
   return true;
 }
 
-bool isNanoServer() {
+static bool isNanoServer() {
   const int BUFFER_SIZE = 256;
   char installationType[BUFFER_SIZE];
   getWindowsInstallationType(installationType, BUFFER_SIZE);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2034,7 +2034,7 @@ static bool getWindowsInstallationType(char* buffer, int bufferSize) {
   }
 
   // If the value being queried is a string the value returned is NOT guaranteed to be null-terminated
-  buffer[valueLength - 1] = '\0'
+  buffer[valueLength - 1] = '\0';
 
   RegCloseKey(hKey);
   return true;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2033,6 +2033,9 @@ static bool getWindowsInstallationType(char* buffer, int bufferSize) {
     return false;
   }
 
+  // If the value being queried is a string the value returned is NOT guaranteed to be null-terminated
+  buffer[valueLength - 1] = '\0'
+
   RegCloseKey(hKey);
   return true;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4308,33 +4308,6 @@ int                       os::win32::_build_minor               = 0;
 bool                      os::win32::_processor_group_warning_displayed = false;
 bool                      os::win32::_job_object_processor_group_warning_displayed = false;
 
-bool getWindowsInstallationType(char* buffer, int bufferSize) {
-  HKEY hKey;
-  const char* subKey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
-  const char* valueName = "InstallationType";
-
-  DWORD valueLength = bufferSize;
-
-  // Initialize buffer with empty string
-  buffer[0] = '\0';
-
-  // Open the registry key
-  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, subKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
-    // Return empty buffer if key cannot be opened
-    return false;
-  }
-
-  // Query the value
-  if (RegQueryValueExA(hKey, valueName, nullptr, nullptr, (LPBYTE)buffer, &valueLength) != ERROR_SUCCESS) {
-    RegCloseKey(hKey);
-    buffer[0] = '\0';
-    return false;
-  }
-
-  RegCloseKey(hKey);
-  return true;
-}
-
 static bool isNanoServer() {
   const int BUFFER_SIZE = 256;
   char installationType[BUFFER_SIZE];

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2010,6 +2010,8 @@ void os::print_os_info(outputStream* st) {
   VM_Version::print_platform_virtualization_info(st);
 }
 
+bool getWindowsInstallationType(char* buffer, int bufferSize);
+
 void os::win32::print_windows_version(outputStream* st) {
   bool is_workstation = !IsWindowsServer();
 
@@ -2097,6 +2099,13 @@ void os::win32::print_windows_version(outputStream* st) {
 
   st->print(" Build %d", build_number);
   st->print(" (%d.%d.%d.%d)", major_version, minor_version, build_number, build_minor);
+  // InstallationType (e.g. Server Core, Nano server)
+  const int BUFFER_SIZE = 256;
+  char installationType[BUFFER_SIZE];
+  bool res = getWindowsInstallationType(installationType, BUFFER_SIZE);
+  if (res) {
+    st->print(" InstallationType %s", installationType);
+  }
   st->cr();
 }
 
@@ -4275,7 +4284,7 @@ int                       os::win32::_build_minor               = 0;
 bool                      os::win32::_processor_group_warning_displayed = false;
 bool                      os::win32::_job_object_processor_group_warning_displayed = false;
 
-void getWindowsInstallationType(char* buffer, int bufferSize) {
+bool getWindowsInstallationType(char* buffer, int bufferSize) {
   HKEY hKey;
   const char* subKey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
   const char* valueName = "InstallationType";
@@ -4288,17 +4297,18 @@ void getWindowsInstallationType(char* buffer, int bufferSize) {
   // Open the registry key
   if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, subKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
     // Return empty buffer if key cannot be opened
-    return;
+    return false;
   }
 
   // Query the value
   if (RegQueryValueExA(hKey, valueName, nullptr, nullptr, (LPBYTE)buffer, &valueLength) != ERROR_SUCCESS) {
     RegCloseKey(hKey);
     buffer[0] = '\0';
-    return;
+    return false;
   }
 
   RegCloseKey(hKey);
+  return true;
 }
 
 bool isNanoServer() {


### PR DESCRIPTION
We have already coding in Hotspot to get the installation type of Windows (Server, Server core, Nano server etc.). This should be added to the existing System info to give a more complete picture.
The OS info in hsinfo / hserr / jcmd output looks like this afterwards (InstallationType Server Core added to previous output)

```
OS:
Windows Server 2025 , 64 bit Build 26100 (10.0.26100.33296) InstallationType Server Core
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391467](https://bugs.openjdk.org/browse/JDK-8391467): Show InstallationType in Windows System info (**Bug** - P4)


### Reviewers
 * [Frederic Thevenet](https://openjdk.org/census#fthevenet) (@fthevenet - no project role) Review applies to [6ec1d201](https://git.openjdk.org/jdk/pull/32605/files/6ec1d20104bc90bea472f8368843f925b301ee63)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [6ec1d201](https://git.openjdk.org/jdk/pull/32605/files/6ec1d20104bc90bea472f8368843f925b301ee63)
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32605/head:pull/32605` \
`$ git checkout pull/32605`

Update a local copy of the PR: \
`$ git checkout pull/32605` \
`$ git pull https://git.openjdk.org/jdk.git pull/32605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32605`

View PR using the GUI difftool: \
`$ git pr show -t 32605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32605.diff">https://git.openjdk.org/jdk/pull/32605.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32605#issuecomment-5478946761)
</details>
