### PR TITLE
8391643: C2: Missing ResourceMark when allocating GrowableArray in type.cpp

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3622,6 +3622,7 @@ void TypeInterfaces::verify() const {
 #endif
 
 const TypeInterfaces* TypeInterfaces::union_with(const TypeInterfaces* other) const {
+  ResourceMark rm;
   GrowableArray<ciInstanceKlass*> result_list;
   int i = 0;
   int j = 0;
@@ -3663,6 +3664,7 @@ const TypeInterfaces* TypeInterfaces::union_with(const TypeInterfaces* other) co
 }
 
 const TypeInterfaces* TypeInterfaces::intersection_with(const TypeInterfaces* other) const {
+  ResourceMark rm;
   GrowableArray<ciInstanceKlass*> result_list;
   int i = 0;
   int j = 0;

--- a/test/hotspot/jtreg/compiler/stringopts/TestLongStringConcat.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestLongStringConcat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/stringopts/TestLongStringConcat.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestLongStringConcat.java
@@ -31,7 +31,7 @@
 /*
  * @test
  * @bug 8391643
- * @summary We miss ResourceMark for TypeInterfaces::intersection_with and
+ * @summary We missed ResourceMark in TypeInterfaces::intersection_with and
  *          TypeInterfaces::union_with.
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:+StressVerifyMeetJoin
  *                   ${test.main.class}

--- a/test/hotspot/jtreg/compiler/stringopts/TestLongStringConcat.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestLongStringConcat.java
@@ -28,6 +28,15 @@
  * @run main/othervm -Xbatch compiler.stringopts.TestLongStringConcat
  */
 
+/*
+ * @test
+ * @bug 8391643
+ * @summary We miss ResourceMark for TypeInterfaces::intersection_with and
+ *          TypeInterfaces::union_with.
+ * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:+StressVerifyMeetJoin
+ *                   ${test.main.class}
+ */
+
 package compiler.stringopts;
 
 public class TestLongStringConcat {


### PR DESCRIPTION
Hi,

We miss `ResourceMark` in `TypeInterfaces::intersection_with` and `TypeInterfaces::union_with`. This means that when doing a large number of consecutive `meet` or `join`, the resource arena can explode. I can observe this running `compiler/stringopts/TestLongStringConcat.java` with `-XX:+StressVerifyMeetJoin`.

Testing:

- [x] tier1, hs-comp-stress

Please take a look and leave your reviews, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391643](https://bugs.openjdk.org/browse/JDK-8391643): C2: Missing ResourceMark when allocating GrowableArray in type.cpp (**Bug** - P4)


### Reviewers
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32645/head:pull/32645` \
`$ git checkout pull/32645`

Update a local copy of the PR: \
`$ git checkout pull/32645` \
`$ git pull https://git.openjdk.org/jdk.git pull/32645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32645`

View PR using the GUI difftool: \
`$ git pr show -t 32645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32645.diff">https://git.openjdk.org/jdk/pull/32645.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32645#issuecomment-5508197144)
</details>
