### PR TITLE
8391280: [Valhalla] PhaseMacroExpand::expand_flatarraycheck_node asserts with "Mixing array and klass inputs"

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4937,7 +4937,7 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
   Node* bol;
   switch(check) {
     case IsFlat:
-      bol = flat_array_test(load_object_klass(array));
+      bol = flat_array_test(array);
       break;
     case IsNullRestricted:
       bol = null_free_array_test(array);
@@ -4947,8 +4947,7 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
       // 1. If not flat, then atomic, or else...
       RegionNode* atomic_region = new RegionNode(1);
       RegionNode* non_atomic_region = new RegionNode(1);
-      Node* array_klass = load_object_klass(array);
-      Node* is_flat_bol = flat_array_test(array_klass);
+      Node* is_flat_bol = flat_array_test(array);
       IfNode* iff_is_flat = create_and_xform_if(control(), is_flat_bol, PROB_FAIR, COUNT_UNKNOWN);
       atomic_region->add_req(_gvn.transform(new IfFalseNode(iff_is_flat)));
       set_control(_gvn.transform(new IfTrueNode(iff_is_flat)));
@@ -4957,6 +4956,7 @@ bool LibraryCallKit::inline_getArrayProperties(ArrayPropertiesCheck check) {
       Node* layout_kind = atomic_layout_array_test_and_get_layout_kind(array, atomic_region);
 
       // 3. ...if the element type is naturally atomic and null-free OR empty and nullable, then atomic, or else...
+      Node* array_klass = load_object_klass(array);
       int element_klass_offset = in_bytes(ObjArrayKlass::element_klass_offset());
       Node* array_element_klass_addr = off_heap_plus_addr(array_klass, element_klass_offset);
       Node* array_element_klass = _gvn.transform(LoadKlassNode::make(_gvn, immutable_memory(), array_element_klass_addr, _gvn.type(array_klass)->is_klassptr()));
@@ -5263,7 +5263,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
     if (Arguments::is_valhalla_enabled()) {
       // Handle inline type arrays
       // TODO 8251971 This is too strong
-      generate_fair_guard(flat_array_test(load_object_klass(original)), bailout);
+      generate_fair_guard(flat_array_test(original), bailout);
       generate_fair_guard(flat_array_test(refined_klass_node), bailout);
       generate_fair_guard(null_free_array_test(original), bailout);
     }
@@ -6320,7 +6320,7 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
           (ary_ptr == nullptr || (!ary_ptr->is_not_flat() && (!ary_ptr->is_flat() || ary_ptr->elem()->inline_klass()->contains_oops())))) {
         // Flat inline type array may have object field that would require a
         // write barrier. Conservatively, go to slow path.
-        generate_fair_guard(flat_array_test(obj_klass), slow_region);
+        generate_fair_guard(flat_array_test(obj), slow_region);
       }
 
       if (!stopped()) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3076,20 +3076,38 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
   _igvn.replace_node(check, C->top());
 }
 
-// FlatArrayCheckNode (array1 array2 ...) is expanded into:
+// FlatArrayCheckNode (array_or_klass1 array_or_klass2 ...) is expanded using
+// mark words if all inputs are arrays and all users are If nodes:
 //
 // long mark = array1.mark | array2.mark | ...;
 // long locked_bit = markWord::unlocked_value & array1.mark & array2.mark & ...;
 // if (locked_bit == 0) {
-//   // One array is locked, load prototype header from the klass
-//   mark = array1.klass.proto | array2.klass.proto | ...
+//   // One array is locked, load its prototype header from the klass
+//   mark = array1.klass.proto | array2.klass.proto | ...;
 // }
 // if ((mark & markWord::flat_array_bit_in_place) == 0) {
