### PR TITLE
8390511: [Valhalla] Problems with array access using VarHandle

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2474,6 +2474,25 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
   // Save state and restore on bailout
   SavedState old_state(this);
 
+  if (const TypeAryPtr* base_ary_type = _gvn.type(base)->isa_aryptr(); type == T_OBJECT && base_ary_type != nullptr) {
+    // Read an object from a primitive array, or a Phi some of whose inputs are primitive arrays
+    if (base_ary_type->elem()->make_ptr() == nullptr) {
+      return false;
+    }
+
+    // Must not be a flat array
+    if (base_ary_type->is_flat()) {
+      return false;
+    }
+
+    // Refine the base so alias analysis can work properly
+    Node* refined_base = must_be_not_null(base, false);
+    base_ary_type = base_ary_type->cast_to_not_flat();
+    refined_base = _gvn.transform(new CheckCastPPNode(control(), base, base_ary_type, ConstraintCastNode::DependencyType::NonFloatingNarrowing));
+    replace_in_map(base, refined_base);
+    base = refined_base;
+  }
+
   Node* adr = make_unsafe_address(base, offset, type, kind == Relaxed);
   assert(!stopped(), "Inlining of unsafe access failed: address construction stopped unexpectedly");
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayVarHandleDifferentLayouts.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayVarHandleDifferentLayouts.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.valhalla.inlinetypes;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import jdk.internal.value.ValueClass;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8370914
+ * @summary Test VarHandle access on an array that is a merged of different layouts.
+ * @library /test/lib /
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileThreshold=1 ${test.main.class}
+ */
+public class TestArrayVarHandleDifferentLayouts {
+    private static final int INDEX = 8;
+    private static final VarHandle HANDLE = MethodHandles.arrayElementVarHandle(Integer[].class);
+    private static final Integer[] FLAT = new Integer[64];
+    private static final Integer[] REFERENCE = (Integer[]) ValueClass.newReferenceArray(Integer.class, 64);
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            testGet((i & 1) == 0);
+        }
+    }
+
+    static Integer testGet(boolean useFlat) {
+        Integer[] array = useFlat ? FLAT : REFERENCE;
+        return (Integer)HANDLE.getVolatile(array, INDEX);
+    }
+}


### PR DESCRIPTION
Hi,

This PR fixes an issue with `VarHandle` access on a non-exactly typed array. Previously, there was a single alias class for all non-primitive arrays, so the type of the array could be whatever. However, since the introduction of Valhalla, arrays in address computation need to be strictly typed, or else all kinds of weird issues can happen. `Unsafe` access is one case where we miss it. In general, `VarHandle::getVolatile` can only access non-flat arrays, this calls `Unsafe::getReferenceVolatile`, which also can only access non-flat arrays. As a result, in `LibraryCallKit::inline_unsafe_access`, we need to cast the array to `not_flat`.

The reason why this issue manifests itself as a `monotonicity violation` is due to [JDK-8358079](https://bugs.openjdk.org/browse/JDK-8358079).

Testing:

- [x] tier1-4,hs-comp-stress,valhalla-comp-stress

Please take a look and leave your reviews, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390511](https://bugs.openjdk.org/browse/JDK-8390511): [Valhalla] Problems with array access using VarHandle (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32669/head:pull/32669` \
`$ git checkout pull/32669`

Update a local copy of the PR: \
`$ git checkout pull/32669` \
`$ git pull https://git.openjdk.org/jdk.git pull/32669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32669`

View PR using the GUI difftool: \
`$ git pr show -t 32669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32669.diff">https://git.openjdk.org/jdk/pull/32669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32669#issuecomment-5520864162)
</details>
