### PR TITLE
8391545: RISC-V: Implement Zibi extension (branch with immediate)

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -899,6 +899,39 @@ protected:
 
 #undef INSN
 
+  // ==========================
+  // RISC-V Zibi Extension
+  // ==========================
+  // Branch-with-immediate: same B-type instruction and immediate format as
+  // beq/bne, but the field that would carry rs2 in a B-type branch carries the
+  // 5-bit cimm constant. The cimm field is not sign-extended; cimm == 0 encodes
+  // the comparison value -1, while cimm 1..31 encode the values 1..31.
+#define INSN(NAME, op, funct3)                                                                           \
+  void NAME(Register Rs1, uint32_t cimm, const int64_t offset) {                                         \
+    guarantee(is_simm13(offset) && ((offset % 2) == 0), "offset is invalid.");                           \
+    guarantee(is_uimm5(cimm), "cimm is invalid.");                                                        \
+    unsigned insn = 0;                                                                                   \
+    uint32_t val  = offset & 0x1fff;                                                                     \
+    uint32_t val11 = (val >> 11) & 0x1;                                                                  \
+    uint32_t val12 = (val >> 12) & 0x1;                                                                  \
+    uint32_t low  = (val >> 1) & 0xf;                                                                    \
+    uint32_t high = (val >> 5) & 0x3f;                                                                   \
+    patch((address)&insn, 6, 0, op);                                                                     \
+    patch((address)&insn, 14, 12, funct3);                                                               \
+    patch_reg((address)&insn, 15, Rs1);                                                                  \
+    patch((address)&insn, 24, 20, cimm);                                                                 \
+    patch((address)&insn, 7, val11);                                                                     \
+    patch((address)&insn, 11, 8, low);                                                                   \
+    patch((address)&insn, 30, 25, high);                                                                 \
+    patch((address)&insn, 31, val12);                                                                    \
+    emit(insn);                                                                                          \
+  }
+
+  INSN(beqi, 0b1100011, 0b010);
+  INSN(bnei, 0b1100011, 0b011);
+
+#undef INSN
+
  private:
 
   enum StoreWidthFunct3 : uint8_t {
@@ -4176,6 +4209,19 @@ public:
   static bool is_uimm8(uint64_t x);
   static bool is_uimm9(uint64_t x);
   static bool is_uimm10(uint64_t x);
+
+  // Zibi: the comparison constant for beqi/bnei is either -1 or a value in the
+  // range [1, 31]. It is not the same as the encoded cimm field (see the
+  // beqi/bnei encoding above); use encode_zibi_cimm to map a valid constant to
+  // its 5-bit cimm encoding.
+  static bool is_zibi_cimm(int64_t c) {
+    return c == -1 || (c >= 1 && c <= 31);
+  }
+
+  static uint32_t encode_zibi_cimm(int64_t c) {
+    assert(is_zibi_cimm(c), "invalid Zibi comparison constant: " INT64_FORMAT, c);
+    return c == -1 ? 0 : (uint32_t)c;
+  }
 
   // The maximum range of a branch is fixed for the RISCV architecture.
   static const unsigned long branch_range = 1 * M;

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2040,6 +2040,21 @@ void C2_MacroAssembler::enc_cmpEqNe_imm0_branch(int cmpFlag, Register op1, Label
   }
 }
 
