### PR TITLE
8391307: VectorAPI: Floating-point test operators throw AssertionError on integral vectors

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -2020,7 +2020,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
                 m = compare(LT, (byte) 0);
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);
@@ -2052,7 +2052,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
                 m = compare(LT, (byte) 0, m);
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -2013,6 +2013,10 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
     M testTemplate(Class<M> maskType, Test op) {
         ByteSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             VectorMask<Byte> m;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (byte) 0);
@@ -2044,6 +2048,10 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         ByteSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             VectorMask<Byte> m = mask;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (byte) 0, m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -2013,10 +2013,6 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
     M testTemplate(Class<M> maskType, Test op) {
         ByteSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             VectorMask<Byte> m;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (byte) 0);
@@ -2024,6 +2020,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
                 m = compare(LT, (byte) 0);
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);
@@ -2048,10 +2045,6 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
         ByteSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             VectorMask<Byte> m = mask;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (byte) 0, m);
@@ -2059,6 +2052,7 @@ public abstract sealed class ByteVector extends AbstractVector<Byte>
                 m = compare(LT, (byte) 0, m);
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -1829,6 +1829,10 @@ public abstract sealed class DoubleVector extends AbstractVector<Double>
     M testTemplate(Class<M> maskType, Test op) {
         DoubleSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             LongVector bits = this.viewAsIntegralLanes();
             VectorMask<Long> m;
             if (op == IS_DEFAULT) {
@@ -1877,6 +1881,10 @@ public abstract sealed class DoubleVector extends AbstractVector<Double>
         DoubleSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             LongVector bits = this.viewAsIntegralLanes();
             VectorMask<Long> m = mask.cast(LongVector.species(shape()));
             if (op == IS_DEFAULT) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -1829,10 +1829,6 @@ public abstract sealed class DoubleVector extends AbstractVector<Double>
     M testTemplate(Class<M> maskType, Test op) {
         DoubleSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             LongVector bits = this.viewAsIntegralLanes();
             VectorMask<Long> m;
             if (op == IS_DEFAULT) {
@@ -1857,6 +1853,7 @@ public abstract sealed class DoubleVector extends AbstractVector<Double>
                 }
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));
@@ -1881,10 +1878,6 @@ public abstract sealed class DoubleVector extends AbstractVector<Double>
         DoubleSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             LongVector bits = this.viewAsIntegralLanes();
             VectorMask<Long> m = mask.cast(LongVector.species(shape()));
             if (op == IS_DEFAULT) {
@@ -1909,6 +1902,7 @@ public abstract sealed class DoubleVector extends AbstractVector<Double>
                 }
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -1853,7 +1853,7 @@ public abstract sealed class DoubleVector extends AbstractVector<Double>
                 }
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));
@@ -1902,7 +1902,7 @@ public abstract sealed class DoubleVector extends AbstractVector<Double>
                 }
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
@@ -1939,7 +1939,7 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
                 }
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));
@@ -1988,7 +1988,7 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
                 }
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
@@ -1915,10 +1915,6 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
     M testTemplate(Class<M> maskType, Test op) {
         Float16Species vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             ShortVector bits = this.viewAsIntegralLanes();
             VectorMask<Short> m;
             if (op == IS_DEFAULT) {
@@ -1943,6 +1939,7 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
                 }
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));
@@ -1967,10 +1964,6 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
         Float16Species vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             ShortVector bits = this.viewAsIntegralLanes();
             VectorMask<Short> m = mask.cast(ShortVector.species(shape()));
             if (op == IS_DEFAULT) {
@@ -1995,6 +1988,7 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
                 }
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16Vector.java
@@ -1915,6 +1915,10 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
     M testTemplate(Class<M> maskType, Test op) {
         Float16Species vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             ShortVector bits = this.viewAsIntegralLanes();
             VectorMask<Short> m;
             if (op == IS_DEFAULT) {
@@ -1963,6 +1967,10 @@ public abstract sealed class Float16Vector extends AbstractVector<Float16>
         Float16Species vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             ShortVector bits = this.viewAsIntegralLanes();
             VectorMask<Short> m = mask.cast(ShortVector.species(shape()));
             if (op == IS_DEFAULT) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -1841,10 +1841,6 @@ public abstract sealed class FloatVector extends AbstractVector<Float>
     M testTemplate(Class<M> maskType, Test op) {
         FloatSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             IntVector bits = this.viewAsIntegralLanes();
             VectorMask<Integer> m;
             if (op == IS_DEFAULT) {
@@ -1869,6 +1865,7 @@ public abstract sealed class FloatVector extends AbstractVector<Float>
                 }
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));
@@ -1893,10 +1890,6 @@ public abstract sealed class FloatVector extends AbstractVector<Float>
         FloatSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             IntVector bits = this.viewAsIntegralLanes();
             VectorMask<Integer> m = mask.cast(IntVector.species(shape()));
             if (op == IS_DEFAULT) {
@@ -1921,6 +1914,7 @@ public abstract sealed class FloatVector extends AbstractVector<Float>
                 }
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -1841,6 +1841,10 @@ public abstract sealed class FloatVector extends AbstractVector<Float>
     M testTemplate(Class<M> maskType, Test op) {
         FloatSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             IntVector bits = this.viewAsIntegralLanes();
             VectorMask<Integer> m;
             if (op == IS_DEFAULT) {
@@ -1889,6 +1893,10 @@ public abstract sealed class FloatVector extends AbstractVector<Float>
         FloatSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             IntVector bits = this.viewAsIntegralLanes();
             VectorMask<Integer> m = mask.cast(IntVector.species(shape()));
             if (op == IS_DEFAULT) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -1865,7 +1865,7 @@ public abstract sealed class FloatVector extends AbstractVector<Float>
                 }
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));
@@ -1914,7 +1914,7 @@ public abstract sealed class FloatVector extends AbstractVector<Float>
                 }
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m.cast(vsp));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -2005,7 +2005,7 @@ public abstract sealed class IntVector extends AbstractVector<Integer>
                 m = compare(LT, (int) 0);
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);
@@ -2037,7 +2037,7 @@ public abstract sealed class IntVector extends AbstractVector<Integer>
                 m = compare(LT, (int) 0, m);
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -1998,6 +1998,10 @@ public abstract sealed class IntVector extends AbstractVector<Integer>
     M testTemplate(Class<M> maskType, Test op) {
         IntSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             VectorMask<Integer> m;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (int) 0);
