### PR TITLE
8391694: [BACKOUT] fixes for JDK-8391683, JDK-8391683, and JDK-8380425

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1345,7 +1345,7 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
     static constexpr uintptr_t valhalla_reserved_bits_in_place = right_n_bits(markWord::valhalla_reserved_bits)
                                                                     << markWord::valhalla_reserved_shift;
     static constexpr uintptr_t markbits_must_be_zero = valhalla_reserved_bits_in_place | markWord::self_fwd_bit_in_place;
-    if ((!mw.has_hash()) && (mw.value() & markbits_must_be_zero) == 0 && Klass::is_valid(mw.klass_without_asserts())) {
+    if (mw.has_no_hash() && (mw.value() & markbits_must_be_zero) == 0 && Klass::is_valid(mw.klass_without_asserts())) {
       st->print(PTR_FORMAT " looks like a valid markword: ", p2i(addr));
       mw.print_on(st);
       st->print(" ");

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1339,21 +1339,8 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
   }
 
   // Compressed klass needs to be decoded first.
+  // Todo: questionable for COH - can we do this better?
 #ifdef _LP64
-  if (UseCompactObjectHeaders) {
-    markWord mw = (markWord)(uintptr_t)(addr);
-    static constexpr uintptr_t valhalla_reserved_bits_in_place = right_n_bits(markWord::valhalla_reserved_bits)
-                                                                    << markWord::valhalla_reserved_shift;
-    static constexpr uintptr_t markbits_must_be_zero = valhalla_reserved_bits_in_place | markWord::self_fwd_bit_in_place;
-    if (mw.has_no_hash() && (mw.value() & markbits_must_be_zero) == 0 && Klass::is_valid(mw.klass_without_asserts())) {
-      st->print(PTR_FORMAT " looks like a valid markword: ", p2i(addr));
-      mw.print_on(st);
-      st->print(" ");
-      mw.klass()->print_on(st);
-      return;
-    }
-  }
-
   if (((uintptr_t)addr &~ (uintptr_t)max_juint) == 0) {
     narrowKlass narrow_klass = (narrowKlass)(uintptr_t)addr;
     Klass* k = CompressedKlassPointers::decode_without_asserts(narrow_klass);

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -29,7 +29,6 @@
 #include "runtime/thread.hpp"
 #include "runtime/threads.hpp"
 #include "testutils.hpp"
-#include "threadHelper.inline.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
@@ -121,81 +120,6 @@ TEST_VM(os, page_size_for_region_unaligned) {
     size_t small_page = os::page_sizes().smallest();
     size_t actual = os::page_size_for_region_unaligned(small_page - 17, 1);
     ASSERT_EQ(small_page, actual);
-  }
-}
-
-TEST_VM(os, test_print_markword) {
-#ifdef _LP64
-  if (UseCompactObjectHeaders) {
-    JavaThread* THREAD = JavaThread::current();
-    ThreadInVMfromNative invm(THREAD);
-    markWord m0 = vmClasses::Byte_klass()->prototype_header();
-    const struct { markWord mw; const char* expected; } patterns[] = {
-      { markWord(0), "is null"},
-      { m0, "mark(is_unlocked no_hash age=0) java.lang.Byte" },
-      { m0.set_age(2), "age=2" },
-      { m0.copy_set_hash(0x12345), "is an unknown value" }
-    };
-    constexpr int nmark = sizeof(patterns) / sizeof(patterns[0]);
-    for (int i = 0; i < nmark; i++) {
-      stringStream st;
-      MutexLocker lock(ClassLoaderDataGraph_lock);
-      os::print_location(&st, (intptr_t) patterns[i].mw.to_pointer(), true);
-      ASSERT_THAT(st.base(), testing::HasSubstr(patterns[i].expected));
-    }
-  }
-#endif
-}
-
-static void assert_test_pattern(oop& obj, const char* pattern, bool is_present=true) {
-  stringStream st;
-  os::print_location(&st, p2i(obj), true);
-  if (is_present) {
-    ASSERT_THAT(st.base(), testing::HasSubstr(pattern));
-  } else {
-    ASSERT_THAT(st.base(), testing::Not(testing::HasSubstr(pattern)));
-  }
-}
-
-TEST_VM(os, test_print_location) {
-
-  JavaThread* THREAD = JavaThread::current();
-  ThreadInVMfromNative invm(THREAD);
-
-  oop obj = vmClasses::Byte_klass()->allocate_instance(THREAD);
-
-  {
-    // wizard mode off, so don't print markword
-    MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_unlocked no_hash", WizardMode);
-  }
-
-  // WizardMode (not available in release mode) prints details
-#ifndef PRODUCT
-  FlagSetting fs(WizardMode, true);
- #endif
-  HandleMark hm(THREAD);
-  Handle h_obj(THREAD, obj);
-
-  // Thread tries to lock it.
-  {
-    MutexLocker lock(ClassLoaderDataGraph_lock);
-    ObjectLocker ol(h_obj, THREAD);
-    assert_test_pattern(obj, "locked");
-    assert_test_pattern(obj, "is_unlocked", false);
-  }
-
-  // Unlocked again
-  {
-    MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_unlocked");
-  }
-
-  // Hash the object then print it.
-  {
-    intx hash = h_obj->identity_hash();
-    MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_unlocked hash=");
   }
 }
 

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -132,7 +132,7 @@ TEST_VM(os, test_print_markword) {
     markWord m0 = vmClasses::Byte_klass()->prototype_header();
     const struct { markWord mw; const char* expected; } patterns[] = {
       { markWord(0), "is null"},
-      { m0, "mark(is_lock_neutral no_hash age=0) java.lang.Byte" },
+      { m0, "mark(is_unlocked no_hash age=0) java.lang.Byte" },
       { m0.set_age(2), "age=2" },
       { m0.copy_set_hash(0x12345), "is an unknown value" }
     };
@@ -167,7 +167,7 @@ TEST_VM(os, test_print_location) {
   {
     // wizard mode off, so don't print markword
     MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_lock_neutral no_hash", WizardMode);
+    assert_test_pattern(obj, "is_unlocked no_hash", WizardMode);
   }
 
   // WizardMode (not available in release mode) prints details
@@ -182,20 +182,20 @@ TEST_VM(os, test_print_location) {
     MutexLocker lock(ClassLoaderDataGraph_lock);
     ObjectLocker ol(h_obj, THREAD);
     assert_test_pattern(obj, "locked");
-    assert_test_pattern(obj, "is_lock_neutral", false);
+    assert_test_pattern(obj, "is_unlocked", false);
   }
 
   // Unlocked again
   {
     MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_lock_neutral");
+    assert_test_pattern(obj, "is_unlocked");
   }
 
   // Hash the object then print it.
   {
     intx hash = h_obj->identity_hash();
     MutexLocker lock(ClassLoaderDataGraph_lock);
-    assert_test_pattern(obj, "is_lock_neutral hash=");
+    assert_test_pattern(obj, "is_unlocked hash=");
   }
 }
 


### PR DESCRIPTION
In order to remove build and test breakage in the JDK28 CI, I'm backing out:

[JDK-8391683](https://bugs.openjdk.org/browse/JDK-8391683) Gtest failure with markWord is_unlocked
[JDK-8391667](https://bugs.openjdk.org/browse/JDK-8391667) Fix for removed has_no_hash() method
[JDK-8380425](https://bugs.openjdk.org/browse/JDK-8380425) os::print_location should handle markword printing with COH

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391694](https://bugs.openjdk.org/browse/JDK-8391694): [BACKOUT] fixes for JDK-8391683, JDK-8391683, and JDK-8380425 (**Bug** - P1)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32662/head:pull/32662` \
`$ git checkout pull/32662`

Update a local copy of the PR: \
`$ git checkout pull/32662` \
`$ git pull https://git.openjdk.org/jdk.git pull/32662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32662`

View PR using the GUI difftool: \
`$ git pr show -t 32662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32662.diff">https://git.openjdk.org/jdk/pull/32662.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32662#issuecomment-5515947388)
</details>
