### PR TITLE
8391451: Various ErrorHandling - related hotspot tests fail after JDK-8379453

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -2100,9 +2100,9 @@ bool VMError::check_timeout() {
     // exceptions to this (printing a callstack from debug information located on a slow file system, or
     // printing a memory map of an extremely fragmented process). To give those rare slow steps enough
     // breathing space while still allowing us to skip any hanging steps, we use a per-step timeout of
-    // <total timeout>/4, or 5 seconds, whichever is smaller.
+    // <total timeout>/4, or 15 seconds, whichever is smaller.
     const jlong step_timeout_nanos = ((jlong)ErrorLogTimeout * SECONDS_TO_NANOS_FACTOR) / 4;
-    const jlong max_step_timeout_nanos = 5LL * SECONDS_TO_NANOS_FACTOR;
+    const jlong max_step_timeout_nanos = 15LL * SECONDS_TO_NANOS_FACTOR;
     const jlong timeout_duration = MIN2(max_step_timeout_nanos, step_timeout_nanos);
     const jlong end = step_start_time + timeout_duration;
     if (end <= now && !_step_did_timeout.load_relaxed()) {


### PR DESCRIPTION
After [JDK-8379453](https://bugs.openjdk.org/browse/JDK-8379453) some tests fail on Linux Alpine when running (fast)debug binaries.
Reason is the effectively smaller hserr step timeout (30s -> 5s).
Examples are the tests
test runtime/ErrorHandling/TestDwarf.java
runtime/ErrorHandling/StackWalkNativeToJava.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391451](https://bugs.openjdk.org/browse/JDK-8391451): Various ErrorHandling - related hotspot tests fail after JDK-8379453 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32640/head:pull/32640` \
`$ git checkout pull/32640`

Update a local copy of the PR: \
`$ git checkout pull/32640` \
`$ git pull https://git.openjdk.org/jdk.git pull/32640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32640`

View PR using the GUI difftool: \
`$ git pr show -t 32640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32640.diff">https://git.openjdk.org/jdk/pull/32640.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32640#issuecomment-5506493639)
</details>
