### PR TITLE
8391574: (fs) Files.createTempFile should reject prefix with root component (win)

### DIFF
--- a/src/java.base/share/classes/java/nio/file/TempFileHelper.java
+++ b/src/java.base/share/classes/java/nio/file/TempFileHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ class TempFileHelper {
         String s = prefix + Long.toUnsignedString(n) + suffix;
         Path name = dir.getFileSystem().getPath(s);
         // the generated name should be a simple file name
-        if (name.getParent() != null)
+        if (name.getParent() != null || name.getRoot() != null)
             throw new IllegalArgumentException("Invalid prefix or suffix");
         return dir.resolve(name);
     }

--- a/test/jdk/java/nio/file/Files/TemporaryFiles.java
+++ b/test/jdk/java/nio/file/Files/TemporaryFiles.java
@@ -75,11 +75,15 @@ class TemporaryFiles {
         return Stream.of(
                 Arguments.arguments(null, null, null),
                 Arguments.arguments(null, "blah", null),
+                Arguments.arguments(null, "", null),
                 Arguments.arguments(null, null, ".dat"),
+                Arguments.arguments(null, null, ""),
                 Arguments.arguments(null, "blah", ".dat"),
                 Arguments.arguments(TEST_TMPDIR, null, null),
                 Arguments.arguments(TEST_TMPDIR, "blah", null),
+                Arguments.arguments(TEST_TMPDIR, "", null),
                 Arguments.arguments(TEST_TMPDIR, null, ".dat"),
+                Arguments.arguments(TEST_TMPDIR, null, ""),
                 Arguments.arguments(TEST_TMPDIR, "blah", ".dat")
         );
     }
