### PR TITLE
8391488: GenShen: Remembered set scan should use compact-object-header aware accessors

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -226,7 +226,7 @@ void ShenandoahCardCluster::update_card_table(HeapWord* start, HeapWord* end) {
     previous_address = address;
 
     const oop obj = cast_to_oop(address);
-    address += obj->size();
+    address += ShenandoahForwarding::size(obj);
   }
 
   // Register the last object seen in this range.
@@ -345,7 +345,7 @@ HeapWord* ShenandoahCardCluster::first_object_start(const size_t card_index, con
       if (prev < left) {
         oop obj = cast_to_oop(prev);
         assert(oopDesc::is_oop(obj), "Should be an object");
-        HeapWord* obj_end = prev + obj->size();
+        HeapWord* obj_end = prev + ShenandoahForwarding::size(obj);
         if (obj_end > left) {
           return prev;
         }
@@ -397,7 +397,7 @@ HeapWord* ShenandoahCardCluster::first_object_start(const size_t card_index, con
     if (ctx->is_marked(p)) {
       oop obj = cast_to_oop(p);
       assert(oopDesc::is_oop(obj), "Should be an object");
-      assert(p + obj->size() > left, "This object should span start of card");
+      assert(p + ShenandoahForwarding::size(obj) > left, "This object should span start of card");
       assert(p < right, "Result must precede right");
       return p;
     } else {
@@ -443,7 +443,7 @@ HeapWord* ShenandoahCardCluster::first_object_start(const size_t card_index, con
 #ifdef ASSERT
   oop obj = cast_to_oop(p);
   assert(oopDesc::is_oop(obj), "Should be an object");
-  assert(p + obj->size() > left, "obj should end after left end of card");
+  assert(p + ShenandoahForwarding::size(obj) > left, "obj should end after left end of card");
 #endif // ASSERT
   return p;
 }
@@ -514,7 +514,7 @@ bool ShenandoahScanRemembered::verify_registration(HeapWord* address, Shenandoah
   while (base_addr + offset < address) {
     oop obj = cast_to_oop(base_addr + offset);
     if (!ctx || ctx->is_marked(obj)) {
-      offset += obj->size();
+      offset += ShenandoahForwarding::size(obj);
     } else {
       // If this object is not live, don't trust its size(); all objects above tams are live.
       ShenandoahHeapRegion* r = heap->heap_region_containing(obj);
@@ -543,7 +543,7 @@ bool ShenandoahScanRemembered::verify_registration(HeapWord* address, Shenandoah
     do {
       oop obj = cast_to_oop(base_addr + offset);
       prev_offset = offset;
-      offset += obj->size();
+      offset += ShenandoahForwarding::size(obj);
     } while (offset < max_offset);
     if (_scc->get_last_start(index) != prev_offset) {
       return false;
@@ -582,7 +582,7 @@ bool ShenandoahScanRemembered::verify_registration(HeapWord* address, Shenandoah
       oop obj = cast_to_oop(base_addr + offset);
       if (ctx->is_marked(obj)) {
         prev_offset = offset;
-        offset += obj->size();
+        offset += ShenandoahForwarding::size(obj);
         last_obj = obj;
       } else {
         offset = ctx->get_next_marked_addr(base_addr + offset, tams) - base_addr;
@@ -592,7 +592,7 @@ bool ShenandoahScanRemembered::verify_registration(HeapWord* address, Shenandoah
         // by consulting the size() fields of each.
       }
     } while (offset < max_offset);
-    if (last_obj != nullptr && prev_offset + last_obj->size() >= max_offset) {
+    if (last_obj != nullptr && prev_offset + ShenandoahForwarding::size(last_obj) >= max_offset) {
       // last marked object extends beyond end of card
       if (_scc->get_last_start(index) != prev_offset) {
         return false;
@@ -1074,7 +1074,7 @@ void ShenandoahReconstructRememberedSetTask::work(uint worker_id) {
         if (r->is_humongous_start()) {
           // First, clear the remembered set
           oop obj = cast_to_oop(obj_addr);
-          size_t size = obj->size();
+          size_t size = ShenandoahForwarding::size(obj);
 
           size_t num_regions = ShenandoahHeapRegion::required_regions(size * HeapWordSize);
           size_t region_index = r->index();


### PR DESCRIPTION
The remembered set is scanned during update refs, so it may encounter forwarded objects. As such, it should use `ShenandoahForwarding::size` to safely access `oop::size`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391488](https://bugs.openjdk.org/browse/JDK-8391488): GenShen: Remembered set scan should use compact-object-header aware accessors (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32613/head:pull/32613` \
`$ git checkout pull/32613`

Update a local copy of the PR: \
`$ git checkout pull/32613` \
`$ git pull https://git.openjdk.org/jdk.git pull/32613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32613`

View PR using the GUI difftool: \
`$ git pr show -t 32613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32613.diff">https://git.openjdk.org/jdk/pull/32613.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32613#issuecomment-5482742765)
</details>
