### PR TITLE
8391476: [Valhalla] PPC64 C1 stubs Load/StoreFlattenedArrayStub require sign extend to pass the index

### DIFF
--- a/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
@@ -155,6 +155,7 @@ LoadFlattenedArrayStub::LoadFlattenedArrayStub(LIR_Opr array, LIR_Opr index, LIR
 
 void LoadFlattenedArrayStub::emit_code(LIR_Assembler* ce) {
   __ bind(_entry);
+  __ extsw(_index->as_register(), _index->as_register()); // see CCallingConventionRequiresIntsAsLongs
   // Pass arguments on stack.
   __ std(_array->as_register(), -16, R1_SP);
   __ std(_index->as_register(), -8, R1_SP);
@@ -182,6 +183,7 @@ StoreFlattenedArrayStub::StoreFlattenedArrayStub(LIR_Opr array, LIR_Opr index, L
 
 void StoreFlattenedArrayStub::emit_code(LIR_Assembler* ce) {
   __ bind(_entry);
+  __ extsw(_index->as_register(), _index->as_register()); // see CCallingConventionRequiresIntsAsLongs
   // Pass arguments on stack.
   __ std(_array->as_register(), -24, R1_SP);
   __ std(_index->as_register(), -16, R1_SP);


### PR DESCRIPTION
Sign extend was missing. Already done in other C1 stubs which are passing an int.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391476](https://bugs.openjdk.org/browse/JDK-8391476): [Valhalla] PPC64 C1 stubs Load/StoreFlattenedArrayStub require sign extend to pass the index (**Bug** - P4)


### Reviewers
 * [David Briemann](https://openjdk.org/census#dbriemann) (@dbriemann - Committer)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32611/head:pull/32611` \
`$ git checkout pull/32611`

Update a local copy of the PR: \
`$ git checkout pull/32611` \
`$ git pull https://git.openjdk.org/jdk.git pull/32611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32611`

View PR using the GUI difftool: \
`$ git pr show -t 32611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32611.diff">https://git.openjdk.org/jdk/pull/32611.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32611#issuecomment-5480230183)
</details>
