### PR TITLE
8391612: Use heapOopSize consistently in AOT

### DIFF
--- a/src/hotspot/share/cds/aotMappedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapWriter.cpp
@@ -437,7 +437,7 @@ size_t AOTMappedHeapWriter::filler_array_byte_size(int length) {
 
 int AOTMappedHeapWriter::filler_array_length(size_t fill_bytes) {
   assert(is_object_aligned(fill_bytes), "must be");
-  size_t elemSize = (UseCompressedOops ? sizeof(narrowOop) : sizeof(oop));
+  size_t elemSize = heapOopSize;
 
   int initial_length = to_array_length(fill_bytes / elemSize);
   for (int length = initial_length; length >= 0; length --) {
@@ -786,7 +786,7 @@ static void log_bitmap_usage(const char* which, BitMap* bitmap, size_t total_bit
 // Update all oop fields embedded in the buffered objects
 void AOTMappedHeapWriter::relocate_embedded_oops(GrowableArrayCHeap<oop, mtClassShared>* roots,
                                                       AOTMappedHeapInfo* heap_info) {
-  size_t oopmap_unit = (UseCompressedOops ? sizeof(narrowOop) : sizeof(oop));
+  size_t oopmap_unit = heapOopSize;
   size_t heap_region_byte_size = _buffer_used;
   heap_info->oopmap()->resize(heap_region_byte_size   / oopmap_unit);
 
@@ -813,7 +813,7 @@ void AOTMappedHeapWriter::relocate_embedded_oops(GrowableArrayCHeap<oop, mtClass
     address buffered_obj = offset_to_buffered_address<address>(seg_offset);
     int length = _heap_root_segments.size_in_elems(seg_idx);
 
-    size_t elem_size = UseCompressedOops ? sizeof(narrowOop) : sizeof(oop);
+    size_t elem_size = heapOopSize;
 
     for (int i = 0; i < length; i++) {
       // There is no source object; these are native oops - load, translate and
@@ -833,7 +833,7 @@ void AOTMappedHeapWriter::relocate_embedded_oops(GrowableArrayCHeap<oop, mtClass
   compute_ptrmap(heap_info);
 
   size_t total_bytes = (size_t)_buffer->length();
-  log_bitmap_usage("oopmap", heap_info->oopmap(), total_bytes / (UseCompressedOops ? sizeof(narrowOop) : sizeof(oop)));
+  log_bitmap_usage("oopmap", heap_info->oopmap(), total_bytes / heapOopSize);
   log_bitmap_usage("ptrmap", heap_info->ptrmap(), total_bytes / sizeof(address));
 }
 

--- a/src/hotspot/share/cds/aotStreamedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotStreamedHeapWriter.cpp
@@ -435,7 +435,7 @@ static void log_bitmap_usage(const char* which, BitMap* bitmap, size_t total_bit
 
 // Update all oop fields embedded in the buffered objects
 void AOTStreamedHeapWriter::map_embedded_oops(AOTStreamedHeapInfo* heap_info) {
-  size_t oopmap_unit = (UseCompressedOops ? sizeof(narrowOop) : sizeof(oop));
+  size_t oopmap_unit = heapOopSize;
   size_t heap_region_byte_size = _buffer_used;
   heap_info->oopmap()->resize(heap_region_byte_size / oopmap_unit);
 


### PR DESCRIPTION
`heapOopSize` is the size of an oop in a Java object: 4 bytes with `UseCompressedOops`, 8 otherwise. The five `UseCompressedOops ? sizeof(narrowOop) : sizeof(oop)` sites in the two AOT heap writers now use it directly. No other occurrence of the pattern remains in HotSpot.

Testing:
- `make CONF=macosx-aarch64-server-fastdebug-nometal test TEST="jtreg:test/hotspot/jtreg/runtime/cds/appcds/cacheObject jtreg:test/hotspot/jtreg/runtime/cds/appcds/aotCache"`
- `aotCache` again with `-XX:-UseCompressedOops`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391612](https://bugs.openjdk.org/browse/JDK-8391612): Use heapOopSize consistently in AOT (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32646/head:pull/32646` \
`$ git checkout pull/32646`

Update a local copy of the PR: \
`$ git checkout pull/32646` \
`$ git pull https://git.openjdk.org/jdk.git pull/32646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32646`

View PR using the GUI difftool: \
`$ git pr show -t 32646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32646.diff">https://git.openjdk.org/jdk/pull/32646.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32646#issuecomment-5508392763)
</details>