@@ -2029,6 +2033,10 @@ public abstract sealed class IntVector extends AbstractVector<Integer>
         IntSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             VectorMask<Integer> m = mask;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (int) 0, m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -1998,10 +1998,6 @@ public abstract sealed class IntVector extends AbstractVector<Integer>
     M testTemplate(Class<M> maskType, Test op) {
         IntSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             VectorMask<Integer> m;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (int) 0);
@@ -2009,6 +2005,7 @@ public abstract sealed class IntVector extends AbstractVector<Integer>
                 m = compare(LT, (int) 0);
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);
@@ -2033,10 +2030,6 @@ public abstract sealed class IntVector extends AbstractVector<Integer>
         IntSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             VectorMask<Integer> m = mask;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (int) 0, m);
@@ -2044,6 +2037,7 @@ public abstract sealed class IntVector extends AbstractVector<Integer>
                 m = compare(LT, (int) 0, m);
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -1918,7 +1918,7 @@ public abstract sealed class LongVector extends AbstractVector<Long>
                 m = compare(LT, (long) 0);
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);
@@ -1950,7 +1950,7 @@ public abstract sealed class LongVector extends AbstractVector<Long>
                 m = compare(LT, (long) 0, m);
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -1911,6 +1911,10 @@ public abstract sealed class LongVector extends AbstractVector<Long>
     M testTemplate(Class<M> maskType, Test op) {
         LongSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             VectorMask<Long> m;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (long) 0);
