### PR TITLE
8391593: Typos and omissions in VarHandle test templates

### DIFF
--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
@@ -317,7 +317,7 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
         // Lazy
         {
             boolean x = (boolean) vh.getAcquire(recv);
-            assertEquals(true, x, "getRelease boolean value");
+            assertEquals(true, x, "getAcquire boolean value");
         }
 
         // Opaque
@@ -377,7 +377,7 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
         // Lazy
         {
             boolean x = (boolean) vh.getAcquire();
-            assertEquals(true, x, "getRelease boolean value");
+            assertEquals(true, x, "getAcquire boolean value");
         }
 
         // Opaque

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessBoolean
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessBoolean
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessBoolean

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
@@ -317,7 +317,7 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
         // Lazy
         {
             byte x = (byte) vh.getAcquire(recv);
-            assertEquals((byte)0x01, x, "getRelease byte value");
+            assertEquals((byte)0x01, x, "getAcquire byte value");
         }
 
         // Opaque
@@ -366,7 +366,7 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
         // Lazy
         {
             byte x = (byte) vh.getAcquire();
-            assertEquals((byte)0x01, x, "getRelease byte value");
+            assertEquals((byte)0x01, x, "getAcquire byte value");
         }
 
         // Opaque
@@ -610,7 +610,7 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             vh.set(recv, (byte)0x01);
 
             byte o = (byte) vh.getAndAddRelease(recv, (byte)0x23);
-            assertEquals((byte)0x01, o, "getAndAddReleasebyte");
+            assertEquals((byte)0x01, o, "getAndAddRelease byte");
             byte x = (byte) vh.get(recv);
             assertEquals((byte)((byte)0x01 + (byte)0x23), x, "getAndAddRelease byte value");
         }
@@ -918,7 +918,7 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             vh.set((byte)0x01);
 
             byte o = (byte) vh.getAndAddRelease((byte)0x23);
-            assertEquals((byte)0x01, o, "getAndAddReleasebyte");
+            assertEquals((byte)0x01, o, "getAndAddRelease byte");
             byte x = (byte) vh.get();
             assertEquals((byte)((byte)0x01 + (byte)0x23), x, "getAndAddRelease byte value");
         }
@@ -1229,7 +1229,7 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
                 vh.set(array, i, (byte)0x01);
 
                 byte o = (byte) vh.getAndAddRelease(array, i, (byte)0x23);
-                assertEquals((byte)0x01, o, "getAndAddReleasebyte");
+                assertEquals((byte)0x01, o, "getAndAddRelease byte");
                 byte x = (byte) vh.get(array, i);
                 assertEquals((byte)((byte)0x01 + (byte)0x23), x, "getAndAddRelease byte value");
             }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessByte
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessByte
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessByte

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessChar
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessChar
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessChar

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
@@ -317,7 +317,7 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
         // Lazy
         {
             char x = (char) vh.getAcquire(recv);
-            assertEquals('\u0123', x, "getRelease char value");
+            assertEquals('\u0123', x, "getAcquire char value");
         }
 
         // Opaque
@@ -366,7 +366,7 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
         // Lazy
         {
             char x = (char) vh.getAcquire();
-            assertEquals('\u0123', x, "getRelease char value");
+            assertEquals('\u0123', x, "getAcquire char value");
         }
 
         // Opaque
@@ -610,7 +610,7 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             vh.set(recv, '\u0123');
 
             char o = (char) vh.getAndAddRelease(recv, '\u4567');
-            assertEquals('\u0123', o, "getAndAddReleasechar");
+            assertEquals('\u0123', o, "getAndAddRelease char");
             char x = (char) vh.get(recv);
             assertEquals((char)('\u0123' + '\u4567'), x, "getAndAddRelease char value");
         }
@@ -918,7 +918,7 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             vh.set('\u0123');
 
             char o = (char) vh.getAndAddRelease('\u4567');
-            assertEquals('\u0123', o, "getAndAddReleasechar");
+            assertEquals('\u0123', o, "getAndAddRelease char");
             char x = (char) vh.get();
             assertEquals((char)('\u0123' + '\u4567'), x, "getAndAddRelease char value");
         }
@@ -1229,7 +1229,7 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
                 vh.set(array, i, '\u0123');
 
                 char o = (char) vh.getAndAddRelease(array, i, '\u4567');
-                assertEquals('\u0123', o, "getAndAddReleasechar");
+                assertEquals('\u0123', o, "getAndAddRelease char");
                 char x = (char) vh.get(array, i);
                 assertEquals((char)('\u0123' + '\u4567'), x, "getAndAddRelease char value");
             }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
@@ -317,7 +317,7 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
         // Lazy
         {
             double x = (double) vh.getAcquire(recv);
-            assertEquals(1.0d, x, "getRelease double value");
+            assertEquals(1.0d, x, "getAcquire double value");
         }
 
         // Opaque
@@ -401,7 +401,7 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
         // Lazy
         {
             double x = (double) vh.getAcquire();
-            assertEquals(1.0d, x, "getRelease double value");
+            assertEquals(1.0d, x, "getAcquire double value");
         }
 
         // Opaque
@@ -680,7 +680,7 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             vh.set(recv, 1.0d);
 
             double o = (double) vh.getAndAddRelease(recv, 2.0d);
-            assertEquals(1.0d, o, "getAndAddReleasedouble");
+            assertEquals(1.0d, o, "getAndAddRelease double");
             double x = (double) vh.get(recv);
             assertEquals((double)(1.0d + 2.0d), x, "getAndAddRelease double value");
         }
@@ -940,7 +940,7 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             vh.set(1.0d);
 
             double o = (double) vh.getAndAddRelease(2.0d);
-            assertEquals(1.0d, o, "getAndAddReleasedouble");
+            assertEquals(1.0d, o, "getAndAddRelease double");
             double x = (double) vh.get();
             assertEquals((double)(1.0d + 2.0d), x, "getAndAddRelease double value");
         }
@@ -1203,7 +1203,7 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
                 vh.set(array, i, 1.0d);
 
                 double o = (double) vh.getAndAddRelease(array, i, 2.0d);
-                assertEquals(1.0d, o, "getAndAddReleasedouble");
+                assertEquals(1.0d, o, "getAndAddRelease double");
                 double x = (double) vh.get(array, i);
                 assertEquals((double)(1.0d + 2.0d), x, "getAndAddRelease double value");
             }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessDouble
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessDouble
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessDouble

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessFloat
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessFloat
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessFloat

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
@@ -317,7 +317,7 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
         // Lazy
         {
             float x = (float) vh.getAcquire(recv);
-            assertEquals(1.0f, x, "getRelease float value");
+            assertEquals(1.0f, x, "getAcquire float value");
         }
 
         // Opaque
@@ -401,7 +401,7 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
         // Lazy
         {
             float x = (float) vh.getAcquire();
-            assertEquals(1.0f, x, "getRelease float value");
+            assertEquals(1.0f, x, "getAcquire float value");
         }
 
         // Opaque
@@ -680,7 +680,7 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             vh.set(recv, 1.0f);
 
             float o = (float) vh.getAndAddRelease(recv, 2.0f);
-            assertEquals(1.0f, o, "getAndAddReleasefloat");
+            assertEquals(1.0f, o, "getAndAddRelease float");
             float x = (float) vh.get(recv);
             assertEquals((float)(1.0f + 2.0f), x, "getAndAddRelease float value");
         }
@@ -940,7 +940,7 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             vh.set(1.0f);
 
             float o = (float) vh.getAndAddRelease(2.0f);
-            assertEquals(1.0f, o, "getAndAddReleasefloat");
+            assertEquals(1.0f, o, "getAndAddRelease float");
             float x = (float) vh.get();
             assertEquals((float)(1.0f + 2.0f), x, "getAndAddRelease float value");
         }
@@ -1203,7 +1203,7 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
                 vh.set(array, i, 1.0f);
 
                 float o = (float) vh.getAndAddRelease(array, i, 2.0f);
-                assertEquals(1.0f, o, "getAndAddReleasefloat");
+                assertEquals(1.0f, o, "getAndAddRelease float");
                 float x = (float) vh.get(array, i);
                 assertEquals((float)(1.0f + 2.0f), x, "getAndAddRelease float value");
             }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
@@ -317,7 +317,7 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
         // Lazy
         {
             int x = (int) vh.getAcquire(recv);
-            assertEquals(0x01234567, x, "getRelease int value");
+            assertEquals(0x01234567, x, "getAcquire int value");
         }
 
         // Opaque
@@ -366,7 +366,7 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
         // Lazy
         {
             int x = (int) vh.getAcquire();
-            assertEquals(0x01234567, x, "getRelease int value");
+            assertEquals(0x01234567, x, "getAcquire int value");
         }
 
         // Opaque
@@ -610,7 +610,7 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             vh.set(recv, 0x01234567);
 
             int o = (int) vh.getAndAddRelease(recv, 0x89ABCDEF);
-            assertEquals(0x01234567, o, "getAndAddReleaseint");
+            assertEquals(0x01234567, o, "getAndAddRelease int");
             int x = (int) vh.get(recv);
             assertEquals((int)(0x01234567 + 0x89ABCDEF), x, "getAndAddRelease int value");
         }
@@ -918,7 +918,7 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             vh.set(0x01234567);
 
             int o = (int) vh.getAndAddRelease(0x89ABCDEF);
-            assertEquals(0x01234567, o, "getAndAddReleaseint");
+            assertEquals(0x01234567, o, "getAndAddRelease int");
             int x = (int) vh.get();
             assertEquals((int)(0x01234567 + 0x89ABCDEF), x, "getAndAddRelease int value");
         }
@@ -1229,7 +1229,7 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
                 vh.set(array, i, 0x01234567);
 
                 int o = (int) vh.getAndAddRelease(array, i, 0x89ABCDEF);
-                assertEquals(0x01234567, o, "getAndAddReleaseint");
+                assertEquals(0x01234567, o, "getAndAddRelease int");
                 int x = (int) vh.get(array, i);
                 assertEquals((int)(0x01234567 + 0x89ABCDEF), x, "getAndAddRelease int value");
             }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessInt
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessInt
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessInt

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
@@ -317,7 +317,7 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
         // Lazy
         {
             long x = (long) vh.getAcquire(recv);
-            assertEquals(0x0123456789ABCDEFL, x, "getRelease long value");
+            assertEquals(0x0123456789ABCDEFL, x, "getAcquire long value");
         }
 
         // Opaque
@@ -366,7 +366,7 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
         // Lazy
         {
             long x = (long) vh.getAcquire();
-            assertEquals(0x0123456789ABCDEFL, x, "getRelease long value");
+            assertEquals(0x0123456789ABCDEFL, x, "getAcquire long value");
         }
 
         // Opaque
@@ -610,7 +610,7 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             vh.set(recv, 0x0123456789ABCDEFL);
 
             long o = (long) vh.getAndAddRelease(recv, 0xCAFEBABECAFEBABEL);
-            assertEquals(0x0123456789ABCDEFL, o, "getAndAddReleaselong");
+            assertEquals(0x0123456789ABCDEFL, o, "getAndAddRelease long");
             long x = (long) vh.get(recv);
             assertEquals((long)(0x0123456789ABCDEFL + 0xCAFEBABECAFEBABEL), x, "getAndAddRelease long value");
         }
@@ -918,7 +918,7 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             vh.set(0x0123456789ABCDEFL);
 
             long o = (long) vh.getAndAddRelease(0xCAFEBABECAFEBABEL);
-            assertEquals(0x0123456789ABCDEFL, o, "getAndAddReleaselong");
+            assertEquals(0x0123456789ABCDEFL, o, "getAndAddRelease long");
             long x = (long) vh.get();
             assertEquals((long)(0x0123456789ABCDEFL + 0xCAFEBABECAFEBABEL), x, "getAndAddRelease long value");
         }
@@ -1229,7 +1229,7 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
                 vh.set(array, i, 0x0123456789ABCDEFL);
 
                 long o = (long) vh.getAndAddRelease(array, i, 0xCAFEBABECAFEBABEL);
-                assertEquals(0x0123456789ABCDEFL, o, "getAndAddReleaselong");
+                assertEquals(0x0123456789ABCDEFL, o, "getAndAddRelease long");
                 long x = (long) vh.get(array, i);
                 assertEquals((long)(0x0123456789ABCDEFL + 0xCAFEBABECAFEBABEL), x, "getAndAddRelease long value");
             }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessLong
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessLong
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessLong

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessNullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessNullRestrictedValue.java
@@ -340,7 +340,7 @@ public class VarHandleTestAccessNullRestrictedValue extends VarHandleBaseTest {
         // Lazy
         {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire(recv);
-            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getRelease NullRestrictedValue value");
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getAcquire NullRestrictedValue value");
         }
 
         // Opaque
@@ -435,7 +435,7 @@ public class VarHandleTestAccessNullRestrictedValue extends VarHandleBaseTest {
         // Lazy
         {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAcquire();
-            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getRelease NullRestrictedValue value");
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "getAcquire NullRestrictedValue value");
         }
 
         // Opaque
@@ -1363,57 +1363,57 @@ public class VarHandleTestAccessNullRestrictedValue extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.compareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetPlain(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetVolatile
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchange
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchangeAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchangeRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // GetAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(array, 0, value);
         });
 
         // GetAndSetAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(array, 0, value);
         });
 
         // GetAndSetRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(array, 0, value);
         });
     }
@@ -1442,57 +1442,57 @@ public class VarHandleTestAccessNullRestrictedValue extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.compareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetPlain(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetVolatile
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSet(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchange
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchangeAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchangeRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // GetAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(recv, value);
         });
 
         // GetAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(recv, value);
         });
 
         // GetAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(recv, value);
         });
     }
@@ -1521,57 +1521,57 @@ public class VarHandleTestAccessNullRestrictedValue extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.compareAndSet(NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetPlain(NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetVolatile
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSet(NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetRelease(NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchange
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchangeAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchangeRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // GetAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(value);
         });
 
         // GetAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(value);
         });
 
         // GetAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(value);
         });
     }
@@ -1601,57 +1601,57 @@ public class VarHandleTestAccessNullRestrictedValue extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.compareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetPlain(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetVolatile
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSet(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // WeakCompareAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchange
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchangeAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // CompareAndExchangeRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(array, 0, NullRestrictedValue.of((byte)20,(short)1854), value);
         });
 
         // GetAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(array, 0, value);
         });
 
         // GetAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(array, 0, value);
         });
 
         // GetAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(array, 0, value);
         });
     }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessNullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessNullRestrictedValue.java
@@ -30,8 +30,8 @@
  *          java.base/jdk.internal.value
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessNullRestrictedValue
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessNullRestrictedValue
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessNullRestrictedValue

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessShort
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessShort
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessShort

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
@@ -317,7 +317,7 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
         // Lazy
         {
             short x = (short) vh.getAcquire(recv);
-            assertEquals((short)0x0123, x, "getRelease short value");
+            assertEquals((short)0x0123, x, "getAcquire short value");
         }
 
         // Opaque
@@ -366,7 +366,7 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
         // Lazy
         {
             short x = (short) vh.getAcquire();
-            assertEquals((short)0x0123, x, "getRelease short value");
+            assertEquals((short)0x0123, x, "getAcquire short value");
         }
 
         // Opaque
@@ -610,7 +610,7 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             vh.set(recv, (short)0x0123);
 
             short o = (short) vh.getAndAddRelease(recv, (short)0x4567);
