### PR TITLE
8391515: AArch64: Remove unreachable non-acquiring CAS/GetAndSet/GetAndAdd match rules

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_atomic.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic.ad
@@ -32,7 +32,7 @@
 // STLXR.
 
 // CompareAndSwapX, GetAndSetX, and GetAndAddX represent sequentially
-// consistent operations. C2 therefore emits a trailing MemBarAcquire for
+// consistent operations. C2 emits a trailing MemBarAcquire for
 // these nodes, so their AArch64 implementation always needs acquire semantics.
 // Non-acquiring match rules would consequently be unreachable.
 

--- a/src/hotspot/cpu/aarch64/aarch64_atomic.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic.ad
@@ -31,6 +31,10 @@
 // can't check the type of memory ordering here, so we always emit a
 // STLXR.
 
+// Only the acquiring variants of CompareAndSwapX, GetAndSetX and GetAndAddX
+// are defined here: needs_acquiring_load_exclusive() always returns true for
+// these opcodes (see is_CAS()), so the non-acquiring variants are unreachable.
+
 // This section is generated from aarch64_atomic_ad.m4
 
 
@@ -210,98 +214,6 @@ instruct compareAndExchangePAcq(iRegPNoSp res, indirect mem, iRegP oldval, iRegP
   ins_encode %{
     __ cmpxchg($mem$$Register, $oldval$$Register, $newval$$Register,
                Assembler::xword, memory_order_seq_cst, $res$$Register);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct compareAndSwapB(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
-  match(Set res (CompareAndSwapB mem (Binary oldval newval)));
-  ins_cost(2*VOLATILE_REF_COST);
-  effect(KILL cr);
-  format %{
-    "cmpxchgb $res = $mem, $oldval, $newval\t# (byte) if $mem == $oldval then $mem <-- $newval"
-    "csetw $res, EQ\t# $res <-- (EQ ? 1 : 0)"
-  %}
-  ins_encode %{
-    __ cmpxchg($mem$$Register, $oldval$$Register, $newval$$Register, Assembler::byte, memory_order_release);
-    __ csetw($res$$Register, Assembler::EQ);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct compareAndSwapS(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
-  match(Set res (CompareAndSwapS mem (Binary oldval newval)));
-  ins_cost(2*VOLATILE_REF_COST);
-  effect(KILL cr);
-  format %{
-    "cmpxchgs $res = $mem, $oldval, $newval\t# (short) if $mem == $oldval then $mem <-- $newval"
-    "csetw $res, EQ\t# $res <-- (EQ ? 1 : 0)"
-  %}
-  ins_encode %{
-    __ cmpxchg($mem$$Register, $oldval$$Register, $newval$$Register, Assembler::halfword, memory_order_release);
-    __ csetw($res$$Register, Assembler::EQ);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct compareAndSwapI(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
-  match(Set res (CompareAndSwapI mem (Binary oldval newval)));
-  ins_cost(2*VOLATILE_REF_COST);
-  effect(KILL cr);
-  format %{
-    "cmpxchgw $res = $mem, $oldval, $newval\t# (int) if $mem == $oldval then $mem <-- $newval"
-    "csetw $res, EQ\t# $res <-- (EQ ? 1 : 0)"
-  %}
-  ins_encode %{
-    __ cmpxchg($mem$$Register, $oldval$$Register, $newval$$Register, Assembler::word, memory_order_release);
-    __ csetw($res$$Register, Assembler::EQ);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct compareAndSwapL(iRegINoSp res, indirect mem, iRegL oldval, iRegL newval, rFlagsReg cr) %{
-  match(Set res (CompareAndSwapL mem (Binary oldval newval)));
-  ins_cost(2*VOLATILE_REF_COST);
-  effect(KILL cr);
-  format %{
-    "cmpxchg $res = $mem, $oldval, $newval\t# (long) if $mem == $oldval then $mem <-- $newval"
-    "csetw $res, EQ\t# $res <-- (EQ ? 1 : 0)"
-  %}
-  ins_encode %{
-    __ cmpxchg($mem$$Register, $oldval$$Register, $newval$$Register, Assembler::xword, memory_order_release);
-    __ csetw($res$$Register, Assembler::EQ);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct compareAndSwapN(iRegINoSp res, indirect mem, iRegN oldval, iRegN newval, rFlagsReg cr) %{
-  predicate(n->as_LoadStore()->barrier_data() == 0);
-  match(Set res (CompareAndSwapN mem (Binary oldval newval)));
-  ins_cost(2*VOLATILE_REF_COST);
-  effect(KILL cr);
-  format %{
-    "cmpxchgw $res = $mem, $oldval, $newval\t# (narrow oop) if $mem == $oldval then $mem <-- $newval"
-    "csetw $res, EQ\t# $res <-- (EQ ? 1 : 0)"
-  %}
-  ins_encode %{
-    __ cmpxchg($mem$$Register, $oldval$$Register, $newval$$Register, Assembler::word, memory_order_release);
-    __ csetw($res$$Register, Assembler::EQ);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct compareAndSwapP(iRegINoSp res, indirect mem, iRegP oldval, iRegP newval, rFlagsReg cr) %{
-  predicate(n->as_LoadStore()->barrier_data() == 0);
-  match(Set res (CompareAndSwapP mem (Binary oldval newval)));
-  ins_cost(2*VOLATILE_REF_COST);
-  effect(KILL cr);
-  format %{
-    "cmpxchg $res = $mem, $oldval, $newval\t# (ptr) if $mem == $oldval then $mem <-- $newval"
-    "csetw $res, EQ\t# $res <-- (EQ ? 1 : 0)"
-  %}
-  ins_encode %{
-    __ cmpxchg($mem$$Register, $oldval$$Register, $newval$$Register, Assembler::xword, memory_order_release);
-    __ csetw($res$$Register, Assembler::EQ);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -590,48 +502,6 @@ instruct weakCompareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP
   ins_pipe(pipe_slow);
 %}
 
-instruct getAndSetI(indirect mem, iRegI newval, iRegINoSp oldval) %{
-  match(Set oldval (GetAndSetI mem newval));
-  ins_cost(2*VOLATILE_REF_COST);
-  format %{ "atomic_xchgw  $oldval, $newval, [$mem]" %}
-  ins_encode %{
-    __ atomic_xchgw($oldval$$Register, $newval$$Register, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
-instruct getAndSetL(indirect mem, iRegL newval, iRegLNoSp oldval) %{
-  match(Set oldval (GetAndSetL mem newval));
-  ins_cost(2*VOLATILE_REF_COST);
-  format %{ "atomic_xchg  $oldval, $newval, [$mem]" %}
-  ins_encode %{
-    __ atomic_xchg($oldval$$Register, $newval$$Register, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
-instruct getAndSetN(indirect mem, iRegN newval, iRegNNoSp oldval) %{
-  predicate(n->as_LoadStore()->barrier_data() == 0);
-  match(Set oldval (GetAndSetN mem newval));
-  ins_cost(2*VOLATILE_REF_COST);
-  format %{ "atomic_xchgw  $oldval, $newval, [$mem]" %}
-  ins_encode %{
-    __ atomic_xchgw($oldval$$Register, $newval$$Register, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
-instruct getAndSetP(indirect mem, iRegP newval, iRegPNoSp oldval) %{
-  predicate(n->as_LoadStore()->barrier_data() == 0);
-  match(Set oldval (GetAndSetP mem newval));
-  ins_cost(2*VOLATILE_REF_COST);
-  format %{ "atomic_xchg  $oldval, $newval, [$mem]" %}
-  ins_encode %{
-    __ atomic_xchg($oldval$$Register, $newval$$Register, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
 instruct getAndSetIAcq(indirect mem, iRegI newval, iRegINoSp oldval) %{
   predicate(needs_acquiring_load_exclusive(n));
   match(Set oldval (GetAndSetI mem newval));
@@ -676,16 +546,6 @@ instruct getAndSetPAcq(indirect mem, iRegP newval, iRegPNoSp oldval) %{
   ins_pipe(pipe_serial);
 %}
 
-instruct getAndAddI(indirect mem, iRegINoSp newval, iRegIorL2I incr) %{
-  match(Set newval (GetAndAddI mem incr));
-  ins_cost(2*VOLATILE_REF_COST+1);
-  format %{ "get_and_addI $newval, [$mem], $incr" %}
-  ins_encode %{
-    __ atomic_addw($newval$$Register, $incr$$Register, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
 instruct getAndAddIAcq(indirect mem, iRegINoSp newval, iRegIorL2I incr) %{
   predicate(needs_acquiring_load_exclusive(n));
   match(Set newval (GetAndAddI mem incr));
@@ -693,17 +553,6 @@ instruct getAndAddIAcq(indirect mem, iRegINoSp newval, iRegIorL2I incr) %{
   format %{ "get_and_addI_acq $newval, [$mem], $incr" %}
   ins_encode %{
     __ atomic_addalw($newval$$Register, $incr$$Register, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
-instruct getAndAddINoRes(indirect mem, Universe dummy, iRegIorL2I incr) %{
-  predicate(n->as_LoadStore()->result_not_used());
-  match(Set dummy (GetAndAddI mem incr));
-  ins_cost(2*VOLATILE_REF_COST);
-  format %{ "get_and_addI noreg, [$mem], $incr" %}
-  ins_encode %{
-    __ atomic_addw(noreg, $incr$$Register, as_Register($mem$$base));
   %}
   ins_pipe(pipe_serial);
 %}
@@ -719,16 +568,6 @@ instruct getAndAddIAcqNoRes(indirect mem, Universe dummy, iRegIorL2I incr) %{
   ins_pipe(pipe_serial);
 %}
 
-instruct getAndAddIConst(indirect mem, iRegINoSp newval, immIAddSub incr) %{
-  match(Set newval (GetAndAddI mem incr));
-  ins_cost(2*VOLATILE_REF_COST+1);
-  format %{ "get_and_addI $newval, [$mem], $incr" %}
-  ins_encode %{
-    __ atomic_addw($newval$$Register, $incr$$constant, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
 instruct getAndAddIAcqConst(indirect mem, iRegINoSp newval, immIAddSub incr) %{
   predicate(needs_acquiring_load_exclusive(n));
   match(Set newval (GetAndAddI mem incr));
@@ -736,17 +575,6 @@ instruct getAndAddIAcqConst(indirect mem, iRegINoSp newval, immIAddSub incr) %{
   format %{ "get_and_addI_acq $newval, [$mem], $incr" %}
   ins_encode %{
     __ atomic_addalw($newval$$Register, $incr$$constant, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
-instruct getAndAddINoResConst(indirect mem, Universe dummy, immIAddSub incr) %{
-  predicate(n->as_LoadStore()->result_not_used());
-  match(Set dummy (GetAndAddI mem incr));
-  ins_cost(2*VOLATILE_REF_COST);
-  format %{ "get_and_addI noreg, [$mem], $incr" %}
-  ins_encode %{
-    __ atomic_addw(noreg, $incr$$constant, as_Register($mem$$base));
   %}
   ins_pipe(pipe_serial);
 %}
@@ -762,16 +590,6 @@ instruct getAndAddIAcqNoResConst(indirect mem, Universe dummy, immIAddSub incr) 
   ins_pipe(pipe_serial);
 %}
 
-instruct getAndAddL(indirect mem, iRegLNoSp newval, iRegL incr) %{
-  match(Set newval (GetAndAddL mem incr));
-  ins_cost(2*VOLATILE_REF_COST+1);
-  format %{ "get_and_addL $newval, [$mem], $incr" %}
-  ins_encode %{
-    __ atomic_add($newval$$Register, $incr$$Register, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
 instruct getAndAddLAcq(indirect mem, iRegLNoSp newval, iRegL incr) %{
   predicate(needs_acquiring_load_exclusive(n));
   match(Set newval (GetAndAddL mem incr));
@@ -779,17 +597,6 @@ instruct getAndAddLAcq(indirect mem, iRegLNoSp newval, iRegL incr) %{
   format %{ "get_and_addL_acq $newval, [$mem], $incr" %}
   ins_encode %{
     __ atomic_addal($newval$$Register, $incr$$Register, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
-instruct getAndAddLNoRes(indirect mem, Universe dummy, iRegL incr) %{
-  predicate(n->as_LoadStore()->result_not_used());
-  match(Set dummy (GetAndAddL mem incr));
-  ins_cost(2*VOLATILE_REF_COST);
-  format %{ "get_and_addL noreg, [$mem], $incr" %}
-  ins_encode %{
-    __ atomic_add(noreg, $incr$$Register, as_Register($mem$$base));
   %}
   ins_pipe(pipe_serial);
 %}
@@ -805,16 +612,6 @@ instruct getAndAddLAcqNoRes(indirect mem, Universe dummy, iRegL incr) %{
   ins_pipe(pipe_serial);
 %}
 
-instruct getAndAddLConst(indirect mem, iRegLNoSp newval, immLAddSub incr) %{
-  match(Set newval (GetAndAddL mem incr));
-  ins_cost(2*VOLATILE_REF_COST+1);
-  format %{ "get_and_addL $newval, [$mem], $incr" %}
-  ins_encode %{
-    __ atomic_add($newval$$Register, $incr$$constant, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
 instruct getAndAddLAcqConst(indirect mem, iRegLNoSp newval, immLAddSub incr) %{
   predicate(needs_acquiring_load_exclusive(n));
   match(Set newval (GetAndAddL mem incr));
@@ -822,17 +619,6 @@ instruct getAndAddLAcqConst(indirect mem, iRegLNoSp newval, immLAddSub incr) %{
   format %{ "get_and_addL_acq $newval, [$mem], $incr" %}
   ins_encode %{
     __ atomic_addal($newval$$Register, $incr$$constant, as_Register($mem$$base));
-  %}
-  ins_pipe(pipe_serial);
-%}
-
-instruct getAndAddLNoResConst(indirect mem, Universe dummy, immLAddSub incr) %{
-  predicate(n->as_LoadStore()->result_not_used());
-  match(Set dummy (GetAndAddL mem incr));
-  ins_cost(2*VOLATILE_REF_COST);
-  format %{ "get_and_addL noreg, [$mem], $incr" %}
-  ins_encode %{
-    __ atomic_add(noreg, $incr$$constant, as_Register($mem$$base));
   %}
   ins_pipe(pipe_serial);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_atomic.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic.ad
@@ -31,9 +31,10 @@
 // can't check the type of memory ordering here, so we always emit a
 // STLXR.
 
-// Only the acquiring variants of CompareAndSwapX, GetAndSetX and GetAndAddX
-// are defined here: needs_acquiring_load_exclusive() always returns true for
-// these opcodes (see is_CAS()), so the non-acquiring variants are unreachable.
+// CompareAndSwapX, GetAndSetX, and GetAndAddX represent sequentially
+// consistent operations. C2 therefore emits a trailing MemBarAcquire for
+// these nodes, so their AArch64 implementation always needs acquire semantics.
+// Non-acquiring match rules would consequently be unreachable.
 
 // This section is generated from aarch64_atomic_ad.m4
 

--- a/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
@@ -31,6 +31,10 @@
 // can't check the type of memory ordering here, so we always emit a
 // STLXR.
 
+// Only the acquiring variants of CompareAndSwapX, GetAndSetX and GetAndAddX
+// are defined here: needs_acquiring_load_exclusive() always returns true for
+// these opcodes (see is_CAS()), so the non-acquiring variants are unreachable.
+
 // This section is generated from aarch64_atomic_ad.m4
 
 dnl Return Arg1 with two spaces before it. We need this because m4
@@ -139,13 +143,6 @@ ifelse($1$6,PAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && (n->as_Lo
   ins_pipe(pipe_slow);
 %}')dnl
 dnl
-CAS_INSN1(B,    I,  byte,       byte,       b,  ,           )
-CAS_INSN1(S,    I,  short,      halfword,   s,  ,           )
-CAS_INSN2(I,    I,  int,        word,       w,  ,           )
-CAS_INSN2(L,    L,  long,       xword,      ,   ,           )
-CAS_INSN2(N,    N,  narrow oop, word,       w,  ,           )
-CAS_INSN2(P,    P,  ptr,        xword,      ,   ,           )
-dnl
 CAS_INSN1(B,    I,  byte,       byte,       b,  Acq,        )
 CAS_INSN1(S,    I,  short,      halfword,   s,  Acq,        )
 CAS_INSN2(I,    I,  int,        word,       w,  Acq,        )
@@ -189,11 +186,6 @@ ifelse($1$3,PAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && (n->as_Lo
   ins_pipe(pipe_serial);
 %}')dnl
 dnl
-GAS_INSN1(I,    w,  )
-GAS_INSN1(L,    ,   )
-GAS_INSN1(N,    w,  )
-GAS_INSN1(P,    ,   )
-dnl
 GAS_INSN1(I,    w,  Acq)
 GAS_INSN1(L,    ,   Acq)
 GAS_INSN1(N,    w,  Acq)
@@ -220,21 +212,13 @@ ifelse($4$5,AcqNoRes,INDENT(predicate(n->as_LoadStore()->result_not_used() && ne
 %}')dnl
 dnl
 dnl
-GAA_INSN1(I,    IorL2I,     w,  ,       ,           )
 GAA_INSN1(I,    IorL2I,     w,  Acq,    ,           )
-GAA_INSN1(I,    IorL2I,     w,  ,       NoRes,      )
 GAA_INSN1(I,    IorL2I,     w,  Acq,    NoRes,      )
-GAA_INSN1(I,    I,          w,  ,       ,       Const)
 GAA_INSN1(I,    I,          w,  Acq,    ,       Const)
-GAA_INSN1(I,    I,          w,  ,       NoRes,  Const)
 GAA_INSN1(I,    I,          w,  Acq,    NoRes,  Const)
 dnl
-GAA_INSN1(L,    L,          ,   ,       ,           )
 GAA_INSN1(L,    L,          ,   Acq,    ,           )
-GAA_INSN1(L,    L,          ,   ,       NoRes,      )
 GAA_INSN1(L,    L,          ,   Acq,    NoRes,      )
-GAA_INSN1(L,    L,          ,   ,       ,       Const)
 GAA_INSN1(L,    L,          ,   Acq,    ,       Const)
-GAA_INSN1(L,    L,          ,   ,       NoRes,  Const)
 GAA_INSN1(L,    L,          ,   Acq,    NoRes,  Const)
 dnl

--- a/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
@@ -32,7 +32,7 @@
 // STLXR.
 
 // CompareAndSwapX, GetAndSetX, and GetAndAddX represent sequentially
-// consistent operations. C2 therefore emits a trailing MemBarAcquire for
+// consistent operations. C2 emits a trailing MemBarAcquire for
 // these nodes, so their AArch64 implementation always needs acquire semantics.
 // Non-acquiring match rules would consequently be unreachable.
 

--- a/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
@@ -31,9 +31,10 @@
 // can't check the type of memory ordering here, so we always emit a
 // STLXR.
 
-// Only the acquiring variants of CompareAndSwapX, GetAndSetX and GetAndAddX
-// are defined here: needs_acquiring_load_exclusive() always returns true for
-// these opcodes (see is_CAS()), so the non-acquiring variants are unreachable.
+// CompareAndSwapX, GetAndSetX, and GetAndAddX represent sequentially
+// consistent operations. C2 therefore emits a trailing MemBarAcquire for
+// these nodes, so their AArch64 implementation always needs acquire semantics.
+// Non-acquiring match rules would consequently be unreachable.
 
 // This section is generated from aarch64_atomic_ad.m4
 


### PR DESCRIPTION
Hi, As discussed here https://mail.openjdk.org/archives/list/hotspot-compiler-dev@openjdk.org/thread/X4IFQVHRZUSU32YWFKWK6JN4WDGQFBX6/, this code is currently unreachable. Keeping it around increases maintenance difficulty and carries some risk. Currently, matching should be based on cost and definition order. On AArch64, the regular node is given an ins_cost twice that of the Acq node to additionally guarantee that the Acq node is always chosen. However, the ins_cost of the Acq node here is lower than that of the non-Acq node, which makes it hard to understand.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391515](https://bugs.openjdk.org/browse/JDK-8391515): AArch64: Remove unreachable non-acquiring CAS/GetAndSet/GetAndAdd match rules (**Enhancement** - P4)


### Reviewers
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer) Review applies to [7b11738f](https://git.openjdk.org/jdk/pull/32617/files/7b11738fbe6a72c99040a0ba67e254d6fdbb6a41)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32617/head:pull/32617` \
`$ git checkout pull/32617`

Update a local copy of the PR: \
`$ git checkout pull/32617` \
`$ git pull https://git.openjdk.org/jdk.git pull/32617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32617`

View PR using the GUI difftool: \
`$ git pr show -t 32617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32617.diff">https://git.openjdk.org/jdk/pull/32617.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32617#issuecomment-5489052908)
</details>
