### PR TITLE
8391600: [TESTBUG] Improve runtime/cds/TestDefaultArchiveLoading.java to check --enable-preview from test.vm.opts

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -82,6 +82,7 @@ import java.nio.file.Paths;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Utils;
 
 import jtreg.SkippedException;
 
@@ -112,9 +113,11 @@ public class TestDefaultArchiveLoading {
 
         String archiveSuffix;
         char coh, coops;
-        String preview = System.getProperty("test.java.opts", "");
-        if (preview.contains("--enable-preview")) {
-            archivePreviewSuffix = "_preview";
+        for (String opt : Utils.getTestJavaOpts()) {
+            if (opt.contains("--enable-preview")) {
+                archivePreviewSuffix = "_preview";
+                break;
+            }
         }
 
         switch (args[0]) {


### PR DESCRIPTION
Issue: currently this test uses System.getProperty("test.java.opts") to decide whether the default CDS archive is the _preview variant. jtreg -javaoptions (make test JTREG="JAVA_OPTIONS=...") goes into "test.java.opts". However, jtreg -vmoption
(make test JTREG="VM_OPTIONS=...") goes into "test.vm.opts". As a result, with --enable-preview only in VM_OPTIONS, the VM would load classes_preview.jsa, however, the test still expects classes.jsa.

Solution: Use Utils.getTestJavaOpts() to check both properties.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391600](https://bugs.openjdk.org/browse/JDK-8391600): [TESTBUG] Improve runtime/cds/TestDefaultArchiveLoading.java to check --enable-preview from test.vm.opts (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32667/head:pull/32667` \
`$ git checkout pull/32667`

Update a local copy of the PR: \
`$ git checkout pull/32667` \
`$ git pull https://git.openjdk.org/jdk.git pull/32667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32667`

View PR using the GUI difftool: \
`$ git pr show -t 32667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32667.diff">https://git.openjdk.org/jdk/pull/32667.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32667#issuecomment-5520080281)
</details>
