### PR TITLE
8391473: jpackage ignores exit code of the "dpkg-deb" command

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebPackager.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebPackager.java
@@ -155,7 +155,7 @@ final class LinuxDebPackager extends LinuxPackager<LinuxDebPackage> {
 
         // run dpkg
         Executor.of(cmdline).retryOnKnownErrorMessage(
-                "semop(1): encountered an error: Invalid argument").execute();
+                "semop(1): encountered an error: Invalid argument").execute().expectExitCode(0);
     }
 
     @Override

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/mock/ScriptSpec.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/mock/ScriptSpec.java
@@ -165,10 +165,6 @@ public record ScriptSpec(List<Item> items, boolean loop) {
             return build(mockSpec).add();
         }
 
-        public Builder addLoop(CommandMockSpec mockSpec) {
-            return build(mockSpec).add();
-        }
-
         public ItemBuilder build(CommandMockSpec mockSpec) {
             return new ItemBuilder(mockSpec);
         }

--- a/test/jdk/tools/jpackage/junit/linux/jdk.jpackage/jdk/jpackage/internal/LinuxDebPackagerTest.java
+++ b/test/jdk/tools/jpackage/junit/linux/jdk.jpackage/jdk/jpackage/internal/LinuxDebPackagerTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jpackage.internal;
+
+import static jdk.jpackage.internal.model.StandardPackageType.LINUX_DEB;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import jdk.jpackage.internal.PackagingPipeline.PackageTaskID;
+import jdk.jpackage.internal.model.RuntimeLayout;
+import jdk.jpackage.internal.util.CommandOutputControl.UnexpectedExitCodeException;
+import jdk.jpackage.internal.util.CommandOutputControl.UnexpectedResultException;
+import jdk.jpackage.internal.util.Result;
+import jdk.jpackage.internal.util.RetryExecutor;
+import jdk.jpackage.internal.util.function.ExceptionBox;
+import jdk.jpackage.test.mock.CommandActionSpecs;
+import jdk.jpackage.test.mock.CommandMockSpec;
+import jdk.jpackage.test.mock.ScriptSpec;
+import jdk.jpackage.test.stdmock.JPackageMockUtils;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LinuxDebPackagerTest {
+
+    /**
+     * Exercise {@link LinuxDebPackager#buildPackage()}.
+     */
+    @ParameterizedTest
+    @MethodSource
+    void test_buildPackage(TestSpec testSpec, @TempDir Path workDir) {
+        testSpec.run(workDir);
+    }
+
+    record TestSpec(ScriptSpec scriptSpec, Optional<Class<? extends Exception>> expectedErrorType) {
+
+        TestSpec {
+            Objects.requireNonNull(scriptSpec);
+            Objects.requireNonNull(expectedErrorType);
+        }
+
+        TestSpec(ScriptSpec scriptSpec) {
+            this(scriptSpec, Optional.empty());
+        }
+
+        TestSpec(ScriptSpec scriptSpec, Class<? extends Exception> expectedErrorType) {
+            this(scriptSpec, Optional.of(expectedErrorType));
+        }
+
+        void run(Path workDir) {
+
+            var script = scriptSpec.create();
+
+            ExecutorFactory executorFactory = JPackageMockUtils.buildJPackage()
+                    .script(script).listener(System.out::println).createExecutorFactory();
+
+            var objectFactory = ObjectFactory.build()
+                    .executorFactory(executorFactory)
+                    .retryExecutorFactory(new RetryExecutorFactory() {
+                        @Override
+                        public <T, E extends Exception> RetryExecutor<T, E> retryExecutor(Class<? extends E> exceptionType) {
+                            return RetryExecutorFactory.DEFAULT.<T, E>retryExecutor(exceptionType).setSleepFunction(_ -> {
+                                // Don't "sleep" to make the test run faster.
+                            });
+                        }
+                    })
+                    .create();
+
+            Globals.main(() -> {
+                Globals.instance().objectFactory(objectFactory);
+
+                expectedErrorType.ifPresentOrElse(v -> {
+                    var ex = assertThrows(Exception.class, () -> {
+                        runPackagingMock(workDir);
+                    });
+
+                    var cause = ExceptionBox.unbox(ex);
+
+                    assertEquals(v, cause.getClass());
+                }, () -> {
+                    assertDoesNotThrow(() -> {
+                        runPackagingMock(workDir);
+                    });
+                });
+
+                return 0;
+            });
+
+            assertEquals(List.of(), script.incompleteMocks());
+        }
+    }
+
+    private static Collection<TestSpec> test_buildPackage() {
+
+        Collection<TestSpec> testCases = new ArrayList<>();
+
+        testCases.add(new TestSpec(
+                ScriptSpec.build()
+                        .build(new CommandMockSpec("fakeroot", CommandActionSpecs.build().exit().create()))
+                        .detailedDescription().add()
+                        .create()));
+
+        testCases.add(new TestSpec(
+                ScriptSpec.build()
+                        .build(new CommandMockSpec("fakeroot", CommandActionSpecs.build().exit(1).create()))
+                        .detailedDescription().add()
+                        .create(),
+                UnexpectedExitCodeException.class));
+
+        testCases.add(new TestSpec(
+                ScriptSpec.build()
+                        .build(new CommandMockSpec("fakeroot", CommandActionSpecs.build()
+                                .stderr("semop(1): encountered an error: Invalid argument")
+                                .exit(1).create()))
+                        .repeat(4).detailedDescription().add()
+                        .create(),
+                UnexpectedResultException.class));
+
+        testCases.add(new TestSpec(
+                ScriptSpec.build()
+                        .build(new CommandMockSpec("fakeroot", CommandActionSpecs.build()
+                                .stderr("semop(1): encountered an error: Invalid argument")
+                                .exit(1).create()))
+                        .repeat(3).detailedDescription().add()
+                        .build(new CommandMockSpec("fakeroot", CommandActionSpecs.build().exit().create()))
+                        .detailedDescription().add()
+                        .create()));
+
+        return testCases;
+    }
+
+    private static LinuxDebSystemEnvironment dummySysEnv() {
+
+        var linuxSysEnv = new LinuxSystemEnvironment.Stub(false, LINUX_DEB, new LinuxPackageArch("acme"), _ -> {
+            throw new AssertionError();
+        });
+        var debMixin = new LinuxDebSystemEnvironmentMixin.Stub(Path.of("dpkg"), Path.of("dpkg-deb"), Path.of("fakeroot"));
+
+        return LinuxSystemEnvironment.mixin(
+                LinuxDebSystemEnvironment.class,
+                Result.ofValue(linuxSysEnv),
+                () -> Result.ofValue(debMixin)).orElseThrow();
+    }
+
+    private static void runPackagingMock(Path workDir) {
+
+        var app = new ApplicationBuilder()
+                .appImageLayout(RuntimeLayout.DEFAULT)
+                .name("foo").create();
+
+        var sysEnv = dummySysEnv();
+
+        var pkg = new LinuxDebPackageBuilder(
+                new LinuxPackageBuilder(new PackageBuilder(app, LINUX_DEB))
+                        .arch(sysEnv.packageArch())
+        ).create();
+
+        var buildEnv = new BuildEnvBuilder(workDir.resolve("build-root")).appImageDirFor(pkg).create();
+
+        var packager = new LinuxDebPackager(buildEnv, pkg, workDir, dummySysEnv());
+
+        var pipelineBuilder = LinuxPackagingPipeline.build(Optional.of(pkg));
+        packager.accept(pipelineBuilder);
+
+        // Disable actions of tasks we don't care about.
+        pipelineBuilder.configuredTasks().filter(taskBuilder -> {
+            return (taskBuilder.task() != PackageTaskID.CREATE_PACKAGE_FILE);
+        }).forEach(taskBuilder -> {
+            taskBuilder.noaction().add();
+        });
+
+        pipelineBuilder.create().execute(buildEnv, pkg, workDir);
+    }
+}