-            assertEquals((short)0x0123, o, "getAndAddReleaseshort");
+            assertEquals((short)0x0123, o, "getAndAddRelease short");
             short x = (short) vh.get(recv);
             assertEquals((short)((short)0x0123 + (short)0x4567), x, "getAndAddRelease short value");
         }
@@ -918,7 +918,7 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             vh.set((short)0x0123);
 
             short o = (short) vh.getAndAddRelease((short)0x4567);
-            assertEquals((short)0x0123, o, "getAndAddReleaseshort");
+            assertEquals((short)0x0123, o, "getAndAddRelease short");
             short x = (short) vh.get();
             assertEquals((short)((short)0x0123 + (short)0x4567), x, "getAndAddRelease short value");
         }
@@ -1229,7 +1229,7 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
                 vh.set(array, i, (short)0x0123);
 
                 short o = (short) vh.getAndAddRelease(array, i, (short)0x4567);
-                assertEquals((short)0x0123, o, "getAndAddReleaseshort");
+                assertEquals((short)0x0123, o, "getAndAddRelease short");
                 short x = (short) vh.get(array, i);
                 assertEquals((short)((short)0x0123 + (short)0x4567), x, "getAndAddRelease short value");
             }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
@@ -27,8 +27,8 @@
  * @test
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessString
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessString
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessString

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
@@ -325,7 +325,7 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
         // Lazy
         {
             String x = (String) vh.getAcquire(recv);
-            assertEquals("foo", x, "getRelease String value");
+            assertEquals("foo", x, "getAcquire String value");
         }
 
         // Opaque
@@ -420,7 +420,7 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
         // Lazy
         {
             String x = (String) vh.getAcquire();
-            assertEquals("foo", x, "getRelease String value");
+            assertEquals("foo", x, "getAcquire String value");
         }
 
         // Opaque
@@ -1348,57 +1348,57 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.compareAndSet(array, 0, "foo", value);
         });
 
         // WeakCompareAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetPlain(array, 0, "foo", value);
         });
 
         // WeakCompareAndSetVolatile
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSet(array, 0, "foo", value);
         });
 
         // WeakCompareAndSetAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(array, 0, "foo", value);
         });
 
         // WeakCompareAndSetRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetRelease(array, 0, "foo", value);
         });
 
         // CompareAndExchange
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             String x = (String) vh.compareAndExchange(array, 0, "foo", value);
         });
 
         // CompareAndExchangeAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             String x = (String) vh.compareAndExchangeAcquire(array, 0, "foo", value);
         });
 
         // CompareAndExchangeRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             String x = (String) vh.compareAndExchangeRelease(array, 0, "foo", value);
         });
 
         // GetAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             String x = (String) vh.getAndSet(array, 0, value);
         });
 
         // GetAndSetAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             String x = (String) vh.getAndSetAcquire(array, 0, value);
         });
 
         // GetAndSetRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             String x = (String) vh.getAndSetRelease(array, 0, value);
         });
     }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
@@ -328,7 +328,7 @@ public class VarHandleTestAccessValue extends VarHandleBaseTest {
         // Lazy
         {
             Value x = (Value) vh.getAcquire(recv);
-            assertEquals(Value.getInstance(10), x, "getRelease Value value");
+            assertEquals(Value.getInstance(10), x, "getAcquire Value value");
         }
 
         // Opaque
@@ -423,7 +423,7 @@ public class VarHandleTestAccessValue extends VarHandleBaseTest {
         // Lazy
         {
             Value x = (Value) vh.getAcquire();
-            assertEquals(Value.getInstance(10), x, "getRelease Value value");
+            assertEquals(Value.getInstance(10), x, "getAcquire Value value");
         }
 
         // Opaque
@@ -1351,57 +1351,57 @@ public class VarHandleTestAccessValue extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.compareAndSet(array, 0, Value.getInstance(10), value);
         });
 
         // WeakCompareAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetPlain(array, 0, Value.getInstance(10), value);
         });
 
         // WeakCompareAndSetVolatile
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSet(array, 0, Value.getInstance(10), value);
         });
 
         // WeakCompareAndSetAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(array, 0, Value.getInstance(10), value);
         });
 
         // WeakCompareAndSetRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetRelease(array, 0, Value.getInstance(10), value);
         });
 
         // CompareAndExchange
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             Value x = (Value) vh.compareAndExchange(array, 0, Value.getInstance(10), value);
         });
 
         // CompareAndExchangeAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             Value x = (Value) vh.compareAndExchangeAcquire(array, 0, Value.getInstance(10), value);
         });
 
         // CompareAndExchangeRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             Value x = (Value) vh.compareAndExchangeRelease(array, 0, Value.getInstance(10), value);
         });
 
         // GetAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             Value x = (Value) vh.getAndSet(array, 0, value);
         });
 
         // GetAndSetAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             Value x = (Value) vh.getAndSetAcquire(array, 0, value);
         });
 
         // GetAndSetRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             Value x = (Value) vh.getAndSetRelease(array, 0, value);
         });
     }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
@@ -30,8 +30,8 @@
  *          java.base/jdk.internal.value
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccessValue
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccessValue
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccessValue

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8154556
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsChar
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestByteArrayAsChar
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:-TieredCompilation  VarHandleTestByteArrayAsChar

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,9 @@ public class VarHandleTestByteArrayAsChar extends VarHandleBaseByteArrayTest {
     public List<VarHandleSource> setupVarHandleSources(boolean same) {
         // Combinations of VarHandle byte[] or ByteBuffer
         List<VarHandleSource> vhss = new ArrayList<>();
-        for (MemoryMode endianess : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
+        for (MemoryMode endianness : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
 
-            ByteOrder bo = endianess == MemoryMode.BIG_ENDIAN
+            ByteOrder bo = endianness == MemoryMode.BIG_ENDIAN
                     ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
             Class<?> arrayType;
@@ -73,12 +73,12 @@ public class VarHandleTestByteArrayAsChar extends VarHandleBaseByteArrayTest {
             }
             VarHandleSource aeh = new VarHandleSource(
                     MethodHandles.byteArrayViewVarHandle(arrayType, bo), false,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(aeh);
 
             VarHandleSource bbh = new VarHandleSource(
                     MethodHandles.byteBufferViewVarHandle(arrayType, bo), true,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(bbh);
         }
         return vhss;
@@ -820,7 +820,7 @@ public class VarHandleTestByteArrayAsChar extends VarHandleBaseByteArrayTest {
                 // Lazy
                 {
                     char x = (char) vh.getAcquire(array, i);
-                    assertEquals(v, x, "getRelease char value");
+                    assertEquals(v, x, "getAcquire char value");
                 }
 
                 // Opaque

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8154556
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsDouble
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestByteArrayAsDouble
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:-TieredCompilation  VarHandleTestByteArrayAsDouble

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,9 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
     public List<VarHandleSource> setupVarHandleSources(boolean same) {
         // Combinations of VarHandle byte[] or ByteBuffer
         List<VarHandleSource> vhss = new ArrayList<>();
-        for (MemoryMode endianess : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
+        for (MemoryMode endianness : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
 
-            ByteOrder bo = endianess == MemoryMode.BIG_ENDIAN
+            ByteOrder bo = endianness == MemoryMode.BIG_ENDIAN
                     ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
             Class<?> arrayType;
@@ -73,12 +73,12 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
             }
             VarHandleSource aeh = new VarHandleSource(
                     MethodHandles.byteArrayViewVarHandle(arrayType, bo), false,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(aeh);
 
             VarHandleSource bbh = new VarHandleSource(
                     MethodHandles.byteBufferViewVarHandle(arrayType, bo), true,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(bbh);
         }
         return vhss;
@@ -1122,7 +1122,7 @@ public class VarHandleTestByteArrayAsDouble extends VarHandleBaseByteArrayTest {
                 // Lazy
                 {
                     double x = (double) vh.getAcquire(array, i);
-                    assertEquals(v, x, "getRelease double value");
+                    assertEquals(v, x, "getAcquire double value");
                 }
 
                 // Opaque

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,9 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
     public List<VarHandleSource> setupVarHandleSources(boolean same) {
         // Combinations of VarHandle byte[] or ByteBuffer
         List<VarHandleSource> vhss = new ArrayList<>();
-        for (MemoryMode endianess : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
+        for (MemoryMode endianness : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
 
-            ByteOrder bo = endianess == MemoryMode.BIG_ENDIAN
+            ByteOrder bo = endianness == MemoryMode.BIG_ENDIAN
                     ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
             Class<?> arrayType;
@@ -73,12 +73,12 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
             }
             VarHandleSource aeh = new VarHandleSource(
                     MethodHandles.byteArrayViewVarHandle(arrayType, bo), false,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(aeh);
 
             VarHandleSource bbh = new VarHandleSource(
                     MethodHandles.byteBufferViewVarHandle(arrayType, bo), true,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(bbh);
         }
         return vhss;
@@ -1122,7 +1122,7 @@ public class VarHandleTestByteArrayAsFloat extends VarHandleBaseByteArrayTest {
                 // Lazy
                 {
                     float x = (float) vh.getAcquire(array, i);
-                    assertEquals(v, x, "getRelease float value");
+                    assertEquals(v, x, "getAcquire float value");
                 }
 
                 // Opaque

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8154556
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsFloat
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestByteArrayAsFloat
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:-TieredCompilation  VarHandleTestByteArrayAsFloat

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8154556
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsInt
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestByteArrayAsInt
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:-TieredCompilation  VarHandleTestByteArrayAsInt

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,9 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
     public List<VarHandleSource> setupVarHandleSources(boolean same) {
         // Combinations of VarHandle byte[] or ByteBuffer
         List<VarHandleSource> vhss = new ArrayList<>();
-        for (MemoryMode endianess : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
+        for (MemoryMode endianness : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
 
-            ByteOrder bo = endianess == MemoryMode.BIG_ENDIAN
+            ByteOrder bo = endianness == MemoryMode.BIG_ENDIAN
                     ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
             Class<?> arrayType;
@@ -73,12 +73,12 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
             }
             VarHandleSource aeh = new VarHandleSource(
                     MethodHandles.byteArrayViewVarHandle(arrayType, bo), false,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(aeh);
 
             VarHandleSource bbh = new VarHandleSource(
                     MethodHandles.byteBufferViewVarHandle(arrayType, bo), true,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(bbh);
         }
         return vhss;
@@ -1388,7 +1388,7 @@ public class VarHandleTestByteArrayAsInt extends VarHandleBaseByteArrayTest {
                 // Lazy
                 {
                     int x = (int) vh.getAcquire(array, i);
-                    assertEquals(v, x, "getRelease int value");
+                    assertEquals(v, x, "getAcquire int value");
                 }
 
                 // Opaque

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8154556
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsLong
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestByteArrayAsLong
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:-TieredCompilation  VarHandleTestByteArrayAsLong

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,9 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
     public List<VarHandleSource> setupVarHandleSources(boolean same) {
         // Combinations of VarHandle byte[] or ByteBuffer
         List<VarHandleSource> vhss = new ArrayList<>();
-        for (MemoryMode endianess : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
+        for (MemoryMode endianness : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
 
-            ByteOrder bo = endianess == MemoryMode.BIG_ENDIAN
+            ByteOrder bo = endianness == MemoryMode.BIG_ENDIAN
                     ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
             Class<?> arrayType;
@@ -73,12 +73,12 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
             }
             VarHandleSource aeh = new VarHandleSource(
                     MethodHandles.byteArrayViewVarHandle(arrayType, bo), false,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(aeh);
 
             VarHandleSource bbh = new VarHandleSource(
                     MethodHandles.byteBufferViewVarHandle(arrayType, bo), true,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(bbh);
         }
         return vhss;
@@ -1388,7 +1388,7 @@ public class VarHandleTestByteArrayAsLong extends VarHandleBaseByteArrayTest {
                 // Lazy
                 {
                     long x = (long) vh.getAcquire(array, i);
-                    assertEquals(v, x, "getRelease long value");
+                    assertEquals(v, x, "getAcquire long value");
                 }
 
                 // Opaque

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,9 @@ public class VarHandleTestByteArrayAsShort extends VarHandleBaseByteArrayTest {
     public List<VarHandleSource> setupVarHandleSources(boolean same) {
         // Combinations of VarHandle byte[] or ByteBuffer
         List<VarHandleSource> vhss = new ArrayList<>();
-        for (MemoryMode endianess : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
+        for (MemoryMode endianness : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
 
-            ByteOrder bo = endianess == MemoryMode.BIG_ENDIAN
+            ByteOrder bo = endianness == MemoryMode.BIG_ENDIAN
                     ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
             Class<?> arrayType;
@@ -73,12 +73,12 @@ public class VarHandleTestByteArrayAsShort extends VarHandleBaseByteArrayTest {
             }
             VarHandleSource aeh = new VarHandleSource(
                     MethodHandles.byteArrayViewVarHandle(arrayType, bo), false,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(aeh);
 
             VarHandleSource bbh = new VarHandleSource(
                     MethodHandles.byteBufferViewVarHandle(arrayType, bo), true,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(bbh);
         }
         return vhss;
@@ -820,7 +820,7 @@ public class VarHandleTestByteArrayAsShort extends VarHandleBaseByteArrayTest {
                 // Lazy
                 {
                     short x = (short) vh.getAcquire(array, i);
-                    assertEquals(v, x, "getRelease short value");
+                    assertEquals(v, x, "getAcquire short value");
                 }
 
                 // Opaque

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8154556
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsShort
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestByteArrayAsShort
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:-TieredCompilation  VarHandleTestByteArrayAsShort

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, true);
+
             boolean o = (boolean) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, false);
             assertEquals(true, o, "getAndSet boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals(false, x, "getAndSet boolean value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, true);
+
+            boolean o = (boolean) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, false);
+            assertEquals(true, o, "getAndSetAcquire boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(false, x, "getAndSetAcquire boolean value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, true);
+
+            boolean o = (boolean) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, false);
+            assertEquals(true, o, "getAndSetRelease boolean");
+            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(false, x, "getAndSetRelease boolean value");
         }
 
 
@@ -560,7 +580,7 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(false, false);
             assertEquals(success, false, "failing weakCompareAndSet boolean");
             boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(true, x, "failing weakCompareAndSetRe boolean value");
+            assertEquals(true, x, "failing weakCompareAndSet boolean value");
         }
 
         // Compare set and get
@@ -573,7 +593,6 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             assertEquals(false, x, "getAndSet boolean value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(true);
 
@@ -583,7 +602,6 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             assertEquals(false, x, "getAndSetAcquire boolean value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(true);
 
@@ -833,10 +851,10 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, true, false);
-                assertEquals(success, false, "failing weakCompareAndSetAcquire boolean");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, true, false);
+                assertEquals(success, false, "failing weakCompareAndSetRelease boolean");
                 boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(false, x, "failing weakCompareAndSetAcquire boolean value");
+                assertEquals(false, x, "failing weakCompareAndSetRelease boolean value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessBoolean
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessByte
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, (byte)0x01);
+
             byte o = (byte) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, (byte)0x23);
             assertEquals((byte)0x01, o, "getAndSet byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals((byte)0x23, x, "getAndSet byte value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, (byte)0x01);
+
+            byte o = (byte) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, (byte)0x23);
+            assertEquals((byte)0x01, o, "getAndSetAcquire byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals((byte)0x23, x, "getAndSetAcquire byte value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, (byte)0x01);
+
+            byte o = (byte) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, (byte)0x23);
+            assertEquals((byte)0x01, o, "getAndSetRelease byte");
+            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals((byte)0x23, x, "getAndSetRelease byte value");
         }
 
         // get and add, add and get
@@ -582,7 +602,7 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact((byte)0x23, (byte)0x45);
             assertEquals(success, false, "failing weakCompareAndSet byte");
             byte x = (byte) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals((byte)0x01, x, "failing weakCompareAndSetRe byte value");
+            assertEquals((byte)0x01, x, "failing weakCompareAndSet byte value");
         }
 
         // Compare set and get
@@ -595,7 +615,6 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             assertEquals((byte)0x23, x, "getAndSet byte value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact((byte)0x01);
 
@@ -605,7 +624,6 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             assertEquals((byte)0x23, x, "getAndSetAcquire byte value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact((byte)0x01);
 
@@ -877,10 +895,10 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, (byte)0x01, (byte)0x45);
-                assertEquals(success, false, "failing weakCompareAndSetAcquire byte");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, (byte)0x01, (byte)0x45);
+                assertEquals(success, false, "failing weakCompareAndSetRelease byte");
                 byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals((byte)0x23, x, "failing weakCompareAndSetAcquire byte value");
+                assertEquals((byte)0x23, x, "failing weakCompareAndSetRelease byte value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessChar
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, '\u0123');
+
             char o = (char) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, '\u4567');
             assertEquals('\u0123', o, "getAndSet char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals('\u4567', x, "getAndSet char value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, '\u0123');
+
+            char o = (char) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, '\u4567');
+            assertEquals('\u0123', o, "getAndSetAcquire char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals('\u4567', x, "getAndSetAcquire char value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, '\u0123');
+
+            char o = (char) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, '\u4567');
+            assertEquals('\u0123', o, "getAndSetRelease char");
+            char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals('\u4567', x, "getAndSetRelease char value");
         }
 
         // get and add, add and get
@@ -582,7 +602,7 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact('\u4567', '\u89AB');
             assertEquals(success, false, "failing weakCompareAndSet char");
             char x = (char) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals('\u0123', x, "failing weakCompareAndSetRe char value");
+            assertEquals('\u0123', x, "failing weakCompareAndSet char value");
         }
 
         // Compare set and get
@@ -595,7 +615,6 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             assertEquals('\u4567', x, "getAndSet char value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact('\u0123');
 
@@ -605,7 +624,6 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             assertEquals('\u4567', x, "getAndSetAcquire char value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact('\u0123');
 
@@ -877,10 +895,10 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, '\u0123', '\u89AB');
-                assertEquals(success, false, "failing weakCompareAndSetAcquire char");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, '\u0123', '\u89AB');
+                assertEquals(success, false, "failing weakCompareAndSetRelease char");
                 char x = (char) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals('\u4567', x, "failing weakCompareAndSetAcquire char value");
+                assertEquals('\u4567', x, "failing weakCompareAndSetRelease char value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessDouble
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 1.0d);
+
             double o = (double) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, 2.0d);
             assertEquals(1.0d, o, "getAndSet double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals(2.0d, x, "getAndSet double value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 1.0d);
+
+            double o = (double) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, 2.0d);
+            assertEquals(1.0d, o, "getAndSetAcquire double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(2.0d, x, "getAndSetAcquire double value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 1.0d);
+
+            double o = (double) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, 2.0d);
+            assertEquals(1.0d, o, "getAndSetRelease double");
+            double x = (double) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(2.0d, x, "getAndSetRelease double value");
         }
 
         // get and add, add and get
@@ -504,7 +524,7 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(2.0d, 3.0d);
             assertEquals(success, false, "failing weakCompareAndSet double");
             double x = (double) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(1.0d, x, "failing weakCompareAndSetRe double value");
+            assertEquals(1.0d, x, "failing weakCompareAndSet double value");
         }
 
         // Compare set and get
@@ -517,7 +537,6 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             assertEquals(2.0d, x, "getAndSet double value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(1.0d);
 
@@ -527,7 +546,6 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             assertEquals(2.0d, x, "getAndSetAcquire double value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(1.0d);
 
@@ -721,10 +739,10 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 1.0d, 3.0d);
-                assertEquals(success, false, "failing weakCompareAndSetAcquire double");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, 1.0d, 3.0d);
+                assertEquals(success, false, "failing weakCompareAndSetRelease double");
                 double x = (double) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(2.0d, x, "failing weakCompareAndSetAcquire double value");
+                assertEquals(2.0d, x, "failing weakCompareAndSetRelease double value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessFloat
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 1.0f);
+
             float o = (float) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, 2.0f);
             assertEquals(1.0f, o, "getAndSet float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals(2.0f, x, "getAndSet float value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 1.0f);
+
+            float o = (float) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, 2.0f);
+            assertEquals(1.0f, o, "getAndSetAcquire float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(2.0f, x, "getAndSetAcquire float value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 1.0f);
+
+            float o = (float) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, 2.0f);
+            assertEquals(1.0f, o, "getAndSetRelease float");
+            float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(2.0f, x, "getAndSetRelease float value");
         }
 
         // get and add, add and get
@@ -504,7 +524,7 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(2.0f, 3.0f);
             assertEquals(success, false, "failing weakCompareAndSet float");
             float x = (float) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(1.0f, x, "failing weakCompareAndSetRe float value");
+            assertEquals(1.0f, x, "failing weakCompareAndSet float value");
         }
 
         // Compare set and get
@@ -517,7 +537,6 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             assertEquals(2.0f, x, "getAndSet float value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(1.0f);
 
@@ -527,7 +546,6 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             assertEquals(2.0f, x, "getAndSetAcquire float value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(1.0f);
 
@@ -721,10 +739,10 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 1.0f, 3.0f);
-                assertEquals(success, false, "failing weakCompareAndSetAcquire float");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, 1.0f, 3.0f);
+                assertEquals(success, false, "failing weakCompareAndSetRelease float");
                 float x = (float) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(2.0f, x, "failing weakCompareAndSetAcquire float value");
+                assertEquals(2.0f, x, "failing weakCompareAndSetRelease float value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessInt
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 0x01234567);
+
             int o = (int) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, 0x89ABCDEF);
             assertEquals(0x01234567, o, "getAndSet int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals(0x89ABCDEF, x, "getAndSet int value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 0x01234567);
+
+            int o = (int) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, 0x89ABCDEF);
+            assertEquals(0x01234567, o, "getAndSetAcquire int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(0x89ABCDEF, x, "getAndSetAcquire int value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 0x01234567);
+
+            int o = (int) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, 0x89ABCDEF);
+            assertEquals(0x01234567, o, "getAndSetRelease int");
+            int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(0x89ABCDEF, x, "getAndSetRelease int value");
         }
 
         // get and add, add and get
