### PR TITLE
8391629: RISC-V: Avoid unnecessary address materialization for loads and stores

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -356,13 +356,10 @@ void C2_MacroAssembler::fast_unlock(Register obj, Register box,
 
     const Register tmp2_owner_addr = tmp2;
 
-    // Compute owner address.
-    la(tmp2_owner_addr, Address(tmp1_monitor, ObjectMonitor::owner_offset()));
-
     // Set owner to null.
     // Release to satisfy the JMM
     membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-    sd(zr, Address(tmp2_owner_addr));
+    sd(zr, Address(tmp1_monitor, ObjectMonitor::owner_offset()), tmp2_owner_addr);
     // We need a full fence after clearing owner to avoid stranding.
     // StoreLoad achieves this.
     membar(StoreLoad);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -354,12 +354,10 @@ void C2_MacroAssembler::fast_unlock(Register obj, Register box,
 
     bind(not_recursive);
 
-    const Register tmp2_owner_addr = tmp2;
-
     // Set owner to null.
     // Release to satisfy the JMM
     membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-    sd(zr, Address(tmp1_monitor, ObjectMonitor::owner_offset()), tmp2_owner_addr);
+    sd(zr, Address(tmp1_monitor, ObjectMonitor::owner_offset()));
     // We need a full fence after clearing owner to avoid stranding.
     // StoreLoad achieves this.
     membar(StoreLoad);

--- a/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
@@ -227,9 +227,9 @@ void DowncallLinker::StubGenerator::generate() {
     _oop_maps->add_gc_map(the_pc - start, map);
 
     // State transition
-    __ mv(t0, _thread_in_native);
+    __ mv(t1, _thread_in_native);
     __ membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-    __ sw(t0, Address(xthread, JavaThread::thread_state_offset()));
+    __ sw(t1, Address(xthread, JavaThread::thread_state_offset()), t0);
     __ block_comment("} thread java2native");
   }
 

--- a/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
@@ -229,7 +229,7 @@ void DowncallLinker::StubGenerator::generate() {
     // State transition
     __ mv(t1, _thread_in_native);
     __ membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-    __ sw(t1, Address(xthread, JavaThread::thread_state_offset()), t0);
+    __ sw(t1, Address(xthread, JavaThread::thread_state_offset()));
     __ block_comment("} thread java2native");
   }
 

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1801,7 +1801,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   // Now set thread in native
   __ mv(t1, _thread_in_native);
   __ membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-  __ sw(t1, Address(xthread, JavaThread::thread_state_offset()), t0);
+  __ sw(t1, Address(xthread, JavaThread::thread_state_offset()));
 
   // Clobbers t1
   __ rt_call(native_func);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1799,10 +1799,9 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   __ la(c_rarg0, Address(xthread, in_bytes(JavaThread::jni_environment_offset())));
 
   // Now set thread in native
-  __ la(t1, Address(xthread, JavaThread::thread_state_offset()));
-  __ mv(t0, _thread_in_native);
+  __ mv(t1, _thread_in_native);
   __ membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-  __ sw(t0, Address(t1));
+  __ sw(t1, Address(xthread, JavaThread::thread_state_offset()), t0);
 
   // Clobbers t1
   __ rt_call(native_func);

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1182,7 +1182,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // Change state to native
   __ mv(t1, _thread_in_native);
   __ membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-  __ sw(t1, Address(xthread, JavaThread::thread_state_offset()), t0);
+  __ sw(t1, Address(xthread, JavaThread::thread_state_offset()));
 
   __ push_cont_fastpath();
 

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1180,10 +1180,9 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 #endif
 
   // Change state to native
-  __ la(t1, Address(xthread, JavaThread::thread_state_offset()));
-  __ mv(t0, _thread_in_native);
+  __ mv(t1, _thread_in_native);
   __ membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-  __ sw(t0, Address(t1));
+  __ sw(t1, Address(xthread, JavaThread::thread_state_offset()), t0);
 
   __ push_cont_fastpath();
 

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -159,9 +159,9 @@ void TemplateTable::patch_bytecode(Bytecodes::Code bc, Register bc_reg,
       __ load_field_entry(temp_reg, bc_reg);
       // Load-acquire the bytecode to match store-release in ResolvedFieldEntry::fill_in()
       if (byte_no == f1_byte) {
-        __ lbu(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::get_code_offset())), bc_reg);
+        __ lbu(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::get_code_offset())));
       } else {
-        __ lbu(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::put_code_offset())), bc_reg);
+        __ lbu(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::put_code_offset())));
       }
       __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
       __ mv(bc_reg, bc);
@@ -3742,7 +3742,7 @@ void TemplateTable::_new() {
   // how Constant Pool is update (see ConstantPool::klass_at_put)
   const int tags_offset = Array<u1>::base_offset_in_bytes();
   __ add(t1, x10, x13);
-  __ lbu(t1, Address(t1, tags_offset), t0);
+  __ lbu(t1, Address(t1, tags_offset));
   __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
   __ subi(t1, t1, (u1)JVM_CONSTANT_Class);
   __ bnez(t1, slow_case);

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -157,12 +157,10 @@ void TemplateTable::patch_bytecode(Bytecodes::Code bc, Register bc_reg,
       assert(byte_no == f1_byte || byte_no == f2_byte, "byte_no out of range");
       assert(load_bc_into_bc_reg, "we use bc_reg as temp");
       __ load_field_entry(temp_reg, bc_reg);
+      int code_offset = (byte_no == f1_byte) ? in_bytes(ResolvedFieldEntry::get_code_offset())
+                                             : in_bytes(ResolvedFieldEntry::put_code_offset());
       // Load-acquire the bytecode to match store-release in ResolvedFieldEntry::fill_in()
-      if (byte_no == f1_byte) {
-        __ lbu(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::get_code_offset())));
-      } else {
-        __ lbu(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::put_code_offset())));
-      }
+      __ lbu(temp_reg, Address(temp_reg, code_offset));
       __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
       __ mv(bc_reg, bc);
       __ beqz(temp_reg, L_patch_done);
