### PR TITLE
8391177: RISC-V: Optimize conditional arithmetic with Zicond

### DIFF
--- a/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
@@ -72,6 +72,8 @@
     return 0;
   }
 
+  static constexpr bool supports_conditional_zero_arithmetic() { return false; }
+
   // This affects two different things:
   //  - how Decode nodes are matched
   //  - how ImplicitNullCheck opportunities are recognized

--- a/src/hotspot/cpu/arm/matcher_arm.hpp
+++ b/src/hotspot/cpu/arm/matcher_arm.hpp
@@ -67,6 +67,8 @@
   // CMOVF/CMOVD are expensive on ARM.
   static int float_cmove_cost() { return ConditionalMoveLimit; }
 
+  static constexpr bool supports_conditional_zero_arithmetic() { return false; }
+
   static bool narrow_oop_use_complex_address() {
     NOT_LP64(ShouldNotCallThis());
     assert(UseCompressedOops, "only for compressed oops code");

--- a/src/hotspot/cpu/ppc/matcher_ppc.hpp
+++ b/src/hotspot/cpu/ppc/matcher_ppc.hpp
@@ -70,6 +70,8 @@
   // Suppress CMOVF for Power8 because there are no fast nodes.
   static int float_cmove_cost() { return (PowerArchitecturePPC64 >= 9) ? 0 : ConditionalMoveLimit; }
 
+  static constexpr bool supports_conditional_zero_arithmetic() { return false; }
+
   // This affects two different things:
   //  - how Decode nodes are matched
   //  - how ImplicitNullCheck opportunities are recognized

--- a/src/hotspot/cpu/riscv/matcher_riscv.hpp
+++ b/src/hotspot/cpu/riscv/matcher_riscv.hpp
@@ -73,6 +73,10 @@
     return 0;
   }
 
+  static bool supports_conditional_zero_arithmetic() {
+    return UseZicond;
+  }
+
   // This affects two different things:
   //  - how Decode nodes are matched
   //  - how ImplicitNullCheck opportunities are recognized

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2235,6 +2235,19 @@ encode %{
     __ mv(dst_reg, con);
   %}
 
