### PR TITLE
8391678: Correct encoding wording and destination bound in MemorySegment.copy(String, Charset, int,  MemorySegment, long,  int)

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1389,9 +1389,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * null-terminated byte sequence using the provided charset.
      * <p>
      * This method always replaces malformed-input and unmappable-character
-     * sequences with this charset's default replacement string. The {@link
-     * java.nio.charset.CharsetDecoder} class should be used when more control
-     * over the decoding process is required.
+     * sequences with this charset's default replacement byte array. The {@link
+     * java.nio.charset.CharsetEncoder} class should be used when more control
+     * over the encoding process is required.
      * <p>
      * If the given string contains any {@code '\0'} characters, they will be
      * copied as well. This means that, depending on the method used to read
@@ -2647,9 +2647,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * to the destination segment.
      * <p>
      * This method always replaces malformed-input and unmappable-character
-     * sequences with this charset's default replacement string. The {@link
-     * java.nio.charset.CharsetDecoder} class should be used when more control
-     * over the decoding process is required.
+     * sequences with this charset's default replacement byte array. The {@link
+     * java.nio.charset.CharsetEncoder} class should be used when more control
+     * over the encoding process is required.
      * <p>
      * If the given string contains any {@code '\0'} characters, they will be
      * copied as well. This means that, depending on the method used to read
@@ -2659,7 +2659,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *
      * @param src      the Java string to be written into the destination segment
      * @param dstEncoding the charset used to {@linkplain Charset#newEncoder() encode}
-     *                 the string bytes.
+     *                 the string bytes
      * @param srcIndex the starting character index of the source string
      * @param dst      the destination segment
      * @param dstOffset the starting offset, in bytes, of the destination segment
@@ -2672,9 +2672,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         are {@code < 0}
      * @throws IndexOutOfBoundsException if {@code srcIndex > src.length() - numChars}
      * @throws IllegalArgumentException if {@code dst} is {@linkplain #isReadOnly() read-only}
-     * @throws IndexOutOfBoundsException if {@code dstOffset > dstSegment.byteSize() - B} where {@code B} is the size,
-     *         in bytes, of the substring of {@code src} encoded using the given charset
-     * @return the number of copied bytes.
+     * @throws IndexOutOfBoundsException if {@code dstOffset > dst.byteSize() - B} where {@code B} is the size,
+     *         in bytes, of {@code src.substring(srcIndex, srcIndex + numChars)} encoded using the given charset
+     * @return the number of copied bytes
      * @since 27
      */
     @ForceInline

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -174,7 +174,7 @@ public interface SegmentAllocator {
      *                 string bytes
      * @param srcIndex the starting index of the source string
      * @param numChars the number of characters to be copied
-     * @return a segment containing the encoded string
+     * @return a new native segment containing the encoded string
      * @throws IndexOutOfBoundsException if either {@code srcIndex} or {@code numChars} are {@code < 0}
      * @throws IndexOutOfBoundsException if {@code srcIndex > str.length() - numChars}
      *

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -174,15 +174,14 @@ public interface SegmentAllocator {
      *                 string bytes
      * @param srcIndex the starting index of the source string
      * @param numChars the number of characters to be copied
-     * @return a new native segment containing the encoded string
+     * @return a segment containing the encoded string
      * @throws IndexOutOfBoundsException if either {@code srcIndex} or {@code numChars} are {@code < 0}
      * @throws IndexOutOfBoundsException if {@code srcIndex > str.length() - numChars}
      *
      * @implSpec The default implementation for this method copies the contents of the
      *           provided Java string into a new memory segment obtained by calling
      *           {@code this.allocate(B)}, where {@code B} is the size, in bytes, of
-     *           the string encoded using the provided charset
-     *           (e.g. {@code str.getBytes(charset).length});
+     *           {@code str.substring(srcIndex, srcIndex + numChars)} encoded using the provided charset.
      * @since 27
      */
     @ForceInline


### PR DESCRIPTION
This change fixes some inaccuracies in the javadoc for methods introduced in [JDK-8369564](https://bugs.openjdk.org/browse/JDK-8369564).

In addition to the issues reported in [JDK-8391678](https://bugs.openjdk.org/browse/JDK-8391678) I took a pass over the rest of the javadoc introduced in [JDK-8369564](https://bugs.openjdk.org/browse/JDK-8369564) and fixed a related issue in `SegmentAllocator.allocateFrom`.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8391678](https://bugs.openjdk.org/browse/JDK-8391678): Correct encoding wording and destination bound in MemorySegment.copy(String, Charset, int,  MemorySegment, long,  int) (**Bug** - P3)
 * [JDK-8391689](https://bugs.openjdk.org/browse/JDK-8391689): Specify selected-range encoding and allocator-neutral results for SegmentAllocator.allocateFrom(String, Charset, int, int) (**Bug** - P3)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32663/head:pull/32663` \
`$ git checkout pull/32663`

Update a local copy of the PR: \
`$ git checkout pull/32663` \
`$ git pull https://git.openjdk.org/jdk.git pull/32663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32663`

View PR using the GUI difftool: \
`$ git pr show -t 32663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32663.diff">https://git.openjdk.org/jdk/pull/32663.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32663#issuecomment-5516381287)
</details>
