### PR TITLE
8387462: ClassFileParser::verify_legal_field_modifiers has out-of-date comment about strict-init field

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4636,10 +4636,9 @@ void ClassFileParser:: verify_legal_field_modifiers(jint flags,
   const char* error_msg = "";
 
   // There is some overlap in the checks that apply, for example interface fields
-  // must be static, static fields can't be strict, and therefore interfaces can't
-  // have strict fields. So we don't have to check every possible invalid combination
-  // individually as long as all are covered. Once we have found an illegal combination
-  // we can stop checking.
+  // must be static, therefore interfaces can't have strict instance fields.
+  // We don't have to check every possible invalid combination individually as long as
+  // all are covered. Once we have found an illegal combination we can stop checking.
 
   if (!is_illegal) {
     if (is_interface) {


### PR DESCRIPTION
It is valid to have strict static fields so the comment in classFileParser needed to be fixed.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387462](https://bugs.openjdk.org/browse/JDK-8387462): ClassFileParser::verify_legal_field_modifiers has out-of-date comment about strict-init field (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32657/head:pull/32657` \
`$ git checkout pull/32657`

Update a local copy of the PR: \
`$ git checkout pull/32657` \
`$ git pull https://git.openjdk.org/jdk.git pull/32657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32657`

View PR using the GUI difftool: \
`$ git pr show -t 32657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32657.diff">https://git.openjdk.org/jdk/pull/32657.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32657#issuecomment-5513125454)
</details>
