### PR TITLE
8391452: C2: Add StressVerifyMeetJoin to CtwRunner

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3971,10 +3971,16 @@ const Type* TypeOopPtr::xjoin_helper(const Type* t) const {
 
     case OopPtr: {
       const TypeOopPtr* tp = t->is_oopptr();
-      int instance_id = join_instance_id(tp->instance_id());
       const TypePtr* speculative = xjoin_speculative(tp);
       int depth = join_inline_depth(tp->inline_depth());
-      return make(join_ptr(tp->ptr()), join_offset(tp->offset()), instance_id, speculative, depth);
+
+      Offset offset = join_offset(tp->offset());
+      if (offset == Offset::top) {
+        return TypePtr::make(AnyPtr, TopPTR, offset, speculative, depth);
+      }
+
+      int instance_id = join_instance_id(tp->instance_id());
+      return make(join_ptr(tp->ptr()), offset, instance_id, speculative, depth);
     }
 
     case InstPtr:

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3762,6 +3762,7 @@ TypeOopPtr::TypeOopPtr(TYPES t, PTR ptr, ciKlass* k, const TypeInterfaces* inter
     interfaces->verify_is_loaded();
   }
   assert(instance_id != InstanceTop, "must not have top instance_id");
+  assert(xk || instance_id == InstanceBot, "a known instance must have an exact type");
   assert(ptr != Constant || instance_id == InstanceBot, "a constant cannot have an instance_id");
 #endif
   if (Compile::current()->eliminate_boxing() && (t == InstPtr) &&
@@ -5534,9 +5535,10 @@ const Type* TypeMetadataPtr::xjoin(const Type* t) const {
   switch (t->base()) {
     case AnyPtr: {
       const TypePtr* tp = t->is_ptr();
-      PTR ptr = join_ptr(tp->ptr());
       Offset offset = join_offset(tp->offset());
-      switch (tp->ptr()) {
+      PTR other_ptr = offset == Offset::top ? TopPTR : tp->ptr();
+      PTR ptr = join_ptr(other_ptr);
+      switch (other_ptr) {
         case TopPTR:
         case Null:
           return TypePtr::make(AnyPtr, ptr, offset, tp->speculative(), tp->inline_depth());
@@ -5887,9 +5889,10 @@ const Type* TypeInstKlassPtr::xjoin(const Type* t) const {
   switch (t->base()) {
     case AnyPtr: {
       const TypePtr* tp = t->is_ptr();
-      PTR ptr = join_ptr(tp->ptr());
       Offset offset = join_offset(tp->offset());
-      switch (tp->ptr()) {
+      PTR other_ptr = offset == Offset::top ? TopPTR : tp->ptr();
+      PTR ptr = join_ptr(other_ptr);
+      switch (other_ptr) {
         case TopPTR:
         case Null:
           return TypePtr::make(AnyPtr, ptr, offset, tp->speculative(), tp->inline_depth());
@@ -6376,9 +6379,10 @@ const Type* TypeAryKlassPtr::xjoin(const Type* t) const {
   switch (t->base()) {
     case AnyPtr: {
       const TypePtr* tp = t->is_ptr();
-      PTR ptr = join_ptr(tp->ptr());
       Offset offset = join_offset(tp->offset());
-      switch (tp->ptr()) {
+      PTR other_ptr = offset == Offset::top ? TopPTR : tp->ptr();
+      PTR ptr = join_ptr(other_ptr);
+      switch (other_ptr) {
         case TopPTR:
         case Null:
           return TypePtr::make(AnyPtr, ptr, offset, tp->speculative(), tp->inline_depth());

--- a/src/hotspot/share/opto/typejavaptr.hpp
+++ b/src/hotspot/share/opto/typejavaptr.hpp
@@ -262,7 +262,7 @@ private:
   static TypePtr::PTR meet_ary_klass_ptr(const AryKlassType* t1, const AryKlassType* t2) {
     // Sometimes, the klass is computed and cached, sometimes it is not. In general, the only time
     // we need to compare klass() is when t1->elem() and t2->elem() are both TypeInt::INT. In other
-    // cases, it is fine if klass_match == true, other parameters must reveal if t1 and t2 is not
+    // cases, it is fine if klass_match == true, other parameters must reveal if t1 and t2 are not
     // of the same type.
     bool klass_match = t1->klass() == nullptr || t2->klass() == nullptr || t1->klass() == t2->klass();
     if (t1->ptr() == TypePtr::Constant && t2->ptr() == TypePtr::Constant &&

--- a/src/hotspot/share/opto/typejavaptr.hpp
+++ b/src/hotspot/share/opto/typejavaptr.hpp
@@ -355,7 +355,8 @@ private:
         if (both_are_exact) {
           return exact_klass != other_klass || exact_type->interfaces() != other_type->interfaces();
         } else {
-          return !exact_klass->is_subtype_of(other_klass) || !exact_type->interfaces()->contains(other_type->interfaces());
+          return !other_klass->is_loaded() || !exact_klass->is_subtype_of(other_klass) ||
+                 !exact_type->interfaces()->contains(other_type->interfaces());
         }
       }
 

--- a/src/hotspot/share/opto/typejavaptr.hpp
+++ b/src/hotspot/share/opto/typejavaptr.hpp
@@ -63,6 +63,11 @@ private:
     Type::Offset offset = meet_offset(t1, t2);
     auto interfaces = meet_interfaces(t1, t2);
     auto flat_in_array = meet_flat_in_array(t1, t2);
+    // Due to value renumbering, types with the same instance_id may correspond to different
+    // allocations. As a result, we may encounter cases when instance_id is not InstanceBot, but
+    // the result is not an exact type, normalize instance_id to InstanceBot then. This is done in
+    // the callees of this function because here we do not know whether the types of the operands
+    // match.
     int instance_id = meet_instance_id(t1, t2);
     auto speculative = meet_speculative(t1, t2);
     int inline_depth = meet_inline_depth(t1, t2);
@@ -70,7 +75,7 @@ private:
     if (base1 != base2) {
       TypePtr::PTR ptr = t1->ptr() == TypePtr::BotPTR || t2->ptr() == TypePtr::BotPTR ? TypePtr::BotPTR : TypePtr::NotNull;
       return OopType::InstType::make(ptr, OopType::ciEnv::current()->Object_klass(), interfaces, false, nullptr, offset,
-                                     flat_in_array, instance_id, speculative, inline_depth);
+                                     flat_in_array, TypeOopPtr::InstanceBot, speculative, inline_depth);
     } else if (base1 == Type::InstPtr) {
       return instptr_type_xmeet(t1->is_instptr(), t2->is_instptr(), offset, interfaces, flat_in_array, instance_id, speculative, inline_depth);
     } else {
@@ -89,6 +94,10 @@ private:
     ConstOopType const_oop = nullptr;
     meet_ptr_and_const_oop(ptr, const_oop, t1, t2);
     bool xk = t1->klass_is_exact() && t2->klass_is_exact() && k1 == k2;
+    if (!xk) {
+      // See oopptr_type_xmeet
+      instance_id = TypeOopPtr::InstanceBot;
+    }
 
     // Consider an unloaded class to be a direct child of j.l.O and not have any subclass
     decltype(k1) k;
@@ -130,6 +139,11 @@ private:
     bool xk = t1->klass_is_exact() && t2->klass_is_exact() && !aryptr_klass_disjoint(t1, t2);
     auto field_offset = t1->field_offset().meet(t2->field_offset());
     bool autobox_cache = t1->is_autobox_cache() && t2->is_autobox_cache();
+
+    if (!xk) {
+      // See oopptr_type_xmeet
+      instance_id = TypeOopPtr::InstanceBot;
+    }
     return AryOopType::make(ptr, const_oop, ary, klass, xk, offset, field_offset, instance_id, speculative, inline_depth, autobox_cache);
   }
 
@@ -246,8 +260,13 @@ private:
 
   template <class AryKlassType>
   static TypePtr::PTR meet_ary_klass_ptr(const AryKlassType* t1, const AryKlassType* t2) {
+    // Sometimes, the klass is computed and cached, sometimes it is not. In general, the only time
+    // we need to compare klass() is when t1->elem() and t2->elem() are both TypeInt::INT. In other
+    // cases, it is fine if klass_match == true, other parameters must reveal if t1 and t2 is not
+    // of the same type.
+    bool klass_match = t1->klass() == nullptr || t2->klass() == nullptr || t1->klass() == t2->klass();
     if (t1->ptr() == TypePtr::Constant && t2->ptr() == TypePtr::Constant &&
-        t1->elem() == t2->elem() && t1->klass() == t2->klass() &&
+        t1->elem() == t2->elem() && klass_match &&
         t1->is_not_flat() == t2->is_not_flat() && t1->is_not_null_free() == t2->is_not_null_free() &&
         t1->is_flat() == t2->is_flat() && t1->is_null_free() == t2->is_null_free() &&
         t1->is_atomic() == t2->is_atomic() && t1->is_refined_type() == t2->is_refined_type()) {

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -323,6 +323,7 @@ public class CtwRunner {
                 "-XX:+StressMacroExpansion",
                 "-XX:+StressMacroElimination",
                 "-XX:+StressIncrementalInlining",
+                "-XX:+StressVerifyMeetJoin",
                 // StressSeed is uint
                 "-XX:StressSeed=" + rng.nextInt(Integer.MAX_VALUE),
                 // Do not fail on huge methods where StressGCM makes register


### PR DESCRIPTION
Hi,

This PR adds `StressVerifyMeetJoin` to `CtwRunner.java`. This uncovers some small implementation issues that are also fixed in this patch.

Testing:

- [x] tier1-4,hs-comp-stress

Please take a look and leave your reviews, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391452](https://bugs.openjdk.org/browse/JDK-8391452): C2: Add StressVerifyMeetJoin to CtwRunner (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32620/head:pull/32620` \
`$ git checkout pull/32620`

Update a local copy of the PR: \
`$ git checkout pull/32620` \
`$ git pull https://git.openjdk.org/jdk.git pull/32620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32620`

View PR using the GUI difftool: \
`$ git pr show -t 32620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32620.diff">https://git.openjdk.org/jdk/pull/32620.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32620#issuecomment-5490272507)
</details>
