### PR TITLE
8391522: G1: Double counting of embedded member in G1CodeRootSetHashTable::mem_size()

### DIFF
--- a/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
@@ -246,7 +246,9 @@ public:
     _table_scanner.set(&_table, BucketClaimSize);
   }
 
-  size_t mem_size() { return sizeof(*this) + _table.get_mem_size(Thread::current()); }
+  size_t mem_size() {
+    return sizeof(*this) - sizeof(_table) + _table.get_mem_size(Thread::current());
+  }
 
   size_t number_of_entries() const { return _num_entries.load_relaxed(); }
 };


### PR DESCRIPTION
Hi all,

  please review this change that fixes a double-counting of an embedded member of `G1CodeRootSet` in its `mem_size()` call. Found during review of JDK-8391351.

Afaict this has been the only remaining such case in g1 code.

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391522](https://bugs.openjdk.org/browse/JDK-8391522): G1: Double counting of embedded member in G1CodeRootSetHashTable::mem_size() (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32621/head:pull/32621` \
`$ git checkout pull/32621`

Update a local copy of the PR: \
`$ git checkout pull/32621` \
`$ git pull https://git.openjdk.org/jdk.git pull/32621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32621`

View PR using the GUI difftool: \
`$ git pr show -t 32621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32621.diff">https://git.openjdk.org/jdk/pull/32621.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32621#issuecomment-5490874792)
</details>