@@ -582,7 +602,7 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(0x89ABCDEF, 0xCAFEBABE);
             assertEquals(success, false, "failing weakCompareAndSet int");
             int x = (int) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(0x01234567, x, "failing weakCompareAndSetRe int value");
+            assertEquals(0x01234567, x, "failing weakCompareAndSet int value");
         }
 
         // Compare set and get
@@ -595,7 +615,6 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             assertEquals(0x89ABCDEF, x, "getAndSet int value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(0x01234567);
 
@@ -605,7 +624,6 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             assertEquals(0x89ABCDEF, x, "getAndSetAcquire int value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(0x01234567);
 
@@ -877,10 +895,10 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 0x01234567, 0xCAFEBABE);
-                assertEquals(success, false, "failing weakCompareAndSetAcquire int");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, 0x01234567, 0xCAFEBABE);
+                assertEquals(success, false, "failing weakCompareAndSetRelease int");
                 int x = (int) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(0x89ABCDEF, x, "failing weakCompareAndSetAcquire int value");
+                assertEquals(0x89ABCDEF, x, "failing weakCompareAndSetRelease int value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessLong
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 0x0123456789ABCDEFL);
+
             long o = (long) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, 0xCAFEBABECAFEBABEL);
             assertEquals(0x0123456789ABCDEFL, o, "getAndSet long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals(0xCAFEBABECAFEBABEL, x, "getAndSet long value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 0x0123456789ABCDEFL);
+
+            long o = (long) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, 0xCAFEBABECAFEBABEL);
+            assertEquals(0x0123456789ABCDEFL, o, "getAndSetAcquire long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(0xCAFEBABECAFEBABEL, x, "getAndSetAcquire long value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, 0x0123456789ABCDEFL);
+
+            long o = (long) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, 0xCAFEBABECAFEBABEL);
+            assertEquals(0x0123456789ABCDEFL, o, "getAndSetRelease long");
+            long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(0xCAFEBABECAFEBABEL, x, "getAndSetRelease long value");
         }
 
         // get and add, add and get
@@ -582,7 +602,7 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(0xCAFEBABECAFEBABEL, 0xDEADBEEFDEADBEEFL);
             assertEquals(success, false, "failing weakCompareAndSet long");
             long x = (long) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(0x0123456789ABCDEFL, x, "failing weakCompareAndSetRe long value");
+            assertEquals(0x0123456789ABCDEFL, x, "failing weakCompareAndSet long value");
         }
 
         // Compare set and get
@@ -595,7 +615,6 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             assertEquals(0xCAFEBABECAFEBABEL, x, "getAndSet long value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(0x0123456789ABCDEFL);
 
@@ -605,7 +624,6 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             assertEquals(0xCAFEBABECAFEBABEL, x, "getAndSetAcquire long value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(0x0123456789ABCDEFL);
 
@@ -877,10 +895,10 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
-                assertEquals(success, false, "failing weakCompareAndSetAcquire long");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, 0x0123456789ABCDEFL, 0xDEADBEEFDEADBEEFL);
+                assertEquals(success, false, "failing weakCompareAndSetRelease long");
                 long x = (long) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(0xCAFEBABECAFEBABEL, x, "failing weakCompareAndSetAcquire long value");
+                assertEquals(0xCAFEBABECAFEBABEL, x, "failing weakCompareAndSetRelease long value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessNullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessNullRestrictedValue.java
@@ -309,10 +309,30 @@ public class VarHandleTestMethodHandleAccessNullRestrictedValue extends VarHandl
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+
             NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854));
             assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSet NullRestrictedValue");
             NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSet NullRestrictedValue value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetAcquire NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetAcquire NullRestrictedValue value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854));
+
+            NullRestrictedValue o = (NullRestrictedValue) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, NullRestrictedValue.of((byte)-42,(short)1854));
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), o, "getAndSetRelease NullRestrictedValue");
+            NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetRelease NullRestrictedValue value");
         }
 
 
@@ -497,7 +517,7 @@ public class VarHandleTestMethodHandleAccessNullRestrictedValue extends VarHandl
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(NullRestrictedValue.of((byte)-42,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
             assertEquals(success, false, "failing weakCompareAndSet NullRestrictedValue");
             NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSetRe NullRestrictedValue value");
+            assertEquals(NullRestrictedValue.of((byte)20,(short)1854), x, "failing weakCompareAndSet NullRestrictedValue value");
         }
 
         // Compare set and get
@@ -510,7 +530,6 @@ public class VarHandleTestMethodHandleAccessNullRestrictedValue extends VarHandl
             assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSet NullRestrictedValue value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
 
@@ -520,7 +539,6 @@ public class VarHandleTestMethodHandleAccessNullRestrictedValue extends VarHandl
             assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "getAndSetAcquire NullRestrictedValue value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(NullRestrictedValue.of((byte)20,(short)1854));
 
@@ -692,10 +710,10 @@ public class VarHandleTestMethodHandleAccessNullRestrictedValue extends VarHandl
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
-                assertEquals(success, false, "failing weakCompareAndSetAcquire NullRestrictedValue");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)-31083));
+                assertEquals(success, false, "failing weakCompareAndSetRelease NullRestrictedValue");
                 NullRestrictedValue x = (NullRestrictedValue) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetAcquire NullRestrictedValue value");
+                assertEquals(NullRestrictedValue.of((byte)-42,(short)1854), x, "failing weakCompareAndSetRelease NullRestrictedValue value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessNullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessNullRestrictedValue.java
@@ -28,8 +28,8 @@
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.value
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessNullRestrictedValue
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, (short)0x0123);
+
             short o = (short) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, (short)0x4567);
             assertEquals((short)0x0123, o, "getAndSet short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals((short)0x4567, x, "getAndSet short value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, (short)0x0123);
+
+            short o = (short) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, (short)0x4567);
+            assertEquals((short)0x0123, o, "getAndSetAcquire short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals((short)0x4567, x, "getAndSetAcquire short value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, (short)0x0123);
+
+            short o = (short) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, (short)0x4567);
+            assertEquals((short)0x0123, o, "getAndSetRelease short");
+            short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals((short)0x4567, x, "getAndSetRelease short value");
         }
 
         // get and add, add and get
@@ -582,7 +602,7 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact((short)0x4567, (short)0x89AB);
             assertEquals(success, false, "failing weakCompareAndSet short");
             short x = (short) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals((short)0x0123, x, "failing weakCompareAndSetRe short value");
+            assertEquals((short)0x0123, x, "failing weakCompareAndSet short value");
         }
 
         // Compare set and get
@@ -595,7 +615,6 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             assertEquals((short)0x4567, x, "getAndSet short value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact((short)0x0123);
 
@@ -605,7 +624,6 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             assertEquals((short)0x4567, x, "getAndSetAcquire short value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact((short)0x0123);
 
@@ -877,10 +895,10 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, (short)0x0123, (short)0x89AB);
-                assertEquals(success, false, "failing weakCompareAndSetAcquire short");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, (short)0x0123, (short)0x89AB);
+                assertEquals(success, false, "failing weakCompareAndSetRelease short");
                 short x = (short) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals((short)0x4567, x, "failing weakCompareAndSetAcquire short value");
+                assertEquals((short)0x4567, x, "failing weakCompareAndSetRelease short value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessShort
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
@@ -294,10 +294,30 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, "foo");
+
             String o = (String) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, "bar");
             assertEquals("foo", o, "getAndSet String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals("bar", x, "getAndSet String value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, "foo");
+
+            String o = (String) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, "bar");
+            assertEquals("foo", o, "getAndSetAcquire String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals("bar", x, "getAndSetAcquire String value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, "foo");
+
+            String o = (String) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, "bar");
+            assertEquals("foo", o, "getAndSetRelease String");
+            String x = (String) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals("bar", x, "getAndSetRelease String value");
         }
 
 
@@ -482,7 +502,7 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact("bar", "baz");
             assertEquals(success, false, "failing weakCompareAndSet String");
             String x = (String) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals("foo", x, "failing weakCompareAndSetRe String value");
+            assertEquals("foo", x, "failing weakCompareAndSet String value");
         }
 
         // Compare set and get
@@ -495,7 +515,6 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             assertEquals("bar", x, "getAndSet String value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact("foo");
 
@@ -505,7 +524,6 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             assertEquals("bar", x, "getAndSetAcquire String value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact("foo");
 
@@ -677,10 +695,10 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, "foo", "baz");
-                assertEquals(success, false, "failing weakCompareAndSetAcquire String");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, "foo", "baz");
+                assertEquals(success, false, "failing weakCompareAndSetRelease String");
                 String x = (String) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals("bar", x, "failing weakCompareAndSetAcquire String value");
