### PR TITLE
8389707: G1: Allocation by VM Thread after GC allocates on VMThread NUMA node id not requesting thread NUMA node id

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -68,8 +68,7 @@ G1Allocator::~G1Allocator() {
 }
 
 #ifdef ASSERT
-bool G1Allocator::has_mutator_alloc_region() {
-  uint node_index = current_node_index();
+bool G1Allocator::has_mutator_alloc_region(uint node_index) {
   return mutator_alloc_region(node_index)->get() != nullptr;
 }
 #endif

--- a/src/hotspot/share/gc/g1/g1Allocator.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ public:
 
 #ifdef ASSERT
   // Do we currently have an active mutator region to allocate into?
-  bool has_mutator_alloc_region();
+  bool has_mutator_alloc_region(uint node_index);
 #endif
 
   void init_mutator_alloc_regions();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -53,6 +53,7 @@
 #include "gc/g1/g1InitLogger.hpp"
 #include "gc/g1/g1MemoryPool.hpp"
 #include "gc/g1/g1MonotonicArenaFreeMemoryTask.hpp"
+#include "gc/g1/g1NUMA.hpp"
 #include "gc/g1/g1OopClosures.inline.hpp"
 #include "gc/g1/g1ParallelCleaning.hpp"
 #include "gc/g1/g1ParScanThreadState.inline.hpp"
@@ -476,7 +477,8 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(uint node_index, size_t word_
     }
 
     bool succeeded;
-    result = do_collection_pause(word_size, gc_count_before, &succeeded, GCCause::_g1_inc_collection_pause);
+    result = do_collection_pause(node_index, word_size, gc_count_before, &succeeded,
+                                 GCCause::_g1_inc_collection_pause);
     if (succeeded) {
       log_trace(gc, alloc)("%s: Successfully scheduled collection returning " PTR_FORMAT,
                            Thread::current()->name(), p2i(result));
@@ -728,7 +730,8 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
     }
 
     bool succeeded;
-    result = do_collection_pause(word_size, gc_count_before, &succeeded, GCCause::_g1_humongous_allocation);
+    result = do_collection_pause(G1NUMA::AnyNodeIndex, word_size, gc_count_before, &succeeded,
+                                 GCCause::_g1_humongous_allocation);
     if (succeeded) {
       log_trace(gc, alloc)("%s: Successfully scheduled collection returning " PTR_FORMAT,
                            Thread::current()->name(), p2i(result));
@@ -766,18 +769,18 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
   return nullptr;
 }
 
-HeapWord* G1CollectedHeap::attempt_allocation_at_safepoint(size_t word_size,
+HeapWord* G1CollectedHeap::attempt_allocation_at_safepoint(uint node_index,
+                                                           size_t word_size,
                                                            bool expect_null_mutator_alloc_region) {
   assert_at_safepoint_on_vm_thread();
-  assert(!_allocator->has_mutator_alloc_region() || !expect_null_mutator_alloc_region,
-         "the current alloc region was unexpectedly found to be non-null");
-
-  // Fix NUMA node association for the duration of this allocation
-  const uint node_index = _allocator->current_node_index();
 
   if (!is_humongous(word_size)) {
+    assert(!_allocator->has_mutator_alloc_region(node_index) || !expect_null_mutator_alloc_region,
+           "the requested alloc region was unexpectedly found to be non-null");
     return _allocator->attempt_allocation_locked(node_index, word_size);
   } else {
+    assert(node_index == G1NUMA::AnyNodeIndex,
+           "Humongous allocation must not have a specific NUMA node index: %u", node_index);
     HeapWord* result = humongous_obj_allocate(word_size);
     if (result != nullptr &&
         // We just allocated the humongous object, so the given allocation size is 0.
@@ -1009,7 +1012,8 @@ bool G1CollectedHeap::gc_overhead_limit_exceeded() {
   return _gc_overhead_counter >= GCOverheadLimitThreshold;
 }
 
-HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
+HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(uint node_index,
+                                                            size_t word_size,
                                                             bool do_gc,
                                                             bool maximal_compaction,
                                                             bool expect_null_mutator_alloc_region) {
@@ -1024,7 +1028,8 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
   if (!gc_overhead_limit_exceeded()) {
     // Let's attempt the allocation first.
     HeapWord* result =
-      attempt_allocation_at_safepoint(word_size,
+      attempt_allocation_at_safepoint(node_index,
+                                      word_size,
                                       expect_null_mutator_alloc_region);
     if (result != nullptr) {
       return result;
@@ -1034,7 +1039,7 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
     // incremental pauses.  Therefore, at least for now, we'll favor
     // expansion over collection.  (This might change in the future if we can
     // do something smarter than full collection to satisfy a failed alloc.)
-    result = expand_and_allocate(word_size);
+    result = expand_and_allocate(node_index, word_size);
     if (result != nullptr) {
       return result;
     }
@@ -1058,7 +1063,7 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
   return nullptr;
 }
 
-HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size) {
+HeapWord* G1CollectedHeap::satisfy_failed_allocation(uint node_index, size_t word_size) {
   assert_at_safepoint_on_vm_thread();
 
   // Update GC overhead limits after the initial garbage collection leading to this
@@ -1067,7 +1072,8 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size) {
 
   // Attempts to allocate followed by Full GC.
   HeapWord* result =
-    satisfy_failed_allocation_helper(word_size,
+    satisfy_failed_allocation_helper(node_index,
+                                     word_size,
                                      true,  /* do_gc */
                                      false, /* maximal_compaction */
                                      false /* expect_null_mutator_alloc_region */);
@@ -1077,7 +1083,8 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size) {
   }
 
   // Attempts to allocate followed by Full GC that will collect all soft references.
-  result = satisfy_failed_allocation_helper(word_size,
+  result = satisfy_failed_allocation_helper(node_index,
+                                            word_size,
                                             true, /* do_gc */
                                             true, /* maximal_compaction */
                                             true /* expect_null_mutator_alloc_region */);
@@ -1087,7 +1094,8 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size) {
   }
 
   // Attempts to allocate, no GC
-  result = satisfy_failed_allocation_helper(word_size,
+  result = satisfy_failed_allocation_helper(node_index,
+                                            word_size,
                                             false, /* do_gc */
                                             false, /* maximal_compaction */
                                             true  /* expect_null_mutator_alloc_region */);
@@ -1112,7 +1120,7 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size) {
 // successful, perform the allocation and return the address of the
 // allocated block, or else null.
 
-HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
+HeapWord* G1CollectedHeap::expand_and_allocate(uint node_index, size_t word_size) {
   assert_at_safepoint_on_vm_thread();
 
   _verifier->verify_region_sets_optional();
@@ -1125,7 +1133,8 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
   if (expand(expand_bytes, _workers)) {
     _hrm.verify_optional();
     _verifier->verify_region_sets_optional();
-    return attempt_allocation_at_safepoint(word_size,
+    return attempt_allocation_at_safepoint(node_index,
+                                           word_size,
                                            false /* expect_null_mutator_alloc_region */);
   }
   return nullptr;
@@ -2115,7 +2124,8 @@ bool G1CollectedHeap::try_collect(size_t allocation_word_size,
     assert(allocation_word_size == 0, "must be");
     // Schedule a standard evacuation pause. We're setting word_size
     // to 0 which means that we are not requesting a post-GC allocation.
-    VM_G1CollectForAllocation op(0,     /* word_size */
+    VM_G1CollectForAllocation op(G1NUMA::AnyNodeIndex,
+                                 0,     /* word_size */
                                  counters_before.total_collections(),
                                  cause);
     VMThread::execute(&op);
@@ -2527,12 +2537,13 @@ void G1CollectedHeap::verify_numa_regions(const char* desc) {
   }
 }
 
-HeapWord* G1CollectedHeap::do_collection_pause(size_t word_size,
+HeapWord* G1CollectedHeap::do_collection_pause(uint node_index,
+                                               size_t word_size,
                                                uint gc_count_before,
                                                bool* succeeded,
                                                GCCause::Cause gc_cause) {
   assert_heap_not_locked_and_not_at_safepoint();
-  VM_G1CollectForAllocation op(word_size, gc_count_before, gc_cause);
+  VM_G1CollectForAllocation op(node_index, word_size, gc_count_before, gc_cause);
   VMThread::execute(&op);
 
   HeapWord* result = op.result();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -469,7 +469,8 @@ private:
   // at the end of a successful GC). expect_null_mutator_alloc_region
   // specifies whether the mutator alloc region is expected to be null
   // or not.
-  HeapWord* attempt_allocation_at_safepoint(size_t word_size,
+  HeapWord* attempt_allocation_at_safepoint(uint node_index,
+                                            size_t word_size,
                                             bool expect_null_mutator_alloc_region);
 
   // These methods are the "callbacks" from the G1AllocRegion class.
@@ -508,7 +509,7 @@ private:
   // Callback from VM_G1CollectForAllocation operation.
   // This function does everything necessary/possible to satisfy a
   // failed allocation request (including collection, expansion, etc.)
-  HeapWord* satisfy_failed_allocation(size_t word_size);
+  HeapWord* satisfy_failed_allocation(uint node_index, size_t word_size);
   // Internal helpers used during full GC to split it up to
   // increase readability.
   bool abort_concurrent_cycle();
@@ -520,7 +521,8 @@ private:
   void print_heap_after_full_collection();
 
   // Helper method for satisfy_failed_allocation()
-  HeapWord* satisfy_failed_allocation_helper(size_t word_size,
+  HeapWord* satisfy_failed_allocation_helper(uint node_index,
+                                             size_t word_size,
                                              bool do_gc,
                                              bool maximal_compaction,
                                              bool expect_null_mutator_alloc_region);
@@ -529,7 +531,7 @@ private:
   // to support an allocation of the given "word_size".  If
   // successful, perform the allocation and return the address of the
   // allocated block, or else null.
-  HeapWord* expand_and_allocate(size_t word_size);
+  HeapWord* expand_and_allocate(uint node_index, size_t word_size);
 
   void verify_numa_regions(const char* desc);
 
@@ -753,7 +755,8 @@ private:
   // it has to be read while holding the Heap_lock. Currently, both
   // methods that call do_collection_pause() release the Heap_lock
   // before the call, so it's easy to read gc_count_before just before.
-  HeapWord* do_collection_pause(size_t word_size,
+  HeapWord* do_collection_pause(uint node_index,
+                                size_t word_size,
                                 uint gc_count_before,
                                 bool* succeeded,
                                 GCCause::Cause gc_cause);

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -114,10 +114,12 @@ void VM_G1TryInitiateConcMark::doit() {
   }
 }
 
-VM_G1CollectForAllocation::VM_G1CollectForAllocation(size_t word_size,
+VM_G1CollectForAllocation::VM_G1CollectForAllocation(uint node_index,
+                                                     size_t word_size,
                                                      uint gc_count_before,
                                                      GCCause::Cause gc_cause) :
-  VM_CollectForAllocation(word_size, gc_count_before, gc_cause) {}
+  VM_CollectForAllocation(word_size, gc_count_before, gc_cause),
+  _node_index(node_index) {}
 
 void VM_G1CollectForAllocation::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
@@ -128,7 +130,7 @@ void VM_G1CollectForAllocation::doit() {
   if (_word_size > 0) {
     // An allocation had been requested. Do it, eventually trying a stronger
     // kind of GC.
-    _result = g1h->satisfy_failed_allocation(_word_size);
+    _result = g1h->satisfy_failed_allocation(_node_index, _word_size);
   } else if (g1h->should_upgrade_to_full_gc()) {
     // There has been a request to perform a GC to free some space. We have no
     // information on how much memory has been asked for. In case there are

--- a/src/hotspot/share/gc/g1/g1VMOperations.hpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.hpp
@@ -68,9 +68,11 @@ public:
 };
 
 class VM_G1CollectForAllocation : public VM_CollectForAllocation {
+  const uint _node_index;
 
 public:
-  VM_G1CollectForAllocation(size_t word_size,
+  VM_G1CollectForAllocation(uint node_index,
+                            size_t word_size,
                             uint gc_count_before,
                             GCCause::Cause gc_cause);
   virtual VMOp_Type type() const { return VMOp_G1CollectForAllocation; }


### PR DESCRIPTION
…UMA node id not requesting thread NUMA node id

G1CollectedHeap::attempt_allocation() captures the NUMA node index of the requesting JavaThread and preserves it through the regular fast and slow paths. But the slow path does not pass the node index into the VM_G1CollectForAllocation operation.

This fix preserves the node index captured by the requesting JavaThread across VM_G1CollectForAllocation and all post-GC allocation retry paths.  The VMThread no longer recomputes the node index from its own affinity.  Humongous and GC-only requests use G1NUMA::AnyNodeIndex.

The assertion in G1CollectedHeap::attempt_allocation_at_safepoint is split into path-specific checks.  Regular allocations check the mutator allocation region for the requested node, humongous allocations check 'AnyNodeIndex' was passed.

Tested on a 4-node Linux/AArch64 NUMA system using a fastdebug build and an external allocation Poc.

Poc: The requesting JavaThread was pinned to CPU 1 on NUMA node 0, while the VMThread was pinned to CPU 73 on NUMA node 3.  The Poc performed 2,000,000 allocations of 64KB arrays with NUMA enabled and TLABs disabled.

Temporary trace logging shows:

Before the change:
request_node=0 vm_node=3 selected_node=3

After the change:
request_node=0 vm_node=3 selected_node=0

The Poc is not included in this change because it requires a multiple NUMA nodes system, manually control over thread affintites and access to internal node selection information. Standard build and regression tests will be checked by GHA.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389707](https://bugs.openjdk.org/browse/JDK-8389707): G1: Allocation by VM Thread after GC allocates on VMThread NUMA node id not requesting thread NUMA node id (**Bug** - P4)


### Reviewers
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32641/head:pull/32641` \
`$ git checkout pull/32641`

Update a local copy of the PR: \
`$ git checkout pull/32641` \
`$ git pull https://git.openjdk.org/jdk.git pull/32641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32641`

View PR using the GUI difftool: \
`$ git pr show -t 32641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32641.diff">https://git.openjdk.org/jdk/pull/32641.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32641#issuecomment-5506582112)
</details>
