### PR TITLE
8391445: (dc) DatagramChannel.open fails with Linux build of JDK on BSD

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -297,10 +297,14 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
     }
 
 #if defined(__linux__)
-    /* IPv4 or IPv6 datagram socket: disable IP_MULTICAST_ALL (Linux 2.6.31) */
+    /*
+     * IPv4 or IPv6 datagram socket: disable IP_MULTICAST_ALL (Linux 2.6.31)
+     * Not supported by the Linux binary compatibility layer on BSD
+     */
     if (type == SOCK_DGRAM && ipv4_available()) {
         int arg = 0;
-        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0)) {
+        if ((setsockopt(fd, IPPROTO_IP, IP_MULTICAST_ALL, (char*)&arg, sizeof(arg)) < 0) &&
+            (errno != ENOPROTOOPT)) {
             JNU_ThrowByNameWithLastError(env,
                                          JNU_JAVANETPKG "SocketException",
                                          "Unable to set IP_MULTICAST_ALL");


### PR DESCRIPTION
After JDK-8389968, someone reports that DatagramChannel.open fails when using an unmodified Linux build of the JDK on BSD. The compat layer on BSD doesn't support IP_MULTICAST_ALL so the setsockopt to set IP_MULTICAST_ALL=0 (disable IP_MULTICAST_ALL) fails. FreeBSD Bug [298076](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=298076) is created to track treating a set of IP_MULTICAST_ALL=0 as a no-op.

For now, tolerate ENOPROTOOPT again, and re-visit if the the BSD compat layer is fixed to handle IP_MULTICAST_ALL=0.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391445](https://bugs.openjdk.org/browse/JDK-8391445): (dc) DatagramChannel.open fails with Linux build of JDK on BSD (**Bug** - P5)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32609/head:pull/32609` \
`$ git checkout pull/32609`

Update a local copy of the PR: \
`$ git checkout pull/32609` \
`$ git pull https://git.openjdk.org/jdk.git pull/32609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32609`

View PR using the GUI difftool: \
`$ git pr show -t 32609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32609.diff">https://git.openjdk.org/jdk/pull/32609.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32609#issuecomment-5481286980)
</details>