+                assertEquals("bar", x, "failing weakCompareAndSetRelease String value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
@@ -25,8 +25,8 @@
 
 /*
  * @test
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessString
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
@@ -297,10 +297,30 @@ public class VarHandleTestMethodHandleAccessValue extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, Value.getInstance(10));
+
             Value o = (Value) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, Value.getInstance(20));
             assertEquals(Value.getInstance(10), o, "getAndSet Value");
             Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals(Value.getInstance(20), x, "getAndSet Value value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, Value.getInstance(10));
+
+            Value o = (Value) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, Value.getInstance(20));
+            assertEquals(Value.getInstance(10), o, "getAndSetAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(Value.getInstance(20), x, "getAndSetAcquire Value value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, Value.getInstance(10));
+
+            Value o = (Value) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, Value.getInstance(20));
+            assertEquals(Value.getInstance(10), o, "getAndSetRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(Value.getInstance(20), x, "getAndSetRelease Value value");
         }
 
 
@@ -485,7 +505,7 @@ public class VarHandleTestMethodHandleAccessValue extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(Value.getInstance(20), Value.getInstance(30));
             assertEquals(success, false, "failing weakCompareAndSet Value");
             Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals(Value.getInstance(10), x, "failing weakCompareAndSetRe Value value");
+            assertEquals(Value.getInstance(10), x, "failing weakCompareAndSet Value value");
         }
 
         // Compare set and get
@@ -498,7 +518,6 @@ public class VarHandleTestMethodHandleAccessValue extends VarHandleBaseTest {
             assertEquals(Value.getInstance(20), x, "getAndSet Value value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(Value.getInstance(10));
 
@@ -508,7 +527,6 @@ public class VarHandleTestMethodHandleAccessValue extends VarHandleBaseTest {
             assertEquals(Value.getInstance(20), x, "getAndSetAcquire Value value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact(Value.getInstance(10));
 
@@ -680,10 +698,10 @@ public class VarHandleTestMethodHandleAccessValue extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, Value.getInstance(10), Value.getInstance(30));
-                assertEquals(success, false, "failing weakCompareAndSetAcquire Value");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, Value.getInstance(10), Value.getInstance(30));
+                assertEquals(success, false, "failing weakCompareAndSetRelease Value");
                 Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals(Value.getInstance(20), x, "failing weakCompareAndSetAcquire Value value");
+                assertEquals(Value.getInstance(20), x, "failing weakCompareAndSetRelease Value value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
@@ -28,8 +28,8 @@
  * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.value
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccessValue
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             boolean x = (boolean) vh.compareAndExchange(recv, true, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.compareAndExchange(0, true, true);
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             boolean x = (boolean) vh.compareAndExchangeAcquire(recv, true, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.compareAndExchangeAcquire(0, true, true);
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             boolean x = (boolean) vh.compareAndExchangeRelease(recv, true, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.compareAndExchangeRelease(0, true, true);
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndSet(0, true);
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndSetAcquire(0, true);
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndSetRelease(0, true);
         });
         // Incorrect return type
@@ -661,7 +661,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseOr(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndBitwiseOr(0, true);
         });
         // Incorrect return type
@@ -691,7 +691,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseOrAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndBitwiseOrAcquire(0, true);
         });
         // Incorrect return type
@@ -716,27 +716,27 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
             boolean x = (boolean) vh.getAndBitwiseOrRelease(null, true);
         });
         checkCCE(() -> { // receiver reference class
-            boolean x = (boolean) vh.getAndBitwiseOr(Void.class, true);
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(Void.class, true);
         });
         checkWMTE(() -> { // value reference class
-            boolean x = (boolean) vh.getAndBitwiseOr(recv, Void.class);
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            boolean x = (boolean) vh.getAndBitwiseOr(0, true);
+        checkWMTE(() -> { // receiver primitive class
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(0, true);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseOr(recv, true);
+            Void r = (Void) vh.getAndBitwiseOrRelease(recv, true);
         });
         checkWMTE(() -> { // primitive class
-            int x = (int) vh.getAndBitwiseOr(recv, true);
+            int x = (int) vh.getAndBitwiseOrRelease(recv, true);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            boolean x = (boolean) vh.getAndBitwiseOr();
+            boolean x = (boolean) vh.getAndBitwiseOrRelease();
         });
         checkWMTE(() -> { // >
-            boolean x = (boolean) vh.getAndBitwiseOr(recv, true, Void.class);
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(recv, true, Void.class);
         });
 
 
@@ -751,7 +751,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseAnd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndBitwiseAnd(0, true);
         });
         // Incorrect return type
@@ -781,7 +781,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseAndAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndBitwiseAndAcquire(0, true);
         });
         // Incorrect return type
@@ -806,27 +806,27 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
             boolean x = (boolean) vh.getAndBitwiseAndRelease(null, true);
         });
         checkCCE(() -> { // receiver reference class
-            boolean x = (boolean) vh.getAndBitwiseAnd(Void.class, true);
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(Void.class, true);
         });
         checkWMTE(() -> { // value reference class
-            boolean x = (boolean) vh.getAndBitwiseAnd(recv, Void.class);
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            boolean x = (boolean) vh.getAndBitwiseAnd(0, true);
+        checkWMTE(() -> { // receiver primitive class
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(0, true);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseAnd(recv, true);
+            Void r = (Void) vh.getAndBitwiseAndRelease(recv, true);
         });
         checkWMTE(() -> { // primitive class
-            int x = (int) vh.getAndBitwiseAnd(recv, true);
+            int x = (int) vh.getAndBitwiseAndRelease(recv, true);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            boolean x = (boolean) vh.getAndBitwiseAnd();
+            boolean x = (boolean) vh.getAndBitwiseAndRelease();
         });
         checkWMTE(() -> { // >
-            boolean x = (boolean) vh.getAndBitwiseAnd(recv, true, Void.class);
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(recv, true, Void.class);
         });
 
 
@@ -841,7 +841,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseXor(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndBitwiseXor(0, true);
         });
         // Incorrect return type
@@ -871,7 +871,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseXorAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             boolean x = (boolean) vh.getAndBitwiseXorAcquire(0, true);
         });
         // Incorrect return type
@@ -896,27 +896,27 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
             boolean x = (boolean) vh.getAndBitwiseXorRelease(null, true);
         });
         checkCCE(() -> { // receiver reference class
-            boolean x = (boolean) vh.getAndBitwiseXor(Void.class, true);
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(Void.class, true);
         });
         checkWMTE(() -> { // value reference class
-            boolean x = (boolean) vh.getAndBitwiseXor(recv, Void.class);
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            boolean x = (boolean) vh.getAndBitwiseXor(0, true);
+        checkWMTE(() -> { // receiver primitive class
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(0, true);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseXor(recv, true);
+            Void r = (Void) vh.getAndBitwiseXorRelease(recv, true);
         });
         checkWMTE(() -> { // primitive class
-            int x = (int) vh.getAndBitwiseXor(recv, true);
+            int x = (int) vh.getAndBitwiseXorRelease(recv, true);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            boolean x = (boolean) vh.getAndBitwiseXor();
+            boolean x = (boolean) vh.getAndBitwiseXorRelease();
         });
         checkWMTE(() -> { // >
-            boolean x = (boolean) vh.getAndBitwiseXor(recv, true, Void.class);
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(recv, true, Void.class);
         });
     }
 
@@ -1034,7 +1034,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                 boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class, Class.class)).
                     invokeExact(recv, true, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class , boolean.class, boolean.class)).
                     invokeExact(0, true, true);
             });
@@ -1071,7 +1071,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                 boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, boolean.class)).
                     invokeExact(0, true);
             });
@@ -1109,7 +1109,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                 boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, boolean.class)).
                     invokeExact(0, true);
             });
@@ -1507,7 +1507,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseOrReleaseRelease
+        // GetAndBitwiseOrRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseOrRelease(Void.class);
@@ -1570,7 +1570,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseAndReleaseRelease
+        // GetAndBitwiseAndRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseAndRelease(Void.class);
@@ -1633,7 +1633,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseXorReleaseRelease
+        // GetAndBitwiseXorRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndBitwiseXorRelease(Void.class);
@@ -2287,7 +2287,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             boolean x = (boolean) vh.getAndSet(0, 0, true);
         });
         checkWMTE(() -> { // index reference class
@@ -2320,7 +2320,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             boolean x = (boolean) vh.getAndSetAcquire(0, 0, true);
         });
         checkWMTE(() -> { // index reference class
@@ -2353,7 +2353,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             boolean x = (boolean) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             boolean x = (boolean) vh.getAndSetRelease(0, 0, true);
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             byte x = (byte) vh.compareAndExchange(recv, (byte)0x01, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.compareAndExchange(0, (byte)0x01, (byte)0x01);
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             byte x = (byte) vh.compareAndExchangeAcquire(recv, (byte)0x01, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.compareAndExchangeAcquire(0, (byte)0x01, (byte)0x01);
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             byte x = (byte) vh.compareAndExchangeRelease(recv, (byte)0x01, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.compareAndExchangeRelease(0, (byte)0x01, (byte)0x01);
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndSet(0, (byte)0x01);
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndSetAcquire(0, (byte)0x01);
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndSetRelease(0, (byte)0x01);
         });
         // Incorrect return type
@@ -660,7 +660,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndAdd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndAdd(0, (byte)0x01);
         });
         // Incorrect return type
@@ -689,7 +689,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndAddAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndAddAcquire(0, (byte)0x01);
         });
         // Incorrect return type
@@ -718,7 +718,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndAddRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndAddRelease(0, (byte)0x01);
         });
         // Incorrect return type
@@ -747,7 +747,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseOr(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndBitwiseOr(0, (byte)0x01);
         });
         // Incorrect return type
@@ -777,7 +777,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseOrAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndBitwiseOrAcquire(0, (byte)0x01);
         });
         // Incorrect return type
@@ -802,27 +802,27 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
             byte x = (byte) vh.getAndBitwiseOrRelease(null, (byte)0x01);
         });
         checkCCE(() -> { // receiver reference class
-            byte x = (byte) vh.getAndBitwiseOr(Void.class, (byte)0x01);
+            byte x = (byte) vh.getAndBitwiseOrRelease(Void.class, (byte)0x01);
         });
         checkWMTE(() -> { // value reference class
-            byte x = (byte) vh.getAndBitwiseOr(recv, Void.class);
+            byte x = (byte) vh.getAndBitwiseOrRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            byte x = (byte) vh.getAndBitwiseOr(0, (byte)0x01);
+        checkWMTE(() -> { // receiver primitive class
+            byte x = (byte) vh.getAndBitwiseOrRelease(0, (byte)0x01);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseOr(recv, (byte)0x01);
+            Void r = (Void) vh.getAndBitwiseOrRelease(recv, (byte)0x01);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseOr(recv, (byte)0x01);
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(recv, (byte)0x01);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            byte x = (byte) vh.getAndBitwiseOr();
+            byte x = (byte) vh.getAndBitwiseOrRelease();
         });
         checkWMTE(() -> { // >
-            byte x = (byte) vh.getAndBitwiseOr(recv, (byte)0x01, Void.class);
+            byte x = (byte) vh.getAndBitwiseOrRelease(recv, (byte)0x01, Void.class);
         });
 
 
@@ -837,7 +837,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseAnd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndBitwiseAnd(0, (byte)0x01);
         });
         // Incorrect return type
@@ -867,7 +867,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseAndAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndBitwiseAndAcquire(0, (byte)0x01);
         });
         // Incorrect return type
@@ -892,27 +892,27 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
             byte x = (byte) vh.getAndBitwiseAndRelease(null, (byte)0x01);
         });
         checkCCE(() -> { // receiver reference class
-            byte x = (byte) vh.getAndBitwiseAnd(Void.class, (byte)0x01);
+            byte x = (byte) vh.getAndBitwiseAndRelease(Void.class, (byte)0x01);
         });
         checkWMTE(() -> { // value reference class
-            byte x = (byte) vh.getAndBitwiseAnd(recv, Void.class);
+            byte x = (byte) vh.getAndBitwiseAndRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            byte x = (byte) vh.getAndBitwiseAnd(0, (byte)0x01);
+        checkWMTE(() -> { // receiver primitive class
+            byte x = (byte) vh.getAndBitwiseAndRelease(0, (byte)0x01);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseAnd(recv, (byte)0x01);
+            Void r = (Void) vh.getAndBitwiseAndRelease(recv, (byte)0x01);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseAnd(recv, (byte)0x01);
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(recv, (byte)0x01);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            byte x = (byte) vh.getAndBitwiseAnd();
+            byte x = (byte) vh.getAndBitwiseAndRelease();
         });
         checkWMTE(() -> { // >
-            byte x = (byte) vh.getAndBitwiseAnd(recv, (byte)0x01, Void.class);
+            byte x = (byte) vh.getAndBitwiseAndRelease(recv, (byte)0x01, Void.class);
         });
 
 
@@ -927,7 +927,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseXor(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndBitwiseXor(0, (byte)0x01);
         });
         // Incorrect return type
@@ -957,7 +957,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseXorAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             byte x = (byte) vh.getAndBitwiseXorAcquire(0, (byte)0x01);
         });
         // Incorrect return type
@@ -982,27 +982,27 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
             byte x = (byte) vh.getAndBitwiseXorRelease(null, (byte)0x01);
         });
         checkCCE(() -> { // receiver reference class
-            byte x = (byte) vh.getAndBitwiseXor(Void.class, (byte)0x01);
+            byte x = (byte) vh.getAndBitwiseXorRelease(Void.class, (byte)0x01);
         });
         checkWMTE(() -> { // value reference class
-            byte x = (byte) vh.getAndBitwiseXor(recv, Void.class);
+            byte x = (byte) vh.getAndBitwiseXorRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            byte x = (byte) vh.getAndBitwiseXor(0, (byte)0x01);
+        checkWMTE(() -> { // receiver primitive class
+            byte x = (byte) vh.getAndBitwiseXorRelease(0, (byte)0x01);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseXor(recv, (byte)0x01);
+            Void r = (Void) vh.getAndBitwiseXorRelease(recv, (byte)0x01);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseXor(recv, (byte)0x01);
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(recv, (byte)0x01);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            byte x = (byte) vh.getAndBitwiseXor();
+            byte x = (byte) vh.getAndBitwiseXorRelease();
         });
         checkWMTE(() -> { // >
-            byte x = (byte) vh.getAndBitwiseXor(recv, (byte)0x01, Void.class);
+            byte x = (byte) vh.getAndBitwiseXorRelease(recv, (byte)0x01, Void.class);
         });
     }
 
@@ -1120,7 +1120,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                 byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class, Class.class)).
                     invokeExact(recv, (byte)0x01, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 byte x = (byte) hs.get(am, methodType(byte.class, int.class , byte.class, byte.class)).
                     invokeExact(0, (byte)0x01, (byte)0x01);
             });
@@ -1157,7 +1157,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                 byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 byte x = (byte) hs.get(am, methodType(byte.class, int.class, byte.class)).
                     invokeExact(0, (byte)0x01);
             });
@@ -1194,7 +1194,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                 byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 byte x = (byte) hs.get(am, methodType(byte.class, int.class, byte.class)).
                     invokeExact(0, (byte)0x01);
             });
@@ -1231,7 +1231,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                 byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 byte x = (byte) hs.get(am, methodType(byte.class, int.class, byte.class)).
                     invokeExact(0, (byte)0x01);
             });
@@ -1690,7 +1690,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseOrReleaseRelease
+        // GetAndBitwiseOrRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseOrRelease(Void.class);
@@ -1753,7 +1753,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseAndReleaseRelease
+        // GetAndBitwiseAndRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseAndRelease(Void.class);
@@ -1816,7 +1816,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseXorReleaseRelease
+        // GetAndBitwiseXorRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndBitwiseXorRelease(Void.class);
@@ -2495,7 +2495,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             byte x = (byte) vh.getAndSet(0, 0, (byte)0x01);
         });
         checkWMTE(() -> { // index reference class
@@ -2528,7 +2528,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             byte x = (byte) vh.getAndSetAcquire(0, 0, (byte)0x01);
         });
         checkWMTE(() -> { // index reference class
@@ -2561,7 +2561,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             byte x = (byte) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             byte x = (byte) vh.getAndSetRelease(0, 0, (byte)0x01);
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             char x = (char) vh.compareAndExchange(recv, '\u0123', Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.compareAndExchange(0, '\u0123', '\u0123');
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             char x = (char) vh.compareAndExchangeAcquire(recv, '\u0123', Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.compareAndExchangeAcquire(0, '\u0123', '\u0123');
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             char x = (char) vh.compareAndExchangeRelease(recv, '\u0123', Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.compareAndExchangeRelease(0, '\u0123', '\u0123');
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndSet(0, '\u0123');
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndSetAcquire(0, '\u0123');
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndSetRelease(0, '\u0123');
         });
         // Incorrect return type
@@ -660,7 +660,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndAdd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndAdd(0, '\u0123');
         });
         // Incorrect return type
@@ -689,7 +689,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndAddAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndAddAcquire(0, '\u0123');
         });
         // Incorrect return type
@@ -718,7 +718,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndAddRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndAddRelease(0, '\u0123');
         });
         // Incorrect return type
@@ -747,7 +747,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseOr(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndBitwiseOr(0, '\u0123');
         });
         // Incorrect return type
@@ -777,7 +777,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseOrAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndBitwiseOrAcquire(0, '\u0123');
         });
         // Incorrect return type
@@ -802,27 +802,27 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
             char x = (char) vh.getAndBitwiseOrRelease(null, '\u0123');
         });
         checkCCE(() -> { // receiver reference class
-            char x = (char) vh.getAndBitwiseOr(Void.class, '\u0123');
+            char x = (char) vh.getAndBitwiseOrRelease(Void.class, '\u0123');
         });
         checkWMTE(() -> { // value reference class
-            char x = (char) vh.getAndBitwiseOr(recv, Void.class);
+            char x = (char) vh.getAndBitwiseOrRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            char x = (char) vh.getAndBitwiseOr(0, '\u0123');
+        checkWMTE(() -> { // receiver primitive class
+            char x = (char) vh.getAndBitwiseOrRelease(0, '\u0123');
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseOr(recv, '\u0123');
+            Void r = (Void) vh.getAndBitwiseOrRelease(recv, '\u0123');
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseOr(recv, '\u0123');
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(recv, '\u0123');
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            char x = (char) vh.getAndBitwiseOr();
+            char x = (char) vh.getAndBitwiseOrRelease();
         });
         checkWMTE(() -> { // >
-            char x = (char) vh.getAndBitwiseOr(recv, '\u0123', Void.class);
+            char x = (char) vh.getAndBitwiseOrRelease(recv, '\u0123', Void.class);
         });
 
 
@@ -837,7 +837,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseAnd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndBitwiseAnd(0, '\u0123');
         });
         // Incorrect return type
@@ -867,7 +867,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseAndAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndBitwiseAndAcquire(0, '\u0123');
         });
         // Incorrect return type
@@ -892,27 +892,27 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
             char x = (char) vh.getAndBitwiseAndRelease(null, '\u0123');
         });
         checkCCE(() -> { // receiver reference class
-            char x = (char) vh.getAndBitwiseAnd(Void.class, '\u0123');
+            char x = (char) vh.getAndBitwiseAndRelease(Void.class, '\u0123');
         });
         checkWMTE(() -> { // value reference class
-            char x = (char) vh.getAndBitwiseAnd(recv, Void.class);
+            char x = (char) vh.getAndBitwiseAndRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            char x = (char) vh.getAndBitwiseAnd(0, '\u0123');
+        checkWMTE(() -> { // receiver primitive class
+            char x = (char) vh.getAndBitwiseAndRelease(0, '\u0123');
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseAnd(recv, '\u0123');
+            Void r = (Void) vh.getAndBitwiseAndRelease(recv, '\u0123');
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseAnd(recv, '\u0123');
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(recv, '\u0123');
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            char x = (char) vh.getAndBitwiseAnd();
+            char x = (char) vh.getAndBitwiseAndRelease();
         });
         checkWMTE(() -> { // >
-            char x = (char) vh.getAndBitwiseAnd(recv, '\u0123', Void.class);
+            char x = (char) vh.getAndBitwiseAndRelease(recv, '\u0123', Void.class);
         });
 
 
@@ -927,7 +927,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseXor(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndBitwiseXor(0, '\u0123');
         });
         // Incorrect return type
@@ -957,7 +957,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseXorAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             char x = (char) vh.getAndBitwiseXorAcquire(0, '\u0123');
         });
         // Incorrect return type
@@ -982,27 +982,27 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
             char x = (char) vh.getAndBitwiseXorRelease(null, '\u0123');
         });
         checkCCE(() -> { // receiver reference class
-            char x = (char) vh.getAndBitwiseXor(Void.class, '\u0123');
+            char x = (char) vh.getAndBitwiseXorRelease(Void.class, '\u0123');
         });
         checkWMTE(() -> { // value reference class
-            char x = (char) vh.getAndBitwiseXor(recv, Void.class);
+            char x = (char) vh.getAndBitwiseXorRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            char x = (char) vh.getAndBitwiseXor(0, '\u0123');
+        checkWMTE(() -> { // receiver primitive class
+            char x = (char) vh.getAndBitwiseXorRelease(0, '\u0123');
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseXor(recv, '\u0123');
+            Void r = (Void) vh.getAndBitwiseXorRelease(recv, '\u0123');
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseXor(recv, '\u0123');
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(recv, '\u0123');
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            char x = (char) vh.getAndBitwiseXor();
+            char x = (char) vh.getAndBitwiseXorRelease();
         });
         checkWMTE(() -> { // >
-            char x = (char) vh.getAndBitwiseXor(recv, '\u0123', Void.class);
+            char x = (char) vh.getAndBitwiseXorRelease(recv, '\u0123', Void.class);
         });
     }
 
@@ -1120,7 +1120,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                 char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class, Class.class)).
                     invokeExact(recv, '\u0123', Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 char x = (char) hs.get(am, methodType(char.class, int.class , char.class, char.class)).
                     invokeExact(0, '\u0123', '\u0123');
             });
@@ -1157,7 +1157,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                 char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 char x = (char) hs.get(am, methodType(char.class, int.class, char.class)).
                     invokeExact(0, '\u0123');
             });
@@ -1194,7 +1194,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                 char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 char x = (char) hs.get(am, methodType(char.class, int.class, char.class)).
                     invokeExact(0, '\u0123');
             });
@@ -1231,7 +1231,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                 char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 char x = (char) hs.get(am, methodType(char.class, int.class, char.class)).
                     invokeExact(0, '\u0123');
             });
@@ -1690,7 +1690,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseOrReleaseRelease
+        // GetAndBitwiseOrRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseOrRelease(Void.class);
@@ -1753,7 +1753,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseAndReleaseRelease
+        // GetAndBitwiseAndRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseAndRelease(Void.class);
@@ -1816,7 +1816,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseXorReleaseRelease
+        // GetAndBitwiseXorRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndBitwiseXorRelease(Void.class);
@@ -2495,7 +2495,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             char x = (char) vh.getAndSet(0, 0, '\u0123');
         });
         checkWMTE(() -> { // index reference class
@@ -2528,7 +2528,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             char x = (char) vh.getAndSetAcquire(0, 0, '\u0123');
         });
         checkWMTE(() -> { // index reference class
@@ -2561,7 +2561,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             char x = (char) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             char x = (char) vh.getAndSetRelease(0, 0, '\u0123');
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             double x = (double) vh.compareAndExchange(recv, 1.0d, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.compareAndExchange(0, 1.0d, 1.0d);
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             double x = (double) vh.compareAndExchangeAcquire(recv, 1.0d, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.compareAndExchangeAcquire(0, 1.0d, 1.0d);
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             double x = (double) vh.compareAndExchangeRelease(recv, 1.0d, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.compareAndExchangeRelease(0, 1.0d, 1.0d);
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.getAndSet(0, 1.0d);
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.getAndSetAcquire(0, 1.0d);
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.getAndSetRelease(0, 1.0d);
         });
         // Incorrect return type
@@ -660,7 +660,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndAdd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.getAndAdd(0, 1.0d);
         });
         // Incorrect return type
@@ -689,7 +689,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndAddAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.getAndAddAcquire(0, 1.0d);
         });
         // Incorrect return type
@@ -718,7 +718,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndAddRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             double x = (double) vh.getAndAddRelease(0, 1.0d);
         });
         // Incorrect return type
@@ -852,7 +852,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                 double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, double.class, Class.class)).
                     invokeExact(recv, 1.0d, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 double x = (double) hs.get(am, methodType(double.class, int.class , double.class, double.class)).
                     invokeExact(0, 1.0d, 1.0d);
             });
@@ -889,7 +889,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                 double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 double x = (double) hs.get(am, methodType(double.class, int.class, double.class)).
                     invokeExact(0, 1.0d);
             });
@@ -926,7 +926,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                 double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 double x = (double) hs.get(am, methodType(double.class, int.class, double.class)).
                     invokeExact(0, 1.0d);
             });
@@ -1979,7 +1979,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             double x = (double) vh.getAndSet(0, 0, 1.0d);
         });
         checkWMTE(() -> { // index reference class
@@ -2012,7 +2012,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             double x = (double) vh.getAndSetAcquire(0, 0, 1.0d);
         });
         checkWMTE(() -> { // index reference class
@@ -2045,7 +2045,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             double x = (double) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             double x = (double) vh.getAndSetRelease(0, 0, 1.0d);
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             float x = (float) vh.compareAndExchange(recv, 1.0f, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.compareAndExchange(0, 1.0f, 1.0f);
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             float x = (float) vh.compareAndExchangeAcquire(recv, 1.0f, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.compareAndExchangeAcquire(0, 1.0f, 1.0f);
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             float x = (float) vh.compareAndExchangeRelease(recv, 1.0f, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.compareAndExchangeRelease(0, 1.0f, 1.0f);
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.getAndSet(0, 1.0f);
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.getAndSetAcquire(0, 1.0f);
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.getAndSetRelease(0, 1.0f);
         });
         // Incorrect return type
@@ -660,7 +660,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndAdd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.getAndAdd(0, 1.0f);
         });
         // Incorrect return type
@@ -689,7 +689,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndAddAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.getAndAddAcquire(0, 1.0f);
         });
         // Incorrect return type
@@ -718,7 +718,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndAddRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             float x = (float) vh.getAndAddRelease(0, 1.0f);
         });
         // Incorrect return type
@@ -852,7 +852,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                 float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, float.class, Class.class)).
                     invokeExact(recv, 1.0f, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 float x = (float) hs.get(am, methodType(float.class, int.class , float.class, float.class)).
                     invokeExact(0, 1.0f, 1.0f);
             });
@@ -889,7 +889,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                 float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 float x = (float) hs.get(am, methodType(float.class, int.class, float.class)).
                     invokeExact(0, 1.0f);
             });
@@ -926,7 +926,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                 float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 float x = (float) hs.get(am, methodType(float.class, int.class, float.class)).
                     invokeExact(0, 1.0f);
             });
@@ -1979,7 +1979,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             float x = (float) vh.getAndSet(0, 0, 1.0f);
         });
         checkWMTE(() -> { // index reference class
@@ -2012,7 +2012,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             float x = (float) vh.getAndSetAcquire(0, 0, 1.0f);
         });
         checkWMTE(() -> { // index reference class
@@ -2045,7 +2045,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             float x = (float) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             float x = (float) vh.getAndSetRelease(0, 0, 1.0f);
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             int x = (int) vh.compareAndExchange(recv, 0x01234567, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.compareAndExchange(0, 0x01234567, 0x01234567);
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             int x = (int) vh.compareAndExchangeAcquire(recv, 0x01234567, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.compareAndExchangeAcquire(0, 0x01234567, 0x01234567);
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             int x = (int) vh.compareAndExchangeRelease(recv, 0x01234567, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.compareAndExchangeRelease(0, 0x01234567, 0x01234567);
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndSet(0, 0x01234567);
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndSetAcquire(0, 0x01234567);
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndSetRelease(0, 0x01234567);
         });
         // Incorrect return type
@@ -660,7 +660,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndAdd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndAdd(0, 0x01234567);
         });
         // Incorrect return type
@@ -689,7 +689,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndAddAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndAddAcquire(0, 0x01234567);
         });
         // Incorrect return type
@@ -718,7 +718,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndAddRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndAddRelease(0, 0x01234567);
         });
         // Incorrect return type
@@ -747,7 +747,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseOr(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndBitwiseOr(0, 0x01234567);
         });
         // Incorrect return type
@@ -777,7 +777,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseOrAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndBitwiseOrAcquire(0, 0x01234567);
         });
         // Incorrect return type
@@ -802,27 +802,27 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
             int x = (int) vh.getAndBitwiseOrRelease(null, 0x01234567);
         });
         checkCCE(() -> { // receiver reference class
-            int x = (int) vh.getAndBitwiseOr(Void.class, 0x01234567);
+            int x = (int) vh.getAndBitwiseOrRelease(Void.class, 0x01234567);
         });
         checkWMTE(() -> { // value reference class
-            int x = (int) vh.getAndBitwiseOr(recv, Void.class);
+            int x = (int) vh.getAndBitwiseOrRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            int x = (int) vh.getAndBitwiseOr(0, 0x01234567);
+        checkWMTE(() -> { // receiver primitive class
+            int x = (int) vh.getAndBitwiseOrRelease(0, 0x01234567);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseOr(recv, 0x01234567);
+            Void r = (Void) vh.getAndBitwiseOrRelease(recv, 0x01234567);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseOr(recv, 0x01234567);
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(recv, 0x01234567);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            int x = (int) vh.getAndBitwiseOr();
+            int x = (int) vh.getAndBitwiseOrRelease();
         });
         checkWMTE(() -> { // >
-            int x = (int) vh.getAndBitwiseOr(recv, 0x01234567, Void.class);
+            int x = (int) vh.getAndBitwiseOrRelease(recv, 0x01234567, Void.class);
         });
 
 
@@ -837,7 +837,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseAnd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndBitwiseAnd(0, 0x01234567);
         });
         // Incorrect return type
@@ -867,7 +867,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseAndAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndBitwiseAndAcquire(0, 0x01234567);
         });
         // Incorrect return type
@@ -892,27 +892,27 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
             int x = (int) vh.getAndBitwiseAndRelease(null, 0x01234567);
         });
         checkCCE(() -> { // receiver reference class
-            int x = (int) vh.getAndBitwiseAnd(Void.class, 0x01234567);
+            int x = (int) vh.getAndBitwiseAndRelease(Void.class, 0x01234567);
         });
         checkWMTE(() -> { // value reference class
-            int x = (int) vh.getAndBitwiseAnd(recv, Void.class);
+            int x = (int) vh.getAndBitwiseAndRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            int x = (int) vh.getAndBitwiseAnd(0, 0x01234567);
+        checkWMTE(() -> { // receiver primitive class
+            int x = (int) vh.getAndBitwiseAndRelease(0, 0x01234567);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseAnd(recv, 0x01234567);
+            Void r = (Void) vh.getAndBitwiseAndRelease(recv, 0x01234567);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseAnd(recv, 0x01234567);
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(recv, 0x01234567);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            int x = (int) vh.getAndBitwiseAnd();
+            int x = (int) vh.getAndBitwiseAndRelease();
         });
         checkWMTE(() -> { // >
-            int x = (int) vh.getAndBitwiseAnd(recv, 0x01234567, Void.class);
+            int x = (int) vh.getAndBitwiseAndRelease(recv, 0x01234567, Void.class);
         });
 
 
@@ -927,7 +927,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseXor(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndBitwiseXor(0, 0x01234567);
         });
         // Incorrect return type
@@ -957,7 +957,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseXorAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             int x = (int) vh.getAndBitwiseXorAcquire(0, 0x01234567);
         });
         // Incorrect return type
@@ -982,27 +982,27 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
             int x = (int) vh.getAndBitwiseXorRelease(null, 0x01234567);
         });
         checkCCE(() -> { // receiver reference class
-            int x = (int) vh.getAndBitwiseXor(Void.class, 0x01234567);
+            int x = (int) vh.getAndBitwiseXorRelease(Void.class, 0x01234567);
         });
         checkWMTE(() -> { // value reference class
-            int x = (int) vh.getAndBitwiseXor(recv, Void.class);
+            int x = (int) vh.getAndBitwiseXorRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            int x = (int) vh.getAndBitwiseXor(0, 0x01234567);
+        checkWMTE(() -> { // receiver primitive class
+            int x = (int) vh.getAndBitwiseXorRelease(0, 0x01234567);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseXor(recv, 0x01234567);
+            Void r = (Void) vh.getAndBitwiseXorRelease(recv, 0x01234567);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseXor(recv, 0x01234567);
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(recv, 0x01234567);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            int x = (int) vh.getAndBitwiseXor();
+            int x = (int) vh.getAndBitwiseXorRelease();
         });
         checkWMTE(() -> { // >
-            int x = (int) vh.getAndBitwiseXor(recv, 0x01234567, Void.class);
+            int x = (int) vh.getAndBitwiseXorRelease(recv, 0x01234567, Void.class);
         });
     }
 
@@ -1120,7 +1120,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                 int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class, Class.class)).
                     invokeExact(recv, 0x01234567, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 int x = (int) hs.get(am, methodType(int.class, int.class , int.class, int.class)).
                     invokeExact(0, 0x01234567, 0x01234567);
             });
@@ -1157,7 +1157,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                 int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 int x = (int) hs.get(am, methodType(int.class, int.class, int.class)).
                     invokeExact(0, 0x01234567);
             });
@@ -1194,7 +1194,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                 int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 int x = (int) hs.get(am, methodType(int.class, int.class, int.class)).
                     invokeExact(0, 0x01234567);
             });
@@ -1231,7 +1231,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                 int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 int x = (int) hs.get(am, methodType(int.class, int.class, int.class)).
                     invokeExact(0, 0x01234567);
             });
@@ -1690,7 +1690,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseOrReleaseRelease
+        // GetAndBitwiseOrRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseOrRelease(Void.class);
@@ -1753,7 +1753,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseAndReleaseRelease
+        // GetAndBitwiseAndRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseAndRelease(Void.class);
@@ -1816,7 +1816,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseXorReleaseRelease
+        // GetAndBitwiseXorRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndBitwiseXorRelease(Void.class);
@@ -2495,7 +2495,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             int x = (int) vh.getAndSet(0, 0, 0x01234567);
         });
         checkWMTE(() -> { // index reference class
@@ -2528,7 +2528,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             int x = (int) vh.getAndSetAcquire(0, 0, 0x01234567);
         });
         checkWMTE(() -> { // index reference class
@@ -2561,7 +2561,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             int x = (int) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             int x = (int) vh.getAndSetRelease(0, 0, 0x01234567);
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             long x = (long) vh.compareAndExchange(recv, 0x0123456789ABCDEFL, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.compareAndExchange(0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             long x = (long) vh.compareAndExchangeAcquire(recv, 0x0123456789ABCDEFL, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.compareAndExchangeAcquire(0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             long x = (long) vh.compareAndExchangeRelease(recv, 0x0123456789ABCDEFL, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.compareAndExchangeRelease(0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndSet(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndSetAcquire(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndSetRelease(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -660,7 +660,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndAdd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndAdd(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -689,7 +689,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndAddAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndAddAcquire(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -718,7 +718,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndAddRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndAddRelease(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -747,7 +747,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseOr(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndBitwiseOr(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -777,7 +777,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseOrAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndBitwiseOrAcquire(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -802,27 +802,27 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
             long x = (long) vh.getAndBitwiseOrRelease(null, 0x0123456789ABCDEFL);
         });
         checkCCE(() -> { // receiver reference class
-            long x = (long) vh.getAndBitwiseOr(Void.class, 0x0123456789ABCDEFL);
+            long x = (long) vh.getAndBitwiseOrRelease(Void.class, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // value reference class
-            long x = (long) vh.getAndBitwiseOr(recv, Void.class);
+            long x = (long) vh.getAndBitwiseOrRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            long x = (long) vh.getAndBitwiseOr(0, 0x0123456789ABCDEFL);
+        checkWMTE(() -> { // receiver primitive class
+            long x = (long) vh.getAndBitwiseOrRelease(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseOr(recv, 0x0123456789ABCDEFL);
+            Void r = (Void) vh.getAndBitwiseOrRelease(recv, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseOr(recv, 0x0123456789ABCDEFL);
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(recv, 0x0123456789ABCDEFL);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            long x = (long) vh.getAndBitwiseOr();
+            long x = (long) vh.getAndBitwiseOrRelease();
         });
         checkWMTE(() -> { // >
-            long x = (long) vh.getAndBitwiseOr(recv, 0x0123456789ABCDEFL, Void.class);
+            long x = (long) vh.getAndBitwiseOrRelease(recv, 0x0123456789ABCDEFL, Void.class);
         });
 
 
@@ -837,7 +837,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseAnd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndBitwiseAnd(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -867,7 +867,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseAndAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndBitwiseAndAcquire(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -892,27 +892,27 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
             long x = (long) vh.getAndBitwiseAndRelease(null, 0x0123456789ABCDEFL);
         });
         checkCCE(() -> { // receiver reference class
-            long x = (long) vh.getAndBitwiseAnd(Void.class, 0x0123456789ABCDEFL);
+            long x = (long) vh.getAndBitwiseAndRelease(Void.class, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // value reference class
-            long x = (long) vh.getAndBitwiseAnd(recv, Void.class);
+            long x = (long) vh.getAndBitwiseAndRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            long x = (long) vh.getAndBitwiseAnd(0, 0x0123456789ABCDEFL);
+        checkWMTE(() -> { // receiver primitive class
+            long x = (long) vh.getAndBitwiseAndRelease(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseAnd(recv, 0x0123456789ABCDEFL);
+            Void r = (Void) vh.getAndBitwiseAndRelease(recv, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseAnd(recv, 0x0123456789ABCDEFL);
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(recv, 0x0123456789ABCDEFL);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            long x = (long) vh.getAndBitwiseAnd();
+            long x = (long) vh.getAndBitwiseAndRelease();
         });
         checkWMTE(() -> { // >
-            long x = (long) vh.getAndBitwiseAnd(recv, 0x0123456789ABCDEFL, Void.class);
+            long x = (long) vh.getAndBitwiseAndRelease(recv, 0x0123456789ABCDEFL, Void.class);
         });
 
 
@@ -927,7 +927,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseXor(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndBitwiseXor(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -957,7 +957,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseXorAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             long x = (long) vh.getAndBitwiseXorAcquire(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
@@ -982,27 +982,27 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
             long x = (long) vh.getAndBitwiseXorRelease(null, 0x0123456789ABCDEFL);
         });
         checkCCE(() -> { // receiver reference class
-            long x = (long) vh.getAndBitwiseXor(Void.class, 0x0123456789ABCDEFL);
+            long x = (long) vh.getAndBitwiseXorRelease(Void.class, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // value reference class
-            long x = (long) vh.getAndBitwiseXor(recv, Void.class);
+            long x = (long) vh.getAndBitwiseXorRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            long x = (long) vh.getAndBitwiseXor(0, 0x0123456789ABCDEFL);
+        checkWMTE(() -> { // receiver primitive class
+            long x = (long) vh.getAndBitwiseXorRelease(0, 0x0123456789ABCDEFL);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseXor(recv, 0x0123456789ABCDEFL);
+            Void r = (Void) vh.getAndBitwiseXorRelease(recv, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseXor(recv, 0x0123456789ABCDEFL);
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(recv, 0x0123456789ABCDEFL);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            long x = (long) vh.getAndBitwiseXor();
+            long x = (long) vh.getAndBitwiseXorRelease();
         });
         checkWMTE(() -> { // >
-            long x = (long) vh.getAndBitwiseXor(recv, 0x0123456789ABCDEFL, Void.class);
+            long x = (long) vh.getAndBitwiseXorRelease(recv, 0x0123456789ABCDEFL, Void.class);
         });
     }
 
@@ -1120,7 +1120,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                 long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class, Class.class)).
                     invokeExact(recv, 0x0123456789ABCDEFL, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 long x = (long) hs.get(am, methodType(long.class, int.class , long.class, long.class)).
                     invokeExact(0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
@@ -1157,7 +1157,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                 long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 long x = (long) hs.get(am, methodType(long.class, int.class, long.class)).
                     invokeExact(0, 0x0123456789ABCDEFL);
             });
@@ -1194,7 +1194,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                 long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 long x = (long) hs.get(am, methodType(long.class, int.class, long.class)).
                     invokeExact(0, 0x0123456789ABCDEFL);
             });
@@ -1231,7 +1231,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                 long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 long x = (long) hs.get(am, methodType(long.class, int.class, long.class)).
                     invokeExact(0, 0x0123456789ABCDEFL);
             });
@@ -1690,7 +1690,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseOrReleaseRelease
+        // GetAndBitwiseOrRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseOrRelease(Void.class);
@@ -1753,7 +1753,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseAndReleaseRelease
+        // GetAndBitwiseAndRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseAndRelease(Void.class);
@@ -1816,7 +1816,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseXorReleaseRelease
+        // GetAndBitwiseXorRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndBitwiseXorRelease(Void.class);
@@ -2495,7 +2495,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             long x = (long) vh.getAndSet(0, 0, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // index reference class
@@ -2528,7 +2528,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             long x = (long) vh.getAndSetAcquire(0, 0, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // index reference class
@@ -2561,7 +2561,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             long x = (long) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             long x = (long) vh.getAndSetRelease(0, 0, 0x0123456789ABCDEFL);
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeNullRestrictedValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeNullRestrictedValue.java
@@ -483,7 +483,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // actual reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchange(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
         });
         // Incorrect return type
@@ -516,7 +516,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // actual reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeAcquire(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
         });
         // Incorrect return type
@@ -549,7 +549,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // actual reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.compareAndExchangeRelease(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
         });
         // Incorrect return type
@@ -579,7 +579,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // value reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(0, NullRestrictedValue.of((byte)20,(short)1854));
         });
         // Incorrect return type
@@ -608,7 +608,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // value reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(0, NullRestrictedValue.of((byte)20,(short)1854));
         });
         // Incorrect return type
@@ -637,7 +637,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // value reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(0, NullRestrictedValue.of((byte)20,(short)1854));
         });
         // Incorrect return type
@@ -772,7 +772,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
                 NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, NullRestrictedValue.class, Class.class)).
                     invokeExact(recv, NullRestrictedValue.of((byte)20,(short)1854), Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, int.class , NullRestrictedValue.class, NullRestrictedValue.class)).
                     invokeExact(0, NullRestrictedValue.of((byte)20,(short)1854), NullRestrictedValue.of((byte)20,(short)1854));
             });
@@ -809,7 +809,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
                 NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, VarHandleTestMethodTypeNullRestrictedValue.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 NullRestrictedValue x = (NullRestrictedValue) hs.get(am, methodType(NullRestrictedValue.class, int.class, NullRestrictedValue.class)).
                     invokeExact(0, NullRestrictedValue.of((byte)20,(short)1854));
             });
@@ -1777,7 +1777,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // value reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSet(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
         });
         checkWMTE(() -> { // index reference class
@@ -1810,7 +1810,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // value reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetAcquire(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
         });
         checkWMTE(() -> { // index reference class
@@ -1843,7 +1843,7 @@ public class VarHandleTestMethodTypeNullRestrictedValue extends VarHandleBaseTes
         checkCCE(() -> { // value reference class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             NullRestrictedValue x = (NullRestrictedValue) vh.getAndSetRelease(0, 0, NullRestrictedValue.of((byte)20,(short)1854));
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             short x = (short) vh.compareAndExchange(recv, (short)0x0123, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.compareAndExchange(0, (short)0x0123, (short)0x0123);
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             short x = (short) vh.compareAndExchangeAcquire(recv, (short)0x0123, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.compareAndExchangeAcquire(0, (short)0x0123, (short)0x0123);
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // actual reference class
             short x = (short) vh.compareAndExchangeRelease(recv, (short)0x0123, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.compareAndExchangeRelease(0, (short)0x0123, (short)0x0123);
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndSet(0, (short)0x0123);
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndSetAcquire(0, (short)0x0123);
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndSetRelease(0, (short)0x0123);
         });
         // Incorrect return type
@@ -660,7 +660,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndAdd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndAdd(0, (short)0x0123);
         });
         // Incorrect return type
@@ -689,7 +689,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndAddAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndAddAcquire(0, (short)0x0123);
         });
         // Incorrect return type
@@ -718,7 +718,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndAddRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndAddRelease(0, (short)0x0123);
         });
         // Incorrect return type
@@ -747,7 +747,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseOr(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndBitwiseOr(0, (short)0x0123);
         });
         // Incorrect return type
@@ -777,7 +777,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseOrAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndBitwiseOrAcquire(0, (short)0x0123);
         });
         // Incorrect return type
@@ -802,27 +802,27 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
             short x = (short) vh.getAndBitwiseOrRelease(null, (short)0x0123);
         });
         checkCCE(() -> { // receiver reference class
-            short x = (short) vh.getAndBitwiseOr(Void.class, (short)0x0123);
+            short x = (short) vh.getAndBitwiseOrRelease(Void.class, (short)0x0123);
         });
         checkWMTE(() -> { // value reference class
-            short x = (short) vh.getAndBitwiseOr(recv, Void.class);
+            short x = (short) vh.getAndBitwiseOrRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            short x = (short) vh.getAndBitwiseOr(0, (short)0x0123);
+        checkWMTE(() -> { // receiver primitive class
+            short x = (short) vh.getAndBitwiseOrRelease(0, (short)0x0123);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseOr(recv, (short)0x0123);
+            Void r = (Void) vh.getAndBitwiseOrRelease(recv, (short)0x0123);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseOr(recv, (short)0x0123);
+            boolean x = (boolean) vh.getAndBitwiseOrRelease(recv, (short)0x0123);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            short x = (short) vh.getAndBitwiseOr();
+            short x = (short) vh.getAndBitwiseOrRelease();
         });
         checkWMTE(() -> { // >
-            short x = (short) vh.getAndBitwiseOr(recv, (short)0x0123, Void.class);
+            short x = (short) vh.getAndBitwiseOrRelease(recv, (short)0x0123, Void.class);
         });
 
 
@@ -837,7 +837,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseAnd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndBitwiseAnd(0, (short)0x0123);
         });
         // Incorrect return type
@@ -867,7 +867,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseAndAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndBitwiseAndAcquire(0, (short)0x0123);
         });
         // Incorrect return type
@@ -892,27 +892,27 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
             short x = (short) vh.getAndBitwiseAndRelease(null, (short)0x0123);
         });
         checkCCE(() -> { // receiver reference class
-            short x = (short) vh.getAndBitwiseAnd(Void.class, (short)0x0123);
+            short x = (short) vh.getAndBitwiseAndRelease(Void.class, (short)0x0123);
         });
         checkWMTE(() -> { // value reference class
-            short x = (short) vh.getAndBitwiseAnd(recv, Void.class);
+            short x = (short) vh.getAndBitwiseAndRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            short x = (short) vh.getAndBitwiseAnd(0, (short)0x0123);
+        checkWMTE(() -> { // receiver primitive class
+            short x = (short) vh.getAndBitwiseAndRelease(0, (short)0x0123);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseAnd(recv, (short)0x0123);
+            Void r = (Void) vh.getAndBitwiseAndRelease(recv, (short)0x0123);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseAnd(recv, (short)0x0123);
+            boolean x = (boolean) vh.getAndBitwiseAndRelease(recv, (short)0x0123);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            short x = (short) vh.getAndBitwiseAnd();
+            short x = (short) vh.getAndBitwiseAndRelease();
         });
         checkWMTE(() -> { // >
-            short x = (short) vh.getAndBitwiseAnd(recv, (short)0x0123, Void.class);
+            short x = (short) vh.getAndBitwiseAndRelease(recv, (short)0x0123, Void.class);
         });
 
 
@@ -927,7 +927,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseXor(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndBitwiseXor(0, (short)0x0123);
         });
         // Incorrect return type
@@ -957,7 +957,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseXorAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             short x = (short) vh.getAndBitwiseXorAcquire(0, (short)0x0123);
         });
         // Incorrect return type
@@ -982,27 +982,27 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
             short x = (short) vh.getAndBitwiseXorRelease(null, (short)0x0123);
         });
         checkCCE(() -> { // receiver reference class
-            short x = (short) vh.getAndBitwiseXor(Void.class, (short)0x0123);
+            short x = (short) vh.getAndBitwiseXorRelease(Void.class, (short)0x0123);
         });
         checkWMTE(() -> { // value reference class
-            short x = (short) vh.getAndBitwiseXor(recv, Void.class);
+            short x = (short) vh.getAndBitwiseXorRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            short x = (short) vh.getAndBitwiseXor(0, (short)0x0123);
+        checkWMTE(() -> { // receiver primitive class
+            short x = (short) vh.getAndBitwiseXorRelease(0, (short)0x0123);
         });
         // Incorrect return type
         checkWMTE(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseXor(recv, (short)0x0123);
+            Void r = (Void) vh.getAndBitwiseXorRelease(recv, (short)0x0123);
         });
         checkWMTE(() -> { // primitive class
-            boolean x = (boolean) vh.getAndBitwiseXor(recv, (short)0x0123);
+            boolean x = (boolean) vh.getAndBitwiseXorRelease(recv, (short)0x0123);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            short x = (short) vh.getAndBitwiseXor();
+            short x = (short) vh.getAndBitwiseXorRelease();
         });
         checkWMTE(() -> { // >
-            short x = (short) vh.getAndBitwiseXor(recv, (short)0x0123, Void.class);
+            short x = (short) vh.getAndBitwiseXorRelease(recv, (short)0x0123, Void.class);
         });
     }
 
@@ -1120,7 +1120,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                 short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class, Class.class)).
                     invokeExact(recv, (short)0x0123, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 short x = (short) hs.get(am, methodType(short.class, int.class , short.class, short.class)).
                     invokeExact(0, (short)0x0123, (short)0x0123);
             });
@@ -1157,7 +1157,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                 short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 short x = (short) hs.get(am, methodType(short.class, int.class, short.class)).
                     invokeExact(0, (short)0x0123);
             });
@@ -1194,7 +1194,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                 short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 short x = (short) hs.get(am, methodType(short.class, int.class, short.class)).
                     invokeExact(0, (short)0x0123);
             });
@@ -1231,7 +1231,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                 short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 short x = (short) hs.get(am, methodType(short.class, int.class, short.class)).
                     invokeExact(0, (short)0x0123);
             });
@@ -1690,7 +1690,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseOrReleaseRelease
+        // GetAndBitwiseOrRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseOrRelease(Void.class);
@@ -1753,7 +1753,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseAndReleaseRelease
+        // GetAndBitwiseAndRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseAndRelease(Void.class);
@@ -1816,7 +1816,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseXorReleaseRelease
+        // GetAndBitwiseXorRelease
         // Incorrect argument types
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndBitwiseXorRelease(Void.class);
@@ -2495,7 +2495,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             short x = (short) vh.getAndSet(0, 0, (short)0x0123);
         });
         checkWMTE(() -> { // index reference class
@@ -2528,7 +2528,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             short x = (short) vh.getAndSetAcquire(0, 0, (short)0x0123);
         });
         checkWMTE(() -> { // index reference class
@@ -2561,7 +2561,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         checkWMTE(() -> { // value reference class
             short x = (short) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             short x = (short) vh.getAndSetRelease(0, 0, (short)0x0123);
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
@@ -477,7 +477,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // actual reference class
             String x = (String) vh.compareAndExchange(recv, "foo", Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             String x = (String) vh.compareAndExchange(0, "foo", "foo");
         });
         // Incorrect return type
@@ -510,7 +510,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // actual reference class
             String x = (String) vh.compareAndExchangeAcquire(recv, "foo", Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             String x = (String) vh.compareAndExchangeAcquire(0, "foo", "foo");
         });
         // Incorrect return type
@@ -543,7 +543,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // actual reference class
             String x = (String) vh.compareAndExchangeRelease(recv, "foo", Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             String x = (String) vh.compareAndExchangeRelease(0, "foo", "foo");
         });
         // Incorrect return type
@@ -573,7 +573,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             String x = (String) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             String x = (String) vh.getAndSet(0, "foo");
         });
         // Incorrect return type
@@ -602,7 +602,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             String x = (String) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             String x = (String) vh.getAndSetAcquire(0, "foo");
         });
         // Incorrect return type
@@ -631,7 +631,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             String x = (String) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             String x = (String) vh.getAndSetRelease(0, "foo");
         });
         // Incorrect return type
@@ -766,7 +766,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                 String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, String.class, Class.class)).
                     invokeExact(recv, "foo", Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 String x = (String) hs.get(am, methodType(String.class, int.class , String.class, String.class)).
                     invokeExact(0, "foo", "foo");
             });
@@ -803,7 +803,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                 String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 String x = (String) hs.get(am, methodType(String.class, int.class, String.class)).
                     invokeExact(0, "foo");
             });
@@ -1771,7 +1771,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             String x = (String) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             String x = (String) vh.getAndSet(0, 0, "foo");
         });
         checkWMTE(() -> { // index reference class
@@ -1804,7 +1804,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             String x = (String) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             String x = (String) vh.getAndSetAcquire(0, 0, "foo");
         });
         checkWMTE(() -> { // index reference class
@@ -1837,7 +1837,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             String x = (String) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             String x = (String) vh.getAndSetRelease(0, 0, "foo");
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
@@ -480,7 +480,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // actual reference class
             Value x = (Value) vh.compareAndExchange(recv, Value.getInstance(10), Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             Value x = (Value) vh.compareAndExchange(0, Value.getInstance(10), Value.getInstance(10));
         });
         // Incorrect return type
@@ -513,7 +513,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // actual reference class
             Value x = (Value) vh.compareAndExchangeAcquire(recv, Value.getInstance(10), Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             Value x = (Value) vh.compareAndExchangeAcquire(0, Value.getInstance(10), Value.getInstance(10));
         });
         // Incorrect return type
@@ -546,7 +546,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // actual reference class
             Value x = (Value) vh.compareAndExchangeRelease(recv, Value.getInstance(10), Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             Value x = (Value) vh.compareAndExchangeRelease(0, Value.getInstance(10), Value.getInstance(10));
         });
         // Incorrect return type
@@ -576,7 +576,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             Value x = (Value) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             Value x = (Value) vh.getAndSet(0, Value.getInstance(10));
         });
         // Incorrect return type
@@ -605,7 +605,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             Value x = (Value) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             Value x = (Value) vh.getAndSetAcquire(0, Value.getInstance(10));
         });
         // Incorrect return type
@@ -634,7 +634,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             Value x = (Value) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             Value x = (Value) vh.getAndSetRelease(0, Value.getInstance(10));
         });
         // Incorrect return type
@@ -769,7 +769,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
                 Value x = (Value) hs.get(am, methodType(Value.class, VarHandleTestMethodTypeValue.class, Value.class, Class.class)).
                     invokeExact(recv, Value.getInstance(10), Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 Value x = (Value) hs.get(am, methodType(Value.class, int.class , Value.class, Value.class)).
                     invokeExact(0, Value.getInstance(10), Value.getInstance(10));
             });
@@ -806,7 +806,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
                 Value x = (Value) hs.get(am, methodType(Value.class, VarHandleTestMethodTypeValue.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 Value x = (Value) hs.get(am, methodType(Value.class, int.class, Value.class)).
                     invokeExact(0, Value.getInstance(10));
             });
@@ -1774,7 +1774,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             Value x = (Value) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             Value x = (Value) vh.getAndSet(0, 0, Value.getInstance(10));
         });
         checkWMTE(() -> { // index reference class
@@ -1807,7 +1807,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             Value x = (Value) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             Value x = (Value) vh.getAndSetAcquire(0, 0, Value.getInstance(10));
         });
         checkWMTE(() -> { // index reference class
@@ -1840,7 +1840,7 @@ public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
         checkCCE(() -> { // value reference class
             Value x = (Value) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             Value x = (Value) vh.getAndSetRelease(0, 0, Value.getInstance(10));
         });
         checkWMTE(() -> { // index reference class

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
@@ -394,7 +394,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         // Lazy
         {
             $type$ x = ($type$) vh.getAcquire(recv);
-            assertEquals($value1$, x, "getRelease $type$ value");
+            assertEquals($value1$, x, "getAcquire $type$ value");
         }
 
         // Opaque
@@ -538,7 +538,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         // Lazy
         {
             $type$ x = ($type$) vh.getAcquire();
-            assertEquals($value1$, x, "getRelease $type$ value");
+            assertEquals($value1$, x, "getAcquire $type$ value");
         }
 
         // Opaque
@@ -880,7 +880,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             vh.set(recv, $value1$);
 
             $type$ o = ($type$) vh.getAndAddRelease(recv, $value2$);
-            assertEquals($value1$, o, "getAndAddRelease$type$");
+            assertEquals($value1$, o, "getAndAddRelease $type$");
             $type$ x = ($type$) vh.get(recv);
             assertEquals(($type$)($value1$ + $value2$), x, "getAndAddRelease $type$ value");
         }
@@ -1289,7 +1289,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             vh.set($value1$);
 
             $type$ o = ($type$) vh.getAndAddRelease($value2$);
-            assertEquals($value1$, o, "getAndAddRelease$type$");
+            assertEquals($value1$, o, "getAndAddRelease $type$");
             $type$ x = ($type$) vh.get();
             assertEquals(($type$)($value1$ + $value2$), x, "getAndAddRelease $type$ value");
         }
@@ -1701,7 +1701,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
                 vh.set(array, i, $value1$);
 
                 $type$ o = ($type$) vh.getAndAddRelease(array, i, $value2$);
-                assertEquals($value1$, o, "getAndAddRelease$type$");
+                assertEquals($value1$, o, "getAndAddRelease $type$");
                 $type$ x = ($type$) vh.get(array, i);
                 assertEquals(($type$)($value1$ + $value2$), x, "getAndAddRelease $type$ value");
             }
@@ -2063,57 +2063,57 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.compareAndSet(array, 0, $value1$, value);
         });
 
         // WeakCompareAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetPlain(array, 0, $value1$, value);
         });
 
         // WeakCompareAndSetVolatile
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSet(array, 0, $value1$, value);
         });
 
         // WeakCompareAndSetAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(array, 0, $value1$, value);
         });
 
         // WeakCompareAndSetRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             boolean r = vh.weakCompareAndSetRelease(array, 0, $value1$, value);
         });
 
         // CompareAndExchange
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             $type$ x = ($type$) vh.compareAndExchange(array, 0, $value1$, value);
         });
 
         // CompareAndExchangeAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             $type$ x = ($type$) vh.compareAndExchangeAcquire(array, 0, $value1$, value);
         });
 
         // CompareAndExchangeRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             $type$ x = ($type$) vh.compareAndExchangeRelease(array, 0, $value1$, value);
         });
 
         // GetAndSet
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             $type$ x = ($type$) vh.getAndSet(array, 0, value);
         });
 
         // GetAndSetAcquire
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             $type$ x = ($type$) vh.getAndSetAcquire(array, 0, value);
         });
 
         // GetAndSetRelease
-        checkASE(() -> { // receiver reference class
+        checkASE(() -> {
             $type$ x = ($type$) vh.getAndSetRelease(array, 0, value);
         });
     }
@@ -2144,57 +2144,57 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.compareAndSet(recv, $value1$, value);
         });
 
         // WeakCompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetPlain(recv, $value1$, value);
         });
 
         // WeakCompareAndSetVolatile
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSet(recv, $value1$, value);
         });
 
         // WeakCompareAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(recv, $value1$, value);
         });
 
         // WeakCompareAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetRelease(recv, $value1$, value);
         });
 
         // CompareAndExchange
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchange(recv, $value1$, value);
         });
 
         // CompareAndExchangeAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchangeAcquire(recv, $value1$, value);
         });
 
         // CompareAndExchangeRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchangeRelease(recv, $value1$, value);
         });
 
         // GetAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSet(recv, value);
         });
 
         // GetAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSetAcquire(recv, value);
         });
 
         // GetAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSetRelease(recv, value);
         });
     }
@@ -2223,57 +2223,57 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.compareAndSet($value1$, value);
         });
 
         // WeakCompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetPlain($value1$, value);
         });
 
         // WeakCompareAndSetVolatile
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSet($value1$, value);
         });
 
         // WeakCompareAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetAcquire($value1$, value);
         });
 
         // WeakCompareAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetRelease($value1$, value);
         });
 
         // CompareAndExchange
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchange($value1$, value);
         });
 
         // CompareAndExchangeAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchangeAcquire($value1$, value);
         });
 
         // CompareAndExchangeRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchangeRelease($value1$, value);
         });
 
         // GetAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSet(value);
         });
 
         // GetAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSetAcquire(value);
         });
 
         // GetAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSetRelease(value);
         });
     }
@@ -2303,57 +2303,57 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         });
 
         // CompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.compareAndSet(array, 0, $value1$, value);
         });
 
         // WeakCompareAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetPlain(array, 0, $value1$, value);
         });
 
         // WeakCompareAndSetVolatile
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSet(array, 0, $value1$, value);
         });
 
         // WeakCompareAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetAcquire(array, 0, $value1$, value);
         });
 
         // WeakCompareAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             boolean r = vh.weakCompareAndSetRelease(array, 0, $value1$, value);
         });
 
         // CompareAndExchange
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchange(array, 0, $value1$, value);
         });
 
         // CompareAndExchangeAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchangeAcquire(array, 0, $value1$, value);
         });
 
         // CompareAndExchangeRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.compareAndExchangeRelease(array, 0, $value1$, value);
         });
 
         // GetAndSet
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSet(array, 0, value);
         });
 
         // GetAndSetAcquire
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSetAcquire(array, 0, value);
         });
 
         // GetAndSetRelease
-        checkNPE(() -> { // receiver reference class
+        checkNPE(() -> {
             $type$ x = ($type$) vh.getAndSetRelease(array, 0, value);
         });
     }

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
@@ -32,8 +32,8 @@
 #end[Value]
  * @run junit/othervm -Diters=10   -Xint                                                   VarHandleTestAccess$Type$
  *
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  *
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestAccess$Type$
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestAccess$Type$

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestByteArrayView.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestByteArrayView.java.template
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8154556
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAs$Type$
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1                         VarHandleTestByteArrayAs$Type$
  * @run junit/othervm/timeout=360 -Diters=2000 -XX:CompileThresholdScaling=0.1 -XX:-TieredCompilation  VarHandleTestByteArrayAs$Type$

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestByteArrayView.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestByteArrayView.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,9 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
     public List<VarHandleSource> setupVarHandleSources(boolean same) {
         // Combinations of VarHandle byte[] or ByteBuffer
         List<VarHandleSource> vhss = new ArrayList<>();
-        for (MemoryMode endianess : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
+        for (MemoryMode endianness : List.of(MemoryMode.BIG_ENDIAN, MemoryMode.LITTLE_ENDIAN)) {
 
-            ByteOrder bo = endianess == MemoryMode.BIG_ENDIAN
+            ByteOrder bo = endianness == MemoryMode.BIG_ENDIAN
                     ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
             Class<?> arrayType;
@@ -77,12 +77,12 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
             }
             VarHandleSource aeh = new VarHandleSource(
                     MethodHandles.byteArrayViewVarHandle(arrayType, bo), false,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(aeh);
 
             VarHandleSource bbh = new VarHandleSource(
                     MethodHandles.byteBufferViewVarHandle(arrayType, bo), true,
-                    endianess, MemoryMode.READ_WRITE);
+                    endianness, MemoryMode.READ_WRITE);
             vhss.add(bbh);
         }
         return vhss;
@@ -1627,7 +1627,7 @@ public class VarHandleTestByteArrayAs$Type$ extends VarHandleBaseByteArrayTest {
                 // Lazy
                 {
                     $type$ x = ($type$) vh.getAcquire(array, i);
-                    assertEquals(v, x, "getRelease $type$ value");
+                    assertEquals(v, x, "getAcquire $type$ value");
                 }
 
                 // Opaque

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
@@ -30,8 +30,8 @@
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.value
 #end[Value]
- * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
- *          to hit compilation thresholds
+ * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop set to 2000 iterations
+ *          hits compilation thresholds
  * @run junit/othervm -Diters=2000 -XX:CompileThresholdScaling=0.1 VarHandleTestMethodHandleAccess$Type$
  */
 

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
@@ -320,10 +320,30 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
 
         // Compare set and get
         {
+            hs.get(TestAccessMode.SET).invokeExact(recv, $value1$);
+
             $type$ o = ($type$) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, $value2$);
             assertEquals($value1$, o, "getAndSet $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
             assertEquals($value2$, x, "getAndSet $type$ value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, $value1$);
+
+            $type$ o = ($type$) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(recv, $value2$);
+            assertEquals($value1$, o, "getAndSetAcquire $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals($value2$, x, "getAndSetAcquire $type$ value");
+        }
+
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, $value1$);
+
+            $type$ o = ($type$) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(recv, $value2$);
+            assertEquals($value1$, o, "getAndSetRelease $type$");
+            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals($value2$, x, "getAndSetRelease $type$ value");
         }
 #end[CAS]
 
@@ -647,7 +667,7 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact($value2$, $value3$);
             assertEquals(success, false, "failing weakCompareAndSet $type$");
             $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact();
-            assertEquals($value1$, x, "failing weakCompareAndSetRe $type$ value");
+            assertEquals($value1$, x, "failing weakCompareAndSet $type$ value");
         }
 
         // Compare set and get