@@ -93,11 +97,13 @@ class TemporaryFiles {
         try {
             // check file name
             String name = file.getFileName().toString();
-            if (prefix != null) {
+            if (prefix != null && !prefix.isEmpty()) {
                 assertTrue(name.startsWith(prefix), "Should start with " + prefix);
             }
-            String expectedSuffix = (suffix != null) ? suffix : ".tmp";
-            assertTrue(name.endsWith(expectedSuffix), "Should end with " + expectedSuffix);
+            if (suffix == null || !suffix.isEmpty()) {
+                String expectedSuffix = (suffix != null) ? suffix : ".tmp";
+                assertTrue(name.endsWith(expectedSuffix), "Should end with " + expectedSuffix);
+            }
 
             // check file is in expected directory
             Path expectedDir = (dir != null) ? dir : SYS_TMPDIR;
@@ -127,8 +133,10 @@ class TemporaryFiles {
         return Stream.of(
                 Arguments.arguments(null, null),
                 Arguments.arguments(null, "blah"),
+                Arguments.arguments(null, ""),
                 Arguments.arguments(TEST_TMPDIR, null),
-                Arguments.arguments(TEST_TMPDIR, "blah")
+                Arguments.arguments(TEST_TMPDIR, "blah"),
+                Arguments.arguments(TEST_TMPDIR, "")
         );
     }
 
@@ -140,7 +148,7 @@ class TemporaryFiles {
             Files.createTempDirectory(dir, prefix);
         try {
             // check directory name
-            if (prefix != null) {
+            if (prefix != null && !prefix.isEmpty()) {
                 String name = subdir.getFileName().toString();
                 assertTrue(name.startsWith(prefix), "Should start with " + prefix);
             }
@@ -250,6 +258,19 @@ class TemporaryFiles {
                 Files.delete(dir);
             }
         }
+    }
+
+    /**
+     * Test Files.createTempXXX with an attribute that cannot be set.
+     */
+    @Test
+    void testUnknownAttribute() {
+        var attr  = new FileAttribute<String>() {
+            @Override public String name()  { return "unknown"; }
+            @Override public String value() { return "foo"; }
+        };
+        assertThrows(UnsupportedOperationException.class, () -> Files.createTempFile("blah", ".dat", attr));
+        assertThrows(UnsupportedOperationException.class, () -> Files.createTempDirectory("blah", attr));
     }
 
     /**

--- a/test/jdk/java/nio/file/Files/TemporaryFiles.java
+++ b/test/jdk/java/nio/file/Files/TemporaryFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,95 +22,142 @@
  */
 
 /* @test
- * @bug 4313887 6838333 7006126 7023034
+ * @bug 4313887 6838333 7006126 7023034 8391574
  * @summary Unit test for Files.createTempXXX
- * @library ..
+ * @run junit ${test.main.class}
  */
 
-import java.nio.file.*;
-import static java.nio.file.StandardOpenOption.*;
-import java.nio.file.attribute.*;
 import java.io.IOException;
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import static java.nio.file.StandardOpenOption.*;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
+import java.util.stream.Stream;
 
-public class TemporaryFiles {
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.*;
 
-    static void checkInDirectory(Path file, Path dir) {
-        if (dir == null)
-            dir = Paths.get(System.getProperty("java.io.tmpdir"));
-        if (!file.getParent().equals(dir))
-            throw new RuntimeException("Not in expected directory");
+class TemporaryFiles {
+
+    // system-wide tmp dir
+    static final Path SYS_TMPDIR = Path.of(System.getProperty("java.io.tmpdir"));
+
+    // local test tmp dir
+    static Path TEST_TMPDIR;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        TEST_TMPDIR = Files.createTempDirectory(Path.of("."), "adir");
     }
 
-    static void testTempFile(String prefix, String suffix, Path dir)
-        throws IOException
-    {
+    @AfterAll
+    static void cleanup() throws Exception {
+        Files.delete(TEST_TMPDIR);
+    }
+
+    /**
+     * Returns directory, prefix, and suffix combinations for temporary file tests.
+     */
+    static Stream<Arguments> tempFiles() {
+        return Stream.of(
+                Arguments.arguments(null, null, null),
+                Arguments.arguments(null, "blah", null),
+                Arguments.arguments(null, null, ".dat"),
+                Arguments.arguments(null, "blah", ".dat"),
+                Arguments.arguments(TEST_TMPDIR, null, null),
+                Arguments.arguments(TEST_TMPDIR, "blah", null),
+                Arguments.arguments(TEST_TMPDIR, null, ".dat"),
+                Arguments.arguments(TEST_TMPDIR, "blah", ".dat")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("tempFiles")
+    void testTempFile(Path dir, String prefix, String suffix) throws Exception {
         Path file = (dir == null) ?
             Files.createTempFile(prefix, suffix) :
             Files.createTempFile(dir, prefix, suffix);
         try {
             // check file name
             String name = file.getFileName().toString();
-            if (prefix != null && !name.startsWith(prefix))
-                throw new RuntimeException("Should start with " + prefix);
-            if (suffix == null && !name.endsWith(".tmp"))
-                throw new RuntimeException("Should end with .tmp");
-            if (suffix != null && !name.endsWith(suffix))
-                throw new RuntimeException("Should end with " + suffix);
+            if (prefix != null) {
+                assertTrue(name.startsWith(prefix), "Should start with " + prefix);
+            }
+            String expectedSuffix = (suffix != null) ? suffix : ".tmp";
+            assertTrue(name.endsWith(expectedSuffix), "Should end with " + expectedSuffix);
 
             // check file is in expected directory
-            checkInDirectory(file, dir);
+            Path expectedDir = (dir != null) ? dir : SYS_TMPDIR;
+            assertEquals(expectedDir, file.getParent(), "Not in expected directory");
 
-            // check that file can be opened for reading and writing
+            // check file can be opened for reading and writing
             Files.newByteChannel(file, READ).close();
             Files.newByteChannel(file, WRITE).close();
-            Files.newByteChannel(file, READ,WRITE).close();
+            Files.newByteChannel(file, READ, WRITE).close();
 
             // check file permissions are 0600 or more secure
             if (Files.getFileStore(file).supportsFileAttributeView("posix")) {
                 Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file);
                 perms.remove(PosixFilePermission.OWNER_READ);
                 perms.remove(PosixFilePermission.OWNER_WRITE);
-                if (!perms.isEmpty())
-                    throw new RuntimeException("Temporary file is not secure");
+                assertTrue(perms.isEmpty(), "Temporary file is not secure");
             }
         } finally {
             Files.delete(file);
         }
     }
 
-    static void testTempFile(String prefix, String suffix)
-        throws IOException
-    {
-        testTempFile(prefix, suffix, null);
+    /**
+     * Returns directory and prefix combinations for temporary directory tests.
+     */
+    static Stream<Arguments> tempDirectories() {
+        return Stream.of(
+                Arguments.arguments(null, null),
+                Arguments.arguments(null, "blah"),
+                Arguments.arguments(TEST_TMPDIR, null),
+                Arguments.arguments(TEST_TMPDIR, "blah")
+        );
     }
 
-    static void testTempDirectory(String prefix, Path dir) throws IOException {
+    @ParameterizedTest
+    @MethodSource("tempDirectories")
+    void testTempDirectory(Path dir, String prefix) throws Exception {
         Path subdir = (dir == null) ?
             Files.createTempDirectory(prefix) :
             Files.createTempDirectory(dir, prefix);
         try {
-            // check file name
-            String name = subdir.getFileName().toString();
-            if (prefix != null && !name.startsWith(prefix))
-                throw new RuntimeException("Should start with " + prefix);
-
-            // check directory is in expected directory
-            checkInDirectory(subdir, dir);
-
-            // check directory is empty
-            DirectoryStream<Path> stream = Files.newDirectoryStream(subdir);
-            try {
-                if (stream.iterator().hasNext())
-                    throw new RuntimeException("Tempory directory not empty");
-            } finally {
-                stream.close();
+            // check directory name
+            if (prefix != null) {
+                String name = subdir.getFileName().toString();
+                assertTrue(name.startsWith(prefix), "Should start with " + prefix);
             }
 
-            // check that we can create file in directory
+            // check directory is in expected directory
+            Path expectedDir = (dir != null) ? dir : SYS_TMPDIR;
+            assertEquals(expectedDir, subdir.getParent(), "Not in expected directory");
+
+            // check directory is readable (and empty)
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(subdir)) {
+                assertFalse(stream.iterator().hasNext(), "Temporary directory not empty");
+            }
+
+            // check directory is writable
             Path file = Files.createFile(subdir.resolve("foo"));
             try {
-                Files.newByteChannel(file, READ,WRITE).close();
+                Files.newByteChannel(file, READ, WRITE).close();
             } finally {
                 Files.delete(file);
             }
@@ -121,77 +168,202 @@ public class TemporaryFiles {
                 perms.remove(PosixFilePermission.OWNER_READ);
                 perms.remove(PosixFilePermission.OWNER_WRITE);
                 perms.remove(PosixFilePermission.OWNER_EXECUTE);
-                if (!perms.isEmpty())
-                    throw new RuntimeException("Temporary directory is not secure");
+                assertTrue(perms.isEmpty(), "Temporary directory is not secure");
             }
         } finally {
             Files.delete(subdir);
         }
     }
 
-    static void testTempDirectory(String prefix) throws IOException {
-        testTempDirectory(prefix, null);
+    /**
+     * Returns file permissions to restrict perissions of temporay file/directory.
+     */
+    static Stream<String> permissions() {
+        return Stream.of(
+                "---------",
+                "r--------",
+                "-w-------",
+                "--x------",
+                "rwx------",
+                "---r-----",
+                "----w----",
+                "-----x---",
+                "---rwx---",
+                "------r--",
+                "-------w-",
+                "--------x",
+                "------rwx",
+                "r--r-----",
+                "r--r--r--",
+                "rw-rw----",
+                "rwxrwx---",
+                "rw-rw-r--",
+                "r-xr-x---",
+                "r-xr-xr-x",
+                "rwxrwxrwx"
+        );
     }
 
-    static void testInvalidFileTemp(String prefix, String suffix) throws IOException {
-        try {
-            Path file = Files.createTempFile(prefix, suffix);
-            Files.delete(file);
-            throw new RuntimeException("IllegalArgumentException expected");
-        } catch (IllegalArgumentException expected) { }
+    /**
+     * Checks that the actual permissions are not less secure than the requested.
+     */
+    void checkSecure(Set<PosixFilePermission> requested, Set<PosixFilePermission> actual) {
+        assertTrue(actual.stream().allMatch(requested::contains), () ->
+                "Actual permissions: " + PosixFilePermissions.toString(actual) +
+                ", requested: " + PosixFilePermissions.toString(requested) +
+                " - file is less secure than requested");
     }
 
-    public static void main(String[] args) throws IOException {
-        // temporary-file directory
-        testTempFile("blah", ".dat");
-        testTempFile("blah", null);
-        testTempFile(null, ".dat");
-        testTempFile(null, null);
-        testTempDirectory("blah");
-        testTempDirectory(null);
+    @ParameterizedTest
+    @MethodSource("permissions")
+    @DisabledOnOs(OS.WINDOWS)
+    void testPosixAttributes(String permsAsString) throws Exception {
+        Set<PosixFilePermission> perms = PosixFilePermissions.fromString(permsAsString);
+        FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
 
-        // a given directory
-        Path dir = Files.createTempDirectory("tmpdir");
-        try {
-            testTempFile("blah", ".dat", dir);
-            testTempFile("blah", null, dir);
-            testTempFile(null, ".dat", dir);
-            testTempFile(null, null, dir);
-            testTempDirectory("blah", dir);
-            testTempDirectory(null, dir);
-        } finally {
-            Files.delete(dir);
+        if (Files.getFileStore(SYS_TMPDIR).supportsFileAttributeView("posix")) {
+            Path file = Files.createTempFile("blah", ".tmp", attr);
+            try {
+                checkSecure(perms, Files.getPosixFilePermissions(file));
+            } finally {
+                Files.delete(file);
+            }
+            Path dir = Files.createTempDirectory("blah", attr);
+            try {
+                checkSecure(perms, Files.getPosixFilePermissions(dir));
+            } finally {
+                Files.delete(dir);
+            }
         }
 
-        // invalid prefix and suffix
-        testInvalidFileTemp("../blah", null);
-        testInvalidFileTemp("dir/blah", null);
-        testInvalidFileTemp("blah", ".dat/foo");
+        if (Files.getFileStore(TEST_TMPDIR).supportsFileAttributeView("posix")) {
+            Path file = Files.createTempFile(TEST_TMPDIR, "blah", ".tmp", attr);
+            try {
+                checkSecure(perms, Files.getPosixFilePermissions(file));
+            } finally {
+                Files.delete(file);
+            }
+            Path dir = Files.createTempDirectory(TEST_TMPDIR, "blah", attr);
+            try {
+                checkSecure(perms, Files.getPosixFilePermissions(dir));
+            } finally {
+                Files.delete(dir);
+            }
+        }
+    }
 
-        // nulls
-        try {
-            Files.createTempFile("blah", ".tmp", (FileAttribute<?>[])null);
-            throw new RuntimeException("NullPointerException expected");
-        } catch (NullPointerException ignore) { }
-        try {
-            Files.createTempFile("blah", ".tmp", new FileAttribute<?>[] { null });
-            throw new RuntimeException("NullPointerException expected");
-        } catch (NullPointerException ignore) { }
-        try {
-            Files.createTempDirectory("blah", (FileAttribute<?>[])null);
-            throw new RuntimeException("NullPointerException expected");
-        } catch (NullPointerException ignore) { }
-        try {
-            Files.createTempDirectory("blah", new FileAttribute<?>[] { null });
-            throw new RuntimeException("NullPointerException expected");
-        } catch (NullPointerException ignore) { }
-        try {
-            Files.createTempFile((Path)null, "blah", ".tmp");
-            throw new RuntimeException("NullPointerException expected");
-        } catch (NullPointerException ignore) { }
-        try {
-            Files.createTempDirectory((Path)null, "blah");
-            throw new RuntimeException("NullPointerException expected");
-        } catch (NullPointerException ignore) { }
+    /**
+     * Test Files.createTempXXX with a directory that does not exist.
+     */
+    @Test
+    void testDirDoesNotExist() {
+        Path dir = Path.of("DoesNotExist");
+        assertTrue(Files.notExists(dir));
+        assertThrows(IOException.class, () -> Files.createTempFile(dir, null, null));
+        assertThrows(IOException.class, () -> Files.createTempFile(dir, "blah", null));
+        assertThrows(IOException.class, () -> Files.createTempFile(dir, null, ".dat"));
+        assertThrows(IOException.class, () -> Files.createTempFile(dir, "blah", ".dat"));
+        assertThrows(IOException.class, () -> Files.createTempDirectory(dir, null));
+        assertThrows(IOException.class, () -> Files.createTempDirectory(dir, "blah"));
+    }
+
+    /**
+     * Returns prefixes that should be rejected.
+     */
+    static Stream<String> badPrefixes() {
+        return Stream.of(
+                "/blah",
+                "../blah",
+                "dir/blah",
+                "foo\0bar"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("badPrefixes")
+    void testBadPrefix(String prefix) {
+        Path dir = Path.of(".");
+        assertThrows(IllegalArgumentException.class, () -> Files.createTempFile(prefix, null));
+        assertThrows(IllegalArgumentException.class, () -> Files.createTempFile(dir, prefix, null));
+        assertThrows(IllegalArgumentException.class, () -> Files.createTempDirectory(prefix));
+        assertThrows(IllegalArgumentException.class, () -> Files.createTempDirectory(dir, prefix));
+    }
+
+    /**
+     * Returns prefixes that should be rejected on Windows.
+     */
+    static Stream<String> badWindowsPrefixes() {
+        return Stream.of(
+                "\\\\server",
+                "\\\\server\\share",
+                "\\\\?\\UNC\\server\\share",
+                "C:\\temp\\blah",
+                "C:temp\\blah",
+                "C:blah"
+        );
+    }
+
+    /**
+     * Tests prefixes that should be rejected on Windows.
+     */
+    @ParameterizedTest
+    @MethodSource("badWindowsPrefixes")
+    @EnabledOnOs(OS.WINDOWS)
+    void testBadWindowsPrefixes(String prefix) {
+        testBadPrefix(prefix);
+    }
+
+    /**
+     * Returns suffixes that should be rejected.
+     */
+    static Stream<String> badSuffixes() {
+        return Stream.of(
+                ".dat/foo",
+                "foo\0bar"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("badSuffixes")
+    void testBadSuffix(String suffix) {
+        Path dir = Path.of(".");
+        assertThrows(IllegalArgumentException.class, () -> Files.createTempFile("blah", suffix));
+        assertThrows(IllegalArgumentException.class, () -> Files.createTempFile(dir, "blah", suffix));
+    }
+
+    /**
+     * Returns suffixes that should be rejected on Windows.
+     */
+    static Stream<String> badWindowsSuffixes() {
+        return Stream.of(
+                ".dat\\foo",
+                ":"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("badWindowsSuffixes")
+    @EnabledOnOs(OS.WINDOWS)
+    void testBadWindowsSuffix(String suffix) {
+        testBadSuffix(suffix);
+    }
+
+    /**
+     * Test nulls.
+     */
+    @Test
+    void testNulls() {
+        assertThrows(NullPointerException.class,
+                () -> Files.createTempFile("blah", ".tmp", (FileAttribute<?>[]) null));
+        assertThrows(NullPointerException.class,
+                () -> Files.createTempFile("blah", ".tmp", new FileAttribute<?>[] { null }));
+        assertThrows(NullPointerException.class,
+                () -> Files.createTempDirectory("blah", (FileAttribute<?>[]) null));
+        assertThrows(NullPointerException.class,
+                () -> Files.createTempDirectory("blah", new FileAttribute<?>[] { null }));
+        assertThrows(NullPointerException.class,
+                () -> Files.createTempFile((Path)null, "blah", ".tmp"));
+        assertThrows(NullPointerException.class,
+                () -> Files.createTempDirectory((Path)null, "blah"));
     }
 }


### PR DESCRIPTION
Files.createTempFile and Files.createTempDirectory don't eagerly reject attempts to create a temp file/dir with a prefix such as "\\\\server\\share" on Windows. These cases should eagerly throw IlegalArgumentException instead of IOException.

The existing TemporaryFiles tests is converted to JUnit. Test coverage is expanded, including more tests for bad prefix and suffix values.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391574](https://bugs.openjdk.org/browse/JDK-8391574): (fs) Files.createTempFile should reject prefix with root component (win) (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32638/head:pull/32638` \
`$ git checkout pull/32638`

Update a local copy of the PR: \
`$ git checkout pull/32638` \
`$ git pull https://git.openjdk.org/jdk.git pull/32638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32638`

View PR using the GUI difftool: \
`$ git pr show -t 32638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32638.diff">https://git.openjdk.org/jdk/pull/32638.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32638#issuecomment-5505912384)
</details>
