### PR TITLE
8391597: RISC-V: Use movptr2 for C2 pointer constants

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3590,7 +3590,7 @@ void MacroAssembler::cmp_klass_bne(Register obj, Register klass,
 }
 
 // Move an oop into a register.
-void MacroAssembler::movoop(Register dst, jobject obj) {
+void MacroAssembler::movoop(Register dst, jobject obj, Register tmp) {
   int oop_index;
   if (obj == nullptr) {
     oop_index = oop_recorder()->allocate_oop_index(obj);
@@ -3606,7 +3606,7 @@ void MacroAssembler::movoop(Register dst, jobject obj) {
   RelocationHolder rspec = oop_Relocation::spec(oop_index);
 
   if (BarrierSet::barrier_set()->barrier_set_assembler()->supports_instruction_patching()) {
-    movptr(dst, Address((address)obj, rspec));
+    movptr(dst, Address((address)obj, rspec), tmp);
   } else {
     address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby aligned address
     ld(dst, Address(dummy, rspec));
@@ -3614,7 +3614,7 @@ void MacroAssembler::movoop(Register dst, jobject obj) {
 }
 
 // Move a metadata address into a register.
-void MacroAssembler::mov_metadata(Register dst, Metadata* obj) {
+void MacroAssembler::mov_metadata(Register dst, Metadata* obj, Register tmp) {
   assert((uintptr_t)obj < (1ull << 48), "48-bit overflow in metadata");
   int oop_index;
   if (obj == nullptr) {
@@ -3623,7 +3623,7 @@ void MacroAssembler::mov_metadata(Register dst, Metadata* obj) {
     oop_index = oop_recorder()->find_index(obj);
   }
   RelocationHolder rspec = metadata_Relocation::spec(oop_index);
-  movptr(dst, Address((address)obj, rspec));
+  movptr(dst, Address((address)obj, rspec), tmp);
 }
 
 void MacroAssembler::inline_layout_info(Register holder_klass, Register index, Register layout_info) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -189,8 +189,8 @@ class MacroAssembler: public Assembler {
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
   void resolve_global_jobject(Register value, Register tmp1, Register tmp2);
 
-  void movoop(Register dst, jobject obj);
-  void mov_metadata(Register dst, Metadata* obj);
+  void movoop(Register dst, jobject obj, Register tmp = noreg);
+  void mov_metadata(Register dst, Metadata* obj, Register tmp = noreg);
   void bang_stack_size(Register size, Register tmp);
   void set_narrow_oop(Register dst, jobject obj);
   void set_narrow_klass(Register dst, Klass* k);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2235,17 +2235,18 @@ encode %{
     __ mv(dst_reg, con);
   %}
 
-  enc_class riscv_enc_mov_p(iRegP dst, immP src) %{
+  enc_class riscv_enc_mov_p(iRegP dst, immP src, iRegP tmp) %{
     Register dst_reg = as_Register($dst$$reg);
+    Register tmp_reg = as_Register($tmp$$reg);
     address con = (address)$src$$constant;
     if (con == nullptr || con == (address)1) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
       if (rtype == relocInfo::oop_type) {
-        __ movoop(dst_reg, (jobject)con);
+        __ movoop(dst_reg, (jobject)con, tmp_reg);
       } else if (rtype == relocInfo::metadata_type) {
-        __ mov_metadata(dst_reg, (Metadata*)con);
+        __ mov_metadata(dst_reg, (Metadata*)con, tmp_reg);
       } else {
         assert(rtype == relocInfo::none || rtype == relocInfo::external_word_type, "unexpected reloc type");
         __ mv(dst_reg, $src$$constant);
@@ -4765,14 +4766,16 @@ instruct loadConL(iRegLNoSp dst, immL src)
 %}
 
 // Load Pointer Constant
-instruct loadConP(iRegPNoSp dst, immP con)
+instruct loadConP(iRegPNoSp dst, immP con, iRegPNoSp tmp)
 %{
   match(Set dst con);
+
+  effect(TEMP_DEF dst, TEMP tmp);
 
   ins_cost(ALU_COST);
   format %{ "mv  $dst, $con\t# ptr, #@loadConP" %}
 
-  ins_encode(riscv_enc_mov_p(dst, con));
+  ins_encode(riscv_enc_mov_p(dst, con, tmp));
 
   ins_pipe(ialu_imm);
 %}


### PR DESCRIPTION
This change gives loadConP a temporary register so relocatable oop and
metadata constants can use movptr2(). In the tested oop case, this reduces
the sequence from 6 instructions to 5.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391597](https://bugs.openjdk.org/browse/JDK-8391597): RISC-V: Use movptr2 for C2 pointer constants (**Enhancement** - P4)


### Reviewers
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32629/head:pull/32629` \
`$ git checkout pull/32629`

Update a local copy of the PR: \
`$ git checkout pull/32629` \
`$ git pull https://git.openjdk.org/jdk.git pull/32629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32629`

View PR using the GUI difftool: \
`$ git pr show -t 32629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32629.diff">https://git.openjdk.org/jdk/pull/32629.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32629#issuecomment-5627956392)
</details>