@@ -660,7 +680,6 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             assertEquals($value2$, x, "getAndSet $type$ value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact($value1$);
 
@@ -670,7 +689,6 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             assertEquals($value2$, x, "getAndSetAcquire $type$ value");
         }
 
-        // Compare set and get
         {
             hs.get(TestAccessMode.SET).invokeExact($value1$);
 
@@ -981,10 +999,10 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             }
 
             {
-                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, $value1$, $value3$);
-                assertEquals(success, false, "failing weakCompareAndSetAcquire $type$");
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(array, i, $value1$, $value3$);
+                assertEquals(success, false, "failing weakCompareAndSetRelease $type$");
                 $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(array, i);
-                assertEquals($value2$, x, "failing weakCompareAndSetAcquire $type$ value");
+                assertEquals($value2$, x, "failing weakCompareAndSetRelease $type$ value");
             }
 
             {

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
@@ -488,7 +488,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // actual reference class
             $type$ x = ($type$) vh.compareAndExchange(recv, $value1$, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.compareAndExchange(0, $value1$, $value1$);
         });
         // Incorrect return type
@@ -521,7 +521,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // actual reference class
             $type$ x = ($type$) vh.compareAndExchangeAcquire(recv, $value1$, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.compareAndExchangeAcquire(0, $value1$, $value1$);
         });
         // Incorrect return type
