### PR TITLE
8391649: Rdn.getType()/getValue() throw uncaught IndexOutOfBoundsException on RDN with no attributeTypeAndValue

### DIFF
--- a/src/java.naming/share/classes/javax/naming/ldap/Rdn.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/Rdn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/javax/naming/ldap/Rdn.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/Rdn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/javax/naming/ldap/Rdn.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/Rdn.java
@@ -166,6 +166,10 @@ public class Rdn implements Serializable, Comparable<Object> {
     public Rdn(String rdnString) throws InvalidNameException {
         entries = new ArrayList<>(DEFAULT_SIZE);
         (new Rfc2253Parser(rdnString)).parseRdn(this);
+        if (entries.isEmpty()) {
+            throw new InvalidNameException(
+                "RDN cannot be empty, got: \"" + rdnString + "\"");
+        }
     }
 
     /**

--- a/src/java.naming/share/classes/javax/naming/ldap/Rfc2253Parser.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/Rfc2253Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.naming/share/classes/javax/naming/ldap/Rfc2253Parser.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/Rfc2253Parser.java
@@ -121,6 +121,21 @@ final class Rfc2253Parser {
                 }
                 ++cur;          // consume '+'
             }
+
+            // RFC 2253: an RDN MUST contain at least one
+            // attributeTypeAndValue. If the outer loop above never ran
+            // (e.g. the string was empty, or we were invoked right after
+            // a trailing ',' / ';' with nothing left to parse), "rdn" has
+            // no entries. Returning it as-is would let a malformed Rdn
+            // escape into Rdn(String) *and* LdapName(String)/add(String),
+            // later crashing getType()/getValue() with an uncaught
+            // IndexOutOfBoundsException instead of the documented
+            // InvalidNameException.
+            if (rdn.size() == 0) {
+            throw new InvalidNameException(
+                "Invalid name: \"" + name + "\" (empty RDN)");
+            }
+
             rdn.sort();
             return rdn;
         }

--- a/src/java.naming/share/classes/javax/naming/ldap/Rfc2253Parser.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/Rfc2253Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/naming/ldap/Rdn/EmptyRdnTest.java
+++ b/test/jdk/javax/naming/ldap/Rdn/EmptyRdnTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8391649
+ * @summary Rdn(String) and, transitively, LdapName(String) / LdapName.add(String)
+ *          must reject an RDN string that contains no attributeTypeAndValue
+ *          (an "empty RDN") by throwing InvalidNameException, per the RFC 2253
+ *          grammar and the documented contract of Rdn.getType()/getValue()
+ *          ("returns the ... type" / "returns the ... value", never an
+ *          exception other than InvalidNameException at construction time).
+ * @run main EmptyRdnTest
+ */
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import java.util.List;
+
+public class EmptyRdnTest {
+
+    private static int failures = 0;
+
+    public static void main(String[] args) throws Exception {
+
+        expectInvalidNameException("new Rdn(\"\")", () -> new Rdn(""));
+
+        expectInvalidNameException("new Rdn(\"   \")", () -> new Rdn("   "));
+
+        expectInvalidNameException("new LdapName(\"cn=x,\")", () -> new LdapName("cn=x,"));
+        expectInvalidNameException("new LdapName(\"cn=x;\")", () -> new LdapName("cn=x;"));
+        expectInvalidNameException("new LdapName(\"cn=a,ou=b,\")", () -> new LdapName("cn=a,ou=b,"));
+
+        expectInvalidNameException("LdapName.add(\"\")", () -> {
+            LdapName dn = new LdapName("dc=example,dc=com");
+            dn.add("");
+        });
+
+        expectInvalidNameException("new LdapName(\"cn=a,,cn=b\")", () -> new LdapName("cn=a,,cn=b"));
+
+        checkValidRdn("cn=x");
+        checkValidRdn("cn=x+ou=y");
+        checkValidRdn("1.2.840.113549.1.9.1=someone@example.com");
+        checkValidRdn("cn=");           // empty *value* is legal: one entry, value ""
+
+        LdapName dn = new LdapName("cn=a,ou=b,dc=c");
+        if (dn.size() != 3) {
+            fail("new LdapName(\"cn=a,ou=b,dc=c\") -> expected size 3, got " + dn.size());
+        }
+        List<Rdn> rdns = dn.getRdns();
+        for (Rdn r : rdns) {
+            if (r.size() == 0) {
+                fail("valid multi-RDN name produced an empty Rdn: " + dn);
+            }
+            r.getType();
+            r.getValue();
+        }
+
+        if (failures > 0) {
+            throw new RuntimeException(failures + " check(s) failed, see output above");
+        }
+        System.out.println("All checks passed.");
+    }
+
+    private static void checkValidRdn(String s) throws InvalidNameException {
+        Rdn r = new Rdn(s);
+        if (r.size() == 0) {
+            fail("new Rdn(\"" + s + "\") produced an empty Rdn (should be valid, size >= 1)");
+            return;
+        }
+        r.getType();
+        r.getValue();
+    }
+
+    private interface Thrower {
+        void run() throws Exception;
+    }
+
+    /**
+     * Runs {@code t}. Passes only if it throws exactly
+     * InvalidNameException. Fails (but does not abort the whole test
+     * run) if it throws nothing, or throws anything else -- most
+     * notably the IndexOutOfBoundsException this test guards against.
+     */
+    private static void expectInvalidNameException(String label, Thrower t) {
+        try {
+            t.run();
+            fail(label + " -> did not throw; expected InvalidNameException");
+        } catch (InvalidNameException e) {
+            System.out.println("OK: " + label + " -> InvalidNameException(\"" + e.getMessage() + "\")");
+        } catch (Throwable e) {
+            fail(label + " -> threw " + e.getClass().getName()
+                    + " (\"" + e.getMessage() + "\"), expected InvalidNameException");
+        }
+    }
+
+    private static void fail(String message) {
+        failures++;
+        System.out.println("FAIL: " + message);
+    }
+}


### PR DESCRIPTION
Rfc2253Parser silently accepted an empty RDN (no attributeTypeAndValue pair) instead of
throwing InvalidNameException. Rdn.getType()/getValue() then indexed an empty
internal list, throwing an uncaught IndexOutOfBoundsException instead of the documented
exception.

Two independent entry points:

Rdn("") - the original fuzzer-found crash.
LdapName("cn=x,") / LdapName.add("") - a string with a trailing , or ;, which never goes
through Rdn(String) at all (LdapName builds the RDN directly via Rfc2253Parser).

Add one check, rdn.size() == 0, throw InvalidNameException, placed in

Rfc2253Parser.doParse(Rdn) - the single method both paths funnel through.

Also add a regression check that "cn=a,,cn=b" still throws as before.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change requires a CSR request matching fixVersion 28 to be approved (needs to be created)
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8391649](https://bugs.openjdk.org/browse/JDK-8391649)

### Issue
 * [JDK-8391649](https://bugs.openjdk.org/browse/JDK-8391649): LdapName and Rdn constructor accepts an empty RDN component (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32648/head:pull/32648` \
`$ git checkout pull/32648`

Update a local copy of the PR: \
`$ git checkout pull/32648` \
`$ git pull https://git.openjdk.org/jdk.git pull/32648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32648`

View PR using the GUI difftool: \
`$ git pr show -t 32648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32648.diff">https://git.openjdk.org/jdk/pull/32648.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32648#issuecomment-5509158654)
</details>
