### PR TITLE
8391667: Fix for removed has_no_hash() method

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1345,7 +1345,7 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
     static constexpr uintptr_t valhalla_reserved_bits_in_place = right_n_bits(markWord::valhalla_reserved_bits)
                                                                     << markWord::valhalla_reserved_shift;
     static constexpr uintptr_t markbits_must_be_zero = valhalla_reserved_bits_in_place | markWord::self_fwd_bit_in_place;
-    if (mw.has_no_hash() && (mw.value() & markbits_must_be_zero) == 0 && Klass::is_valid(mw.klass_without_asserts())) {
+    if ((!mw.has_hash()) && (mw.value() & markbits_must_be_zero) == 0 && Klass::is_valid(mw.klass_without_asserts())) {
       st->print(PTR_FORMAT " looks like a valid markword: ", p2i(addr));
       mw.print_on(st);
       st->print(" ");


### PR DESCRIPTION
The commit for [JDK-8391174](https://bugs.openjdk.org/browse/JDK-8391174) removed mark_word::has_no_hash().

[JDK-8380425](https://bugs.openjdk.org/browse/JDK-8380425) was committed against an older commit.
The code for [JDK-8380425](https://bugs.openjdk.org/browse/JDK-8380425) needs to be corrected to use has_hash() instead of has_no_hash()

This PR updates the code to use has_hash().

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391667](https://bugs.openjdk.org/browse/JDK-8391667): Fix for removed has_no_hash() method (**Bug** - P2)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32656/head:pull/32656` \
`$ git checkout pull/32656`

Update a local copy of the PR: \
`$ git checkout pull/32656` \
`$ git pull https://git.openjdk.org/jdk.git pull/32656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32656`

View PR using the GUI difftool: \
`$ git pr show -t 32656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32656.diff">https://git.openjdk.org/jdk/pull/32656.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32656#issuecomment-5512433932)
</details>