@@ -554,7 +554,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // actual reference class
             $type$ x = ($type$) vh.compareAndExchangeRelease(recv, $value1$, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.compareAndExchangeRelease(0, $value1$, $value1$);
         });
         // Incorrect return type
@@ -584,7 +584,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndSet(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndSet(0, $value1$);
         });
         // Incorrect return type
@@ -613,7 +613,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndSetAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndSetAcquire(0, $value1$);
         });
         // Incorrect return type
@@ -642,7 +642,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndSetRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndSetRelease(0, $value1$);
         });
         // Incorrect return type
@@ -673,7 +673,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndAdd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndAdd(0, $value1$);
         });
         // Incorrect return type
@@ -702,7 +702,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndAddAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndAddAcquire(0, $value1$);
         });
         // Incorrect return type
@@ -731,7 +731,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndAddRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndAddRelease(0, $value1$);
         });
         // Incorrect return type
@@ -762,7 +762,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseOr(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndBitwiseOr(0, $value1$);
         });
         // Incorrect return type
@@ -792,7 +792,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseOrAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndBitwiseOrAcquire(0, $value1$);
         });
         // Incorrect return type
@@ -817,27 +817,27 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
             $type$ x = ($type$) vh.getAndBitwiseOrRelease(null, $value1$);
         });
         checkCCE(() -> { // receiver reference class
-            $type$ x = ($type$) vh.getAndBitwiseOr(Void.class, $value1$);
+            $type$ x = ($type$) vh.getAndBitwiseOrRelease(Void.class, $value1$);
         });
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
-            $type$ x = ($type$) vh.getAndBitwiseOr(recv, Void.class);
+            $type$ x = ($type$) vh.getAndBitwiseOrRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            $type$ x = ($type$) vh.getAndBitwiseOr(0, $value1$);
+        checkWMTE(() -> { // receiver primitive class
+            $type$ x = ($type$) vh.getAndBitwiseOrRelease(0, $value1$);
         });
         // Incorrect return type
         check{#if[Object]?CCE:WMTE}(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseOr(recv, $value1$);
+            Void r = (Void) vh.getAndBitwiseOrRelease(recv, $value1$);
         });
         checkWMTE(() -> { // primitive class
-            $wrong_primitive_type$ x = ($wrong_primitive_type$) vh.getAndBitwiseOr(recv, $value1$);
+            $wrong_primitive_type$ x = ($wrong_primitive_type$) vh.getAndBitwiseOrRelease(recv, $value1$);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            $type$ x = ($type$) vh.getAndBitwiseOr();
+            $type$ x = ($type$) vh.getAndBitwiseOrRelease();
         });
         checkWMTE(() -> { // >
-            $type$ x = ($type$) vh.getAndBitwiseOr(recv, $value1$, Void.class);
+            $type$ x = ($type$) vh.getAndBitwiseOrRelease(recv, $value1$, Void.class);
         });
 
 