@@ -1942,6 +1946,10 @@ public abstract sealed class LongVector extends AbstractVector<Long>
         LongSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             VectorMask<Long> m = mask;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (long) 0, m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -1911,10 +1911,6 @@ public abstract sealed class LongVector extends AbstractVector<Long>
     M testTemplate(Class<M> maskType, Test op) {
         LongSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             VectorMask<Long> m;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (long) 0);
@@ -1922,6 +1918,7 @@ public abstract sealed class LongVector extends AbstractVector<Long>
                 m = compare(LT, (long) 0);
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);
@@ -1946,10 +1943,6 @@ public abstract sealed class LongVector extends AbstractVector<Long>
         LongSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             VectorMask<Long> m = mask;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (long) 0, m);
@@ -1957,6 +1950,7 @@ public abstract sealed class LongVector extends AbstractVector<Long>
                 m = compare(LT, (long) 0, m);
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -2014,6 +2014,10 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
     M testTemplate(Class<M> maskType, Test op) {
         ShortSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             VectorMask<Short> m;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (short) 0);
@@ -2045,6 +2049,10 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         ShortSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
             VectorMask<Short> m = mask;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (short) 0, m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -2014,10 +2014,6 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
     M testTemplate(Class<M> maskType, Test op) {
         ShortSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             VectorMask<Short> m;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (short) 0);
@@ -2025,6 +2021,7 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
                 m = compare(LT, (short) 0);
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);
@@ -2049,10 +2046,6 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
         ShortSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
             VectorMask<Short> m = mask;
             if (op == IS_DEFAULT) {
                 m = compare(EQ, (short) 0, m);
@@ -2060,6 +2053,7 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
                 m = compare(LT, (short) 0, m);
             }
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -2021,7 +2021,7 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
                 m = compare(LT, (short) 0);
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);
@@ -2053,7 +2053,7 @@ public abstract sealed class ShortVector extends AbstractVector<Short>
                 m = compare(LT, (short) 0, m);
             }
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
@@ -2774,6 +2774,8 @@ public abstract sealed class Vector<E> extends jdk.internal.vm.vector.VectorSupp
      * @param op the operation used to test lane values
      * @return the mask result of testing the lanes of this vector,
      *         according to the selected test operator
+     * @throws UnsupportedOperationException if this vector does
+     *         not support the requested operation
      * @see VectorOperators.Comparison
      * @see #test(VectorOperators.Test, VectorMask)
      * @see #compare(VectorOperators.Comparison, Vector)
@@ -2796,6 +2798,8 @@ public abstract sealed class Vector<E> extends jdk.internal.vm.vector.VectorSupp
      * @return the mask result of testing the lanes of this vector,
      *         according to the selected test operator,
      *         and only in the lanes selected by the mask
