### PR TITLE
8391707: JFR: Underscoped SerializerRegistrationGuard

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeManager.cpp
@@ -219,11 +219,11 @@ static bool register_static_type(JfrTypeId id, bool permit_cache, JfrSerializer*
     delete serializer;
     return false;
   }
+  SerializerRegistrationGuard guard;
   if (JfrRecorder::is_recording()) {
     JfrCheckpointWriter writer(Thread::current(), true, STATICS, JFR_THREADLOCAL);
     registration->invoke(writer);
   }
-  SerializerRegistrationGuard guard;
   assert(!types.in_list(registration), "invariant");
   DEBUG_ONLY(assert_not_registered_twice(id, types);)
   types.add(registration);


### PR DESCRIPTION
Greetings,

In [JDK-8389756](https://bugs.openjdk.org/browse/JDK-8389756), I moved SerializerRegistrationGuard into register_static_type(), but placed it after the immediate serialization, unintentionally narrowing its original scope. A serializer-list traversal can therefore occur between serialization and registration, miss the serializer, and leave the new chunk without its constants.

Hoist the guard to make immediate serialization and registration indivisible with respect to list traversal.

```
+SerializerRegistrationGuard guard;
   if (JfrRecorder::is_recording()) {
     JfrCheckpointWriter writer(Thread::current(), true, STATICS, JFR_THREADLOCAL);
     registration->invoke(writer);
   }
-SerializerRegistrationGuard guard;
   types.add(registration);
```

Testing: jdk_jfr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391707](https://bugs.openjdk.org/browse/JDK-8391707): JFR: Underscoped SerializerRegistrationGuard (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32665/head:pull/32665` \
`$ git checkout pull/32665`

Update a local copy of the PR: \
`$ git checkout pull/32665` \
`$ git pull https://git.openjdk.org/jdk.git pull/32665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32665`

View PR using the GUI difftool: \
`$ git pr show -t 32665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32665.diff">https://git.openjdk.org/jdk/pull/32665.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32665#issuecomment-5516903203)
</details>
