### PR TITLE
8384101: C2: Memory edge of boxed load incorrectly moved above modifying call

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -882,14 +882,14 @@ bool CallNode::may_modify(const TypeOopPtr* t_oop, PhaseValues* phase) const {
   }
   if (t_oop->is_ptr_to_boxed_value() && is_CallStaticJava()) {
     ciKlass* boxing_klass = t_oop->is_instptr()->instance_klass();
-    if (is_CallStaticJava() && as_CallStaticJava()->is_boxing_method()) {
+    if (as_CallStaticJava()->is_boxing_method()) {
       // Skip unrelated boxing methods.
       Node* proj = proj_out_or_null(TypeFunc::Parms);
       if ((proj == nullptr) || (phase->type(proj)->is_instptr()->instance_klass() != boxing_klass)) {
         return false;
       }
     }
-    ciMethod* meth = as_CallJava()->method();
+    ciMethod* meth = as_CallStaticJava()->method();
     if (meth != nullptr && meth->is_getter()) {
       return false;
     }

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -880,40 +880,9 @@ bool CallNode::may_modify(const TypeOopPtr* t_oop, PhaseValues* phase) const {
     // are not passed as arguments according to Escape Analysis.
     return false;
   }
-  if (t_oop->is_ptr_to_boxed_value()) {
-    ciKlass* boxing_klass = t_oop->is_instptr()->instance_klass();
-    if (is_CallStaticJava() && as_CallStaticJava()->is_boxing_method()) {
-      // Skip unrelated boxing methods.
-      Node* proj = proj_out_or_null(TypeFunc::Parms);
-      if ((proj == nullptr) || (phase->type(proj)->is_instptr()->instance_klass() != boxing_klass)) {
-        return false;
-      }
-    }
-    if (is_CallJava() && as_CallJava()->method() != nullptr) {
-      ciMethod* meth = as_CallJava()->method();
-      if (meth->is_getter()) {
-        return false;
-      }
-      // May modify (by reflection) if an boxing object is passed
-      // as argument or returned.
-      Node* proj = returns_pointer() ? proj_out_or_null(TypeFunc::Parms) : nullptr;
-      if (proj != nullptr) {
-        const TypeInstPtr* inst_t = phase->type(proj)->isa_instptr();
-        if ((inst_t != nullptr) && (!inst_t->klass_is_exact() ||
-                                   (inst_t->instance_klass() == boxing_klass))) {
-          return true;
-        }
-      }
-      const TypeTuple* d = tf()->domain_cc();
-      for (uint i = TypeFunc::Parms; i < d->cnt(); i++) {
-        const TypeInstPtr* inst_t = d->field_at(i)->isa_instptr();
-        if ((inst_t != nullptr) && (!inst_t->klass_is_exact() ||
-                                 (inst_t->instance_klass() == boxing_klass))) {
-          return true;
-        }
-      }
-      return false;
-    }
+  if (t_oop->is_ptr_to_boxed_value() && is_CallJava() && as_CallJava()->method() != nullptr &&
+      as_CallJava()->method()->is_getter()) {
+    return false;
   }
   return true;
 }

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -880,9 +880,19 @@ bool CallNode::may_modify(const TypeOopPtr* t_oop, PhaseValues* phase) const {
     // are not passed as arguments according to Escape Analysis.
     return false;
   }
-  if (t_oop->is_ptr_to_boxed_value() && is_CallJava() && as_CallJava()->method() != nullptr &&
-      as_CallJava()->method()->is_getter()) {
-    return false;
+  if (t_oop->is_ptr_to_boxed_value() && is_CallStaticJava()) {
+    ciKlass* boxing_klass = t_oop->is_instptr()->instance_klass();
+    if (is_CallStaticJava() && as_CallStaticJava()->is_boxing_method()) {
+      // Skip unrelated boxing methods.
+      Node* proj = proj_out_or_null(TypeFunc::Parms);
+      if ((proj == nullptr) || (phase->type(proj)->is_instptr()->instance_klass() != boxing_klass)) {
+        return false;
+      }
+    }
+    ciMethod* meth = as_CallJava()->method();
+    if (meth != nullptr && meth->is_getter()) {
+      return false;
+    }
   }
   return true;
 }

--- a/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
+++ b/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
@@ -40,9 +40,10 @@ import jdk.test.lib.Asserts;
 public class TestWrappedBoxedPrimitive {
     private static class Holder {
         Integer notZero = 0xbad;
+        Integer value = 42;
 
         Integer get() {
-            return notZero;
+            return value;
         }
 
         private void touch () {
@@ -54,8 +55,23 @@ public class TestWrappedBoxedPrimitive {
         @Override
         Integer get() {
             notZero = 1234;
-            return notZero;
+            return value;
         }
+    }
+
+    private static final class FooHolder extends Holder { }
+    private static final class BarHolder extends Holder { }
+
+    static Holder make(boolean evil, int i) {
+        if (evil) {
+            return new EvilHolder();
+        }
+
+        return switch (i % 3) {
+            case 0   -> new FooHolder();
+            case 1  -> new BarHolder();
+            default -> new Holder();
+        };
     }
 
     private static int testHolderKlass() {
@@ -75,8 +91,8 @@ public class TestWrappedBoxedPrimitive {
 
     }
 
-    private static int testGetter() {
-        Holder holder = new EvilHolder();
+    private static int testGetter(boolean evil, int i) {
+        Holder holder = make(evil, i);
         holder.get();
         return holder.notZero;
     }
@@ -84,15 +100,15 @@ public class TestWrappedBoxedPrimitive {
     public static void main(String[] args) {
         int intHolderKlass = testHolderKlass();
         int intHolderArray = testArray();
-        int intHolderGetter = testGetter();
+        int intHolderGetter = testGetter(true, 0);
         for (int i = 0; i < 10_000; i++) {
             testHolderKlass();
             testArray();
-            testGetter();
+            testGetter(i % 2 == 0, i);
         }
         int c2HolderKlass = testHolderKlass();
         int c2HolderArray = testArray();
-        int c2HolderGetter = testGetter();
+        int c2HolderGetter = testGetter(true, 0);
 
         Asserts.assertEQ(intHolderKlass, c2HolderKlass);
         Asserts.assertEQ(intHolderArray, c2HolderArray);

--- a/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
+++ b/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
@@ -38,10 +38,23 @@ package compiler.c2;
 import jdk.test.lib.Asserts;
 
 public class TestWrappedBoxedPrimitive {
-    private static final class Holder {
+    private static class Holder {
         Integer notZero = 0xbad;
+
+        Integer get() {
+            return notZero;
+        }
+
         private void touch () {
             notZero = 1234;
+        }
+    }
+
+    private static final class EvilHolder extends Holder {
+        @Override
+        Integer get() {
+            notZero = 1234;
+            return notZero;
         }
     }
 
@@ -62,17 +75,27 @@ public class TestWrappedBoxedPrimitive {
 
     }
 
+    private static int testGetter() {
+        Holder holder = new EvilHolder();
+        holder.get();
+        return holder.notZero;
+    }
+
     public static void main(String[] args) {
         int intHolderKlass = testHolderKlass();
         int intHolderArray = testArray();
+        int intHolderGetter = testGetter();
         for (int i = 0; i < 10_000; i++) {
             testHolderKlass();
             testArray();
+            testGetter();
         }
         int c2HolderKlass = testHolderKlass();
         int c2HolderArray = testArray();
+        int c2HolderGetter = testGetter();
 
         Asserts.assertEQ(intHolderKlass, c2HolderKlass);
         Asserts.assertEQ(intHolderArray, c2HolderArray);
+        Asserts.assertEQ(intHolderGetter, c2HolderGetter);
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
+++ b/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
@@ -26,7 +26,7 @@
  * @bug 8384101
  * @summary Test that references to boxed primitives are not considered final.
  * @library /test/lib /
- * @run main/othervm -Xbatch -XX:-TieredCompilation
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
  *                   -XX:+StressIncrementalInlining -XX:StressSeed=2
  *                   ${test.main.class}

--- a/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
+++ b/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8384101
+ * @summary Test that references to boxed primitives are not considered final.
+ * @library /test/lib /
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   -XX:+StressIncrementalInlining -XX:StressSeed=2
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+package compiler.c2;
+
+import jdk.test.lib.Asserts;
+
+public class TestWrappedBoxedPrimitive {
+    private static final class Holder {
+        Integer notZero = 0xbad;
+        private void touch () {
+            notZero = 1234;
+        }
+    }
+
+    private static int testHolderKlass() {
+        Holder holder = new Holder();
+        holder.touch();
+        return holder.notZero;
+    }
+
+    private static void touchArray(Integer[] arr) {
+        arr[0] = 12345;
+    }
+
+    private static int testArray() {
+        Integer[] ary = new Integer[] { 0xbad };
+        touchArray(ary);
+        return ary[0];
+
+    }
+
+    public static void main(String[] args) {
+        int intHolderKlass = testHolderKlass();
+        int intHolderArray = testArray();
+        for (int i = 0; i < 10_000; i++) {
+            testHolderKlass();
+            testArray();
+        }
+        int c2HolderKlass = testHolderKlass();
+        int c2HolderArray = testArray();
+
+        Asserts.assertEQ(intHolderKlass, c2HolderKlass);
+        Asserts.assertEQ(intHolderArray, c2HolderArray);
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
+++ b/test/hotspot/jtreg/compiler/c2/TestWrappedBoxedPrimitive.java
@@ -25,10 +25,15 @@
  * @test
  * @bug 8384101
  * @summary Test that references to boxed primitives are not considered final.
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
  *                   -XX:+StressIncrementalInlining -XX:StressSeed=2
+ *                   ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   -XX:+StressIncrementalInlining
  *                   ${test.main.class}
  * @run main ${test.main.class}
  */
@@ -38,20 +43,24 @@ package compiler.c2;
 import jdk.test.lib.Asserts;
 
 public class TestWrappedBoxedPrimitive {
-    private static class Holder {
+    private static final class Holder {
+        Integer notZero = 0xbad;
+
+        private void touch() {
+            notZero = 123456;
+        }
+    }
+
+    private static class BaseHolder {
         Integer notZero = 0xbad;
         Integer value = 42;
 
         Integer get() {
             return value;
         }
-
-        private void touch () {
-            notZero = 1234;
-        }
     }
 
-    private static final class EvilHolder extends Holder {
+    private static final class EvilHolder extends BaseHolder {
         @Override
         Integer get() {
             notZero = 1234;
@@ -59,18 +68,17 @@ public class TestWrappedBoxedPrimitive {
         }
     }
 
-    private static final class FooHolder extends Holder { }
-    private static final class BarHolder extends Holder { }
+    private static final class FooHolder extends BaseHolder { }
+    private static final class BarHolder extends BaseHolder { }
 
-    static Holder make(boolean evil, int i) {
+    static BaseHolder make(boolean evil, int i) {
         if (evil) {
             return new EvilHolder();
         }
-
         return switch (i % 3) {
-            case 0   -> new FooHolder();
+            case 0  -> new FooHolder();
             case 1  -> new BarHolder();
-            default -> new Holder();
+            default -> new BaseHolder();
         };
     }
 
@@ -92,7 +100,7 @@ public class TestWrappedBoxedPrimitive {
     }
 
     private static int testGetter(boolean evil, int i) {
-        Holder holder = make(evil, i);
+        BaseHolder holder = make(evil, i);
         holder.get();
         return holder.notZero;
     }
@@ -103,15 +111,19 @@ public class TestWrappedBoxedPrimitive {
         int intHolderGetter = testGetter(true, 0);
         for (int i = 0; i < 10_000; i++) {
             testHolderKlass();
+        }
+        for (int i = 0; i < 10_000; i++) {
             testArray();
+        }
+        for (int i = 0; i < 10_000; i++) {
             testGetter(i % 2 == 0, i);
         }
         int c2HolderKlass = testHolderKlass();
         int c2HolderArray = testArray();
         int c2HolderGetter = testGetter(true, 0);
 
-        Asserts.assertEQ(intHolderKlass, c2HolderKlass);
-        Asserts.assertEQ(intHolderArray, c2HolderArray);
-        Asserts.assertEQ(intHolderGetter, c2HolderGetter);
+        Asserts.assertEQ(intHolderKlass, c2HolderKlass, "unexpected value from holder class:");
+        Asserts.assertEQ(intHolderArray, c2HolderArray, "unexpected value from array:");
+        Asserts.assertEQ(intHolderGetter, c2HolderGetter, "unexpected value from getter:");
     }
 }


### PR DESCRIPTION
Consider the following Java code with a holder class containing a single boxed primitive field:

```java
class Test {
    private static final class Holder {
        Integer notZero = 42;
        private void touch() { notZero = 1234; }
    }
    private static int test() {
      Holder holder = new Holder();
      holder.touch();
      return holder.notZero;
    }

    public static void main(String[] args) {
        for (int i = 0; i < 10_000; i++) { test(); }
        int c2Result = test();
        if (c2Result == 0) {
            throw new RuntimeException("notZero is zero?!?");
        }
    }
}
```

Running this program with `-XX:+StressIncrementalInlining -XX:StressSeed=2` will crash with the `RuntimeException`.

### Root Cause Analysis

The relevant and simplified ideal subgraph for the `Test.test` right after parsing looks as follows:

```
      Param: mem
          |
      Initialize
          | (Proj)
CallStaticJava Holder::<init>
          | (Proj)
CallStaticJava Holder::touch
          |
        Proj
       /    \
  (mem)|  AddP(CastPP(DecodeN(LoadN(AddP(instptr Holder, 8)))), 8)
       |    /  (Pointer to the first field in Integer in the first field in Holder)
       LoadI     
         | 
      Return
```

Inside the codepath of `LoadNode::Ideal()` and `optimize_simple_memory_chain` we end up in the following piece
of code in `CallNode::may_modify()` that wants to determine when a method might modify a boxed primitive:

https://github.com/openjdk/jdk/blob/34dda4ecd89e07d4530f9c26e88f9968788d695f/src/hotspot/share/opto/callnode.cpp#L882-L915

The core assumption of this code is that the `value` field of a boxed primitive is final and thus a method
cannot modify it unless it uses reflection, which can only be done when the box is passed in an argument or
returned from the method we are looking at. For our `LoadI` looking at each `CallStaticJava` above it, this
method returns `false`. Thus, the `LoadI`'s memory input is rewired to the memory `Param`:

```
    Param: mem
   /    |
  / Initialize
 /      | (Proj)
| CallStaticJava Holder::<init>
|      | (Proj)
| CallStaticJava Holder::touch
|      |
 \    Proj
  \    |
   \  AddP(Pointer to Holder.notZero, 8)
    \  |
     LoadI     
       | 
    Return
```

Usually, incremental inlining will expand all calls and the load gets constant folded to a constant.
If we get unlucky or stress incremental inlining, however, the load's memory edge will float above all
calls and thus stores. This in turn leads to the load itself floating above all calls (due to the address
folding to a constant) and thus incorrectly return zero.

The assumption of `CallNode::may_modify()` is correct only if the boxed primitive object is itself not
referenced through another reference. In our example we replace the entire boxed primitive object with
a new instance in `touch()`.

### Fixing it

A fix for this bug would either need dominator information or a potentially unbounded upwards graph walk
to figure out if the boxed primitive oop is a non-final field in another wrapper object. This is prohibitively
expensive for `CallNode::may_modify()`, which runs once for every call to `optimize_simple_memory_chain()`.

Thus, I propose to just remove most code special casing primitive boxes in `CallNode::may_modify()` as other
optimizations in C2 optimize them adequately because our inlining and escape analysis are quite good.
Running benchmarks with the special casing removed, I find no significant regression or improvement in any
benchmark I ran. Further, Valhalla and final meaning final further improve the situation and thus completely
removing the need for this optimization. With this patch, `CallNode::may_modify()` only returns `false` due
to a boxed primitive if the call is to a getter.

Testing:
 - [x] Github Actions
 - [x] tier1,tier2,tier3 plus stress testing

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384101](https://bugs.openjdk.org/browse/JDK-8384101): C2: Memory edge of boxed load incorrectly moved above modifying call (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [5e871950](https://git.openjdk.org/jdk/pull/32606/files/5e8719506326116de193d133fc2cd7adb45324bf)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32606/head:pull/32606` \
`$ git checkout pull/32606`

Update a local copy of the PR: \
`$ git checkout pull/32606` \
`$ git pull https://git.openjdk.org/jdk.git pull/32606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32606`

View PR using the GUI difftool: \
`$ git pr show -t 32606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32606.diff">https://git.openjdk.org/jdk/pull/32606.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32606#issuecomment-5478985377)
</details>
