### PR TITLE
8391646: Shenandoah: Mach node analysis should not strip extra bits

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -464,13 +464,19 @@ void ShenandoahBarrierSetC2::elide_dominated_barrier(MachNode* node, MachNode* d
   }
 
   if (orig_bd != bd) {
-    // We are already in final output.
-    // Strip the extra barrier data if no real bits are left.
-    if ((bd & ShenandoahBitsReal) != 0) {
-      node->set_barrier_data(bd);
-    } else {
-      node->set_barrier_data(0);
-    }
+#ifdef ASSERT
+    PhaseRegAlloc* ra = Compile::current()->regalloc();
+    uint old_size = node->size(ra);
+#endif
+    // We are already in final output. This means all nodes have already matched,
+    // and we are about to use Shenandoah match rules with stripped-down barriers.
+    // In this case, we must *not* strip non-real bits, because it would shift the
+    // encoding.
+    node->set_barrier_data(bd);
+#ifdef ASSERT
+    uint new_size = node->size(ra);
+    assert(new_size <= old_size, "Node must not grow: %u -> %u", old_size, new_size);
+#endif
   }
 }
 


### PR DESCRIPTION
A little bug in Shenandoah LBE. During mach node analysis, we have accidentally stripped `ShenandoahBitNotNull`, so it invoked a less efficient sequence in `SBSA::store_c2`. That sequence is _larger_ than the non-stripped version when hotpatching is present, and it makes emitter sick.

Additional testing:
 - [x] Linux x86_64 server fastdebug, hotpatching reproducer no longer fails
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseShenandoahGC`
 - [x] Linux AArch64 server fastdebug, `all` with `-XX:+UseShenandoahGC`
 - [x] Regular testing pipelines 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391646](https://bugs.openjdk.org/browse/JDK-8391646): Shenandoah: Mach node analysis should not strip extra bits (**Bug** - P3)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32647/head:pull/32647` \
`$ git checkout pull/32647`

Update a local copy of the PR: \
`$ git checkout pull/32647` \
`$ git pull https://git.openjdk.org/jdk.git pull/32647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32647`

View PR using the GUI difftool: \
`$ git pr show -t 32647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32647.diff">https://git.openjdk.org/jdk/pull/32647.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32647#issuecomment-5508979277)
</details>
