### PR TITLE
8367022: MethodHandles.foldArguments handle negative pos

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5924,9 +5924,10 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
         int foldArgs   = combinerType.parameterCount();
         Class<?> rtype = combinerType.returnType();
         int foldVals = rtype == void.class ? 0 : 1;
-        int afterInsertPos = foldPos + foldVals;
-        boolean ok = (targetType.parameterCount() >= afterInsertPos + foldArgs);
+        boolean ok = foldPos >= 0 &&
+                foldPos <= targetType.parameterCount() - foldVals - foldArgs;
         if (ok) {
+            int afterInsertPos = foldPos + foldVals;
             for (int i = 0; i < foldArgs; i++) {
                 if (combinerType.parameterType(i) != targetType.parameterType(i + afterInsertPos)) {
                     ok = false;

--- a/test/jdk/java/lang/invoke/FoldTest.java
+++ b/test/jdk/java/lang/invoke/FoldTest.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8139885
+ * @bug 8139885 8367022
  * @run junit/othervm -ea -esa test.java.lang.invoke.FoldTest
  */
 
@@ -39,6 +39,7 @@ import static java.lang.invoke.MethodType.methodType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for the new fold method handle combinator added in JEP 274.
@@ -90,6 +91,33 @@ public class FoldTest {
         MethodHandle catTrace = MethodHandles.foldArguments(cat, 1, trace);
         assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
         assertEquals("jum", swr.toString());
+    }
+
+    @Test
+    public void testInvalidFoldPositions() {
+        MethodHandle voidCombiner = MethodHandles.empty(methodType(void.class, int.class));
+        int[] invalidPositions = {
+                -1,
+                Integer.MIN_VALUE,
+                Fold.MH_multer.type().parameterCount(),
+                Integer.MAX_VALUE
+        };
+        for (int pos : invalidPositions) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> MethodHandles.foldArguments(Fold.MH_multer, pos, Fold.MH_adder1));
+            assertThrows(IllegalArgumentException.class,
+                    () -> MethodHandles.foldArguments(Fold.MH_multer, pos, voidCombiner));
+        }
+    }
+
+    @Test
+    public void testVoidFoldAtEnd() throws Throwable {
+        MethodHandle voidCombiner = MethodHandles.empty(methodType(void.class));
+        int position = Fold.MH_multer.type().parameterCount();
+        MethodHandle fold = MethodHandles.foldArguments(Fold.MH_multer, position, voidCombiner);
+
+        assertEquals(Fold.MT_multer, fold.type());
+        assertEquals(120, (int) fold.invoke(2, 3, 4, 5));
     }
 
     static class Fold {


### PR DESCRIPTION
Please review this small fix.

**Problem:**

`MethodHandles.foldArguments` throws `ArrayIndexOutOfBoundsException` instead of `IllegalArgumentException` for negative `pos` values, which violates the API's exception contract. Extreme values such as `Integer.MAX_VALUE` can also overflow the existing addition-based bounds check.

**Fix:**

Validate that `foldPos` is non-negative and use:

```java
foldPos <= targetType.parameterCount() - foldVals - foldArgs
```

**Testing:**

- Added tests for invalid positions and the valid boundary case where a zero-argument `void` combiner is folded at the end of the target parameter list.
- `make test TEST=test/jdk/java/lang/invoke`: 198 passed, 4 excluded, 0 failed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8367022](https://bugs.openjdk.org/browse/JDK-8367022): MethodHandles.foldArguments handle negative pos (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32618/head:pull/32618` \
`$ git checkout pull/32618`

Update a local copy of the PR: \
`$ git checkout pull/32618` \
`$ git pull https://git.openjdk.org/jdk.git pull/32618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32618`

View PR using the GUI difftool: \
`$ git pr show -t 32618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32618.diff">https://git.openjdk.org/jdk/pull/32618.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32618#issuecomment-5489874259)
</details>