+     * @throws UnsupportedOperationException if this vector does
+     *         not support the requested operation
      * @see #test(VectorOperators.Test)
      */
     public abstract VectorMask<E> test(VectorOperators.Test op,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -2517,6 +2517,10 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     M testTemplate(Class<M> maskType, Test op) {
         $Type$Species vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
 #if[FP]
             $Bitstype$Vector bits = this.viewAsIntegralLanes();
 #end[FP]
@@ -2569,6 +2573,10 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         $Type$Species vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
+            if (!op.compatibleWith(vsp.elementType())) {
+                throw new UnsupportedOperationException(
+                        op + ": incompatible with " + vsp.elementType().getSimpleName());
+            }
 #if[FP]
             $Bitstype$Vector bits = this.viewAsIntegralLanes();
             VectorMask<$Boxbitstype$> m = mask.cast($Bitstype$Vector.species(shape()));
@@ -6155,4 +6163,3 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     public static final VectorSpecies<$Boxtype$> SPECIES_PREFERRED
         = ($Type$Species) VectorSpecies.ofPreferred($elemtype$.class);
 }
-

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -2517,10 +2517,6 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     M testTemplate(Class<M> maskType, Test op) {
         $Type$Species vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
 #if[FP]
             $Bitstype$Vector bits = this.viewAsIntegralLanes();
 #end[FP]
@@ -2549,6 +2545,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
             }
 #end[FP]
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m{#if[FP]?.cast(vsp)});
@@ -2573,10 +2570,6 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
         $Type$Species vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            if (!op.compatibleWith(vsp.elementType())) {
-                throw new UnsupportedOperationException(
-                        op + ": incompatible with " + vsp.elementType().getSimpleName());
-            }
 #if[FP]
             $Bitstype$Vector bits = this.viewAsIntegralLanes();
             VectorMask<$Boxbitstype$> m = mask.cast($Bitstype$Vector.species(shape()));
@@ -2607,6 +2600,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
             }
 #end[FP]
             else {
+                opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m{#if[FP]?.cast(vsp)});
@@ -6163,3 +6157,4 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
     public static final VectorSpecies<$Boxtype$> SPECIES_PREFERRED
         = ($Type$Species) VectorSpecies.ofPreferred($elemtype$.class);
 }
+

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -2545,7 +2545,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
             }
 #end[FP]
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m{#if[FP]?.cast(vsp)});
@@ -2600,7 +2600,7 @@ public abstract sealed class $abstractvectortype$ extends AbstractVector<$Boxtyp
             }
 #end[FP]
             else {
-                opCode(op);
+                int opc = opCode(op);
                 throw new AssertionError(op);
             }
             return maskType.cast(m{#if[FP]?.cast(vsp)});

--- a/test/jdk/jdk/incubator/vector/VectorLanewiseOpCompatibleWithTest.java
+++ b/test/jdk/jdk/incubator/vector/VectorLanewiseOpCompatibleWithTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import jdk.incubator.vector.Float16;
 import jdk.incubator.vector.Vector;
@@ -40,7 +41,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @bug 8389844
+ * @bug 8389844 8391307
  * @modules jdk.incubator.vector
  * @run testng VectorLanewiseOpCompatibleWithTest
  */
@@ -73,6 +74,33 @@ public class VectorLanewiseOpCompatibleWithTest {
         return List.copyOf(operators);
     }
 
+    private static Object[][] operatorProvider(boolean compatible,
+                                               Predicate<VectorOperators.Operator> opFilter) {
+        return ELEMENT_TYPES.stream()
+                .flatMap(elementType -> Arrays.stream(VectorShape.values())
+                        .map(shape -> VectorSpecies.of(elementType, shape)))
+                .flatMap(species -> OPERATORS.stream()
+                        // These operators are more restrictive, exclude for now.
+                        .filter(op -> op != VectorOperators.COMPRESS_BITS &&
+                                      op != VectorOperators.EXPAND_BITS)
+                        .filter(opFilter)
+                        .filter(op -> op.compatibleWith(species.elementType()) == compatible)
+                        .map(op -> new Object[] {species, op}))
+                .toArray(Object[][]::new);
+    }
+
+    private static Object[][] operatorProvider(boolean compatible) {
+        return operatorProvider(compatible,
+                                op -> op instanceof VectorOperators.Unary ||
+                                      op instanceof VectorOperators.Binary ||
+                                      op instanceof VectorOperators.Ternary);
+    }
+
+    private static Object[][] testOperatorProvider(boolean compatible) {
+        return operatorProvider(compatible,
+                                op -> op instanceof VectorOperators.Test);
+    }
+
     @DataProvider
     public Object[][] unsupportedOperatorProvider() {
         return operatorProvider(false);
@@ -83,20 +111,14 @@ public class VectorLanewiseOpCompatibleWithTest {
         return operatorProvider(true);
     }
 
-    private static Object[][] operatorProvider(boolean compatible) {
-        return ELEMENT_TYPES.stream()
-                .flatMap(elementType -> Arrays.stream(VectorShape.values())
-                        .map(shape -> VectorSpecies.of(elementType, shape)))
-                .flatMap(species -> OPERATORS.stream()
-                        .filter(op -> op instanceof VectorOperators.Unary ||
-                                op instanceof VectorOperators.Binary ||
-                                op instanceof VectorOperators.Ternary)
-                        // These operators are more restrictive, exclude for now.
-                        .filter(op -> op != VectorOperators.COMPRESS_BITS &&
-                                op != VectorOperators.EXPAND_BITS)
-                        .filter(op -> op.compatibleWith(species.elementType()) == compatible)
-                        .map(op -> new Object[] {species, op}))
-                .toArray(Object[][]::new);
+    @DataProvider
+    public Object[][] unsupportedTestOperatorProvider() {
+        return testOperatorProvider(false);
+    }
+
+    @DataProvider
+    public Object[][] supportedTestOperatorProvider() {
+        return testOperatorProvider(true);
     }
 
     @Test(dataProvider = "unsupportedOperatorProvider")
@@ -155,5 +177,41 @@ public class VectorLanewiseOpCompatibleWithTest {
             }
             default -> throw new AssertionError("Not a lanewise operator: " + op);
         }
+    }
+
+    @Test(dataProvider = "unsupportedTestOperatorProvider")
+    public <E> void testUnsupportedTestOperator(VectorSpecies<E> species,
+                                                VectorOperators.Test op) {
+        Vector<E> vector = species.zero();
+
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> vector.test(op));
+    }
+
+    @Test(dataProvider = "unsupportedTestOperatorProvider")
+    public <E> void testUnsupportedMaskedTestOperator(VectorSpecies<E> species,
+                                                      VectorOperators.Test op) {
+        Vector<E> vector = species.zero();
+        VectorMask<E> mask = species.maskAll(false);
+
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> vector.test(op, mask));
+    }
+
+    @Test(dataProvider = "supportedTestOperatorProvider")
+    public <E> void testSupportedTestOperator(VectorSpecies<E> species,
+                                              VectorOperators.Test op) {
+        Vector<E> vector = species.zero();
+
+        vector.test(op);
+    }
+
+    @Test(dataProvider = "supportedTestOperatorProvider")
+    public <E> void testSupportedMaskedTestOperator(VectorSpecies<E> species,
+                                                    VectorOperators.Test op) {
+        Vector<E> vector = species.zero();
+        VectorMask<E> mask = species.maskAll(true);
+
+        vector.test(op, mask);
     }
 }