+  enc_class riscv_enc_czero_cond(zicondCmpOpEqNe cop, iRegIorL dst, iRegIorL cond) %{
+    switch ($cop$$cmpcode) {
+      case BoolTest::eq:
+        __ czero_eqz(as_Register($dst$$reg), as_Register($dst$$reg), as_Register($cond$$reg));
+        break;
+      case BoolTest::ne:
+        __ czero_nez(as_Register($dst$$reg), as_Register($dst$$reg), as_Register($cond$$reg));
+        break;
+      default:
+        ShouldNotReachHere();
+    }
+  %}
+
   enc_class riscv_enc_mov_p(iRegP dst, immP src) %{
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
@@ -3726,6 +3739,29 @@ operand cmpOpEqNe()
     overflow(0x2, "overflow");
     less(0x3, "lt");
     not_equal(0x4, "ne");
+    less_equal(0x5, "le");
+    no_overflow(0x6, "no_overflow");
+    greater_equal(0x7, "ge");
+  %}
+%}
+
+// Equal/not-equal comparison used as the zero condition of a Zicond
+// instruction. The condition codes are unchanged, but the format strings
+// use the architectural instruction suffixes.
+operand zicondCmpOpEqNe()
+%{
+  match(Bool);
+  op_cost(0);
+  predicate(n->as_Bool()->_test._test == BoolTest::ne ||
+            n->as_Bool()->_test._test == BoolTest::eq);
+
+  format %{ "" %}
+  interface(COND_INTER) %{
+    equal(0x0, "eqz");
+    greater(0x1, "gt");
+    overflow(0x2, "overflow");
+    less(0x3, "lt");
+    not_equal(0x4, "nez");
     less_equal(0x5, "le");
     no_overflow(0x6, "no_overflow");
     greater_equal(0x7, "ge");
@@ -10647,6 +10683,33 @@ instruct cmovI_cmpP_zero(iRegINoSp dst, immI0 src, iRegP op1, iRegP op2, cmpOpU 
   ins_pipe(pipe_class_compare);
 %}
 
+// Specialize the zero-result CMove rules above when the comparison is also
+// against zero. Zicond can then use the compared register directly as its
+// condition and emit a single instruction.
+
+instruct cmovI_cmpI_zero_cond(iRegINoSp dst, immI0 result_zero, iRegI cond, immI0 cmp_zero, zicondCmpOpEqNe cop) %{
+  predicate(UseZicond);
+  match(Set dst (CMoveI (Binary cop (CmpI cond cmp_zero)) (Binary dst result_zero)));
+  ins_cost(ALU_COST);
+
+  format %{ "czero.$cop $dst, $dst, $cond\t#@cmovI_cmpI_zero_cond" %}
+
+  ins_encode(riscv_enc_czero_cond(cop, dst, cond));
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct cmovI_cmpL_zero_cond(iRegINoSp dst, immI0 result_zero, iRegL cond, immL0 cmp_zero, zicondCmpOpEqNe cop) %{
+  predicate(UseZicond);
+  match(Set dst (CMoveI (Binary cop (CmpL cond cmp_zero)) (Binary dst result_zero)));
+  ins_cost(ALU_COST);
+
+  format %{ "czero.$cop $dst, $dst, $cond\t#@cmovI_cmpL_zero_cond" %}
+
+  ins_encode(riscv_enc_czero_cond(cop, dst, cond));
+
+  ins_pipe(ialu_reg_reg);
+%}
 // --------- CMoveL ---------
 
 instruct cmovL_cmpL(iRegLNoSp dst, iRegL src, iRegL op1, iRegL op2, cmpOp cop) %{
@@ -10817,6 +10880,29 @@ instruct cmovL_cmpUL_zero(iRegLNoSp dst, immL0 src, iRegL op1, iRegL op2, cmpOpU
   ins_pipe(pipe_class_compare);
 %}
 
+instruct cmovL_cmpI_zero_cond(iRegLNoSp dst, immL0 result_zero, iRegI cond, immI0 cmp_zero, zicondCmpOpEqNe cop) %{
+  predicate(UseZicond);
+  match(Set dst (CMoveL (Binary cop (CmpI cond cmp_zero)) (Binary dst result_zero)));
+  ins_cost(ALU_COST);
+
+  format %{ "czero.$cop $dst, $dst, $cond\t#@cmovL_cmpI_zero_cond" %}
+
+  ins_encode(riscv_enc_czero_cond(cop, dst, cond));
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct cmovL_cmpL_zero_cond(iRegLNoSp dst, immL0 result_zero, iRegL cond, immL0 cmp_zero, zicondCmpOpEqNe cop) %{
+  predicate(UseZicond);
+  match(Set dst (CMoveL (Binary cop (CmpL cond cmp_zero)) (Binary dst result_zero)));
+  ins_cost(ALU_COST);
+
+  format %{ "czero.$cop $dst, $dst, $cond\t#@cmovL_cmpL_zero_cond" %}
+
+  ins_encode(riscv_enc_czero_cond(cop, dst, cond));
+
+  ins_pipe(ialu_reg_reg);
+%}
 // --------- CMoveF ---------
 
 instruct cmovF_cmpI(fRegF dst, fRegF src, iRegI op1, iRegI op2, cmpOp cop) %{

--- a/src/hotspot/cpu/s390/matcher_s390.hpp
+++ b/src/hotspot/cpu/s390/matcher_s390.hpp
@@ -74,6 +74,8 @@
     return VM_Version::has_LoadStoreConditional() ? 0 : ConditionalMoveLimit;
   }
 
+  static constexpr bool supports_conditional_zero_arithmetic() { return false; }
+
   // Set this as clone_shift_expressions.
   static bool narrow_oop_use_complex_address() {
     if (CompressedOops::base() == nullptr && CompressedOops::shift() == 0) return true;

--- a/src/hotspot/cpu/x86/matcher_x86.hpp
+++ b/src/hotspot/cpu/x86/matcher_x86.hpp
@@ -69,6 +69,8 @@
   // No CMOVF/CMOVD with SSE2
   static int float_cmove_cost() { return ConditionalMoveLimit; }
 
+  static constexpr bool supports_conditional_zero_arithmetic() { return false; }
+
   static bool narrow_oop_use_complex_address() {
     assert(UseCompressedOops, "only for compressed oops code");
     return (LogMinObjAlignmentInBytes <= 3);

--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -31,6 +31,92 @@
 #include "opto/subnode.hpp"
 
 //=============================================================================
+static Node* make_conditional_zero_arithmetic(PhaseGVN* phase, CMoveNode* cmove) {
+  if (!Matcher::supports_conditional_zero_arithmetic()) {
+    return nullptr;
+  }
+
+  const BasicType bt = cmove->bottom_type()->basic_type();
+  if (bt != T_INT && bt != T_LONG) {
+    return nullptr;
+  }
+
+  Node* bol = cmove->in(CMoveNode::Condition);
+  if (!bol->is_Bool()) {
+    return nullptr;
+  }
+
+  Node* cmp = bol->in(1);
+  if (cmp->Opcode() != Op_CmpI && cmp->Opcode() != Op_CmpL) {
+    return nullptr;
+  }
+
+  if (bol->as_Bool()->_test._test != BoolTest::eq &&
+      bol->as_Bool()->_test._test != BoolTest::ne) {
+    return nullptr;
+  }
+
+  if (!phase->type(cmp->in(2))->is_zero_type()) {
+    return nullptr;
+  }
+
+  auto is_supported_opcode = [bt](int opc) {
+    const bool is_or = bt == T_INT ? opc == Op_OrI : opc == Op_OrL;
+    return opc == Op_Add(bt) || opc == Op_Sub(bt) || is_or || opc == Op_Xor(bt) || opc == Op_And(bt);
+  };
+  auto find_value = [&is_supported_opcode, bt](Node* operation, Node* base) -> Node* {
+    const int opcode = operation->Opcode();
+    if (!is_supported_opcode(opcode)) {
+      return nullptr;
+    }
+    if (operation->in(1) == base) {
+      return operation->in(2);
+    }
+    if (opcode != Op_Sub(bt) && operation->in(2) == base) {
+      return operation->in(1);
+    }
+    return nullptr;
+  };
+
+  Node* base = cmove->in(CMoveNode::IfFalse);
+  Node* operation = cmove->in(CMoveNode::IfTrue);
+  bool operation_is_true = true;
+  Node* value = find_value(operation, base);
+  if (value == nullptr) {
+    base = cmove->in(CMoveNode::IfTrue);
+    operation = cmove->in(CMoveNode::IfFalse);
+    operation_is_true = false;
+    value = find_value(operation, base);
+  }
+  if (value == nullptr || operation->outcnt() != 1) {
+    return nullptr;
+  }
+  const int opcode = operation->Opcode();
+
+  // Keep the select as a CMove so the target can lower the zero-result arm
+  // directly to czero.eqz/czero.nez. The surrounding operation then maps to
+  // the conditional arithmetic sequences from the Zicond specification.
+  Node* zero = phase->zerocon(bt);
+  const Type* result_zero_type = Type::get_zero_type(bt);
+  const Type* value_type = phase->type(value)->meet_speculative(result_zero_type);
+  if (opcode == Op_And(bt)) {
+    const Type* base_type = phase->type(base)->meet_speculative(result_zero_type);
+    Node* selected_base = operation_is_true
+        ? phase->transform(CMoveNode::make(bol, base, zero, base_type))
+        : phase->transform(CMoveNode::make(bol, zero, base, base_type));
+    return bt == T_INT ? static_cast<Node*>(new OrINode(operation, selected_base))
+                       : static_cast<Node*>(new OrLNode(operation, selected_base));
+  }
+
+  Node* selected_value = operation_is_true
+      ? phase->transform(CMoveNode::make(bol, zero, value, value_type))
+      : phase->transform(CMoveNode::make(bol, value, zero, value_type));
+  Node* conditional_operation = operation->clone();
+  conditional_operation->set_req(operation->in(1) == base ? 2 : 1, selected_value);
+  return conditional_operation;
+}
+
+//=============================================================================
 /*
  The major change is for CMoveP and StrComp.  They have related but slightly
  different problems.  They both take in TWO oops which are both null-checked
@@ -100,6 +186,11 @@ Node *CMoveNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   Node* minmax = Ideal_minmax(phase, this);
   if (minmax != nullptr) {
     return minmax;
+  }
+
+  Node* conditional_operation = make_conditional_zero_arithmetic(phase, this);
+  if (conditional_operation != nullptr) {
+    return conditional_operation;
   }
 
   // Canonicalize the node by moving constants to the true-case input.

--- a/test/hotspot/jtreg/compiler/c2/riscv64/TestZicondConditionalArithmetic.java
+++ b/test/hotspot/jtreg/compiler/c2/riscv64/TestZicondConditionalArithmetic.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test Zicond conditional arithmetic and logical instruction sequences
+ * @library /test/lib /
+ * @requires os.arch == "riscv64" & vm.cpu.features ~= ".*zicond.*"
+ * @requires vm.debug & vm.compiler2.enabled
+ * @run driver compiler.c2.riscv64.TestZicondConditionalArithmetic
+ */
+
+package compiler.c2.riscv64;
+
+import compiler.lib.ir_framework.*;
+
+public class TestZicondConditionalArithmetic {
+    public static void main(String[] args) {
+        TestFramework framework = new TestFramework();
+        framework.addFlags("-XX:+UseCMoveUnconditionally", "-XX:-UseRVV",
+                           "-XX:-UseSuperWord");
+        framework.addScenarios(new Scenario(0, "-XX:+UseZicond"),
+                               new Scenario(1, "-XX:-UseZicond"));
+        framework.setDefaultWarmup(1000);
+        framework.start();
+    }
+
+    private static final String CMOVE_I_ZERO_COND = "cmovI_cmpI_zero_cond";
+    private static final String CMOVE_I_LONG_ZERO_COND = "cmovI_cmpL_zero_cond";
+    private static final String CMOVE_L_ZERO_COND = "cmovL_cmpL_zero_cond";
+    private static final String CMOVE_L_INT_ZERO_COND = "cmovL_cmpI_zero_cond";
+
+    @Test
+    @IR(counts = {CMOVE_I_ZERO_COND, "1"}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "true"})
+    @IR(failOn = {CMOVE_I_ZERO_COND}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "false"})
+    static int addEqI(int base, int value, int condition) {
+        return condition == 0 ? base + value : base;
+    }
+
+    @Test
+    @IR(counts = {CMOVE_I_ZERO_COND, "1"}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "true"})
+    static int subNeI(int base, int value, int condition) {
+        return condition != 0 ? base : base - value;
+    }
+
+    @Test
+    @IR(counts = {CMOVE_I_LONG_ZERO_COND, "1"}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "true"})
+    @IR(failOn = {CMOVE_I_LONG_ZERO_COND}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "false"})
+    static int orEqILongCondition(int base, int value, long condition) {
+        return condition == 0 ? value | base : base;
+    }
+
+    @Test
+    @IR(counts = {CMOVE_I_LONG_ZERO_COND, "1"}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "true"})
+    static int xorNeILongCondition(int base, int value, long condition) {
+        return condition != 0 ? base : value ^ base;
+    }
+
+    @Test
+    @IR(counts = {CMOVE_L_INT_ZERO_COND, "1"}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "true"})
+    @IR(failOn = {CMOVE_L_INT_ZERO_COND}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "false"})
+    static long andEqLIntCondition(long base, long value, int condition) {
+        return condition == 0 ? base & value : base;
+    }
+
+    @Test
+    @IR(counts = {CMOVE_L_INT_ZERO_COND, "1"}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "true"})
+    static long addNeLIntCondition(long base, long value, int condition) {
+        return condition != 0 ? base : base + value;
+    }
+
+    @Test
+    @IR(counts = {CMOVE_L_ZERO_COND, "1"}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "true"})
+    @IR(failOn = {CMOVE_L_ZERO_COND}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "false"})
+    static long subEqL(long base, long value, long condition) {
+        return condition == 0 ? base - value : base;
+    }
+
+    @Test
+    @IR(counts = {CMOVE_L_ZERO_COND, "1"}, phase = CompilePhase.MATCHING, applyIf = {"UseZicond", "true"})
+    static long andNeL(long base, long value, long condition) {
+        return condition != 0 ? base : value & base;
+    }
+
+    @Test
+    @IR(failOn = {CMOVE_I_ZERO_COND}, phase = CompilePhase.MATCHING)
+    static int sharedOperationI(int base, int value, int condition) {
+        int operation = base + value;
+        return (condition == 0 ? operation : base) + operation;
+    }
+
+    @Test
+    @IR(failOn = {CMOVE_I_ZERO_COND}, phase = CompilePhase.MATCHING)
+    static int compareNonZeroI(int base, int value, int condition) {
+        return condition == 42 ? base + value : base;
+    }
+
+    @Test
+    @IR(failOn = {CMOVE_I_ZERO_COND}, phase = CompilePhase.MATCHING)
+    static int valueBaseSubI(int base, int value, int condition) {
+        return condition == 0 ? value - base : base;
+    }
+
+    @Test
+    @IR(failOn = {CMOVE_I_ZERO_COND}, phase = CompilePhase.MATCHING)
+    static int unsupportedMulI(int base, int value, int condition) {
+        return condition == 0 ? base * value : base;
+    }
+
+    @Run(test = {"addEqI", "subNeI", "orEqILongCondition", "xorNeILongCondition",
+                 "andEqLIntCondition", "addNeLIntCondition", "subEqL", "andNeL",
+                 "sharedOperationI", "compareNonZeroI", "valueBaseSubI",
+                 "unsupportedMulI"})
+    static void run() {
+        int[] basesI = {0, 1, -1, Integer.MIN_VALUE, Integer.MAX_VALUE,
+                        0x5555_5555, 0xaaaa_aaaa, 123_456_789};
+        int[] valuesI = {0, -1, 1, Integer.MAX_VALUE, Integer.MIN_VALUE,
+                         0xaaaa_aaaa, 0x5555_5555, -123_456_789};
+        int[] conditionsI = {0, 1, -1, Integer.MIN_VALUE, Integer.MAX_VALUE, 42, 0, -42};
+        long[] basesL = {0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE,
+                         0x5555_5555_5555_5555L, 0xaaaa_aaaa_aaaa_aaaaL, 123_456_789L};
+        long[] valuesL = {0L, -1L, 1L, Long.MAX_VALUE, Long.MIN_VALUE,
+                          0xaaaa_aaaa_aaaa_aaaaL, 0x5555_5555_5555_5555L, -123_456_789L};
+        long[] conditionsL = {0L, 1L, -1L, Long.MIN_VALUE, Long.MAX_VALUE,
+                              42L, 0L, 0x1_0000_0000L};
+
+        for (int i = 0; i < basesI.length; i++) {
+            int baseI = basesI[i];
+            int valueI = valuesI[i];
+            int conditionI = conditionsI[i];
+            long baseL = basesL[i];
+            long valueL = valuesL[i];
+            long conditionL = conditionsL[i];
+
+            check(addEqI(baseI, valueI, conditionI), conditionI == 0 ? baseI + valueI : baseI);
+            check(subNeI(baseI, valueI, conditionI), conditionI != 0 ? baseI : baseI - valueI);
+            check(orEqILongCondition(baseI, valueI, conditionL),
+                  conditionL == 0 ? valueI | baseI : baseI);
+            check(xorNeILongCondition(baseI, valueI, conditionL),
+                  conditionL != 0 ? baseI : valueI ^ baseI);
+            check(andEqLIntCondition(baseL, valueL, conditionI),
+                  conditionI == 0 ? baseL & valueL : baseL);
+            check(addNeLIntCondition(baseL, valueL, conditionI),
+                  conditionI != 0 ? baseL : baseL + valueL);
+            check(subEqL(baseL, valueL, conditionL), conditionL == 0 ? baseL - valueL : baseL);
+            check(andNeL(baseL, valueL, conditionL), conditionL != 0 ? baseL : valueL & baseL);
+
+            int operation = baseI + valueI;
+            check(sharedOperationI(baseI, valueI, conditionI),
+                  (conditionI == 0 ? operation : baseI) + operation);
+            check(compareNonZeroI(baseI, valueI, conditionI),
+                  conditionI == 42 ? baseI + valueI : baseI);
+            check(valueBaseSubI(baseI, valueI, conditionI),
+                  conditionI == 0 ? valueI - baseI : baseI);
+            check(unsupportedMulI(baseI, valueI, conditionI),
+                  conditionI == 0 ? baseI * valueI : baseI);
+        }
+    }
+
+    private static void check(int actual, int expected) {
+        if (actual != expected) {
+            throw new RuntimeException(actual + " != " + expected);
+        }
+    }
+
+    private static void check(long actual, long expected) {
+        if (actual != expected) {
+            throw new RuntimeException(actual + " != " + expected);
+        }
+    }
+}


### PR DESCRIPTION
Recognize conditional add, subtract, and, or, and xor CMove patterns and rewrite them around a zero-result conditional move.

Add RISC-V match rules that use the compared register directly as the Zicond condition, plus IR coverage for int/long, eq/ne, mixed-width conditions, reversed forms, sharing, and the UseZicond gate.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391177](https://bugs.openjdk.org/browse/JDK-8391177): RISC-V: Optimize conditional arithmetic with Zicond (**Enhancement** - P4)


### Contributors
 * Pengcheng Wang `<wangpengcheng.pp@bytedance.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32635/head:pull/32635` \
`$ git checkout pull/32635`

Update a local copy of the PR: \
`$ git checkout pull/32635` \
`$ git pull https://git.openjdk.org/jdk.git pull/32635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32635`

View PR using the GUI difftool: \
`$ git pr show -t 32635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32635.diff">https://git.openjdk.org/jdk/pull/32635.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32635#issuecomment-5503994948)
</details>
