### PR TITLE
8385698: [Valhalla] C1 omits type profiling for null-free types

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1371,10 +1371,14 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
 
   assert_different_registers(obj, k_RInfo, klass_RInfo);
 
+  Register mdo = noreg;
+  if (should_profile) {
+    mdo  = klass_RInfo;
+    __ mov_metadata(mdo, md->constant_encoding());
+  }
+
   if (op->need_null_check()) {
     if (should_profile) {
-      Register mdo  = klass_RInfo;
-      __ mov_metadata(mdo, md->constant_encoding());
       Label not_null;
       __ cbnz(obj, not_null);
       // Object is null; update MDO and exit
@@ -1387,13 +1391,15 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
       __ strb(rscratch1, data_addr);
       __ b(*obj_is_null);
       __ bind(not_null);
-
-      Register recv = k_RInfo;
-      __ load_klass(recv, obj, rscratch1);
-      type_profile_helper(mdo, md, data, recv);
     } else {
       __ cbz(obj, *obj_is_null);
     }
+  }
+
+  if (should_profile) {
+      Register recv = k_RInfo;
+      __ load_klass(recv, obj, rscratch1);
+      type_profile_helper(mdo, md, data, recv);
   }
 
   if (!k->is_loaded()) {

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1373,7 +1373,7 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
 
   Register mdo = noreg;
   if (should_profile) {
-    mdo  = klass_RInfo;
+    mdo = klass_RInfo;
     __ mov_metadata(mdo, md->constant_encoding());
   }
 

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2415,12 +2415,16 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
     CodeStub* stub = op->stub();
     // Check if it needs to be profiled.
     ciMethodData* md = nullptr;
+    Register mdo = noreg;
     ciProfileData* data = nullptr;
     int mdo_offset_bias = 0;
     if (should_profile) {
       ciMethod* method = op->profiled_method();
       assert(method != nullptr, "Should have method");
       setup_md_access(method, op->profiled_bci(), md, data, mdo_offset_bias);
+      mdo = k_RInfo;
+      metadata2reg(md->constant_encoding(), mdo);
+      __ add_const_optimized(mdo, mdo, mdo_offset_bias, R0);
     }
 
     Label done;
@@ -2428,26 +2432,26 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
     if (op->need_null_check()) {
       if (should_profile) {
         Label not_null;
-        Register mdo      = k_RInfo;
         Register data_val = Rtmp1;
-        metadata2reg(md->constant_encoding(), mdo);
-        __ add_const_optimized(mdo, mdo, mdo_offset_bias, R0);
         __ cmpdi(CR0, value, 0);
         __ bne(CR0, not_null);
+        // Object is null, update mdo and exit
         __ lbz(data_val, md->byte_offset_of_slot(data, DataLayout::flags_offset()) - mdo_offset_bias, mdo);
         __ ori(data_val, data_val, BitData::null_seen_byte_constant());
         __ stb(data_val, md->byte_offset_of_slot(data, DataLayout::flags_offset()) - mdo_offset_bias, mdo);
         __ b(done);
         __ bind(not_null);
-
-        Register recv = klass_RInfo;
-        __ load_klass(recv, value);
-        type_profile_helper(mdo, mdo_offset_bias, md, data, recv, Rtmp1); // kills recv
       } else {
         __ cmpdi(CR0, value, 0);
         __ beq(CR0, done);
       }
     }
+    if (should_profile) {
+      Register recv = klass_RInfo;
+      __ load_klass(recv, value);
+      type_profile_helper(mdo, mdo_offset_bias, md, data, recv, Rtmp1); // kills recv
+    }
+
     if (!os::zero_page_read_protected() || !ImplicitNullChecks) {
       explicit_null_check(array, op->info_for_exception());
     } else {

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1140,19 +1140,23 @@ void LIR_Assembler::typecheck_helper_slowcheck(ciKlass *k, Register obj, Registe
   }
 }
 
-void LIR_Assembler::profile_object(ciMethodData* md, ciProfileData* data, Register obj,
+void LIR_Assembler::profile_object(LIR_OpTypeCheck* op, ciMethodData* md, ciProfileData* data, Register obj,
                                    Register k_RInfo, Register klass_RInfo, Label* obj_is_null) {
+  assert (op->should_profile(), "tried to profile though we should not");
+
   Register mdo = klass_RInfo;
   __ mov_metadata(mdo, md->constant_encoding());
-  Label not_null;
-  __ bnez(obj, not_null);
-  // Object is null, update MDO and exit
-  Address data_addr = __ form_address(t1, mdo, md->byte_offset_of_slot(data, DataLayout::flags_offset()));
-  __ lbu(t0, data_addr);
-  __ ori(t0, t0, BitData::null_seen_byte_constant());
-  __ sb(t0, data_addr);
-  __ j(*obj_is_null);
-  __ bind(not_null);
+  if (op->need_null_check()) {
+    Label not_null;
+    __ bnez(obj, not_null);
+    // Object is null, update MDO and exit
+    Address data_addr = __ form_address(t1, mdo, md->byte_offset_of_slot(data, DataLayout::flags_offset()));
+    __ lbu(t0, data_addr);
+    __ ori(t0, t0, BitData::null_seen_byte_constant());
+    __ sb(t0, data_addr);
+    __ j(*obj_is_null);
+    __ bind(not_null);
+  }
 
   Register recv = k_RInfo;
   __ load_klass(recv, obj);
@@ -1196,12 +1200,10 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
 
   assert_different_registers(obj, k_RInfo, klass_RInfo);
 
-  if (op->need_null_check()) {
-    if (should_profile) {
-      profile_object(md, data, obj, k_RInfo, klass_RInfo, obj_is_null);
-    } else {
-      __ beqz(obj, *obj_is_null);
-    }
+  if (should_profile) {
+    profile_object(op, md, data, obj, k_RInfo, klass_RInfo, obj_is_null);
+  } else if (op->need_null_check()) {
+    __ beqz(obj, *obj_is_null);
   }
 
   typecheck_loaded(op, k, k_RInfo);
@@ -2230,7 +2232,7 @@ void LIR_Assembler::typecheck_lir_store(LIR_OpTypeCheck* op, bool should_profile
   Label* failure_target = stub->entry();
 
   if (should_profile) {
-    profile_object(md, data, value, k_RInfo, klass_RInfo, &done);
+    profile_object(op, md, data, value, k_RInfo, klass_RInfo, &done);
   } else {
     __ beqz(value, done);
   }

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
@@ -94,7 +94,7 @@ private:
   void typecheck_helper_slowcheck(ciKlass* k, Register obj, Register Rtmp1,
                                   Register k_RInfo, Register klass_RInfo,
                                   Label* failure_target, Label* success_target);
-  void profile_object(ciMethodData* md, ciProfileData* data, Register obj,
+  void profile_object(LIR_OpTypeCheck* op, ciMethodData* md, ciProfileData* data, Register obj,
                       Register k_RInfo, Register klass_RInfo, Label* obj_is_null);
   void typecheck_loaded(LIR_OpTypeCheck* op, ciKlass* k, Register k_RInfo);
 

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2510,10 +2510,14 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
   }
   assert_different_registers(obj, k_RInfo, klass_RInfo);
 
+  Register mdo = noreg;
+  if (op->should_profile()) {
+    mdo = klass_RInfo;
+    metadata2reg(md->constant_encoding(), mdo);
+  }
+
   if (op->need_null_check()) {
     if (op->should_profile()) {
-      Register mdo = klass_RInfo;
-      metadata2reg(md->constant_encoding(), mdo);
       NearLabel not_null;
       __ compareU64_and_branch(obj, (intptr_t) 0, Assembler::bcondNotEqual, not_null);
       // Object is null; update MDO and exit.
@@ -2522,13 +2526,15 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
       __ or2mem_8(data_addr, header_bits);
       __ branch_optimized(Assembler::bcondAlways, *obj_is_null);
       __ bind(not_null);
-
-      Register recv = k_RInfo;
-      __ load_klass(recv, obj);
-      type_profile_helper(mdo, md, data, recv, Rtmp1);
     } else {
       __ compareU64_and_branch(obj, (intptr_t) 0, Assembler::bcondEqual, *obj_is_null);
     }
+  }
+
+  if (op->should_profile()) {
+      Register recv = k_RInfo;
+      __ load_klass(recv, obj);
+      type_profile_helper(mdo, md, data, recv, Rtmp1);
   }
 
   Label *failure_target = failure;

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -2532,9 +2532,9 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
   }
 
   if (op->should_profile()) {
-      Register recv = k_RInfo;
-      __ load_klass(recv, obj);
-      type_profile_helper(mdo, md, data, recv, Rtmp1);
+    Register recv = k_RInfo;
+    __ load_klass(recv, obj);
+    type_profile_helper(mdo, md, data, recv, Rtmp1);
   }
 
   Label *failure_target = failure;

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1375,7 +1375,7 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
 
   Register mdo = noreg;
   if (op->should_profile()) {
-    mdo  = klass_RInfo;
+    mdo = klass_RInfo;
     __ mov_metadata(mdo, md->constant_encoding());
   }
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1373,12 +1373,16 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
 
   assert_different_registers(obj, k_RInfo, klass_RInfo);
 
+  Register mdo = noreg;
+  if (op->should_profile()) {
+    mdo  = klass_RInfo;
+    __ mov_metadata(mdo, md->constant_encoding());
+  }
+
   if (op->need_null_check()) {
     __ testptr(obj, obj);
     if (op->should_profile()) {
       Label not_null;
-      Register mdo  = klass_RInfo;
-      __ mov_metadata(mdo, md->constant_encoding());
       __ jccb(Assembler::notEqual, not_null);
       // Object is null; update MDO and exit
       Address data_addr(mdo, md->byte_offset_of_slot(data, DataLayout::flags_offset()));
@@ -1386,13 +1390,15 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
       __ orb(data_addr, header_bits);
       __ jmp(*obj_is_null);
       __ bind(not_null);
-
-    Register recv = k_RInfo;
-    __ load_klass(recv, obj, tmp_load_klass);
-    type_profile_helper(mdo, md, data, recv);
     } else {
       __ jcc(Assembler::equal, *obj_is_null);
     }
+  }
+
+  if (op->should_profile()) {
+    Register recv = k_RInfo;
+    __ load_klass(recv, obj, tmp_load_klass);
+    type_profile_helper(mdo, md, data, recv);
   }
 
   if (!k->is_loaded()) {


### PR DESCRIPTION
All ports implementing JEP401 do not emit profiling in C1 for a type check for a null-free value object even when `should_profile` is true. This does not lead to any problems currently (at least I do not know of any and was not able to come up with a case that would fail due to this), which is why this PR only provides a fix without a regression test.

Testing:
 - [x] Github Actions
 - [x] tier1, tier2, tier3 and stress testing with `--enable-preview`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385698](https://bugs.openjdk.org/browse/JDK-8385698): [Valhalla] C1 omits type profiling for null-free types (**Bug** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Contributors
 * Tobias Hartmann `<thartmann@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32643/head:pull/32643` \
`$ git checkout pull/32643`

Update a local copy of the PR: \
`$ git checkout pull/32643` \
`$ git pull https://git.openjdk.org/jdk.git pull/32643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32643`

View PR using the GUI difftool: \
`$ git pr show -t 32643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32643.diff">https://git.openjdk.org/jdk/pull/32643.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32643#issuecomment-5506928521)
</details>
