### PR TITLE
8391477: G1: CSet candidate groups selected for optional collection are not sorted

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -388,6 +388,11 @@ void G1CollectionSet::finalize_old_part(double time_remaining_ms) {
     if (candidates()->retained_groups().num_regions() > 0) {
       select_candidates_from_retained(time_remaining_ms);
     }
+    // Optional groups are selected separately from marking and retained candidate
+    // lists; sort the combined list to maintain the GC efficiency ordering.
+    _optional_groups.sort_by_efficiency();
+    _optional_groups.verify();
+
     candidates()->verify();
   } else {
     log_debug(gc, ergo, cset)("No candidates to reclaim.");

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -128,16 +128,23 @@ double G1CSetCandidateGroup::predict_group_total_time_ms() const {
 }
 
 int G1CSetCandidateGroup::compare_gc_efficiency(G1CSetCandidateGroup** gr1, G1CSetCandidateGroup** gr2) {
-  double gc_eff1 = (*gr1)->gc_efficiency();
-  double gc_eff2 = (*gr2)->gc_efficiency();
+  G1CSetCandidateGroup* group_1 = *gr1;
+  G1CSetCandidateGroup* group_2 = *gr2;
+  double gc_eff1 = group_1->gc_efficiency();
+  double gc_eff2 = group_2->gc_efficiency();
 
   if (gc_eff1 > gc_eff2) {
     return -1;
   } else if (gc_eff1 < gc_eff2) {
     return 1;
-  } else {
-    return 0;
   }
+
+  if (group_1->group_id() < group_2->group_id()) {
+    return -1;
+  } else if (group_1->group_id() > group_2->group_id()) {
+    return 1;
+  }
+  return 0;
 }
 
 G1CSetCandidateGroupList::G1CSetCandidateGroupList() : _groups(8, mtGC), _num_regions(0) { }

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -139,6 +139,7 @@ int G1CSetCandidateGroup::compare_gc_efficiency(G1CSetCandidateGroup** gr1, G1CS
     return 1;
   }
 
+  // Make ordering deterministic by breaking ties with group ids.
   if (group_1->group_id() < group_2->group_id()) {
     return -1;
   } else if (group_1->group_id() > group_2->group_id()) {


### PR DESCRIPTION
Hi,

Please review this change to add sorting to groups selected for optional collection. Previously, optional groups were selected from marking and retained, however, the combined list was not sorted, which could violate the ordering expected when selected groups are removed.

We also made the sorting deterministic by breaking GC efficiency ties using the `group_id`. This ensures that marking, retained and optional lists use a consistent order as expect by `G1CSetCandidateGroupList::remove`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391477](https://bugs.openjdk.org/browse/JDK-8391477): G1: CSet candidate groups selected for optional collection are not sorted (**Bug** - P2)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Contributors
 * Thomas Schatzl `<tschatzl@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32627/head:pull/32627` \
`$ git checkout pull/32627`

Update a local copy of the PR: \
`$ git checkout pull/32627` \
`$ git pull https://git.openjdk.org/jdk.git pull/32627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32627`

View PR using the GUI difftool: \
`$ git pr show -t 32627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32627.diff">https://git.openjdk.org/jdk/pull/32627.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32627#issuecomment-5493799922)
</details>