@@ -852,7 +852,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseAnd(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndBitwiseAnd(0, $value1$);
         });
         // Incorrect return type
@@ -882,7 +882,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseAndAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndBitwiseAndAcquire(0, $value1$);
         });
         // Incorrect return type
@@ -907,27 +907,27 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
             $type$ x = ($type$) vh.getAndBitwiseAndRelease(null, $value1$);
         });
         checkCCE(() -> { // receiver reference class
-            $type$ x = ($type$) vh.getAndBitwiseAnd(Void.class, $value1$);
+            $type$ x = ($type$) vh.getAndBitwiseAndRelease(Void.class, $value1$);
         });
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
-            $type$ x = ($type$) vh.getAndBitwiseAnd(recv, Void.class);
+            $type$ x = ($type$) vh.getAndBitwiseAndRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            $type$ x = ($type$) vh.getAndBitwiseAnd(0, $value1$);
+        checkWMTE(() -> { // receiver primitive class
+            $type$ x = ($type$) vh.getAndBitwiseAndRelease(0, $value1$);
         });
         // Incorrect return type
         check{#if[Object]?CCE:WMTE}(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseAnd(recv, $value1$);
+            Void r = (Void) vh.getAndBitwiseAndRelease(recv, $value1$);
         });
         checkWMTE(() -> { // primitive class
-            $wrong_primitive_type$ x = ($wrong_primitive_type$) vh.getAndBitwiseAnd(recv, $value1$);
+            $wrong_primitive_type$ x = ($wrong_primitive_type$) vh.getAndBitwiseAndRelease(recv, $value1$);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            $type$ x = ($type$) vh.getAndBitwiseAnd();
+            $type$ x = ($type$) vh.getAndBitwiseAndRelease();
         });
         checkWMTE(() -> { // >
-            $type$ x = ($type$) vh.getAndBitwiseAnd(recv, $value1$, Void.class);
+            $type$ x = ($type$) vh.getAndBitwiseAndRelease(recv, $value1$, Void.class);
         });
 
 
