### PR TITLE
8223933: Stream.distinct() on sorted streams must respect Object.equals

### DIFF
--- a/src/java.base/share/classes/java/util/stream/DistinctOps.java
+++ b/src/java.base/share/classes/java/util/stream/DistinctOps.java
@@ -122,14 +122,21 @@ final class DistinctOps {
                 if (StreamOpFlag.DISTINCT.isKnown(flags)) {
                     return sink;
                 } else if (StreamOpFlag.SORTED.isKnown(flags)) {
+                    // Keep lastSeen as a fast path for the common case where equal
+                    // elements are adjacent after sorting, and also track all emitted
+                    // elements in a set so duplicates are still removed when
+                    // compareTo is inconsistent with equals (including when equal
+                    // elements are not in the same sort group).
                     return new Sink.ChainedReference<>(sink) {
                         boolean seenNull;
                         T lastSeen;
+                        Set<T> seen;
 
                         @Override
                         public void begin(long size) {
                             seenNull = false;
                             lastSeen = null;
+                            seen = new HashSet<>();
                             downstream.begin(-1);
                         }
 
@@ -137,6 +144,7 @@ final class DistinctOps {
                         public void end() {
                             seenNull = false;
                             lastSeen = null;
+                            seen = null;
                             downstream.end();
                         }
 
@@ -145,10 +153,15 @@ final class DistinctOps {
                             if (t == null) {
                                 if (!seenNull) {
                                     seenNull = true;
-                                    downstream.accept(lastSeen = null);
+                                    lastSeen = null;
+                                    seen.add(null);
+                                    downstream.accept(null);
                                 }
-                            } else if (lastSeen == null || !t.equals(lastSeen)) {
-                                downstream.accept(lastSeen = t);
+                            } else if (lastSeen != null && t.equals(lastSeen)) {
+                                // Consecutive duplicate — common after a consistent sort
+                            } else if (seen.add(t)) {
+                                lastSeen = t;
+                                downstream.accept(t);
                             }
                         }
                     };

--- a/test/jdk/java/util/stream/SortedDistinctTest.java
+++ b/test/jdk/java/util/stream/SortedDistinctTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/*
+ * @test
+ * @bug 8223933
+ * @summary Stream.distinct() on sorted streams must use Object.equals
+ */
+public class SortedDistinctTest {
+
+    /**
+     * compareTo uses x; equals uses x and y (weaker ordering than equality).
+     * Equal duplicates can be split by another element with the same sort key.
+     */
+    static final class Element implements Comparable<Element> {
+        private final int x;
+        private final int y;
+
+        Element(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Element element = (Element) o;
+            return x == element.x && y == element.y;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(x, y);
+        }
+
+        @Override
+        public int compareTo(Element o) {
+            return Integer.compare(x, o.x);
+        }
+
+        @Override
+        public String toString() {
+            return "Element{x=" + x + ", y=" + y + "}";
+        }
+    }
+
+    /**
+     * compareTo uses x; equals uses only y (unrelated fields).
+     * Equal duplicates can appear in different sort groups.
+     */
+    static final class ByYEquals implements Comparable<ByYEquals> {
+        private final int x;
+        private final int y;
+
+        ByYEquals(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return y == ((ByYEquals) o).y;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(y);
+        }
+
+        @Override
+        public int compareTo(ByYEquals o) {
+            return Integer.compare(x, o.x);
+        }
+
+        @Override
+        public String toString() {
+            return "ByYEquals{x=" + x + ", y=" + y + "}";
+        }
+    }
+
+    public static void main(String[] args) {
+        testSameSortGroupDuplicates();
+        testDifferentSortGroupDuplicates();
+    }
+
+    private static void testSameSortGroupDuplicates() {
+        Element element1 = new Element(1, 1);
+        Element element2 = new Element(1, 2);
+        Element element3 = new Element(2, 1);
+        Element element4 = new Element(2, 2);
+        Element element5 = new Element(2, 1);
+
+        List<Element> result = Stream.of(element1, element2, element3, element4, element5)
+                .sorted()
+                .distinct()
+                .collect(Collectors.toList());
+
+        assertNoEqualsDuplicates(result, 4);
+    }
+
+    private static void testDifferentSortGroupDuplicates() {
+        // After sorted() by x: (1,5), (2,7), (3,5) — last two non-adjacent equals by y
+        List<ByYEquals> result = Stream.of(
+                        new ByYEquals(1, 5),
+                        new ByYEquals(2, 7),
+                        new ByYEquals(3, 5))
+                .sorted()
+                .distinct()
+                .collect(Collectors.toList());
+
+        assertNoEqualsDuplicates(result, 2);
+    }
+
+    private static <T> void assertNoEqualsDuplicates(List<T> result, int expectedSize) {
+        if (result.size() != expectedSize) {
+            throw new RuntimeException(
+                    "Expected " + expectedSize + " distinct elements, got "
+                            + result.size() + ": " + result);
+        }
+        Set<T> distinctSet = new HashSet<>(result);
+        if (distinctSet.size() != result.size()) {
+            throw new RuntimeException("Duplicate elements in result: " + result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

[`JDK-8223933`](https://bugs.openjdk.org/browse/JDK-8223933)

`Stream.distinct()` must remove duplicates according to `Object.equals`. On sorted streams it only compared each element to the previous one, which fails when `compareTo` is inconsistent with `equals`, so duplicates can still be emitted.

## Fix
Keep the sorted-path consecutive check, and also track emitted elements in a `HashSet` so uniqueness always follows `equals`. Add a regression test for the reported case and for equals-duplicates in different sort groups.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8223933](https://bugs.openjdk.org/browse/JDK-8223933)

### Issue
 * [JDK-8223933](https://bugs.openjdk.org/browse/JDK-8223933): Stream.distinct() sometimes allows duplicates when the stream is sorted (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32670/head:pull/32670` \
`$ git checkout pull/32670`

Update a local copy of the PR: \
`$ git checkout pull/32670` \
`$ git pull https://git.openjdk.org/jdk.git pull/32670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32670`

View PR using the GUI difftool: \
`$ git pr show -t 32670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32670.diff">https://git.openjdk.org/jdk/pull/32670.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32670#issuecomment-5522000204)
</details>
