### PR TITLE
8361207: Build native Windows ARM64 MSI packages

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixPipeline.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixPipeline.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
+import jdk.internal.util.Architecture;
 import jdk.jpackage.internal.util.PathUtils;
 
 /**
@@ -191,7 +192,7 @@ final class WixPipeline {
                 "-pdbtype", "none",
                 "-intermediatefolder", wixObjDir.toString(),
                 "-ext", "WixToolset.Util.wixext",
-                "-arch", WixFragmentBuilder.is64Bit() ? "x64" : "x86"
+                "-arch", wix4ArchArg(Architecture.current())
         ));
 
         cmdline.addAll(lightOptions);
@@ -236,7 +237,7 @@ final class WixPipeline {
                 "-nologo",
                 wixSource.path.toString(),
                 "-ext", "WixUtilExtension",
-                "-arch", WixFragmentBuilder.is64Bit() ? "x64" : "x86",
+                "-arch", wix3ArchArg(Architecture.current()),
                 "-out", wixObj.toString()
         ));
 
@@ -253,6 +254,31 @@ final class WixPipeline {
 
     private void execute(List<String> cmdline) throws IOException {
         Executor.of(new ProcessBuilder(cmdline).directory(workDir.toFile())).executeExpectSuccess();
+    }
+
+    // Maps the given architecture to the value of the "-arch" argument of the
+    // WiX v4+ "build" command. WiX v4 added support for building arm64 MSI
+    // packages, so AArch64 is mapped to "arm64" unlike the WiX v3 mapping below.
+    static String wix4ArchArg(Architecture arch) {
+        return switch (arch) {
+            case X86 -> "x86";
+            case X64 -> "x64";
+            case AARCH64 -> "arm64";
+            default -> throw I18N.buildConfigException("error.msi-arch-unsupported", arch).create();
+        };
+    }
+
+    // Maps the given architecture to the value of the "-arch" argument of the
+    // WiX v3 "candle" command. WiX v3 doesn't support building arm64 MSI
+    // packages, so AArch64 is explicitly rejected.
+    static String wix3ArchArg(Architecture arch) {
+        return switch (arch) {
+            case X86 -> "x86";
+            case X64 -> "x64";
+            default -> throw I18N.buildConfigException("error.msi-arch-unsupported-wix3", arch)
+                    .advice("error.msi-arch-unsupported-wix3.advice")
+                    .create();
+        };
     }
 
     private void addWixVariablesToCommandLine(Stream<WixSource> wixSources, Consumer<List<String>> sink) {

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixPipeline.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixPipeline.java
@@ -275,9 +275,13 @@ final class WixPipeline {
         return switch (arch) {
             case X86 -> "x86";
             case X64 -> "x64";
-            default -> throw I18N.buildConfigException("error.msi-arch-unsupported-wix3", arch)
-                    .advice("error.msi-arch-unsupported-wix3.advice")
-                    .create();
+            default -> {
+                var ex = I18N.buildConfigException("error.msi-arch-unsupported-wix3", arch);
+                if (arch == Architecture.AARCH64) {
+                    ex.advice("error.msi-arch-unsupported-wix3.advice");
+                }
+                throw ex.create();
+            }
         };
     }
 

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/WinResources.properties
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/WinResources.properties
@@ -56,6 +56,9 @@ error.extract-culture-from-wix-l10n-file=Failed to read value of culture from {0
 error.short-path-conv-fail=Failed to get short version of "{0}" path
 error.missing-service-installer='service-installer.exe' service installer not found in the resource directory
 error.missing-service-installer.advice=Add 'service-installer.exe' service installer to the resource directory
+error.msi-arch-unsupported-wix3=WiX Toolset v3 does not support building MSI packages for the {0} architecture
+error.msi-arch-unsupported-wix3.advice=Install WiX Toolset v4 or later from https://github.com/wixtoolset/wix/releases to build MSI packages for this architecture
+error.msi-arch-unsupported=Building MSI packages for the {0} architecture is not supported
 
 message.icon-not-ico=The specified icon "{0}" is not an ICO file and will not be used. The default icon will be used in it's place.
 message.tool-version=Detected [{0}] version [{1}].

--- a/test/jdk/tools/jpackage/junit/windows/jdk.jpackage/jdk/jpackage/internal/WixPipelineTest.java
+++ b/test/jdk/tools/jpackage/junit/windows/jdk.jpackage/jdk/jpackage/internal/WixPipelineTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jpackage.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import jdk.internal.util.Architecture;
+import jdk.jpackage.internal.model.ConfigException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Unit tests proving the mapping from {@link Architecture} to the value of
+ * the WiX Toolset "-arch" command line argument used to build MSI packages.
+ */
+class WixPipelineTest {
+
+    @ParameterizedTest
+    @EnumSource(value = Architecture.class, names = {"X86", "X64", "AARCH64"})
+    void test_wix4ArchArg_supported(Architecture arch) {
+        var expected = switch (arch) {
+            case X86 -> "x86";
+            case X64 -> "x64";
+            case AARCH64 -> "arm64";
+            default -> throw new IllegalArgumentException();
+        };
+        assertEquals(expected, WixPipeline.wix4ArchArg(arch));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Architecture.class, names = {"X86", "X64", "AARCH64"}, mode = EnumSource.Mode.EXCLUDE)
+    void test_wix4ArchArg_unsupported(Architecture arch) {
+        // Unsupported architectures must be reported with a self-contained,
+        // user-facing ConfigException, not a raw stack trace (see the
+        // jdk.jpackage.internal.cli.Main error reporter, which only omits
+        // the stack trace for exceptions annotated with
+        // jdk.jpackage.internal.model.SelfContainedException).
+        assertThrowsExactly(ConfigException.class, () -> {
+            WixPipeline.wix4ArchArg(arch);
+        });
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Architecture.class, names = {"X86", "X64"})
+    void test_wix3ArchArg_supported(Architecture arch) {
+        var expected = switch (arch) {
+            case X86 -> "x86";
+            case X64 -> "x64";
+            default -> throw new IllegalArgumentException();
+        };
+        assertEquals(expected, WixPipeline.wix3ArchArg(arch));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Architecture.class, names = {"X86", "X64"}, mode = EnumSource.Mode.EXCLUDE)
+    void test_wix3ArchArg_unsupported(Architecture arch) {
+        // WiX v3 doesn't support arm64 (nor any other architecture); it must
+        // be rejected explicitly and clearly, including AArch64, with a
+        // self-contained, user-facing ConfigException (see above).
+        assertThrowsExactly(ConfigException.class, () -> {
+            WixPipeline.wix3ArchArg(arch);
+        });
+    }
+}