@@ -942,7 +942,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseXor(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndBitwiseXor(0, $value1$);
         });
         // Incorrect return type
@@ -972,7 +972,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseXorAcquire(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
+        checkWMTE(() -> { // receiver primitive class
             $type$ x = ($type$) vh.getAndBitwiseXorAcquire(0, $value1$);
         });
         // Incorrect return type
@@ -997,27 +997,27 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
             $type$ x = ($type$) vh.getAndBitwiseXorRelease(null, $value1$);
         });
         checkCCE(() -> { // receiver reference class
-            $type$ x = ($type$) vh.getAndBitwiseXor(Void.class, $value1$);
+            $type$ x = ($type$) vh.getAndBitwiseXorRelease(Void.class, $value1$);
         });
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
-            $type$ x = ($type$) vh.getAndBitwiseXor(recv, Void.class);
+            $type$ x = ($type$) vh.getAndBitwiseXorRelease(recv, Void.class);
         });
-        checkWMTE(() -> { // reciever primitive class
-            $type$ x = ($type$) vh.getAndBitwiseXor(0, $value1$);
+        checkWMTE(() -> { // receiver primitive class
+            $type$ x = ($type$) vh.getAndBitwiseXorRelease(0, $value1$);
         });
         // Incorrect return type
         check{#if[Object]?CCE:WMTE}(() -> { // reference class
-            Void r = (Void) vh.getAndBitwiseXor(recv, $value1$);
+            Void r = (Void) vh.getAndBitwiseXorRelease(recv, $value1$);
         });
         checkWMTE(() -> { // primitive class
-            $wrong_primitive_type$ x = ($wrong_primitive_type$) vh.getAndBitwiseXor(recv, $value1$);
+            $wrong_primitive_type$ x = ($wrong_primitive_type$) vh.getAndBitwiseXorRelease(recv, $value1$);
         });
         // Incorrect arity
         checkWMTE(() -> { // 0
-            $type$ x = ($type$) vh.getAndBitwiseXor();
+            $type$ x = ($type$) vh.getAndBitwiseXorRelease();
         });
         checkWMTE(() -> { // >
-            $type$ x = ($type$) vh.getAndBitwiseXor(recv, $value1$, Void.class);
+            $type$ x = ($type$) vh.getAndBitwiseXorRelease(recv, $value1$, Void.class);
         });
 #end[Bitwise]
     }
@@ -1137,7 +1137,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                 $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class, Class.class)).
                     invokeExact(recv, $value1$, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class , $type$.class, $type$.class)).
                     invokeExact(0, $value1$, $value1$);
             });
@@ -1174,7 +1174,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                 $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, $type$.class)).
                     invokeExact(0, $value1$);
             });
@@ -1213,7 +1213,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                 $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, $type$.class)).
                     invokeExact(0, $value1$);
             });
@@ -1252,7 +1252,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                 $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
-            checkWMTE(() -> { // reciever primitive class
+            checkWMTE(() -> { // receiver primitive class
                 $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, $type$.class)).
                     invokeExact(0, $value1$);
             });
@@ -1717,7 +1717,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseOrReleaseRelease
+        // GetAndBitwiseOrRelease
         // Incorrect argument types
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseOrRelease(Void.class);
@@ -1780,7 +1780,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseAndReleaseRelease
+        // GetAndBitwiseAndRelease
         // Incorrect argument types
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseAndRelease(Void.class);
@@ -1843,7 +1843,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         });
 
 
-        // GetAndBitwiseXorReleaseRelease
+        // GetAndBitwiseXorRelease
         // Incorrect argument types
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndBitwiseXorRelease(Void.class);
@@ -2530,7 +2530,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndSet(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             $type$ x = ($type$) vh.getAndSet(0, 0, $value1$);
         });
         checkWMTE(() -> { // index reference class
@@ -2563,7 +2563,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndSetAcquire(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             $type$ x = ($type$) vh.getAndSetAcquire(0, 0, $value1$);
         });
         checkWMTE(() -> { // index reference class
@@ -2596,7 +2596,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         check{#if[Object]?CCE:WMTE}(() -> { // value reference class
             $type$ x = ($type$) vh.getAndSetRelease(array, 0, Void.class);
         });
-        checkWMTE(() -> { // reciarrayever primitive class
+        checkWMTE(() -> { // array primitive class
             $type$ x = ($type$) vh.getAndSetRelease(0, 0, $value1$);
         });
         checkWMTE(() -> { // index reference class


### PR DESCRIPTION
There are some typos in VarHandle test templates and some functional omissions. This patch fixes a few of them identified by coding agents.

Note to reviewers: The actual changes are all in the last 4 .template files. All the other changes are generated by `generate-vh-tests.sh`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391593](https://bugs.openjdk.org/browse/JDK-8391593): Typos and omissions in VarHandle test templates (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32630/head:pull/32630` \
`$ git checkout pull/32630`

Update a local copy of the PR: \
`$ git checkout pull/32630` \
`$ git pull https://git.openjdk.org/jdk.git pull/32630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32630`

View PR using the GUI difftool: \
`$ git pr show -t 32630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32630.diff">https://git.openjdk.org/jdk/pull/32630.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32630#issuecomment-5500278836)
</details>
