### PR TITLE
8391474: [windows] TimeZone_md.c some RegCloseKey calls on hSubKey are missing

### DIFF
--- a/src/java.base/windows/native/libjava/TimeZone_md.c
+++ b/src/java.base/windows/native/libjava/TimeZone_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -327,6 +327,7 @@ static int getWinTimeZone(char *winZoneName, size_t winZoneNameBufSize)
                 if (ret != ERROR_SUCCESS) {
                     goto err;
                 }
+                RegCloseKey(hSubKey);
                 break;
             }
 
@@ -363,6 +364,7 @@ static int getWinTimeZone(char *winZoneName, size_t winZoneNameBufSize)
                  * found matched record, terminate search
                  */
                 strcpy(winZoneName, subKeyName);
+                RegCloseKey(hSubKey);
                 break;
             }
         out:


### PR DESCRIPTION
Some RegCloseKey calls on hSubKey are missing; and the "NT 4.0 SP3" coding in the file looks a bit outdated - is it maybe some leftover from older coding ? 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391474](https://bugs.openjdk.org/browse/JDK-8391474): [windows] TimeZone_md.c some RegCloseKey calls on hSubKey are missing (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32608/head:pull/32608` \
`$ git checkout pull/32608`

Update a local copy of the PR: \
`$ git checkout pull/32608` \
`$ git pull https://git.openjdk.org/jdk.git pull/32608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32608`

View PR using the GUI difftool: \
`$ git pr show -t 32608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32608.diff">https://git.openjdk.org/jdk/pull/32608.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32608#issuecomment-5479756921)
</details>
