### PR TITLE
8387457: Test compiler/c2/Test6857159.java times out

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test6857159.java
+++ b/test/hotspot/jtreg/compiler/c2/Test6857159.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,60 +25,34 @@
  * @test
  * @bug 6857159
  * @summary local schedule failed with checkcast of Thread.currentThread()
- * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *      -Xbatch -XX:CompileCommand=compileonly,compiler.c2.Test6857159$ct0::run
- *      compiler.c2.Test6857159
+ * @modules java.base/jdk.internal.access
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   -XX:CompileCommand=dontinline,${test.main.class}::notInlined
+ *                   ${test.main.class}
  */
 
 package compiler.c2;
 
-import jdk.test.whitebox.WhiteBox;
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 
-public class Test6857159 extends Thread {
-    public static void main(String[] args) throws Exception {
-        var whiteBox = WhiteBox.getWhiteBox();
-        var method = ct0.class.getDeclaredMethod("run");
-        for (int i = 0; i < 20000; i++) {
-            Thread t = null;
-            switch (i % 3) {
-                case 0:
-                    t = new ct0();
-                    break;
-                case 1:
-                    t = new ct1();
-                    break;
-                case 2:
-                    t = new ct2();
-                    break;
-            }
-            t.start();
-            t.join();
-        }
-        if (!whiteBox.isMethodCompiled(method)) {
-            throw new AssertionError(method + " didn't get compiled");
+public class Test6857159 {
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; i++) {
+            test();
         }
     }
 
-    static class ct0 extends Test6857159 {
-        public void message() { }
+    static void notInlined() { }
 
-        public void run() {
-            message();
-            ct0 ct = (ct0) Thread.currentThread();
-            ct.message();
-        }
-    }
+    static Class<?> test() {
+        notInlined();
 
-    static class ct1 extends ct0 {
-        public void message() { }
-    }
-
-    static class ct2 extends ct0 {
-        public void message() { }
+        // These intrinsics create immutable klass loads whose addresses depend on the carrier thread load
+        return JLA.currentCarrierThread().getClass().getSuperclass();
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/TestLoadKlassAntiDep.java
+++ b/test/hotspot/jtreg/compiler/c2/TestLoadKlassAntiDep.java
@@ -38,7 +38,7 @@ package compiler.c2;
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 
-public class Test6857159 {
+public class TestLoadKlassAntiDep {
     private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
     public static void main(String[] args) {


### PR DESCRIPTION
The test sequentially creates, starts, and joins 20,000 platform threads solely to trigger C2 compilation. This is especially slow on Windows and creates frequent timeouts. I checked and the test does not even reproduce the issue it was originally designed for anymore. The original issue [JDK-6857159](https://bugs.openjdk.org/browse/JDK-6857159) was that C2 incorrectly added anti-dependencies for effectively immutable `LoadKlass` nodes, creating an unschedulable dependency cycle. I reverted the original fix like this
```
diff --git a/src/hotspot/share/adlc/formssel.cpp b/src/hotspot/share/adlc/formssel.cpp
index 8abaa62982b..ef5f003701e 100644
--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -593,7 +593,7 @@ bool InstructForm::rematerialize(FormDict &globals, RegisterForm *registers ) {
 
 // loads from memory, so must check for anti-dependence
 bool InstructForm::needs_anti_dependence_check(FormDict &globals) const {
-  if ( skip_antidep_check() ) return false;
```
and re-designed the test to still trigger the issue:

```
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/oracle/jdk/open/src/hotspot/share/opto/lcm.cpp:1229), pid=2355862, tid=2355877
#  assert(C->failure_is_artificial()) failed: graph should be schedulable
#
# JRE version: Java(TM) SE Runtime Environment (28.0) (fastdebug build 28-internal-tohartma.open)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (fastdebug 28-internal-tohartma.open, mixed mode, compressed oops, compact obj headers, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x15392ec]  PhaseCFG::schedule_local(Block*, GrowableArray<int>&, VectorSet&, long*)+0x27ac

Current CompileTask:
C2:338   43    b        compiler.c2.Test6857159::run (18 bytes)

Stack: [0x00007fae7eba3000,0x00007fae7eca3000],  sp=0x00007fae7ec9e4b0,  free space=1005k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x15392ec]  PhaseCFG::schedule_local(Block*, GrowableArray<int>&, VectorSet&, long*)+0x27ac  (lcm.cpp:1229)
V  [libjvm.so+0x1098a6a]  PhaseCFG::global_code_motion()+0xb7a  (gcm.cpp:1888)
V  [libjvm.so+0x109b1e8]  PhaseCFG::do_global_code_motion()+0x68  (gcm.cpp:1933)
V  [libjvm.so+0xc1e245]  Compile::Code_Gen()+0x5e5  (compile.cpp:3840)
V  [libjvm.so+0xc243d5]  Compile::Compile(ciEnv*, ciMethod*, int, Options, DirectiveSet*)+0x2245  (compile.cpp:946)
V  [libjvm.so+0xa071c8]  C2Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*)+0x4b8  (c2compiler.cpp:149)
V  [libjvm.so+0xc33c14]  CompileBroker::invoke_compiler_on_method(CompileTask*)+0x844  (compileBroker.cpp:2041)
V  [libjvm.so+0xc35098]  CompileBroker::compiler_thread_loop()+0x5e8  (compileBroker.cpp:1748)
V  [libjvm.so+0x123c8db]  JavaThread::thread_main_inner()+0x13b  (javaThread.cpp:654)
V  [libjvm.so+0x1c7acc6]  Thread::call_run()+0xb6  (thread.cpp:243)
V  [libjvm.so+0x1860648]  thread_native_entry(Thread*)+0x118  (os_linux.cpp:932)
```

No need to spawn threads. The call to internal `JavaLangAccess.currentCarrierThread()` is needed because it consumes all memory while C2 would treat `Thread.currentThread()` as immutable, allowing it to move before `dontInline()`. 

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387457](https://bugs.openjdk.org/browse/JDK-8387457): Test compiler/c2/Test6857159.java times out (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32610/head:pull/32610` \
`$ git checkout pull/32610`

Update a local copy of the PR: \
`$ git checkout pull/32610` \
`$ git pull https://git.openjdk.org/jdk.git pull/32610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32610`

View PR using the GUI difftool: \
`$ git pr show -t 32610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32610.diff">https://git.openjdk.org/jdk/pull/32610.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32610#issuecomment-5480188180)
</details>
