### PR TITLE
8388363: [Valhalla] C1: Constant fold substitutability check with non-value objects

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -731,7 +731,7 @@ void Canonicalizer::do_If(If* x) {
     if (l_exact_type != nullptr && l_exact_type->is_inlinetype() &&
         r_exact_type != nullptr && r_exact_type->is_inlinetype() && x->substitutability_check()) {
       // If we have a substitutability check and both sides are known inline types we must
-      // preserve it instread of performing a pointer comparison during compile time.
+      // preserve it instead of performing a pointer comparison during compile time.
       return;
     }
 

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -724,9 +724,17 @@ void Canonicalizer::do_If(If* x) {
     return;
   }
 
-  // Simplify further when we have two constants. However, if we have a substitutability check
-  // we must not constant fold as this would loose the substitutability semantics.
-  if (lt->is_constant() && rt->is_constant() && !x->substitutability_check()) {
+  // Simplify further when we have two constants.
+  if (lt->is_constant() && rt->is_constant()) {
+    const ciType* l_exact_type = l->exact_type();
+    const ciType* r_exact_type = r->exact_type();
+    if (l_exact_type != nullptr && l_exact_type->is_inlinetype() &&
+        r_exact_type != nullptr && r_exact_type->is_inlinetype() && x->substitutability_check()) {
+      // If we have a substitutability check and both sides are known inline types we must
+      // preserve it instread of performing a pointer comparison during compile time.
+      return;
+    }
+
     if (x->x()->as_Constant() != nullptr) {
       // pattern: If (lc cond rc) => simplify to: Goto
       BlockBegin* sux = x->x()->as_Constant()->compare(x->cond(), x->y(),

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1381,8 +1381,8 @@ void GraphBuilder::if_node(Value x, If::Condition cond, Value y, ValueStack* sta
       if (left_klass == nullptr || right_klass == nullptr) {
         // The klass is still unloaded, or came from a Phi node. Go slow case;
         subst_check = true;
-      } else if (left_klass->can_be_inline_klass() || right_klass->can_be_inline_klass()) {
-        // Either operand may be a value object, but we're not sure. Go slow case;
+      } else if (left_klass->can_be_inline_klass() && right_klass->can_be_inline_klass()) {
+        // Both operands may be a value object, but we're not sure. Go slow case;
         subst_check = true;
       } else {
         // No need to do substitutability check


### PR DESCRIPTION
This PR relaxes some overly strict application of substitutability checks in C1 where eliding them would be possible. This lead to overly large code being generated unnecessarily. With this PR, we take some more opportunities to elide substitutability checks.

Testing:
 - [x] Github Actions
 - [x] tier1, tier2, tier3 plus stress testing with `--enable-preview`
 - [x] `testlibrary_tests/template_framework/examples/TestVectorTypes.java` with `--enable-preview -XX:TieredStopAtLevel=3`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388363](https://bugs.openjdk.org/browse/JDK-8388363): [Valhalla] C1: Constant fold substitutability check with non-value objects (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32649/head:pull/32649` \
`$ git checkout pull/32649`

Update a local copy of the PR: \
`$ git checkout pull/32649` \
`$ git pull https://git.openjdk.org/jdk.git pull/32649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32649`

View PR using the GUI difftool: \
`$ git pr show -t 32649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32649.diff">https://git.openjdk.org/jdk/pull/32649.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32649#issuecomment-5509482392)
</details>