--- a/test/jdk/tools/jpackage/junit/linux/junit.java
+++ b/test/jdk/tools/jpackage/junit/linux/junit.java
@@ -88,3 +88,14 @@
  *    jdk/jpackage/internal/DesktopEntryFileValidatorTest.java
  * @run junit jdk.jpackage/jdk.jpackage.internal.DesktopEntryFileValidatorTest
  */
+
+/* @test
+ * @summary Test LinuxDebPackager
+ * @requires (os.family == "linux")
+ * @library /test/jdk/tools/jpackage/helpers
+ * @build jdk.jpackage.test.mock.*
+ * @build jdk.jpackage.test.stdmock.*
+ * @compile/module=jdk.jpackage -Xlint:all -Werror
+ *    jdk/jpackage/internal/LinuxDebPackagerTest.java
+ * @run junit jdk.jpackage/jdk.jpackage.internal.LinuxDebPackagerTest
+ */


### PR DESCRIPTION
Add a check for the exit code of the "dpkg-deb" command that builds the output DEB package. Add a regression test.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8391473: jpackage ignores exit code of the "dpkg-deb" command`

### Issue
 * [JDK-8391473](https://bugs.openjdk.org/browse/JDK-8391473): jpackage ignores exit code of the "dpkg-deb" command (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32607/head:pull/32607` \
`$ git checkout pull/32607`

Update a local copy of the PR: \
`$ git checkout pull/32607` \
`$ git pull https://git.openjdk.org/jdk.git pull/32607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32607`

View PR using the GUI difftool: \
`$ git pr show -t 32607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32607.diff">https://git.openjdk.org/jdk/pull/32607.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32607#issuecomment-5479508299)
</details>
