### PR TITLE
8391599: Remove runtime/cds/appcds/aotCode/AOTCodeFlags.java from problem list

### DIFF
--- a/test/hotspot/jtreg/ProblemList-enable-preview.txt
+++ b/test/hotspot/jtreg/ProblemList-enable-preview.txt
@@ -38,6 +38,3 @@
 # Compiler:
 
 # Runtime:
-runtime/cds/appcds/aotCode/AOTCodeFlags.java#default_gc 8382398 generic-all
-runtime/cds/appcds/aotCode/AOTCodeFlags.java#parallel   8382398 generic-all
-runtime/cds/appcds/aotCode/AOTCodeFlags.java#Z          8382398 generic-all


### PR DESCRIPTION
This issue was fixed by JDK-8381932, which is duplicate of JDK-8382398.

Test: this test can pass on both Linux/AArch64 and Linux/x86_64 now.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391599](https://bugs.openjdk.org/browse/JDK-8391599): Remove runtime/cds/appcds/aotCode/AOTCodeFlags.java from problem list (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32668/head:pull/32668` \
`$ git checkout pull/32668`

Update a local copy of the PR: \
`$ git checkout pull/32668` \
`$ git pull https://git.openjdk.org/jdk.git pull/32668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32668`

View PR using the GUI difftool: \
`$ git pr show -t 32668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32668.diff">https://git.openjdk.org/jdk/pull/32668.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32668#issuecomment-5520738330)
</details>
