### PR TITLE
8391296: C2: Assert in PhaseIdealLoop::intrinsify_fill too strong with compact object headers

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -4076,11 +4076,6 @@ bool PhaseIdealLoop::intrinsify_fill(IdealLoopTree* lpt) {
   }
   Node* from = AddPNode::make_with_base(base, index);
   _igvn.register_new_node_with_optimizer(from);
-  // For normal array fills, C2 uses two AddP nodes for array element
-  // addressing. But for array fills with Unsafe call, there's only one
-  // AddP node adding an absolute offset, so we do a null check here.
-  assert(offset != nullptr || C->has_unsafe_access(),
-         "Only array fills with unsafe have no extra offset");
   if (offset != nullptr) {
     from = AddPNode::make_with_base(base, from, offset);
     _igvn.register_new_node_with_optimizer(from);

--- a/test/hotspot/jtreg/compiler/loopopts/TestArrayFillWithSubIndexMin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestArrayFillWithSubIndexMin.java
@@ -21,57 +21,55 @@
  * questions.
  */
 
-/**
- * @test id=default
- * @summary Exercise minimal int array fill with i - c index and default fill optimization settings.
- * @requires vm.compiler2.enabled
- *
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
- *                   -XX:-TieredCompilation
- *                   -XX:CompileCommand=quiet
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::offsetMinusLiteral
- *                   compiler.loopopts.TestArrayFillWithSubIndexMin
- */
 
 /**
- * @test id=optimize-fill
+ * @test id=coh
  * @summary Exercise minimal int array fill with i - c index and forced fill optimization.
  * @requires vm.compiler2.enabled
  *
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-TieredCompilation
- *                   -XX:LoopUnrollLimit=0 -XX:+OptimizeFill
- *                   -XX:CompileCommand=quiet
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::offsetMinusLiteral
+ *                   -XX:+OptimizeFill
+ *                   -XX:+UseCompactObjectHeaders
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::test_coh
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::test_nocoh
  *                   compiler.loopopts.TestArrayFillWithSubIndexMin
  */
 
 /**
- * @test id=no-optimize-fill
+ * @test id=no-coh
  * @summary Exercise minimal int array fill with i - c index and disabled fill optimization.
  * @requires vm.compiler2.enabled
  *
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-TieredCompilation
- *                   -XX:-OptimizeFill
- *                   -XX:CompileCommand=quiet
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::offsetMinusLiteral
+ *                   -XX:+OptimizeFill
+ *                   -XX:-UseCompactObjectHeaders
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::test_coh
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::test_nocoh
  *                   compiler.loopopts.TestArrayFillWithSubIndexMin
  */
 
 package compiler.loopopts;
 
 public class TestArrayFillWithSubIndexMin {
-    static final int N = 1000;
-    static final int[] A = new int[N + 16];
+    static final int ARRAY_SIZE = 100;
+    static final int[] ARRAY = new int[ARRAY_SIZE];
 
-    public static void offsetMinusLiteral() {
-        for (int i = 3; i < N + 3; i++) {
-            A[i - 3] = 7;
+    public static void test_coh() {
+        for (int i = 3; i < ARRAY_SIZE; i++) {
+            ARRAY[i - 3] = 42;
+        }
+    }
+
+    public static void test_nocoh() {
+        for (int i = 4; i < ARRAY_SIZE; i++) {
+            ARRAY[i - 4] = 42;
         }
     }
 
     public static void main(String[] args) {
-        offsetMinusLiteral();
+        test_coh();
+        test_nocoh();
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestArrayFillWithSubIndexMin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestArrayFillWithSubIndexMin.java
@@ -26,7 +26,7 @@
  * @summary Exercise minimal int array fill with i - c index and forced fill optimization.
  * @requires vm.compiler2.enabled
  *
-  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-TieredCompilation
  *                   -XX:+OptimizeFill
  *                   -XX:+UseCompactObjectHeaders

--- a/test/hotspot/jtreg/compiler/loopopts/TestArrayFillWithSubIndexMin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestArrayFillWithSubIndexMin.java
@@ -21,33 +21,26 @@
  * questions.
  */
 
-
 /**
- * @test id=coh
+ * @test
  * @summary Exercise minimal int array fill with i - c index and forced fill optimization.
  * @requires vm.compiler2.enabled
  *
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
+  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-TieredCompilation
  *                   -XX:+OptimizeFill
  *                   -XX:+UseCompactObjectHeaders
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::test_coh
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::test_nocoh
- *                   compiler.loopopts.TestArrayFillWithSubIndexMin
- */
-
-/**
- * @test id=no-coh
- * @summary Exercise minimal int array fill with i - c index and disabled fill optimization.
- * @requires vm.compiler2.enabled
- *
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test_coh
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test_nocoh
+ *                   ${test.main.class}
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-TieredCompilation
  *                   -XX:+OptimizeFill
  *                   -XX:-UseCompactObjectHeaders
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::test_coh
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::test_nocoh
- *                   compiler.loopopts.TestArrayFillWithSubIndexMin
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test_coh
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test_nocoh
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
  */
 
 package compiler.loopopts;

--- a/test/hotspot/jtreg/compiler/loopopts/TestArrayFillWithSubIndexMin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestArrayFillWithSubIndexMin.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test id=default
+ * @summary Exercise minimal int array fill with i - c index and default fill optimization settings.
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:-TieredCompilation
+ *                   -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::offsetMinusLiteral
+ *                   compiler.loopopts.TestArrayFillWithSubIndexMin
+ */
+
+/**
+ * @test id=optimize-fill
+ * @summary Exercise minimal int array fill with i - c index and forced fill optimization.
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:-TieredCompilation
+ *                   -XX:LoopUnrollLimit=0 -XX:+OptimizeFill
+ *                   -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::offsetMinusLiteral
+ *                   compiler.loopopts.TestArrayFillWithSubIndexMin
+ */
+
+/**
+ * @test id=no-optimize-fill
+ * @summary Exercise minimal int array fill with i - c index and disabled fill optimization.
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:-TieredCompilation
+ *                   -XX:-OptimizeFill
+ *                   -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestArrayFillWithSubIndexMin::offsetMinusLiteral
+ *                   compiler.loopopts.TestArrayFillWithSubIndexMin
+ */
+
+package compiler.loopopts;
+
+public class TestArrayFillWithSubIndexMin {
+    static final int N = 1000;
+    static final int[] A = new int[N + 16];
+
+    public static void offsetMinusLiteral() {
+        for (int i = 3; i < N + 3; i++) {
+            A[i - 3] = 7;
+        }
+    }
+
+    public static void main(String[] args) {
+        offsetMinusLiteral();
+    }
+}


### PR DESCRIPTION
Please review this small fix which removes an assert in the array filling code. The assert was too strong and didn't account for the graph transformations C2 could apply to the nodes computing the array element address. A more detailed analysis is available in the CR.

Tested tier 1 to 3.

Thanks

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391296](https://bugs.openjdk.org/browse/JDK-8391296): C2: Assert in PhaseIdealLoop::intrinsify_fill too strong with compact object headers (**Bug** - P4)


### Reviewers
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32655/head:pull/32655` \
`$ git checkout pull/32655`

Update a local copy of the PR: \
`$ git checkout pull/32655` \
`$ git pull https://git.openjdk.org/jdk.git pull/32655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32655`

View PR using the GUI difftool: \
`$ git pr show -t 32655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32655.diff">https://git.openjdk.org/jdk/pull/32655.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32655#issuecomment-5511879684)
</details>