--- a/test/jdk/jdk/incubator/vector/VectorLanewiseOpCompatibleWithTest.java
+++ b/test/jdk/jdk/incubator/vector/VectorLanewiseOpCompatibleWithTest.java
@@ -93,12 +93,8 @@ public class VectorLanewiseOpCompatibleWithTest {
         return operatorProvider(compatible,
                                 op -> op instanceof VectorOperators.Unary ||
                                       op instanceof VectorOperators.Binary ||
-                                      op instanceof VectorOperators.Ternary);
-    }
-
-    private static Object[][] testOperatorProvider(boolean compatible) {
-        return operatorProvider(compatible,
-                                op -> op instanceof VectorOperators.Test);
+                                      op instanceof VectorOperators.Ternary ||
+                                      op instanceof VectorOperators.Test);
     }
 
     @DataProvider
@@ -109,16 +105,6 @@ public class VectorLanewiseOpCompatibleWithTest {
     @DataProvider
     public Object[][] supportedOperatorProvider() {
         return operatorProvider(true);
-    }
-
-    @DataProvider
-    public Object[][] unsupportedTestOperatorProvider() {
-        return testOperatorProvider(false);
-    }
-
-    @DataProvider
-    public Object[][] supportedTestOperatorProvider() {
-        return testOperatorProvider(true);
     }
 
     @Test(dataProvider = "unsupportedOperatorProvider")
@@ -150,6 +136,12 @@ public class VectorLanewiseOpCompatibleWithTest {
                 Assert.assertThrows(UnsupportedOperationException.class,
                         () -> vector.lanewise(ternary, vector, vector, mask));
             }
+            case VectorOperators.Test test -> {
+                Assert.assertThrows(UnsupportedOperationException.class,
+                        () -> vector.test(test));
+                Assert.assertThrows(UnsupportedOperationException.class,
+                        () -> vector.test(test, mask));
+            }
             default -> throw new AssertionError("Not a lanewise operator: " + op);
         }
     }