@@ -2350,12 +2348,10 @@ void TemplateTable::resolve_cache_and_index_for_field(int byte_no,
 
   assert(byte_no == f1_byte || byte_no == f2_byte, "byte_no out of range");
   __ load_field_entry(Rcache, index);
+  int code_offset = (byte_no == f1_byte) ? in_bytes(ResolvedFieldEntry::get_code_offset())
+                                         : in_bytes(ResolvedFieldEntry::put_code_offset());
   // Load-acquire the bytecode to match store-release in ResolvedFieldEntry::fill_in()
-  if (byte_no == f1_byte) {
-    __ lbu(temp, Address(Rcache, in_bytes(ResolvedFieldEntry::get_code_offset())));
-  } else {
-    __ lbu(temp, Address(Rcache, in_bytes(ResolvedFieldEntry::put_code_offset())));
-  }
+  __ lbu(temp, Address(Rcache, code_offset));
   __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
   __ mv(t0, (int) code);  // have we resolved this bytecode?
 

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -157,13 +157,12 @@ void TemplateTable::patch_bytecode(Bytecodes::Code bc, Register bc_reg,
       assert(byte_no == f1_byte || byte_no == f2_byte, "byte_no out of range");
       assert(load_bc_into_bc_reg, "we use bc_reg as temp");
       __ load_field_entry(temp_reg, bc_reg);
-      if (byte_no == f1_byte) {
-        __ la(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::get_code_offset())));
-      } else {
-        __ la(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::put_code_offset())));
-      }
       // Load-acquire the bytecode to match store-release in ResolvedFieldEntry::fill_in()
-      __ lbu(temp_reg, Address(temp_reg, 0));
+      if (byte_no == f1_byte) {
+        __ lbu(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::get_code_offset())), bc_reg);
+      } else {
+        __ lbu(temp_reg, Address(temp_reg, in_bytes(ResolvedFieldEntry::put_code_offset())), bc_reg);
+      }
       __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
       __ mv(bc_reg, bc);
       __ beqz(temp_reg, L_patch_done);
@@ -2351,13 +2350,12 @@ void TemplateTable::resolve_cache_and_index_for_field(int byte_no,
 
   assert(byte_no == f1_byte || byte_no == f2_byte, "byte_no out of range");
   __ load_field_entry(Rcache, index);
-  if (byte_no == f1_byte) {
-    __ la(temp, Address(Rcache, in_bytes(ResolvedFieldEntry::get_code_offset())));
-  } else {
-    __ la(temp, Address(Rcache, in_bytes(ResolvedFieldEntry::put_code_offset())));
-  }
   // Load-acquire the bytecode to match store-release in ResolvedFieldEntry::fill_in()
-  __ lbu(temp, Address(temp, 0));
+  if (byte_no == f1_byte) {
+    __ lbu(temp, Address(Rcache, in_bytes(ResolvedFieldEntry::get_code_offset())));
+  } else {
+    __ lbu(temp, Address(Rcache, in_bytes(ResolvedFieldEntry::put_code_offset())));
+  }
   __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
   __ mv(t0, (int) code);  // have we resolved this bytecode?
 
@@ -3743,11 +3741,10 @@ void TemplateTable::_new() {
   // This is done before loading InstanceKlass to be consistent with the order
   // how Constant Pool is update (see ConstantPool::klass_at_put)
   const int tags_offset = Array<u1>::base_offset_in_bytes();
-  __ add(t0, x10, x13);
-  __ la(t0, Address(t0, tags_offset));
-  __ lbu(t0, t0);
+  __ add(t1, x10, x13);
+  __ lbu(t1, Address(t1, tags_offset), t0);
   __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
-  __ subi(t1, t0, (u1)JVM_CONSTANT_Class);
+  __ subi(t1, t1, (u1)JVM_CONSTANT_Class);
   __ bnez(t1, slow_case);
 
   // get InstanceKlass


### PR DESCRIPTION
Hi, please consider.
The RISC-V MacroAssembler load/store helpers that accept an `Address` already handle both cases:
If the displacement fits in a signed 12-bit immediate, it is encoded directly in the load/store instruction. 
Otherwise, the effective address is materialized using the supplied temporary register.
This allows several `la` followed by a zero-offset load/store sequences to be replaced with a single load/store using the original base and displacement.

### Testing
- [x]  Run tier1-tier3 test with release on SG2044

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391629](https://bugs.openjdk.org/browse/JDK-8391629): RISC-V: Avoid unnecessary address materialization for loads and stores (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32644/head:pull/32644` \
`$ git checkout pull/32644`

Update a local copy of the PR: \
`$ git checkout pull/32644` \
`$ git pull https://git.openjdk.org/jdk.git pull/32644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32644`

View PR using the GUI difftool: \
`$ git pr show -t 32644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32644.diff">https://git.openjdk.org/jdk/pull/32644.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32644#issuecomment-5507232785)
</details>
