### PR TITLE
8391353: C2: Missed Identity optimization opportunity in PhaseIterGVN for CMoveI

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2540,6 +2540,20 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
   uint use_op = use->Opcode();
   if(use->is_Cmp()) {       // Enable CMP/BOOL optimization
     add_users_to_worklist0(use, worklist); // Put Bool on worklist
+    // CMoveNode::Identity folds "(x == y) ? y : x" by comparing the inputs of
+    // the Cmp with those of the CMove, so a CMove behind the Bool has to be
+    // revisited when an input of the Cmp changes.
+    for (DUIterator_Fast jmax, j = use->fast_outs(jmax); j < jmax; j++) {
+      Node* bol = use->fast_out(j);
+      if (bol->is_Bool()) {
+        for (DUIterator_Fast kmax, k = bol->fast_outs(kmax); k < kmax; k++) {
+          Node* cmov = bol->fast_out(k);
+          if (cmov->is_CMove()) {
+            worklist.push(cmov);
+          }
+        }
+      }
+    }
     if (use->outcnt() > 0) {
       Node* bol = use->raw_out(0);
       if (bol->outcnt() > 0) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2540,34 +2540,29 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
   uint use_op = use->Opcode();
   if(use->is_Cmp()) {       // Enable CMP/BOOL optimization
     add_users_to_worklist0(use, worklist); // Put Bool on worklist
-    // CMoveNode::Identity folds "(x == y) ? y : x" by comparing the inputs of
-    // the Cmp with those of the CMove, so a CMove behind the Bool has to be
-    // revisited when an input of the Cmp changes.
     for (DUIterator_Fast jmax, j = use->fast_outs(jmax); j < jmax; j++) {
       Node* bol = use->fast_out(j);
-      if (bol->is_Bool()) {
-        for (DUIterator_Fast kmax, k = bol->fast_outs(kmax); k < kmax; k++) {
-          Node* cmov = bol->fast_out(k);
-          if (cmov->is_CMove()) {
-            worklist.push(cmov);
-          }
-        }
+      if (!bol->is_Bool()) {
+        continue;
       }
-    }
-    if (use->outcnt() > 0) {
-      Node* bol = use->raw_out(0);
-      if (bol->outcnt() > 0) {
-        Node* iff = bol->raw_out(0);
-        if (iff->outcnt() == 2) {
+      for (DUIterator_Fast kmax, k = bol->fast_outs(kmax); k < kmax; k++) {
+        Node* bol_use = bol->fast_out(k);
+        if (bol_use->is_CMove()) {
+          // CMoveNode::Identity folds "(x == y) ? y : x" by comparing the inputs
+          // of the Cmp with those of the CMove.
+          worklist.push(bol_use);
+        } else if (bol_use->is_If() && bol_use->outcnt() == 2) {
           // Look for the 'is_x2logic' pattern: "x ? : 0 : 1" and put the
           // phi merging either 0 or 1 onto the worklist
-          Node* ifproj0 = iff->raw_out(0);
-          Node* ifproj1 = iff->raw_out(1);
-          if (ifproj0->outcnt() > 0 && ifproj1->outcnt() > 0) {
+          Node* ifproj0 = bol_use->raw_out(0);
+          Node* ifproj1 = bol_use->raw_out(1);
+          if (ifproj0->is_IfProj() && ifproj1->is_IfProj() &&
+              ifproj0->outcnt() > 0 && ifproj1->outcnt() > 0) {
             Node* region0 = ifproj0->raw_out(0);
             Node* region1 = ifproj1->raw_out(0);
-            if( region0 == region1 )
+            if (region0 == region1 && region0->is_Region()) {
               add_users_to_worklist0(region0, worklist);
+            }
           }
         }
       }

--- a/test/hotspot/jtreg/compiler/c2/igvn/TestCMoveIdentityNotification.java
+++ b/test/hotspot/jtreg/compiler/c2/igvn/TestCMoveIdentityNotification.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.igvn;
+
+/*
+ * @test
+ * @bug 8391353
+ * @summary CMoveNode::Identity folds "(x == c) ? c : x" to x by looking at the
+ *          inputs of the Cmp behind the Bool. When an input of that Cmp changes,
+ *          the CMove must be put back on the IGVN worklist. Use
+ *          -XX:VerifyIterativeGVN=1110 to catch missing optimizations.
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *      -Xcomp -XX:-TieredCompilation
+ *      -XX:+StressIGVN -XX:StressSeed=3
+ *      -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *      -XX:VerifyIterativeGVN=1110
+ *      ${test.main.class}
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *      -Xcomp -XX:-TieredCompilation
+ *      -XX:+StressIGVN
+ *      -XX:CompileCommand=compileonly,${test.main.class}::test*
+ *      -XX:VerifyIterativeGVN=1110
+ *      ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+public class TestCMoveIdentityNotification {
+    static void test() {
+        for (int i = 0, j = 0, k = 0; j < 9; j++) {
+            for (i += j - 1L; k < 3; k++) {
+                if (i != 0) { }
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        test();
+    }
+}


### PR DESCRIPTION
`CMoveNode::Identity` folds `(x == c) ? c : x` to `x` through `is_cmove_id`, which looks at the inputs of the Cmp behind the CMove's Bool. In the fuzzer case a Phi feeding that Cmp collapsed to the CMove's own false input after its If was removed. That change is two nodes away from the CMove: `add_users_of_use_to_worklist` pushed the Bool and looked past it only for an If, so the CMove was never revisited.

When an input of a Cmp changes, CMoves behind its Bools now go on the worklist as well.

Testing:
- new `compiler/c2/igvn/TestCMoveIdentityNotification.java`, the reduced fuzzer test with the flags from the report, which fails before the change and passes after
- `compiler/c2/igvn`, `compiler/igvn` and `hotspot:tier1_compiler` on macos-aarch64 fastdebug
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391353](https://bugs.openjdk.org/browse/JDK-8391353): C2: Missed Identity optimization opportunity in PhaseIterGVN for CMoveI (**Bug** - P5)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32650/head:pull/32650` \
`$ git checkout pull/32650`

Update a local copy of the PR: \
`$ git checkout pull/32650` \
`$ git pull https://git.openjdk.org/jdk.git pull/32650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32650`

View PR using the GUI difftool: \
`$ git pr show -t 32650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32650.diff">https://git.openjdk.org/jdk/pull/32650.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32650#issuecomment-5509668014)
</details>
