### PR TITLE
8391601: RISC-V: Add support for sv57

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
@@ -64,10 +64,10 @@ private:
   void deoptimize_trap(CodeEmitInfo *info);
 
   enum {
-    // call stub: CompiledDirectCall::to_interp_stub_size() +
-    //            CompiledDirectCall::to_trampoline_stub_size()
-    _call_stub_size = 11 * MacroAssembler::instruction_size +
-                      1 * MacroAssembler::instruction_size + wordSize,
+    // Maximum call stub size used by the shared C1 code-buffer estimate.
+    _call_stub_size = MacroAssembler::movptr1_sv57_instruction_size +
+                      MacroAssembler::movptr2_sv57_instruction_size +
+                      MacroAssembler::instruction_size + wordSize,
     // See emit_exception_handler for detail
     _exception_handler_size = DEBUG_ONLY(1*K) NOT_DEBUG(175), // or smaller
     // See emit_deopt_handler for detail

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -148,6 +148,32 @@ bool MacroAssembler::is_movptr2_sv48_at(address instr) {
          check_movptr2_sv48_data_dependency(instr);
 }
 
+bool MacroAssembler::is_movptr1_sv57_at(address instr) {
+  return is_lui_at(instr) &&
+         is_addi_at(instr + MacroAssembler::instruction_size) &&
+         is_slli_shift_at(instr + MacroAssembler::instruction_size * 2, 11) &&
+         is_addi_at(instr + MacroAssembler::instruction_size * 3) &&
+         is_slli_shift_at(instr + MacroAssembler::instruction_size * 4, 10) &&
+         is_addi_at(instr + MacroAssembler::instruction_size * 5) &&
+         is_slli_shift_at(instr + MacroAssembler::instruction_size * 6, 6) &&
+         (is_addi_at(instr + MacroAssembler::instruction_size * 7) ||
+          is_jalr_at(instr + MacroAssembler::instruction_size * 7) ||
+          is_load_at(instr + MacroAssembler::instruction_size * 7)) &&
+         check_movptr1_sv57_data_dependency(instr);
+}
+
+bool MacroAssembler::is_movptr2_sv57_at(address instr) {
+  return is_lui_at(instr) &&
+         is_addi_at(instr + MacroAssembler::instruction_size) &&
+         is_lui_at(instr + MacroAssembler::instruction_size * 2) &&
+         is_slli_shift_at(instr + MacroAssembler::instruction_size * 3, 30) &&
+         is_add_at(instr + MacroAssembler::instruction_size * 4) &&
+         (is_addi_at(instr + MacroAssembler::instruction_size * 5) ||
+          is_jalr_at(instr + MacroAssembler::instruction_size * 5) ||
+          is_load_at(instr + MacroAssembler::instruction_size * 5)) &&
+         check_movptr2_sv57_data_dependency(instr);
+}
+
 bool MacroAssembler::is_li16u_at(address instr) {
   return is_lui_at(instr) && // lui
          is_srli_at(instr + MacroAssembler::instruction_size) && // srli
@@ -2935,6 +2961,47 @@ static int patch_addr_in_movptr2_sv48(address instruction_address, address targe
   return MacroAssembler::movptr2_sv48_instruction_size;
 }
 
+static int patch_addr_in_movptr1_sv57(address instruction_address, address target) {
+  uintptr_t addr = (uintptr_t)target;
+
+  assert(addr < (1ull << 57), "57-bit overflow in address constant");
+  uint64_t upper30 = addr >> 27;
+  int64_t lower12 = ((int64_t)(upper30 << 52)) >> 52;
+  int64_t hi20 = upper30 - lower12;
+
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 0), 31, 12, (hi20 >> 12) & 0xfffff);
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 1), 31, 20, lower12 & 0xfff);
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 3), 31, 20, (addr >> 16) & 0x7ff);
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 5), 31, 20, (addr >> 6) & 0x3ff);
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 7), 31, 20, addr & 0x3f);
+
+  assert(MacroAssembler::target_addr_for_insn(instruction_address) == target, "Must be");
+
+  return MacroAssembler::movptr1_sv57_instruction_size;
+}
+
+static int patch_addr_in_movptr2_sv57(address instruction_address, address target) {
+  uintptr_t addr = (uintptr_t)target;
+
+  assert(addr < (1ull << 57), "57-bit overflow in address constant");
+  uint64_t upper27 = addr >> 30;
+  int64_t upper_lower12 = ((int64_t)(upper27 << 52)) >> 52;
+  int64_t upper_hi20 = upper27 - upper_lower12;
+
+  uint64_t lower30 = addr & 0x3fffffff;
+  int64_t lower12 = ((int64_t)(lower30 << 52)) >> 52;
+  int64_t mid18 = (lower30 - lower12) >> 12;
+
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 0), 31, 12, (upper_hi20 >> 12) & 0xfffff);
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 1), 31, 20, upper_lower12 & 0xfff);
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 2), 31, 12, mid18 & 0xfffff);
+  Assembler::patch(instruction_address + (MacroAssembler::instruction_size * 5), 31, 20, lower12 & 0xfff);
+
+  assert(MacroAssembler::target_addr_for_insn(instruction_address) == target, "Must be");
+
+  return MacroAssembler::movptr2_sv57_instruction_size;
+}
+
 static bool patch_addr_in_movptr_for_mode(address instruction_address, address target, int& patched_size) {
   switch (VM_Version::satp_mode.value()) {
     case VM_Version::VM_SV39:
@@ -2949,6 +3016,15 @@ static bool patch_addr_in_movptr_for_mode(address instruction_address, address t
         return true;
       } else if (MacroAssembler::is_movptr2_sv48_at(instruction_address)) {
         patched_size = patch_addr_in_movptr2_sv48(instruction_address, target);
+        return true;
+      }
+      break;
+    case VM_Version::VM_SV57:
+      if (MacroAssembler::is_movptr1_sv57_at(instruction_address)) {
+        patched_size = patch_addr_in_movptr1_sv57(instruction_address, target);
+        return true;
+      } else if (MacroAssembler::is_movptr2_sv57_at(instruction_address)) {
+        patched_size = patch_addr_in_movptr2_sv57(instruction_address, target);
         return true;
       }
       break;
@@ -3037,6 +3113,28 @@ static address get_target_of_movptr2_sv48(address insn_addr) {
   return ret;
 }
 
+static address get_target_of_movptr1_sv57(address insn_addr) {
+  assert_cond(insn_addr != nullptr);
+  intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 12;
+  target_address += (int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 1), 31, 20);
+  target_address <<= 11;
+  target_address += (int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 3), 31, 20);
+  target_address <<= 10;
+  target_address += (int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 5), 31, 20);
+  target_address <<= 6;
+  target_address += (int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 7), 31, 20);
+  return (address)target_address;
+}
+
+static address get_target_of_movptr2_sv57(address insn_addr) {
+  assert_cond(insn_addr != nullptr);
+  intptr_t upper27 = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 12;
+  upper27 += (int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 1), 31, 20);
+  intptr_t mid18 = ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 2), 31, 12)) & 0xfffff;
+  intptr_t low12 = (int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + MacroAssembler::instruction_size * 5), 31, 20);
+  return (address)((upper27 << 30) + (mid18 << 12) + low12);
+}
+
 static bool get_target_of_movptr_for_mode(address insn_addr, address& target) {
   switch (VM_Version::satp_mode.value()) {
     case VM_Version::VM_SV39:
@@ -3051,6 +3149,15 @@ static bool get_target_of_movptr_for_mode(address insn_addr, address& target) {
         return true;
       } else if (MacroAssembler::is_movptr2_sv48_at(insn_addr)) {
         target = get_target_of_movptr2_sv48(insn_addr);
+        return true;
+      }
+      break;
+    case VM_Version::VM_SV57:
+      if (MacroAssembler::is_movptr1_sv57_at(insn_addr)) {
+        target = get_target_of_movptr1_sv57(insn_addr);
+        return true;
+      } else if (MacroAssembler::is_movptr2_sv57_at(insn_addr)) {
+        target = get_target_of_movptr2_sv57(insn_addr);
         return true;
       }
       break;
@@ -3119,8 +3226,8 @@ address MacroAssembler::target_addr_for_insn(address insn_addr) {
 }
 
 int MacroAssembler::patch_oop(address insn_addr, address o) {
-  // OOPs are either narrow (32 bits) or wide (48 bits on sv48, 39 bits
-  // on sv39).  We encode narrow OOPs by setting the upper 16 bits in the
+  // OOPs are either narrow (32 bits) or wide (up to 57 bits, depending on
+  // the satp mode). We encode narrow OOPs by setting the upper 16 bits in the
   // first instruction.
   int movptr_size = 0;
   if (MacroAssembler::is_li32_at(insn_addr)) {
@@ -3186,6 +3293,13 @@ void MacroAssembler::movptr_for_mode(Register Rd, uint64_t addr, int32_t &offset
         movptr2_sv48(Rd, addr, offset, temp);
       }
       break;
+    case VM_Version::VM_SV57:
+      if (temp == noreg) {
+        movptr1_sv57(Rd, addr, offset);
+      } else {
+        movptr2_sv57(Rd, addr, offset, temp);
+      }
+      break;
     default:
       ShouldNotReachHere();
   }
@@ -3197,6 +3311,8 @@ int MacroAssembler::movptr_instruction_size() {
       return movptr_sv39_instruction_size;
     case VM_Version::VM_SV48:
       return movptr2_sv48_instruction_size;
+    case VM_Version::VM_SV57:
+      return movptr2_sv57_instruction_size;
     default: ShouldNotReachHere(); return 0;
   }
 }
@@ -3273,6 +3389,46 @@ void MacroAssembler::movptr2_sv48(Register Rd, uint64_t addr, int32_t &offset, R
   lui(Rd, mid18);
 
   slli(tmp, tmp, 18);
+  add(Rd, Rd, tmp);
+
+  offset = lower12;
+}
+
+void MacroAssembler::movptr1_sv57(Register Rd, uint64_t addr, int32_t &offset) {
+  // addr: [upper30[hi20, low12], mid11, mid10, lower6]
+  // Keeping the initial value within 30 bits avoids sign extension by lui
+  // and covers the complete [0, 2^57) range, including non-address sentinels.
+  uint64_t upper30 = addr >> 27;
+  int64_t lower12 = ((int64_t)(upper30 << 52)) >> 52;
+  int64_t hi20 = upper30 - lower12;
+  lui(Rd, hi20);
+  addi(Rd, Rd, lower12);
+
+  slli(Rd, Rd, 11);
+  addi(Rd, Rd, (addr >> 16) & 0x7ff);
+  slli(Rd, Rd, 10);
+  addi(Rd, Rd, (addr >> 6) & 0x3ff);
+  slli(Rd, Rd, 6);
+
+  offset = addr & 0x3f;
+}
+
+void MacroAssembler::movptr2_sv57(Register Rd, uint64_t addr, int32_t &offset, Register tmp) {
+  assert_different_registers(Rd, tmp, noreg);
+
+  // addr: [upper27(bits 56:30), lower30(mid18, lower12)]
+  uint64_t upper27 = addr >> 30;
+  int64_t upper_lower12 = ((int64_t)(upper27 << 52)) >> 52;
+  int64_t upper_hi20 = upper27 - upper_lower12;
+  lui(tmp, upper_hi20);
+  addi(tmp, tmp, upper_lower12);
+
+  uint64_t lower30 = addr & 0x3fffffff;
+  int64_t lower12 = ((int64_t)(lower30 << 52)) >> 52;
+  int64_t mid18 = lower30 - lower12;
+  lui(Rd, mid18);
+
+  slli(tmp, tmp, 30);
   add(Rd, Rd, tmp);
 
   offset = lower12;
@@ -5828,6 +5984,8 @@ int MacroAssembler::static_call_stub_size() {
       return 2 * movptr_sv39_instruction_size;
     case VM_Version::VM_SV48:
       return movptr1_sv48_instruction_size + movptr2_sv48_instruction_size;
+    case VM_Version::VM_SV57:
+      return movptr1_sv57_instruction_size + movptr2_sv57_instruction_size;
     default:
       ShouldNotReachHere();
       return 0;

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -962,7 +962,8 @@ public:
   void movptr_sv39(Register Rd, uintptr_t addr, int32_t &offset);
   void movptr1_sv48(Register Rd, uintptr_t addr, int32_t &offset);
   void movptr2_sv48(Register Rd, uintptr_t addr, int32_t &offset, Register tmp);
-
+  void movptr1_sv57(Register Rd, uintptr_t addr, int32_t &offset);
+  void movptr2_sv57(Register Rd, uintptr_t addr, int32_t &offset, Register tmp);
  public:
   // float imm move
   static bool can_hf_imm_load(short imm);
@@ -1706,6 +1707,8 @@ public:
     movptr_sv39_instruction_size = 4 * MacroAssembler::instruction_size, // lui, addi, slli, addi.  See movptr_sv39().
     movptr1_sv48_instruction_size = 6 * MacroAssembler::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1_sv48().
     movptr2_sv48_instruction_size = 5 * MacroAssembler::instruction_size, // lui, lui, slli, add, addi.  See movptr2_sv48().
+    movptr1_sv57_instruction_size = 8 * MacroAssembler::instruction_size, // lui, addi, slli, addi, slli, addi, slli, addi.
+    movptr2_sv57_instruction_size = 6 * MacroAssembler::instruction_size, // lui, addi, lui, slli, add, addi.
     load_pc_relative_instruction_size = 2 * MacroAssembler::instruction_size // auipc, ld
   };
 
@@ -1744,6 +1747,8 @@ public:
   static bool is_movptr_sv39_at(address instr);
   static bool is_movptr1_sv48_at(address instr);
   static bool is_movptr2_sv48_at(address instr);
+  static bool is_movptr1_sv57_at(address instr);
+  static bool is_movptr2_sv57_at(address instr);
 
   static bool is_lwu_to_zr(address instr);
 
@@ -1812,6 +1817,51 @@ public:
            extract_rs2(add) == extract_rd(slli) &&
            extract_rs1(slli) == extract_rd(lui1) &&
            extract_rd(slli) == extract_rd(lui1) &&
+           extract_rs1(last_instr) == extract_rd(add);
+  }
+
+  // movptr1_sv57: lui, addi, slli(11), addi, slli(10), addi,
+  //                slli(6), addi/jalr/load
+  static bool check_movptr1_sv57_data_dependency(address instr) {
+    address lui = instr;
+    address addi1 = lui + MacroAssembler::instruction_size;
+    address slli1 = addi1 + MacroAssembler::instruction_size;
+    address addi2 = slli1 + MacroAssembler::instruction_size;
+    address slli2 = addi2 + MacroAssembler::instruction_size;
+    address addi3 = slli2 + MacroAssembler::instruction_size;
+    address slli3 = addi3 + MacroAssembler::instruction_size;
+    address last_instr = slli3 + MacroAssembler::instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rd(addi1) == extract_rd(lui) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rd(slli1) == extract_rd(addi1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rd(addi2) == extract_rd(slli1) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rd(slli2) == extract_rd(addi2) &&
+           extract_rs1(addi3) == extract_rd(slli2) &&
+           extract_rd(addi3) == extract_rd(slli2) &&
+           extract_rs1(slli3) == extract_rd(addi3) &&
+           extract_rd(slli3) == extract_rd(addi3) &&
+           extract_rs1(last_instr) == extract_rd(slli3);
+  }
+
+  // movptr2_sv57: lui(tmp), addi(tmp), lui(Rd), slli(tmp, 30),
+  //                add(Rd, Rd, tmp), addi/jalr/load
+  static bool check_movptr2_sv57_data_dependency(address instr) {
+    address lui1 = instr;
+    address addi = lui1 + MacroAssembler::instruction_size;
+    address lui2 = addi + MacroAssembler::instruction_size;
+    address slli = lui2 + MacroAssembler::instruction_size;
+    address add = slli + MacroAssembler::instruction_size;
+    address last_instr = add + MacroAssembler::instruction_size;
+    return extract_rs1(addi) == extract_rd(lui1) &&
+           extract_rd(addi) == extract_rd(lui1) &&
+           extract_rs1(slli) == extract_rd(addi) &&
+           extract_rd(slli) == extract_rd(addi) &&
+           extract_rd(add) == extract_rd(lui2) &&
+           extract_rs1(add) == extract_rd(lui2) &&
+           extract_rs2(add) == extract_rd(slli) &&
            extract_rs1(last_instr) == extract_rd(add);
   }
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -56,6 +56,13 @@ static int current_mode_movptr_size_at(address addr) {
         return MacroAssembler::movptr2_sv48_instruction_size;
       }
       return 0;
+    case VM_Version::VM_SV57:
+      if (MacroAssembler::is_movptr1_sv57_at(addr)) {
+        return MacroAssembler::movptr1_sv57_instruction_size;
+      } else if (MacroAssembler::is_movptr2_sv57_at(addr)) {
+        return MacroAssembler::movptr2_sv57_instruction_size;
+      }
+      return 0;
     default:
       ShouldNotReachHere();
       return 0;

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -66,6 +66,8 @@ class NativeInstruction {
   bool is_movptr_sv39()                     const { return MacroAssembler::is_movptr_sv39_at(addr_at(0));  }
   bool is_movptr1_sv48()                    const { return MacroAssembler::is_movptr1_sv48_at(addr_at(0)); }
   bool is_movptr2_sv48()                    const { return MacroAssembler::is_movptr2_sv48_at(addr_at(0)); }
+  bool is_movptr1_sv57()                    const { return MacroAssembler::is_movptr1_sv57_at(addr_at(0)); }
+  bool is_movptr2_sv57()                    const { return MacroAssembler::is_movptr2_sv57_at(addr_at(0)); }
   bool is_auipc()                           const { return MacroAssembler::is_auipc_at(addr_at(0));       }
   bool is_jump()                            const { return MacroAssembler::is_jump_at(addr_at(0));        }
   bool is_call()                            const { return is_call_at(addr_at(0));                        }
@@ -170,7 +172,8 @@ class NativeMovConstReg: public NativeInstruction {
     movptr_sv39_instruction_size        =    MacroAssembler::movptr_sv39_instruction_size,
     movptr1_sv48_instruction_size       =    MacroAssembler::movptr1_sv48_instruction_size,
     movptr2_sv48_instruction_size       =    MacroAssembler::movptr2_sv48_instruction_size,
-
+    movptr1_sv57_instruction_size       =    MacroAssembler::movptr1_sv57_instruction_size,
+    movptr2_sv57_instruction_size       =    MacroAssembler::movptr2_sv57_instruction_size,
     load_pc_relative_instruction_size   =    MacroAssembler::load_pc_relative_instruction_size // auipc, ld
   };
 
@@ -252,10 +255,10 @@ inline NativeJump* nativeJump_at(address addr) {
 class NativeGeneralJump: public NativeJump {
 public:
   enum RISCV_specific_constants {
-    // Maximum sequence size, used by shared C1 code-buffer estimates.
-    instruction_size            =    5 * NativeInstruction::instruction_size, // sv48: lui, lui, slli, add, jalr
+    instruction_size            =    6 * NativeInstruction::instruction_size, // Maximum: sv57 movptr2 + jalr
     instruction_size_sv39       =    4 * NativeInstruction::instruction_size, // lui, addi, slli, jalr
     instruction_size_sv48       =    5 * NativeInstruction::instruction_size, // lui, lui, slli, add, jalr
+    instruction_size_sv57       =    6 * NativeInstruction::instruction_size, // lui, addi, lui, slli, add, jalr
   };
 
   static int insn_size() {

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1221,12 +1221,12 @@ int MachCallDynamicJavaNode::ret_addr_offset() const
 int MachCallRuntimeNode::ret_addr_offset() const {
   // For address inside the code cache the call will be:
   //   auipc + jalr
-  // For real runtime callouts it will be 8 instructions
-  // (7 on sv39, whose movptr is one instruction shorter)
+  // For real runtime callouts it will be 7 instructions on sv39,
+  // 8 on sv48, and 9 on sv57.
   // see riscv_enc_java_to_runtime
   //   la(t0, retaddr)                                             ->  auipc + addi
   //   sd(t0, Address(xthread, JavaThread::last_Java_pc_offset())) ->  sd
-  //   movptr(t1, addr, offset, t0)                                ->  lui + lui + slli + add
+  //   movptr(t1, addr, offset, t0)                                ->  mode-dependent sequence
   //   jalr(t1, offset)                                            ->  jalr
   if (CodeCache::contains(_entry_point)) {
     return 2 * NativeInstruction::instruction_size;
@@ -1258,7 +1258,9 @@ int CallStaticJavaDirectNode::compute_padding(int current_offset) const
 int CallDynamicJavaDirectNode::compute_padding(int current_offset) const
 {
   // skip the movptr in MacroAssembler::ic_call():
-  // lui, lui, slli, add, addi (sv39: lui, addi, slli, addi)
+  // sv39: lui, addi, slli, addi
+  // sv48: lui, lui, slli, add, addi
+  // sv57: lui, addi, lui, slli, add, addi
   // Though movptr() has already 4-byte aligned with or without RVC,
   // We need to prevent from further changes by explicitly calculating the size.
   current_offset += MacroAssembler::movptr_instruction_size();

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -86,11 +86,11 @@ void VM_Version::common_initialize() {
 
   setup_cpu_available_features();
 
-  // check if satp.mode is supported, currently supports up to SV48(RV64)
-  if (satp_mode.value() > VM_SV48 || satp_mode.value() <= VM_MBARE) {
+  // check if satp.mode is supported, currently supports up to SV57(RV64)
+  if (satp_mode.value() > VM_SV57 || satp_mode.value() <= VM_MBARE) {
     vm_exit_during_initialization(
       err_msg(
-         "Unsupported satp mode: SV%d. Only satp modes up to sv48 are supported for now.",
+         "Unsupported satp mode: SV%d. Only satp modes up to sv57 are supported for now.",
          (int)satp_mode.value()));
   }
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -536,6 +536,7 @@ private:
     switch ((int)satp_mode.value()) {
       case VM_SV39: return 39;
       case VM_SV48: return 48;
+      case VM_SV57: return 57;
       default:      return 48;
     }
   }

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -210,9 +210,14 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
     address addr = (address) info->si_addr;
 
-    // Make sure the high order byte is sign extended, as it may be masked away by the hardware.
-    if ((uintptr_t(addr) & (uintptr_t(1) << 55)) != 0) {
-      addr = address(uintptr_t(addr) | (uintptr_t(0xFF) << 56));
+    // Make sure the high order bits are sign extended, as they may be masked
+    // away by the hardware. The sign bit depends on the active address mode.
+    const int va_bits = VM_Version::max_va_bits();
+    if (va_bits > 0 && va_bits < BitsPerWord) {
+      const uintptr_t sign_bit = uintptr_t(1) << (va_bits - 1);
+      if ((uintptr_t(addr) & sign_bit) != 0) {
+        addr = address(uintptr_t(addr) | (~uintptr_t(0) << va_bits));
+      }
     }
 
     // Handle ALL stack overflow variations here


### PR DESCRIPTION
This change adds HotSpot support for the RISC-V Sv57 virtual memory mode.
HotSpot already detects the MMU mode from `/proc/cpuinfo`, but previously rejected modes above Sv48 and its patchable pointer materialization only supported Sv39 and Sv48.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Dependency #32346 must be integrated first

### Issue
 * [JDK-8391601](https://bugs.openjdk.org/browse/JDK-8391601): RISC-V: Add support for sv57 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32636/head:pull/32636` \
`$ git checkout pull/32636`

Update a local copy of the PR: \
`$ git checkout pull/32636` \
`$ git pull https://git.openjdk.org/jdk.git pull/32636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32636`

View PR using the GUI difftool: \
`$ git pr show -t 32636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32636.diff">https://git.openjdk.org/jdk/pull/32636.diff</a>

</details>
