### PR TITLE
8391518: Un-ProblemList runtime/Thread/TestAlwaysPreTouchStacks.java on macOS

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,7 +102,6 @@ runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/NMT/VirtualAllocCommitMerge.java 8309698 linux-s390x
-runtime/Thread/TestAlwaysPreTouchStacks.java 8383372 macosx-aarch64
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
Remove from the PL so we can see if the test is still failing and if so gather more data on those failures. 

Thanks

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391518](https://bugs.openjdk.org/browse/JDK-8391518): Un-ProblemList runtime/Thread/TestAlwaysPreTouchStacks.java on macOS (**Sub-task** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32619/head:pull/32619` \
`$ git checkout pull/32619`

Update a local copy of the PR: \
`$ git checkout pull/32619` \
`$ git pull https://git.openjdk.org/jdk.git pull/32619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32619`

View PR using the GUI difftool: \
`$ git pr show -t 32619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32619.diff">https://git.openjdk.org/jdk/pull/32619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32619#issuecomment-5490052846)
</details>