-//    ...
+//   ...
+// }
+//
+// Otherwise, it is expanded using the klass layout helpers:
+//
+// int layout = klass(array_or_klass1).layout_helper |
+//              klass(array_or_klass2).layout_helper | ...;
+// if ((layout & Klass::_lh_array_tag_flat_value_bit_inplace) == 0) {
+//   ...
 // }
 void PhaseMacroExpand::expand_flatarraycheck_node(FlatArrayCheckNode* check) {
-  bool array_inputs = _igvn.type(check->in(FlatArrayCheckNode::ArrayOrKlass))->isa_oopptr() != nullptr;
-  if (array_inputs) {
+  bool use_mark_word = _igvn.type(check->in(FlatArrayCheckNode::ArrayOrKlass))->isa_oopptr() != nullptr;
+  Node* bol = check->unique_out();
+  for (DUIterator_Fast imax, i = bol->fast_outs(imax); i < imax; i++) {
+    if (!bol->fast_out(i)->is_If()) {
+      // No control input, fall back to layout helper check
+      use_mark_word = false;
+      break;
+    }
+  }
+
+  if (use_mark_word) {
     Node* mark = MakeConX(0);
     Node* locked_bit = MakeConX(markWord::unlocked_value);
     Node* mem = check->in(FlatArrayCheckNode::Memory);
@@ -3108,10 +3126,9 @@ void PhaseMacroExpand::expand_flatarraycheck_node(FlatArrayCheckNode* check) {
     Node* is_unlocked = _igvn.transform(new BoolNode(cmp, BoolTest::ne));
 
     // BoolNode might be shared, replace each if user
-    Node* old_bol = check->unique_out();
-    assert(old_bol->is_Bool() && old_bol->as_Bool()->_test._test == BoolTest::ne, "unexpected condition");
-    for (DUIterator_Last imin, i = old_bol->last_outs(imin); i >= imin; --i) {
-      IfNode* old_iff = old_bol->last_out(i)->as_If();
+    assert(bol->is_Bool() && bol->as_Bool()->_test._test == BoolTest::ne, "unexpected condition");
+    for (DUIterator_Last imin, i = bol->last_outs(imin); i >= imin; --i) {
+      IfNode* old_iff = bol->last_out(i)->as_If();
       Node* ctrl = old_iff->in(0);
       RegionNode* region = new RegionNode(3);
       Node* mark_phi = new PhiNode(region, TypeX_X);
@@ -3170,18 +3187,16 @@ void PhaseMacroExpand::expand_flatarraycheck_node(FlatArrayCheckNode* check) {
     }
     Node* masked = transform_later(new AndINode(lhs, intcon(Klass::_lh_array_tag_flat_value_bit_inplace)));
     Node* cmp = transform_later(new CmpINode(masked, intcon(0)));
-    Node* bol = transform_later(new BoolNode(cmp, BoolTest::eq));
+    Node* new_bol = transform_later(new BoolNode(cmp, BoolTest::eq));
     Node* m2b = transform_later(new Conv2BNode(masked));
     // The matcher expects the input to If/CMove nodes to be produced by a Bool(CmpI..)
     // pattern, but the input to other potential users (e.g. Phi) to be some
     // other pattern (e.g. a Conv2B node, possibly idealized as a CMoveI).
-    Node* old_bol = check->unique_out();
-    for (DUIterator_Last imin, i = old_bol->last_outs(imin); i >= imin; --i) {
-      Node* user = old_bol->last_out(i);
+    for (DUIterator_Last imin, i = bol->last_outs(imin); i >= imin; --i) {
+      Node* user = bol->last_out(i);
       for (uint j = 0; j < user->req(); j++) {
-        Node* n = user->in(j);
-        if (n == old_bol) {
-          _igvn.replace_input_of(user, j, (user->is_If() || user->is_CMove()) ? bol : m2b);
+        if (user->in(j) == bol) {
+          _igvn.replace_input_of(user, j, (user->is_If() || user->is_CMove()) ? new_bol : m2b);
         }
       }
     }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -3076,8 +3076,11 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
   _igvn.replace_node(check, C->top());
 }
 
-// FlatArrayCheckNode (array_or_klass1 array_or_klass2 ...) is expanded using
-// mark words if all inputs are arrays and all users are If nodes:
+// FlatArrayCheckNode inputs must be homogeneous: either all array inputs
+// (array1 array2 ...) or all klass inputs (klass1 klass2 ...).
+//
+// For array inputs whose users are all If nodes, the check is expanded using
+// mark words:
 //
 // long mark = array1.mark | array2.mark | ...;
 // long locked_bit = markWord::unlocked_value & array1.mark & array2.mark & ...;
@@ -3089,10 +3092,11 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
 //   ...
 // }
 //
-// Otherwise, it is expanded using the klass layout helpers:
+// For klass inputs, and for array inputs with a non-If user, the check is
+// expanded using the klass layout helpers. For array inputs, the klasses are
+// loaded first:
 //
-// int layout = klass(array_or_klass1).layout_helper |
-//              klass(array_or_klass2).layout_helper | ...;
+// int layout = klass1.layout_helper | klass2.layout_helper | ...;
 // if ((layout & Klass::_lh_array_tag_flat_value_bit_inplace) == 0) {
 //   ...
 // }

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -311,8 +311,8 @@ public:
 };
 
 //--------------------------FlatArrayCheckNode---------------------------------
-// Returns true if one of the input array objects or array klass ptrs (there
-// can be multiple) is flat.
+// Returns true if one of the inputs is flat. There can be multiple inputs, but
+// all must be of the same kind: either array objects or array klass ptrs.
 class FlatArrayCheckNode : public CmpNode {
 public:
   enum {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayCheckExpansion.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayCheckExpansion.java
@@ -26,10 +26,9 @@ package compiler.valhalla.inlinetypes;
 import jdk.internal.value.ValueClass;
 import jdk.test.lib.Asserts;
 
-// TODO bug ID
-
 /**
  * @test
+ * @bug 8391280
  * @summary Test macro expansion of merged flat-array checks with array and klass inputs
  * @enablePreview
  * @library /test/lib
@@ -39,10 +38,7 @@ import jdk.test.lib.Asserts;
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
  *                   ${test.main.class}
  */
-
 public class TestFlatArrayCheckExpansion {
-
-// TODO different arrays
 
     static int test1(Object[] array) {
         int res = 0;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayCheckExpansion.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayCheckExpansion.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.value.ValueClass;
+import jdk.test.lib.Asserts;
+
+// TODO bug ID
+
+/**
+ * @test
+ * @summary Test macro expansion of merged flat-array checks with array and klass inputs
+ * @enablePreview
+ * @library /test/lib
+ * @modules java.base/jdk.internal.value
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *                   ${test.main.class}
+ */
+
+public class TestFlatArrayCheckExpansion {
+
+// TODO different arrays
+
+    static int test1(Object[] array) {
+        int res = 0;
+        for (int i = 0; i < 4; i++) {
+            // FlatArrayCheckNode with a Klass* input
+            if (ValueClass.isFlatArray(array)) {
+                res += 1;
+            } else {
+                res += 2;
+            }
+            // FlatArrayCheckNode with an oop input
+            res += (Integer)array[i];
+        }
+        return res;
+    }
+
+    // Same as test1 but different order of checks
+    static int test2(Object[] array) {
+        int res = 0;
+        for (int i = 0; i < 4; i++) {
+            // FlatArrayCheckNode with an oop input
+            res += (Integer)array[i];
+            // FlatArrayCheckNode with a Klass* input
+            if (ValueClass.isFlatArray(array)) {
+                res += 1;
+            } else {
+                res += 2;
+            }
+        }
+        return res;
+    }
+
+    // Same as test1 but with two different arrays
+    static int test3(Object[] array1, Object[] array2) {
+        int res = 0;
+        for (int i = 0; i < 4; i++) {
+            // FlatArrayCheckNode with a Klass* input
+            if (ValueClass.isFlatArray(array1)) {
+                res += 1;
+            } else {
+                res += 2;
+            }
+            // FlatArrayCheckNode with an oop input
+            res += (Integer)array2[i];
+        }
+        return res;
+    }
+
+    // Same as test2 but with two different arrays
+    static int test4(Object[] array1, Object[] array2) {
+        int res = 0;
+        for (int i = 0; i < 4; i++) {
+            // FlatArrayCheckNode with an oop input
+            res += (Integer)array2[i];
+            // FlatArrayCheckNode with a Klass* input
+            if (ValueClass.isFlatArray(array1)) {
+                res += 1;
+            } else {
+                res += 2;
+            }
+        }
+        return res;
+    }
+
+    public static void main(String[] args) {
+        Object[] refArray = {1, 2, 3, 4};
+        Integer[] flatArray = {1, 2, 3, 4};
+        boolean isFlat = ValueClass.isFlatArray(flatArray);
+
+        for (int i = 0; i < 50_000; i++) {
+            Asserts.assertEQ(test1(refArray), 18);
+            Asserts.assertEQ(test1(flatArray), isFlat ? 14 : 18);
+
+            Asserts.assertEQ(test2(refArray), 18);
+            Asserts.assertEQ(test2(flatArray), isFlat ? 14 : 18);
+
+            Asserts.assertEQ(test3(refArray, refArray), 18);
+            Asserts.assertEQ(test3(refArray, flatArray), 18);
+            Asserts.assertEQ(test3(flatArray, refArray), isFlat ? 14 : 18);
+            Asserts.assertEQ(test3(flatArray, flatArray), isFlat ? 14 : 18);
+
+            Asserts.assertEQ(test4(refArray, refArray), 18);
+            Asserts.assertEQ(test4(refArray, flatArray), 18);
+            Asserts.assertEQ(test4(flatArray, refArray), isFlat ? 14 : 18);
+            Asserts.assertEQ(test4(flatArray, flatArray), isFlat ? 14 : 18);
+        }
+    }
+}
+


### PR DESCRIPTION
We hit an assert during macro expansion of a `FlatArrayCheckNode` because one input is an array oop while the other input is an array klass pointer. The loop that triggers this has two flat array checks that are then merged by loop unswitching:
https://github.com/openjdk/jdk/blob/9b81cf8c25c2584273f5295fbaab3106b0cef4dc/src/hotspot/share/opto/loopUnswitch.cpp#L331-L332

One check is from a regular array access, while the other one comes from an explicit `ValueClass::isFlatArray` (see `TestFlatArrayCheckExpansion::test1`). As Marc explained in https://github.com/openjdk/valhalla/pull/2468, the intrinsic for `ValueClass::isFlatArray` -> `LibraryCallKit::inline_getArrayProperties` needs to use the klass because mark-word-check expansion of the flat array check can not handle `CMoveI` users.

I fixed this by checking if the `FlatArrayCheckNode` has a non-`IfNode` user and then falling back to the layout helper check. With that, we can now convert all but one `flat_array_test` users to use the array oop instead of the array klass. The only remaining use is the `copyOf` bailout:
https://github.com/openjdk/jdk/blob/71e04e3d85db379a718e440e587f31812090265a/src/hotspot/share/opto/library_call.cpp#L5267

But since it goes to an uncommon trap and thus a loop exit, loop unswitching does not merge it with any other `FlatArrayCheckNode`. Should that ever change, we'll hit the assert again (but I'm hoping that we can also get rid of this last use when we fix [JDK-8251971](https://bugs.openjdk.org/browse/JDK-8251971)).

I noticed that some comments were outdated and also fixed them.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391280](https://bugs.openjdk.org/browse/JDK-8391280): [Valhalla] PhaseMacroExpand::expand_flatarraycheck_node asserts with "Mixing array and klass inputs" (**Bug** - P2)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32625/head:pull/32625` \
`$ git checkout pull/32625`

Update a local copy of the PR: \
`$ git checkout pull/32625` \
`$ git pull https://git.openjdk.org/jdk.git pull/32625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32625`

View PR using the GUI difftool: \
`$ git pr show -t 32625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32625.diff">https://git.openjdk.org/jdk/pull/32625.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32625#issuecomment-5492136409)
</details>
