### PR TITLE
8391656: MethodHandles::print_as_basic_type_signature_on has unreachable code

### DIFF
--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -667,6 +667,7 @@ void MethodHandles::print_as_basic_type_signature_on(outputStream* st,
     } else {
       st->put(cp[0]);
     }
+    prev_type = true;
   }
 }
 


### PR DESCRIPTION
print_as_basic_type_signature_on has unreachable code because of
missing state update. The prev_type variable was initialized to false and
never changed to true inside the loop. This made the else if (prev_type)
condition always false, preventing commas from being printed between method
arguments and breaking the debug output format.

Add the missing prev_type = true; assignment at the end of the loop body.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391656](https://bugs.openjdk.org/browse/JDK-8391656): MethodHandles::print_as_basic_type_signature_on has unreachable code (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32653/head:pull/32653` \
`$ git checkout pull/32653`

Update a local copy of the PR: \
`$ git checkout pull/32653` \
`$ git pull https://git.openjdk.org/jdk.git pull/32653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32653`

View PR using the GUI difftool: \
`$ git pr show -t 32653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32653.diff">https://git.openjdk.org/jdk/pull/32653.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32653#issuecomment-5510578275)
</details>