+void C2_MacroAssembler::cmpi_branch(int cmpFlag, Register op1, int64_t constant, Label& L, bool is_far) {
+  assert(UseZibi, "must be");
+  uint32_t cimm = Assembler::encode_zibi_cimm(constant);
+  switch (cmpFlag) {
+    case BoolTest::eq:
+      beqi(op1, cimm, L, is_far);
+      break;
+    case BoolTest::ne:
+      bnei(op1, cimm, L, is_far);
+      break;
+    default:
+      ShouldNotReachHere();
+  }
+}
+
 void C2_MacroAssembler::enc_cmove(int cmpFlag, Register op1, Register op2, Register dst, Register src) {
   if (dst != src) {
     bool is_unsigned = (cmpFlag & unsigned_branch_mask) == unsigned_branch_mask;

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -127,6 +127,11 @@
   void enc_cmpEqNe_imm0_branch(int cmpFlag, Register op,
                                Label& L, bool is_far = false);
 
+  // Zibi branch-with-immediate: compare op1 with a small constant (-1 or
+  // [1, 31]) and branch on eq/ne.
+  void cmpi_branch(int cmpFlag, Register op1, int64_t constant,
+                   Label& L, bool is_far = false);
+
   void enc_cmove(int cmpFlag,
                  Register op1, Register op2,
                  Register dst, Register src);

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -117,6 +117,8 @@ define_pd_global(bool, InlineTypeReturnedAsFields, false);
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \
   product(bool, UseZicboz, false, EXPERIMENTAL, "Use Zicboz instructions")       \
   product(bool, UseZicond, false, DIAGNOSTIC, "Use Zicond instructions")         \
+  product(bool, UseZibi, false, EXPERIMENTAL,                                    \
+          "Use Zibi (branch with immediate) instructions")                       \
   product(bool, UseZihintpause, false, EXPERIMENTAL,                             \
           "Use Zihintpause instructions")                                        \
   product(bool, UseZtso, false, EXPERIMENTAL, "Assume Ztso memory model")        \

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1219,6 +1219,26 @@ void MacroAssembler::wrap_label(Register r1, Register r2, Label &L,
   }
 }
 
+// Zibi branch-with-immediate. The far form is realized by negating the
+// condition (beqi <-> bnei) over the same comparison constant and jumping.
+void MacroAssembler::wrap_label(Register r1, uint32_t cimm, Label &L,
+                                cimm_branch_insn insn,
+                                cimm_branch_label_insn neg_insn, bool is_far) {
+  if (is_far) {
+    Label done;
+    (this->*neg_insn)(r1, cimm, done, /* is_far */ false);
+    j(L);
+    bind(done);
+  } else {
+    if (L.is_bound()) {
+      (this->*insn)(r1, cimm, target(L));
+    } else {
+      L.add_patch_at(code(), locator());
+      (this->*insn)(r1, cimm, pc());
+    }
+  }
+}
+
 #define INSN(NAME, NEG_INSN)                                                              \
   void MacroAssembler::NAME(Register Rs1, Register Rs2, Label &L, bool is_far) {          \
     wrap_label(Rs1, Rs2, L, &MacroAssembler::NAME, &MacroAssembler::NEG_INSN, is_far);    \
@@ -1230,6 +1250,16 @@ void MacroAssembler::wrap_label(Register r1, Register r2, Label &L,
   INSN(bge,  blt);
   INSN(bltu, bgeu);
   INSN(bgeu, bltu);
+
+#undef INSN
+
+#define INSN(NAME, NEG_INSN)                                                              \
+  void MacroAssembler::NAME(Register Rs1, uint32_t cimm, Label &L, bool is_far) {         \
+    wrap_label(Rs1, cimm, L, &MacroAssembler::NAME, &MacroAssembler::NEG_INSN, is_far);   \
+  }
+
+  INSN(beqi, bnei);
+  INSN(bnei, beqi);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -806,6 +806,10 @@ class MacroAssembler: public Assembler {
   void bgtu(Register Rs, Register Rt, Label &l, bool is_far = false);
   void bleu(Register Rs, Register Rt, Label &l, bool is_far = false);
 
+  // Zibi branch-with-immediate (label form)
+  void beqi(Register Rs1, uint32_t cimm, Label &L, bool is_far = false);
+  void bnei(Register Rs1, uint32_t cimm, Label &L, bool is_far = false);
+
 #define INSN_ENTRY_RELOC(result_type, header)                               \
   result_type header {                                                      \
     guarantee(rtype == relocInfo::internal_word_type,                       \
@@ -832,6 +836,25 @@ class MacroAssembler: public Assembler {
   INSN(bgeu);
   INSN(blt);
   INSN(bltu);
+
+#undef INSN
+
+  // Zibi branch-with-immediate (address form)
+#define INSN(NAME)                                                                                       \
+  void NAME(Register Rs1, uint32_t cimm, const address dest) {                                           \
+    assert_cond(dest != nullptr);                                                                        \
+    int64_t offset = dest - pc();                                                                        \
+    guarantee(is_simm13(offset) && is_even(offset),                                                      \
+              "offset is invalid: is_simm_13: %s offset: " INT64_FORMAT,                                 \
+              BOOL_TO_STR(is_simm13(offset)), offset);                                                   \
+    Assembler::NAME(Rs1, cimm, offset);                                                                  \
+  }                                                                                                      \
+  INSN_ENTRY_RELOC(void, NAME(Register Rs1, uint32_t cimm, address dest, relocInfo::relocType rtype))    \
+    NAME(Rs1, cimm, dest);                                                                               \
+  }
+
+  INSN(beqi);
+  INSN(bnei);
 
 #undef INSN
 
@@ -917,10 +940,17 @@ public:
   typedef void (MacroAssembler::* compare_and_branch_label_insn)(Register Rs1, Register Rs2, Label &L, bool is_far);
   typedef void (MacroAssembler::* jal_jalr_insn)(Register Rt, address dest);
 
+  // Zibi branch-with-immediate (beqi/bnei).
+  typedef void (MacroAssembler::* cimm_branch_insn)(Register Rs1, uint32_t cimm, const address dest);
+  typedef void (MacroAssembler::* cimm_branch_label_insn)(Register Rs1, uint32_t cimm, Label &L, bool is_far);
+
   void wrap_label(Register r, Label &L, jal_jalr_insn insn);
   void wrap_label(Register r1, Register r2, Label &L,
                   compare_and_branch_insn insn,
                   compare_and_branch_label_insn neg_insn, bool is_far = false);
+  void wrap_label(Register r1, uint32_t cimm, Label &L,
+                  cimm_branch_insn insn,
+                  cimm_branch_label_insn neg_insn, bool is_far = false);
 
   void la(Register Rd, Label &label);
   void la(Register Rd, const address addr);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2764,6 +2764,28 @@ operand immL5()
   interface(CONST_INTER);
 %}
 
+// Zibi branch-with-immediate comparison constant (int): -1 or [1, 31].
+operand immIZibi()
+%{
+  predicate(UseZibi && Assembler::is_zibi_cimm((int64_t)n->get_int()));
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+// Zibi branch-with-immediate comparison constant (long): -1 or [1, 31].
+operand immLZibi()
+%{
+  predicate(UseZibi && Assembler::is_zibi_cimm(n->get_long()));
+  match(ConL);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 // Integer operands 64 bit
 // 64 bit immediate
 operand immL()
@@ -10085,6 +10107,84 @@ instruct cmpP_narrowOop_imm0_branch(cmpOpEqNe cmp, iRegN op1, immP0 zero, label 
   ins_short_branch(1);
 %}
 
+// Zibi: compare signed int with small immediate and branch near instructions
+instruct cmpI_imm_branch(cmpOpEqNe cmp, iRegI op1, immIZibi imm, label lbl)
+%{
+  predicate(UseZibi);
+  // Same match rule as `far_cmpI_imm_branch'.
+  match(If cmp (CmpI op1 imm));
+
+  effect(USE lbl);
+
+  ins_cost(BRANCH_COST);
+  format %{ "b$cmp  $op1, $imm, $lbl\t#@cmpI_imm_branch" %}
+
+  ins_encode %{
+    __ cmpi_branch($cmp$$cmpcode, as_Register($op1$$reg), $imm$$constant, *($lbl$$label));
+  %}
+
+  ins_pipe(pipe_cmp_branch);
+  ins_short_branch(1);
+%}
+
+instruct cmpI_imm_loop(cmpOpEqNe cmp, iRegI op1, immIZibi imm, label lbl)
+%{
+  predicate(UseZibi);
+  // Same match rule as `far_cmpI_imm_loop'.
+  match(CountedLoopEnd cmp (CmpI op1 imm));
+
+  effect(USE lbl);
+
+  ins_cost(BRANCH_COST);
+  format %{ "b$cmp  $op1, $imm, $lbl\t#@cmpI_imm_loop" %}
+
+  ins_encode %{
+    __ cmpi_branch($cmp$$cmpcode, as_Register($op1$$reg), $imm$$constant, *($lbl$$label));
+  %}
+
+  ins_pipe(pipe_cmp_branch);
+  ins_short_branch(1);
+%}
+
+// Zibi: compare signed long with small immediate and branch near instructions
+instruct cmpL_imm_branch(cmpOpEqNe cmp, iRegL op1, immLZibi imm, label lbl)
+%{
+  predicate(UseZibi);
+  // Same match rule as `far_cmpL_imm_branch'.
+  match(If cmp (CmpL op1 imm));
+
+  effect(USE lbl);
+
+  ins_cost(BRANCH_COST);
+  format %{ "b$cmp  $op1, $imm, $lbl\t#@cmpL_imm_branch" %}
+
+  ins_encode %{
+    __ cmpi_branch($cmp$$cmpcode, as_Register($op1$$reg), $imm$$constant, *($lbl$$label));
+  %}
+
+  ins_pipe(pipe_cmp_branch);
+  ins_short_branch(1);
+%}
+
+instruct cmpL_imm_loop(cmpOpEqNe cmp, iRegL op1, immLZibi imm, label lbl)
+%{
+  predicate(UseZibi);
+  // Same match rule as `far_cmpL_imm_loop'.
+  match(CountedLoopEnd cmp (CmpL op1 imm));
+
+  effect(USE lbl);
+
+  ins_cost(BRANCH_COST);
+  format %{ "b$cmp  $op1, $imm, $lbl\t#@cmpL_imm_loop" %}
+
+  ins_encode %{
+    __ cmpi_branch($cmp$$cmpcode, as_Register($op1$$reg), $imm$$constant, *($lbl$$label));
+  %}
+
+  ins_pipe(pipe_cmp_branch);
+  ins_short_branch(1);
+%}
+
 // Patterns for far (20KiB) variants
 
 instruct far_cmpFlag_branch(cmpOp cmp, rFlagsReg cr, label lbl) %{
@@ -10437,6 +10537,68 @@ instruct far_cmpP_narrowOop_imm0_branch(cmpOpEqNe cmp, iRegN op1, immP0 zero, la
   %}
 
   ins_pipe(pipe_cmpz_branch);
+%}
+
+// Zibi: compare signed int with small immediate and branch far instructions
+instruct far_cmpI_imm_branch(cmpOpEqNe cmp, iRegI op1, immIZibi imm, label lbl) %{
+  predicate(UseZibi);
+  match(If cmp (CmpI op1 imm));
+  effect(USE lbl);
+
+  ins_cost(BRANCH_COST * 2);
+  format %{ "far_b$cmp  $op1, $imm, $lbl\t#@far_cmpI_imm_branch" %}
+
+  ins_encode %{
+    __ cmpi_branch($cmp$$cmpcode, as_Register($op1$$reg), $imm$$constant, *($lbl$$label), /* is_far */ true);
+  %}
+
+  ins_pipe(pipe_cmp_branch);
+%}
+
+instruct far_cmpI_imm_loop(cmpOpEqNe cmp, iRegI op1, immIZibi imm, label lbl) %{
+  predicate(UseZibi);
+  match(CountedLoopEnd cmp (CmpI op1 imm));
+  effect(USE lbl);
+
+  ins_cost(BRANCH_COST * 2);
+  format %{ "far_b$cmp  $op1, $imm, $lbl\t#@far_cmpI_imm_loop" %}
+
+  ins_encode %{
+    __ cmpi_branch($cmp$$cmpcode, as_Register($op1$$reg), $imm$$constant, *($lbl$$label), /* is_far */ true);
+  %}
+
+  ins_pipe(pipe_cmp_branch);
+%}
+
+// Zibi: compare signed long with small immediate and branch far instructions
+instruct far_cmpL_imm_branch(cmpOpEqNe cmp, iRegL op1, immLZibi imm, label lbl) %{
+  predicate(UseZibi);
+  match(If cmp (CmpL op1 imm));
+  effect(USE lbl);
+
+  ins_cost(BRANCH_COST * 2);
+  format %{ "far_b$cmp  $op1, $imm, $lbl\t#@far_cmpL_imm_branch" %}
+
+  ins_encode %{
+    __ cmpi_branch($cmp$$cmpcode, as_Register($op1$$reg), $imm$$constant, *($lbl$$label), /* is_far */ true);
+  %}
+
+  ins_pipe(pipe_cmp_branch);
+%}
+
+instruct far_cmpL_imm_loop(cmpOpEqNe cmp, iRegL op1, immLZibi imm, label lbl) %{
+  predicate(UseZibi);
+  match(CountedLoopEnd cmp (CmpL op1 imm));
+  effect(USE lbl);
+
+  ins_cost(BRANCH_COST * 2);
+  format %{ "far_b$cmp  $op1, $imm, $lbl\t#@far_cmpL_imm_loop" %}
+
+  ins_encode %{
+    __ cmpi_branch($cmp$$cmpcode, as_Register($op1$$reg), $imm$$constant, *($lbl$$label), /* is_far */ true);
+  %}
+
+  ins_pipe(pipe_cmp_branch);
 %}
 
 // ============================================================================

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -272,6 +272,8 @@ class VM_Version : public Abstract_VM_Version {
   decl(Zicntr      ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                         \
   /* Zicond Conditional operations */                                                                     \
   decl(Zicond      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicond))                                 \
+  /* Zibi Branch with immediate */                                                                        \
+  decl(Zibi        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZibi))                                   \
   /* Zicsr Control and Status Register (CSR) Instructions */                                              \
   decl(Zicsr       ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                         \
   /* Zic64b Cache blocks must be 64 bytes in size, naturally aligned in the address space. */             \
@@ -526,6 +528,12 @@ private:
   // RISCV64 supports fast class initialization checks
   static bool supports_fast_class_init_checks() { return true; }
   static bool supports_fencei_barrier() { return ext_Zifencei.enabled(); }
+
+  // Whether the current CPU actually implements the Zibi branch-with-immediate
+  // extension. Distinct from the UseZibi flag: UseZibi merely requests codegen,
+  // while this reflects detected hardware capability. Used to guard tests that
+  // execute beqi/bnei so they do not SIGILL on hardware without Zibi.
+  static bool supports_Zibi() { return ext_Zibi.enabled(); }
 
   static bool supports_float16_float_conversion() {
     return UseZfh || UseZfhmin;

--- a/test/hotspot/gtest/riscv/test_assembler_riscv.cpp
+++ b/test/hotspot/gtest/riscv/test_assembler_riscv.cpp
@@ -30,6 +30,7 @@
 #include "memory/resourceArea.hpp"
 #include "metaprogramming/enableIf.hpp"
 #include "runtime/orderAccess.hpp"
+#include "runtime/vm_version.hpp"
 #include "threadHelper.inline.hpp"
 #include "unittest.hpp"
 
@@ -834,6 +835,133 @@ TEST_VM(RiscV, weak_cmpxchg_int8_concurrent_maybe_zacas_zabha) {
     run_concurrent_weak_cmpxchg_tests<int8_t, Assembler::int8>();
     run_concurrent_alt_weak_cmpxchg_tests<int8_t, Assembler::int8>();
   }
+}
+
+// ------------------------------ Zibi ---------------------------------------
+
+// Decode the B-immediate (in bytes) out of an already-emitted beqi/bnei word.
+static int64_t zibi_decode_offset(uint32_t insn) {
+  int64_t offset = 0;
+  offset |= (int64_t)((insn >> 31) & 0x1)  << 12; // imm[12]
+  offset |= (int64_t)((insn >> 7)  & 0x1)  << 11; // imm[11]
+  offset |= (int64_t)((insn >> 25) & 0x3f) << 5;  // imm[10:5]
+  offset |= (int64_t)((insn >> 8)  & 0xf)  << 1;  // imm[4:1]
+  // Sign-extend the 13-bit signed offset.
+  offset = (offset << 51) >> 51;
+  return offset;
+}
+
+// Verify that beqi/bnei encode exactly as the Zibi spec prescribes:
+//  opcode = 0b1100011, funct3 = 010 (beqi) / 011 (bnei), rs1 in [19:15],
+//  cimm in [24:20], and the standard B-type immediate scatter.
+static void check_zibi_encoding(bool is_beqi, Register rs1, uint32_t cimm, int64_t offset) {
+  BufferBlob* bb = BufferBlob::create("zibiEnc", 128);
+  CodeBuffer code(bb);
+  MacroAssembler _masm(&code);
+  address entry = _masm.pc();
+  if (is_beqi) {
+    _masm.beqi(rs1, cimm, entry + offset);
+  } else {
+    _masm.bnei(rs1, cimm, entry + offset);
+  }
+  _masm.flush();
+
+  uint32_t insn = Assembler::ld_instr(entry);
+  EXPECT_EQ(insn & 0x7f, (uint32_t)0b1100011)           << "opcode";
+  EXPECT_EQ((insn >> 12) & 0x7, is_beqi ? 0b010u : 0b011u) << "funct3";
+  EXPECT_EQ((insn >> 15) & 0x1f, (uint32_t)rs1->encoding()) << "rs1";
+  EXPECT_EQ((insn >> 20) & 0x1f, cimm)                  << "cimm";
+  EXPECT_EQ(zibi_decode_offset(insn), offset)           << "offset";
+
+  BufferBlob::free(bb);
+}
+
+TEST_VM(RiscV, zibi_encoding) {
+  // cimm covers the full 5-bit range: 0 (encodes value -1) through 31.
+  for (uint32_t cimm = 0; cimm <= 31; cimm++) {
+    check_zibi_encoding(true,  x5,  cimm, 4);
+    check_zibi_encoding(false, x5,  cimm, 4);
+  }
+  // Exercise different source registers.
+  check_zibi_encoding(true,  x0,  1, 8);
+  check_zibi_encoding(true,  x31, 7, 16);
+  check_zibi_encoding(false, x1,  31, 2);
+  // Exercise the full B-immediate bit scatter, forward and backward.
+  check_zibi_encoding(true,  x10, 5, 4094);
+  check_zibi_encoding(true,  x10, 5, -4096);
+  check_zibi_encoding(false, x10, 5, 2048);
+  check_zibi_encoding(false, x10, 5, -2048);
+  check_zibi_encoding(true,  x10, 5, 42);
+}
+
+// The comparison constant maps to the cimm field as: -1 -> 0, 1..31 -> 1..31.
+TEST_VM(RiscV, zibi_encode_cimm) {
+  EXPECT_TRUE(Assembler::is_zibi_cimm(-1));
+  EXPECT_TRUE(Assembler::is_zibi_cimm(1));
+  EXPECT_TRUE(Assembler::is_zibi_cimm(31));
+  EXPECT_FALSE(Assembler::is_zibi_cimm(0));
+  EXPECT_FALSE(Assembler::is_zibi_cimm(32));
+  EXPECT_FALSE(Assembler::is_zibi_cimm(-2));
+
+  EXPECT_EQ(Assembler::encode_zibi_cimm(-1), 0u);
+  EXPECT_EQ(Assembler::encode_zibi_cimm(1), 1u);
+  EXPECT_EQ(Assembler::encode_zibi_cimm(31), 31u);
+}
+
+typedef int64_t (*zibi_func)(int64_t arg);
+
+// Emit: <branch> arg, cimm, taken; mv a0, not_taken_val; ret; taken: mv a0, taken_val; ret;
+static int64_t run_zibi_branch(bool is_beqi, uint32_t cimm, int64_t arg) {
+  const int64_t taken_val = 1;
+  const int64_t not_taken_val = 0;
+  BufferBlob* bb = BufferBlob::create("zibiRun", 256);
+  CodeBuffer code(bb);
+  MacroAssembler _masm(&code);
+  address entry = _masm.pc();
+  {
+    Label taken;
+    if (is_beqi) {
+      _masm.beqi(c_rarg0, cimm, taken);
+    } else {
+      _masm.bnei(c_rarg0, cimm, taken);
+    }
+    _masm.mv(c_rarg0, not_taken_val);
+    _masm.ret();
+    _masm.bind(taken);
+    _masm.mv(c_rarg0, taken_val);
+    _masm.ret();
+  }
+  _masm.flush();
+  int64_t ret = ((zibi_func)entry)(arg);
+  BufferBlob::free(bb);
+  return ret;
+}
+
+TEST_VM(RiscV, zibi_execution) {
+  // Only run if the current CPU actually implements Zibi. UseZibi alone is not
+  // sufficient: a user can request -XX:+UseZibi on hardware without the
+  // extension, and executing beqi/bnei there would SIGILL. supports_Zibi()
+  // reflects detected hardware capability, so require both.
+  if (!UseZibi || !VM_Version::supports_Zibi()) {
+    return;
+  }
+  // cimm == 0 decodes to the comparison value -1.
+  EXPECT_EQ(run_zibi_branch(true, 0, -1), 1); // beqi: -1 == -1 -> taken
+  EXPECT_EQ(run_zibi_branch(true, 0, 0), 0);  // beqi: 0 == -1 -> not taken
+  EXPECT_EQ(run_zibi_branch(false, 0, -1), 0); // bnei: -1 != -1 -> not taken
+  EXPECT_EQ(run_zibi_branch(false, 0, 0), 1);  // bnei: 0 != -1 -> taken
+
+  // cimm in [1, 31] decodes to the corresponding positive value.
+  EXPECT_EQ(run_zibi_branch(true, 1, 1), 1);
+  EXPECT_EQ(run_zibi_branch(true, 1, 2), 0);
+  EXPECT_EQ(run_zibi_branch(true, 31, 31), 1);
+  EXPECT_EQ(run_zibi_branch(true, 31, 30), 0);
+  EXPECT_EQ(run_zibi_branch(false, 7, 7), 0);
+  EXPECT_EQ(run_zibi_branch(false, 7, 8), 1);
+  // Comparison constant is zero-extended to XLEN, so a negative arg never
+  // equals a positive cimm.
+  EXPECT_EQ(run_zibi_branch(true, 5, -5), 0);
+  EXPECT_EQ(run_zibi_branch(false, 5, -5), 1);
 }
 
 #endif  // RISCV

--- a/test/hotspot/jtreg/compiler/c2/riscv64/TestZibiBranch.java
+++ b/test/hotspot/jtreg/compiler/c2/riscv64/TestZibiBranch.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Verify C2 selects beqi/bnei for the Zibi branch-with-immediate
+ *          extension. Runs only on hardware that implements Zibi (see note
+ *          below) and force-enables -XX:+UseZibi.
+ * @library /test/lib /
+ * @requires os.arch == "riscv64" & vm.cpu.features ~= ".*zibi.*"
+ * @run main/othervm compiler.c2.riscv64.TestZibiBranch
+ */
+
+package compiler.c2.riscv64;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+// This test follows the conservative "run only on real hardware support"
+// policy: it verifies that C2 actually selects beqi/bnei for the Zibi
+// branch-with-immediate extension, and only runs where Zibi is present.
+//
+// Zibi source: there is currently no Linux hwprobe/HWCAP bit for Zibi, so the
+// only mechanism that reports it in vm.cpu.features is the vendor detection
+// path (PicoHeart Jupiter A2 enables ext_Zibi, whose feature string "zibi" is
+// then appended to vm.cpu.features). The @requires gate above therefore only
+// selects this test on hardware where Zibi was reliably detected. Each @IR rule
+// is additionally gated with applyIfCPUFeature={"zibi","true"} so the codegen
+// checks fire only when the VM confirms the feature is active.
+//
+// Each test method is shaped as a one-armed `if` with a store side effect so
+// that C2 keeps a real two-way branch (a boolean-returning comparison would be
+// folded into a branchless set/CMove sequence and would never select beqi/bnei).
+//
+// Zibi has no dedicated IR node; the CmpI/CmpL near/far branch instructs are the
+// only place the extension shows up. We therefore match the instruct `format`
+// marker (`#@cmpI_imm_branch` / `#@cmpL_imm_branch`, which also matches the
+// `far_` variants as a substring) against the PrintOptoAssembly output. Without
+// this the test would silently pass even if codegen fell back to a materialize-
+// plus-reg-reg branch.
+public class TestZibiBranch {
+
+    static int  intCounter;
+    static long longCounter;
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:-TieredCompilation",
+                                   "-XX:CompileThresholdScaling=0.3",
+                                   "-XX:+UnlockExperimentalVMOptions",
+                                   "-XX:+UseZibi");
+    }
+
+    // ---- int: constants Zibi CAN encode -> must select the Zibi branch ----
+
+    // cimm == 0 encodes the comparison value -1.
+    @Test
+    @IR(counts = {"cmpI_imm_branch", ">= 1"},
+        applyIfCPUFeature = {"zibi", "true"},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    static void eqI_m1(int x) {
+        if (x == -1) {
+            intCounter++;
+        }
+    }
+
+    @Test
+    @IR(counts = {"cmpI_imm_branch", ">= 1"},
+        applyIfCPUFeature = {"zibi", "true"},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    static void neI_1(int x) {
+        if (x != 1) {
+            intCounter++;
+        }
+    }
+
+    @Test
+    @IR(counts = {"cmpI_imm_branch", ">= 1"},
+        applyIfCPUFeature = {"zibi", "true"},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    static void eqI_31(int x) {
+        if (x == 31) {
+            intCounter++;
+        }
+    }
+
+    // ---- int: constants Zibi CANNOT encode -> must fall back, no Zibi branch ----
+
+    @Test
+    @IR(failOn = {"cmpI_imm_branch"},
+        applyIfCPUFeature = {"zibi", "true"},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    static void eqI_32(int x) {
+        if (x == 32) {
+            intCounter++;
+        }
+    }
+
+    @Test
+    @IR(failOn = {"cmpI_imm_branch"},
+        applyIfCPUFeature = {"zibi", "true"},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    static void eqI_0(int x) {
+        if (x == 0) {
+            intCounter++;
+        }
+    }
+
+    // ---- long: constants Zibi CAN encode -> must select the Zibi branch ----
+
+    @Test
+    @IR(counts = {"cmpL_imm_branch", ">= 1"},
+        applyIfCPUFeature = {"zibi", "true"},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    static void eqL_m1(long x) {
+        if (x == -1L) {
+            longCounter++;
+        }
+    }
+
+    @Test
+    @IR(counts = {"cmpL_imm_branch", ">= 1"},
+        applyIfCPUFeature = {"zibi", "true"},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    static void neL_7(long x) {
+        if (x != 7L) {
+            longCounter++;
+        }
+    }
+
+    // ---- long: constant Zibi CANNOT encode -> must fall back, no Zibi branch ----
+
+    @Test
+    @IR(failOn = {"cmpL_imm_branch"},
+        applyIfCPUFeature = {"zibi", "true"},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    static void eqL_32(long x) {
+        if (x == 32L) {
+            longCounter++;
+        }
+    }
+
+    @Run(test = {"eqI_m1", "neI_1", "eqI_31", "eqI_32", "eqI_0",
+                 "eqL_m1", "neL_7", "eqL_32"})
+    static void run() {
+        // Exercise both directions of every branch so the profile keeps a real
+        // two-way branch (avoids the untaken side being pruned to an uncommon
+        // trap) and so the functional result stays verifiable.
+
+        // --- int, Zibi-encodable ---
+        intCounter = 0;
+        eqI_m1(-1);            // -1 == -1 -> taken
+        eqI_m1(0);             // not taken
+        eqI_m1(-2);            // not taken
+        Asserts.assertEQ(intCounter, 1);
+
+        intCounter = 0;
+        neI_1(0);              // 0 != 1 -> taken
+        neI_1(2);              // taken
+        neI_1(1);              // not taken
+        Asserts.assertEQ(intCounter, 2);
+
+        intCounter = 0;
+        eqI_31(31);            // taken
+        eqI_31(30);            // not taken
+        Asserts.assertEQ(intCounter, 1);
+
+        // --- int, fallback (constant out of {-1, 1..31}) ---
+        intCounter = 0;
+        eqI_32(32);            // taken
+        eqI_32(31);            // not taken
+        Asserts.assertEQ(intCounter, 1);
+
+        intCounter = 0;
+        eqI_0(0);              // taken
+        eqI_0(1);              // not taken
+        Asserts.assertEQ(intCounter, 1);
+
+        // --- long, Zibi-encodable ---
+        longCounter = 0;
+        eqL_m1(-1L);           // taken
+        eqL_m1(0L);            // not taken
+        Asserts.assertEQ(longCounter, 1L);
+
+        longCounter = 0;
+        neL_7(8L);             // taken
+        neL_7(7L);             // not taken
+        Asserts.assertEQ(longCounter, 1L);
+
+        // --- long, fallback ---
+        longCounter = 0;
+        eqL_32(32L);           // taken
+        eqL_32(31L);           // not taken
+        Asserts.assertEQ(longCounter, 1L);
+    }
+}


### PR DESCRIPTION
Add JVM/HotSpot support for the RISC-V Zibi extension (v0.7), which
defines two B-type conditional branches that compare an integer register
against a small immediate constant:
```
  beqi rs1, cimm, offset   (funct3=0b010): branch if rs1 == constant
  bnei rs1, cimm, offset   (funct3=0b011): branch if rs1 != constant
```
Both reuse the BRANCH major opcode and the standard B-type immediate
layout; the 5-bit field that would hold rs2 carries cimm instead. The
comparison constant decodes as cimm=0 -> -1 and cimm=1..31 -> 1..31
(comparison with zero keeps using beq/bne with x0).

Spec: https://github.com/riscv/zibi/blob/main/src/unpriv/zibi.adoc

Changes:
  - Add the UseZibi flag and ext_Zibi feature detection. Auto-detection
    is left unwired because there is no hwprobe/HWCAP bit yet; enable
    with -XX:+UseZibi.
  - Add the beqi/bnei encodings plus is_zibi_cimm/encode_zibi_cimm
    helpers in the assembler.
  - Add near/far label and address forms in the MacroAssembler, with the
    far form realized by negating the condition (beqi <-> bnei) over the
    same constant.
  - Add the C2 cmpi_branch encoder helper.
  - Add immIZibi/immLZibi operands and the CmpI/CmpL near/far branch and
    loop instructs, all gated on UseZibi so codegen falls back to
    materialize-plus-reg-branch when the extension is off.

The existing conditional-branch bind/patch machinery works unchanged
because beqi/bnei share the BRANCH opcode and B-immediate layout.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391545](https://bugs.openjdk.org/browse/JDK-8391545): RISC-V: Implement Zibi extension (branch with immediate) (**Enhancement** - P4)


### Contributors
 * Pengcheng Wang `<wangpengcheng.pp@bytedance.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32624/head:pull/32624` \
`$ git checkout pull/32624`

Update a local copy of the PR: \
`$ git checkout pull/32624` \
`$ git pull https://git.openjdk.org/jdk.git pull/32624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32624`

View PR using the GUI difftool: \
`$ git pr show -t 32624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32624.diff">https://git.openjdk.org/jdk/pull/32624.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32624#issuecomment-5492230721)
</details>
