### PR TITLE
8391567: Type annotation before qualified method reference crashes javac

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -490,12 +490,12 @@ public class TreeInfo {
                         checkStaticSym.test(base);
             case SELECT:
                 return checkStaticSym.test(base) &&
-                    isStaticSelector(((JCFieldAccess)base).selected, names);
+                    isTypeSelector(((JCFieldAccess)base).selected, names, checkStaticSym);
             case TYPEAPPLY:
             case TYPEARRAY:
                 return true;
             case ANNOTATED_TYPE:
-                return isStaticSelector(((JCAnnotatedType)base).underlyingType, names);
+                return isTypeSelector(((JCAnnotatedType)base).underlyingType, names, checkStaticSym);
             default:
                 return false;
         }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/QualifiedMethodReference.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/QualifiedMethodReference.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8391567
+ * @summary Type annotation before a qualified method reference crashes javac
+ * @compile QualifiedMethodReference.java
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.util.function.Supplier;
+
+class QualifiedMethodReference {
+    @Target(ElementType.TYPE_USE)
+    @interface A { }
+
+    static class Nested {
+        static String method() {
+            return "";
+        }
+    }
+
+    Supplier<Nested> constructor = @A QualifiedMethodReference.Nested::new;
+    Supplier<String> method = @A QualifiedMethodReference.Nested::method;
+}


### PR DESCRIPTION
This change preserves the selector predicate while recursively checking qualified and annotated types. This prevents javac from attempting to inspect symbols during parsing, when those symbols are not yet available.

A regression test covers annotated qualified constructor and method references.

Testing:
- `make images`
- `make test TEST=test/langtools/tools/javac/annotations/typeAnnotations/QualifiedMethodReference.java`
- `make test TEST=test/langtools/tools/javac`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8391567](https://bugs.openjdk.org/browse/JDK-8391567)

### Issue
 * [JDK-8391567](https://bugs.openjdk.org/browse/JDK-8391567): javac crashes with a NullPointerException in TreeInfo.isStaticSym when a type annotation precedes a qualified method reference (**Bug** - P3) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32654/head:pull/32654` \
`$ git checkout pull/32654`

Update a local copy of the PR: \
`$ git checkout pull/32654` \
`$ git pull https://git.openjdk.org/jdk.git pull/32654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32654`

View PR using the GUI difftool: \
`$ git pr show -t 32654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32654.diff">https://git.openjdk.org/jdk/pull/32654.diff</a>

</details>
