### PR TITLE
8391683: Gtest failure with markWord is_unlocked

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -132,7 +132,7 @@ TEST_VM(os, test_print_markword) {
     markWord m0 = vmClasses::Byte_klass()->prototype_header();
     const struct { markWord mw; const char* expected; } patterns[] = {
       { markWord(0), "is null"},
-      { m0, "mark(is_unlocked no_hash age=0) java.lang.Byte" },
+      { m0, "mark(is_lock_neutral no_hash age=0) java.lang.Byte" },
       { m0.set_age(2), "age=2" },
       { m0.copy_set_hash(0x12345), "is an unknown value" }
     };
@@ -167,7 +167,7 @@ TEST_VM(os, test_print_location) {
   {
     // wizard mode off, so don't print markword
     MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_unlocked no_hash", WizardMode);
+    assert_test_pattern(obj, "is_lock_neutral no_hash", WizardMode);
   }
 
   // WizardMode (not available in release mode) prints details
@@ -182,20 +182,20 @@ TEST_VM(os, test_print_location) {
     MutexLocker lock(ClassLoaderDataGraph_lock);
     ObjectLocker ol(h_obj, THREAD);
     assert_test_pattern(obj, "locked");
-    assert_test_pattern(obj, "is_unlocked", false);
+    assert_test_pattern(obj, "is_lock_neutral", false);
   }
 
   // Unlocked again
   {
     MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_unlocked");
+    assert_test_pattern(obj, "is_lock_neutral");
   }
 
   // Hash the object then print it.
   {
     intx hash = h_obj->identity_hash();
     MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_unlocked hash=");
+    assert_test_pattern(obj, "is_lock_neutral hash=");
   }
 }
 


### PR DESCRIPTION
Looks like the markWord printing function was changed missing this test.
Ran gtests again without failure.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391683](https://bugs.openjdk.org/browse/JDK-8391683): Gtest failure with markWord is_unlocked (**Bug** - P2)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32658/head:pull/32658` \
`$ git checkout pull/32658`

Update a local copy of the PR: \
`$ git checkout pull/32658` \
`$ git pull https://git.openjdk.org/jdk.git pull/32658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32658`

View PR using the GUI difftool: \
`$ git pr show -t 32658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32658.diff">https://git.openjdk.org/jdk/pull/32658.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32658#issuecomment-5513831028)
</details>