--- a/test/jdk/tools/jpackage/junit/windows/jdk.jpackage/jdk/jpackage/internal/WixPipelineTest.java
+++ b/test/jdk/tools/jpackage/junit/windows/jdk.jpackage/jdk/jpackage/internal/WixPipelineTest.java
@@ -26,6 +26,8 @@
 package jdk.jpackage.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import jdk.internal.util.Architecture;
@@ -76,13 +78,20 @@ class WixPipelineTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Architecture.class, names = {"X86", "X64"}, mode = EnumSource.Mode.EXCLUDE)
-    void test_wix3ArchArg_unsupported(Architecture arch) {
-        // WiX v3 doesn't support arm64 (nor any other architecture); it must
-        // be rejected explicitly and clearly, including AArch64, with a
-        // self-contained, user-facing ConfigException (see above).
-        assertThrowsExactly(ConfigException.class, () -> {
+    @EnumSource(value = Architecture.class, names = {"AARCH64"})
+    void test_wix3ArchArg_aarch64(Architecture arch) {
+        var ex = assertThrowsExactly(ConfigException.class, () -> {
             WixPipeline.wix3ArchArg(arch);
         });
+        assertNotNull(ex.getAdvice());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Architecture.class, names = {"X86", "X64", "AARCH64"}, mode = EnumSource.Mode.EXCLUDE)
+    void test_wix3ArchArg_otherUnsupported(Architecture arch) {
+        var ex = assertThrowsExactly(ConfigException.class, () -> {
+            WixPipeline.wix3ArchArg(arch);
+        });
+        assertNull(ex.getAdvice());
     }
 }

--- a/test/jdk/tools/jpackage/junit/windows/junit.java
+++ b/test/jdk/tools/jpackage/junit/windows/junit.java
@@ -38,6 +38,14 @@
  */
 
 /* @test
+ * @summary Test mapping of Architecture to WiX Toolset "-arch" argument
+ * @requires (os.family == "windows")
+ * @compile/module=jdk.jpackage -Xlint:all -Werror
+ *    jdk/jpackage/internal/WixPipelineTest.java
+ * @run junit jdk.jpackage/jdk.jpackage.internal.WixPipelineTest
+ */
+
+/* @test
  * @summary UiSpec unit tests
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal.wixui:open

--- a/test/jdk/tools/jpackage/resources/close-application-os-condition.wxf
+++ b/test/jdk/tools/jpackage/resources/close-application-os-condition.wxf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+-->
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Fragment>
+    <util:CloseApplication Id="CloseMainLauncher"
+                           Target="$(var.JpAppName).exe"
+                           RebootPrompt="no"/>
+    <Condition Message="!(loc.OsConditionMessage)">
+      <![CDATA[Installed OR (VersionNT >= $(var.JpExecutableOSVersion))]]>
+    </Condition>
+    <!--
+      Fragment contents must be referenced. Otherwise, the fragment will be ignored.
+      Use empty component group as an anchor for the reference.
+    -->
+    <ComponentGroup Id="FragmentOsCondition"/>
+  </Fragment>
+</Wix>

--- a/test/jdk/tools/jpackage/windows/WinArm64MsiTest.java
+++ b/test/jdk/tools/jpackage/windows/WinArm64MsiTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import java.util.List;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Executor;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.JPackageCommand.MessageCategory;
+import jdk.jpackage.test.PackageTest;
+import jdk.jpackage.test.PackageType;
+import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.WindowsHelper;
+
+/**
+ * Test will build a native Windows Arm64 MSI package with WiX Toolset v4+
+ * and validate that it was built for the Arm64 platform rather than the x64
+ * platform used for every other 64-bit Windows architecture. See JDK-8361207.
+ * <p>
+ * This test only runs on a Windows/AArch64 JDK, as it relies on the
+ * host/target architecture reported by the running JDK matching the
+ * architecture of the produced MSI. It is not expected to run in emulation.
+ */
+
+/*
+ * @test
+ * @summary jpackage test to verify native Windows Arm64 MSI packages built
+ *          with WiX 4+ use "-arch arm64" and select the Arm64 ("A64") custom
+ *          actions from the WiX Util extension instead of the X64 ones.
+ * @library /test/jdk/tools/jpackage/helpers
+ * @build jdk.jpackage.test.*
+ * @requires (os.family == "windows" & os.arch == "aarch64")
+ * @compile -Xlint:all -Werror WinArm64MsiTest.java
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=WinArm64MsiTest
+ */
+public class WinArm64MsiTest {
+
+    @Test
+    public static void test() {
+        // Probe which WiX Toolset version jpackage will actually use before
+        // running the full test. This test only makes sense with WiX 4+, as
+        // WiX 3 doesn't support the Arm64 platform in this path and jpackage
+        // will fail the build outright (see JDK-8361207). Detect that ahead
+        // of time and skip with a clear message instead of failing the test
+        // for an environmental reason.
+        final JPackageCommand probeCmd = JPackageCommand.helloAppImage()
+                .setPackageType(PackageType.WIN_MSI)
+                .setFakeRuntime()
+                .saveConsoleOutput(true)
+                // The WiX version is only reported in jpackage's SUMMARY
+                // output. Request it explicitly so this probe doesn't
+                // depend on any external "verbose" test configuration
+                // that may otherwise reduce the default verbosity level.
+                .enableMessageCategories(MessageCategory.SUMMARY);
+        final Executor.Result probeResult = probeCmd.executeIgnoreExitCode();
+
+        final WindowsHelper.WixType wixType;
+        try {
+            wixType = WindowsHelper.getWixTypeFromVerboseJPackageOutput(probeResult);
+        } catch (IllegalArgumentException ex) {
+            throw TKit.throwSkippedException(
+                    "Could not detect the WiX Toolset version from jpackage output: "
+                    + ex.getMessage());
+        }
+
+        if (wixType != WindowsHelper.WixType.WIX4) {
+            throw TKit.throwSkippedException(String.format(
+                    "This test requires WiX Toolset v4+ to validate native "
+                    + "Arm64 MSI support, but detected %s", wixType));
+        }
+
+        new PackageTest()
+                .forTypes(PackageType.WIN_MSI)
+                .configureHelloApp()
+                .addBundleVerifier(WinArm64MsiTest::verifyArm64Msi)
+                .run(PackageTest.Action.CREATE);
+    }
+
+    private static void verifyArm64Msi(JPackageCommand cmd) throws Exception {
+        final Path msi = cmd.outputBundle();
+
+        // Verify the MSI Summary Information "Template" property reports the
+        // Arm64 platform (e.g. "Arm64;1033"), proving WiX was invoked with
+        // "-arch arm64" rather than the x64 default.
+        final String template = queryMsiSummaryTemplate(msi);
+        TKit.assertTrue(template.contains("Arm64"),
+                "Check MSI Summary Information \"Template\" property reports "
+                + "the Arm64 platform, got: [" + template + "]");
+
+        // Verify the WiX Util extension selected the Arm64 ("A64") flavor of
+        // its CloseApplications custom action, not the X64 one.
+        final List<String> customActions = queryMsiCustomActionNames(msi);
+        TKit.assertTrue(customActions.contains("Wix4CloseApplications_A64"),
+                "Check MSI selects the Wix4CloseApplications_A64 custom action");
+        TKit.assertTrue(!customActions.contains("Wix4CloseApplications_X64"),
+                "Check MSI does not select the Wix4CloseApplications_X64 custom action");
+    }
+
+    // Reads the MSI Summary Information "Template" property (id 7) using the
+    // Windows Installer COM API through PowerShell. Avoids requiring the MSI
+    // to be installed to validate its metadata.
+    private static String queryMsiSummaryTemplate(Path msi) {
+        // Database.SummaryInformation is documented as a (parameterized)
+        // Property of the Windows Installer Automation interface, not a
+        // method - see
+        // https://learn.microsoft.com/windows/win32/msi/database-summaryinformation-property
+        // Its single argument is the "updateCount" (0 for read-only access),
+        // analogous to the "StringData" parameterized property used below
+        // to read record columns. Both are correctly invoked with
+        // 'GetProperty', not 'InvokeMethod'.
+        return runInstallerScript(msi, List.of(
+                "$si = $db.GetType().InvokeMember('SummaryInformation', 'GetProperty', $null, $db, @(0))",
+                "$tpl = $si.GetType().InvokeMember('Property', 'GetProperty', $null, $si, @(7))",
+                "Write-Output $tpl"
+        )).stream().findFirst().orElse("");
+    }
+
+    // Reads the names of all rows of the MSI "CustomAction" table using the
+    // Windows Installer COM API through PowerShell.
+    private static List<String> queryMsiCustomActionNames(Path msi) {
+        return runInstallerScript(msi, List.of(
+                "$view = $db.GetType().InvokeMember('OpenView', 'InvokeMethod', $null, $db,"
+                + " @('SELECT `Action` FROM `CustomAction`'))",
+                "$view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null)",
+                "while ($true) {",
+                "  $rec = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)",
+                "  if ($rec -eq $null) { break }",
+                "  Write-Output $rec.GetType().InvokeMember('StringData', 'GetProperty', $null, $rec, @(1))",
+                "}"
+        ));
+    }
+
+    private static List<String> runInstallerScript(Path msi, List<String> body) {
+        // Escape embedded single quotes for PowerShell's single-quoted string
+        // literal syntax (doubling the quote), so paths containing "'" (e.g.
+        // "O'Connor") don't break the script or enable injection.
+        final var escapedMsiPath = msi.toAbsolutePath().toString().replace("'", "''");
+        final var script = new java.util.ArrayList<String>();
+        script.add("$installer = New-Object -ComObject WindowsInstaller.Installer");
+        script.add("$db = $installer.GetType().InvokeMember('OpenDatabase', 'InvokeMethod', $null, $installer,"
+                + " @('" + escapedMsiPath + "', 0))");
+        script.addAll(body);
+        return Executor.of(WindowsHelper.PowerShellPath(), "-NoProfile", "-NonInteractive", "-Command",
+                String.join("; ", script)).saveOutput().executeAndGetOutput();
+    }
+}

--- a/test/jdk/tools/jpackage/windows/WinArm64MsiTest.java
+++ b/test/jdk/tools/jpackage/windows/WinArm64MsiTest.java
@@ -23,6 +23,8 @@
  * questions.
  */
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import jdk.jpackage.test.Annotations.Test;
@@ -95,8 +97,17 @@ public class WinArm64MsiTest {
         new PackageTest()
                 .forTypes(PackageType.WIN_MSI)
                 .configureHelloApp()
+                .addInitializer(WinArm64MsiTest::configureCustomResources)
                 .addBundleVerifier(WinArm64MsiTest::verifyArm64Msi)
                 .run(PackageTest.Action.CREATE);
+    }
+
+    private static void configureCustomResources(JPackageCommand cmd) throws IOException {
+        final Path resourceDir = TKit.createTempDirectory("resources");
+        Files.copy(
+                TKit.TEST_SRC_ROOT.resolve("resources/close-application-os-condition.wxf"),
+                resourceDir.resolve("os-condition.wxf"));
+        cmd.addArguments("--resource-dir", resourceDir.toString());
     }
 
     private static void verifyArm64Msi(JPackageCommand cmd) throws Exception {
@@ -110,8 +121,10 @@ public class WinArm64MsiTest {
                 "Check MSI Summary Information \"Template\" property reports "
                 + "the Arm64 platform, got: [" + template + "]");
 
-        // Verify the WiX Util extension selected the Arm64 ("A64") flavor of
-        // its CloseApplications custom action, not the X64 one.
+        // The custom os-condition.wxf resource injected by this test adds a
+        // util:CloseApplication entry, giving WiX a concrete reason to link
+        // the architecture-specific CloseApplications custom action. Verify it
+        // selected the Arm64 ("A64") flavor, not the X64 one.
         final List<String> customActions = queryMsiCustomActionNames(msi);
         TKit.assertTrue(customActions.contains("Wix4CloseApplications_A64"),
                 "Check MSI selects the Wix4CloseApplications_A64 custom action");


### PR DESCRIPTION
8361207: Build native Windows ARM64 MSI packages  ## Summary  `jpackage --type app-image` already works correctly on Windows Arm64. This change fixes `jpackage --type msi` so it invokes WiX Toolset 4+ with `-arch arm64` on an AArch64 JDK, instead of collapsing every 64-bit architecture down to `x64`. This lets WiX select its Arm64 ("A64") custom actions (e.g. `Wix4CloseApplications_A64` instead of `Wix4CloseApplications_X64`) and produce native Arm64 MSI Summary Information metadata.  `WixPipeline` now maps the running architecture to the WiX `-arch` argument directly from `jdk.internal.util.Architecture.current()`, via two small package-private switch-expression helpers (`wix4ArchArg`/`wix3ArchArg`):  - WiX 4+: `x86 -> "x86"`, `x64 -> "x64"`, `aarch64 -> "arm64"` (new). - WiX 3: `x86 -> "x86"`, `x64 -> "x64"`; `aarch64` (and any other   unsupported architecture) is explicitly rejected, since the WiX v3   toolchain does not support building Arm64 MSI packages.  Unsupported-architecture cases throw `jdk.jpackage.internal.model.ConfigException` (built via the existing `I18N.buildConfigException` helper, the same pattern already used by e.g. `MsiVersion`), which is a `JPackageException` annotated `@SelfContainedException`, so jpackage's CLI error reporter prints a clean, localized, actionable message instead of a raw stack trace. The WiX v3 + AArch64 case additionally carries an advice message telling the user to install WiX v4+.  ## Relationship to JDK-8361207 / PR #26093  This supersedes the closed PR #26093 for the same issue (https://bugs.openjdk.org/browse/JDK-8361207), which was auto-closed for inactivity after receiving three review comments that are all addressed here:  1. **No redundant architecture enum/helper added to `WixFragmentBuilder`.**    `WixPipeline` uses `jdk.internal.util.Architecture.current()`    directly in a plain switch expression - no new enum/wrapper type. 2. **WiX 3 explicitly rejects AArch64** with a clear, actionable    `ConfigException` (including advice to install WiX 4+), rather than    silently falling back to `x64`. x86/x64 behavior for WiX 3 is    unchanged. 3. **Unsupported architectures throw a specific, self-contained,    localized exception** (`ConfigException`) rather than either a    generic `IOException` (as in the original PR) or a bare    `UnsupportedOperationException` (an earlier iteration of this PR),    matching jpackage's current established convention for clean    user-facing configuration errors.  ## Testing  - Added `WixPipelineTest` (JUnit 5): a host-architecture-independent   unit test asserting the exact `-arch` argument (or `ConfigException`)   produced for every `Architecture` value, for both the WiX v3 and   WiX v4+ mappings. - Added `WinArm64MsiTest` (jtreg `PackageTest`), gated   `@requires (os.family == "windows" & os.arch == "aarch64")`, that   builds a real MSI and asserts: (a) WiX is invoked with `-arch arm64`;   (b) the MSI's Summary Information Template property reports the   Arm64 platform; (c) the WiX Util extension resolves to   `Wix4CloseApplications_A64`, not `_X64`. The test runs a lightweight   fake-runtime pre-flight probe to detect the installed WiX toolset   version and skips cleanly (not a failure) if WiX v4+ isn't present. - Existing x86/x64 behavior is fully preserved and covered by   `WixPipelineTest` for both WiX-version code paths.  This change was iteratively reviewed and hardened over 8 rounds of automated Copilot code review on a fork PR (https://github.com/yeelam-gordon/jdk/pull/1) before being opened here, converging to zero open findings.  ## Validation performed  - No full `configure && make` build was available in the development   environment used to prepare this change (no GNU Make/Cygwin/MSYS2   toolchain). As a substitute: a standalone `javac` compile of   `src/jdk.jpackage/{share,windows}/classes` against a JDK 25 build   confirmed **zero new compilation errors** introduced by this change   (only pre-existing, unrelated `jdk.internal.joptsimple`   module-visibility gaps remain, present identically before and after   this diff). A standalone reproduction of the `wix4ArchArg`/   `wix3ArchArg` switch logic was compiled and executed directly,   covering all 10 positive/negative architecture cases (pass). - `WinArm64MsiTest` requires native Windows/AArch64 hardware with WiX   v4+ installed and has **not** been executed end-to-end; no Arm64 MSI   installation or WiX invocation is claimed to be proven by this PR   alone. CI (including a hosted `windows-11-arm` runner already   present in this repository's workflow) is expected to provide that   coverage once this PR is built.  ## Bug  https://bugs.openjdk.org/browse/JDK-8361207  - [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8361207](https://bugs.openjdk.org/browse/JDK-8361207): Build native Windows ARM64 MSI packages (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32634/head:pull/32634` \
`$ git checkout pull/32634`

Update a local copy of the PR: \
`$ git checkout pull/32634` \
`$ git pull https://git.openjdk.org/jdk.git pull/32634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32634`

View PR using the GUI difftool: \
`$ git pr show -t 32634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32634.diff">https://git.openjdk.org/jdk/pull/32634.diff</a>

</details>