@@ -175,43 +167,11 @@ public class VectorLanewiseOpCompatibleWithTest {
                 vector.lanewise(ternary, vector, vector);
                 vector.lanewise(ternary, vector, vector, mask);
             }
+            case VectorOperators.Test test -> {
+                vector.test(test);
+                vector.test(test, mask);
+            }
             default -> throw new AssertionError("Not a lanewise operator: " + op);
         }
-    }
-
-    @Test(dataProvider = "unsupportedTestOperatorProvider")
-    public <E> void testUnsupportedTestOperator(VectorSpecies<E> species,
-                                                VectorOperators.Test op) {
-        Vector<E> vector = species.zero();
-
-        Assert.assertThrows(UnsupportedOperationException.class,
-                () -> vector.test(op));
-    }
-
-    @Test(dataProvider = "unsupportedTestOperatorProvider")
-    public <E> void testUnsupportedMaskedTestOperator(VectorSpecies<E> species,
-                                                      VectorOperators.Test op) {
-        Vector<E> vector = species.zero();
-        VectorMask<E> mask = species.maskAll(false);
-
-        Assert.assertThrows(UnsupportedOperationException.class,
-                () -> vector.test(op, mask));
-    }
-
-    @Test(dataProvider = "supportedTestOperatorProvider")
-    public <E> void testSupportedTestOperator(VectorSpecies<E> species,
-                                              VectorOperators.Test op) {
-        Vector<E> vector = species.zero();
-
-        vector.test(op);
-    }
-
-    @Test(dataProvider = "supportedTestOperatorProvider")
-    public <E> void testSupportedMaskedTestOperator(VectorSpecies<E> species,
-                                                    VectorOperators.Test op) {
-        Vector<E> vector = species.zero();
-        VectorMask<E> mask = species.maskAll(true);
-
-        vector.test(op, mask);
     }
 }


### PR DESCRIPTION
VectorOperators.IS_FINITE, IS_NAN, and IS_INFINITE are floating-point-only test operators. Applying one of these operators to an integral vector currently reaches the **_if (opKind(op, VO_SPECIAL)) {...}_** handing branch implemented in testTemplate and throws AssertionError, instead of reporting an unsupported operation.

This change:

- Checks VectorOperators.Test.compatibleWith(...) before executing specially implemented test operations.
- Throws UnsupportedOperationException for incompatible element types in both masked and unmasked test(...) operations.
- Documents UnsupportedOperationException in both public Vector.test(...) overloads.
- Updates VectorLanewiseOpCompatibleWithTest to cover supported and unsupported test operators, with and without masks, across the available vector species.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Change requires CSR request [JDK-8391596](https://bugs.openjdk.org/browse/JDK-8391596) to be approved
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8391307](https://bugs.openjdk.org/browse/JDK-8391307): VectorAPI: Floating-point test operators throw AssertionError on integral vectors (**Bug** - P4)
 * [JDK-8391596](https://bugs.openjdk.org/browse/JDK-8391596): VectorAPI: Floating-point test operators throw AssertionError on integral vectors (**CSR**)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32633/head:pull/32633` \
`$ git checkout pull/32633`

Update a local copy of the PR: \
`$ git checkout pull/32633` \
`$ git pull https://git.openjdk.org/jdk.git pull/32633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32633`

View PR using the GUI difftool: \
`$ git pr show -t 32633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32633.diff">https://git.openjdk.org/jdk/pull/32633.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32633#issuecomment-5502520249)
</details>
