### PR TITLE
8391717: [VectorAPI] Assertion error in Float16 FMA kernel with -XX:-UseFMA

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3055,13 +3055,18 @@ bool Matcher::match_rule_supported(int opcode) {
       }  // fallthrough
     case Op_AddHF:
     case Op_DivHF:
-    case Op_FmaHF:
     case Op_MulHF:
     case Op_ReinterpretS2HF:
     case Op_ReinterpretHF2S:
     case Op_SubHF:
     case Op_SqrtHF:
       if (!VM_Version::supports_avx512_fp16()) {
+        return false;
+      }
+      break;
+    case Op_FmaHF:
+      // UseFMA also needs to be checked along with AVX512-FP16.
+      if (!UseFMA || !VM_Version::supports_avx512_fp16()) {
         return false;
       }
       break;
@@ -3178,6 +3183,7 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_FmaD:
     case Op_FmaVD:
     case Op_FmaVF:
+    case Op_FmaVHF:
       if (!UseFMA) {
         return false;
       }
@@ -25249,6 +25255,7 @@ instruct scalar_fma_HF_reg(regF dst, regF src1, regF src2)
   match(Set dst (FmaHF dst (Binary src1 src2)));
   format %{ "scalar_fma_fp16 $dst, $src1, $src2\t# $dst = $src1 * $src2 + $dst fma packedH" %}
   ins_encode %{
+    assert(UseFMA, "Needs FMA instructions support.");
     __ vfmadd231sh($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
@@ -25315,6 +25322,7 @@ instruct vector_fma_HF_reg(vec dst, vec src1, vec src2)
   match(Set dst (FmaVHF dst (Binary src1 src2)));
   format %{ "vector_fma_fp16 $dst, $src1, $src2\t# $dst = $src1 * $src2 + $dst fma packedH" %}
   ins_encode %{
+    assert(UseFMA, "Needs FMA instructions support.");
     int vlen_enc = vector_length_encoding(this);
     __ evfmadd231ph($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
   %}
@@ -25327,6 +25335,7 @@ instruct vector_fma_HF_mem(vec dst, vec src1, memory src2)
   match(Set dst (FmaVHF dst (Binary src1 (VectorReinterpret (LoadVector src2)))));
   format %{ "vector_fma_fp16_mem $dst, $src1, $src2\t# $dst = $src1 * $src2 + $dst fma packedH" %}
   ins_encode %{
+    assert(UseFMA, "Needs FMA instructions support.");
     int vlen_enc = vector_length_encoding(this);
     __ evfmadd231ph($dst$$XMMRegister, $src1$$XMMRegister, $src2$$Address, vlen_enc);
   %}

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFloat16ScalarOperations.java
@@ -24,7 +24,7 @@
 
 /**
 * @test
-* @bug 8308363 8336406 8381617
+* @bug 8308363 8336406 8381617 8391717
 * @summary Validate compiler IR for various Float16 scalar operations.
 * @modules jdk.incubator.vector
 * @requires vm.compiler2.enabled
@@ -99,6 +99,7 @@ public class TestFloat16ScalarOperations {
 
     public static void main(String args[]) {
         new TestFramework().addFlags("--add-modules=jdk.incubator.vector").start();
+        new TestFramework().addFlags("--add-modules=jdk.incubator.vector", "-XX:-UseFMA").start();
     }
 
     public TestFloat16ScalarOperations() {
@@ -287,9 +288,13 @@ public class TestFloat16ScalarOperations {
 
     @Test
     @IR(counts = {IRNode.FMA_HF, " >0 ", IRNode.REINTERPRET_S2HF, " >0 ", IRNode.REINTERPRET_HF2S, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})
     @IR(counts = {IRNode.FMA_HF, " >0 ", IRNode.REINTERPRET_S2HF, " >0 ", IRNode.REINTERPRET_HF2S, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
+    @IR(failOn = {IRNode.FMA_HF},
+        applyIf = {"UseFMA", "false"})
     public void testFma() {
         Float16 res = shortBitsToFloat16((short)0);
         for (int i = 0; i < count; i++) {
@@ -799,9 +804,21 @@ public class TestFloat16ScalarOperations {
     @Test
     @IR(counts = {IRNode.ADD_HF, " >0 ", IRNode.SUB_HF, " >0 ", IRNode.MUL_HF, " >0 ",
                   IRNode.DIV_HF, " >0 ", IRNode.SQRT_HF, " >0 ", IRNode.FMA_HF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})
     @IR(counts = {IRNode.ADD_HF, " >0 ", IRNode.SUB_HF, " >0 ", IRNode.MUL_HF, " >0 ",
                   IRNode.DIV_HF, " >0 ", IRNode.SQRT_HF, " >0 ", IRNode.FMA_HF, " >0 "},
+        applyIf = {"UseFMA", "true"},
+        applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
+    @IR(counts = {IRNode.ADD_HF, " >0 ", IRNode.SUB_HF, " >0 ", IRNode.MUL_HF, " >0 ",
+                  IRNode.DIV_HF, " >0 ", IRNode.SQRT_HF, " >0 "},
+        failOn = {IRNode.FMA_HF},
+        applyIf = {"UseFMA", "false"},
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "zfh", "true"})
+    @IR(counts = {IRNode.ADD_HF, " >0 ", IRNode.SUB_HF, " >0 ", IRNode.MUL_HF, " >0 ",
+                  IRNode.DIV_HF, " >0 ", IRNode.SQRT_HF, " >0 "},
+        failOn = {IRNode.FMA_HF},
+        applyIf = {"UseFMA", "false"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     @Warmup(10000)
     public void testRounding2() {

--- a/test/hotspot/jtreg/compiler/vectorapi/TestFloat16VectorFMAAccumSpill.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestFloat16VectorFMAAccumSpill.java
@@ -23,7 +23,7 @@
 
 /**
 * @test
-* @bug 8387213
+* @bug 8387213 8391717
 * @summary Float16Vector.fma must accumulate in-place (231-form) so a register
 *          blocked FMA reduction does not spill accumulators to the stack.
 * @modules jdk.incubator.vector
@@ -81,9 +81,11 @@ public class TestFloat16VectorFMAAccumSpill {
     // reintroduces the accumulator-preserving copies/spills and fails this test.
     @Test
     @IR(counts = {IRNode.FMA_VHF, ">0"},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeature = {"avx512_fp16", "true"})
     @IR(failOn = {IRNode.MEM_TO_REG_SPILL_COPY_TYPE, "vector[xyz]"},
         phase = {CompilePhase.FINAL_CODE},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeature = {"avx512_fp16", "true"})
     void fmaAccum() {
         Float16Vector c00 = (Float16Vector) SPECIES.zero();

--- a/test/hotspot/jtreg/compiler/vectorapi/TestFloat16VectorOperations.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestFloat16VectorOperations.java
@@ -23,7 +23,7 @@
 
 /**
 * @test
-* @bug 8370691
+* @bug 8370691 8391717
 * @summary Test intrinsification of Float16Vector operations
 * @modules jdk.incubator.vector
 * @library /test/lib /
@@ -61,6 +61,9 @@ public class TestFloat16VectorOperations {
         TestFramework.runWithFlags("--add-modules=jdk.incubator.vector", "-XX:MaxVectorSize=16");
         TestFramework.runWithFlags("--add-modules=jdk.incubator.vector", "-XX:MaxVectorSize=32");
         TestFramework.runWithFlags("--add-modules=jdk.incubator.vector", "-XX:MaxVectorSize=64");
+
+        // Test with FMA instructions disabled
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector", "-XX:-UseFMA");
     }
 
     static void assertResults(int arity, short ... values) {
@@ -299,8 +302,10 @@ public class TestFloat16VectorOperations {
 
     @Test
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     void vectorFmaFloat16() {
         int i = 0;
@@ -332,8 +337,10 @@ public class TestFloat16VectorOperations {
 
     @Test
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     void vectorFmaFloat16ScalarMixedConstants() {
         int i = 0;
@@ -366,8 +373,10 @@ public class TestFloat16VectorOperations {
 
     @Test
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     void vectorFmaFloat16MixedConstants() {
         short input3 = floatToFloat16(3.0f);
@@ -401,8 +410,10 @@ public class TestFloat16VectorOperations {
 
     @Test
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true", "sve", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     void vectorFmaFloat16AllConstants() {
         short input1 = floatToFloat16(1.0f);

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOperations.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOperations.java
@@ -24,7 +24,7 @@
 
 /**
 * @test
-* @bug 8346236 8381617
+* @bug 8346236 8381617 8391717
 * @summary Auto-vectorization support for various Float16 operations
 * @modules jdk.incubator.vector
 * @library /test/lib /
@@ -238,8 +238,10 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorFmaFloat16() {
         for (int i = 0; i < LEN; ++i) {
@@ -260,8 +262,10 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorFmaFloat16ScalarMixedConstants() {
         for (int i = 0; i < LEN; ++i) {
@@ -283,8 +287,10 @@ public class TestFloat16VectorOperations {
     @Test
     @Warmup(50)
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "zvfh", "true"})
     @IR(counts = {IRNode.FMA_VHF, " >0 "},
+        applyIf = {"UseFMA", "true"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorFmaFloat16MixedConstants() {
         short input3 = floatToFloat16(3.0f);


### PR DESCRIPTION
Hi,

This bug fix patch rejects creation of Float16 FMA scalar and vector IR if UseFMA is set to false.
Patch also extended existing IR based tests around Float16 FMA IR to enforce rules only if UseFMA is true.

Kindly review and share your feedback.

Best Regards,
Jatin

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391717](https://bugs.openjdk.org/browse/JDK-8391717): [VectorAPI] Assertion error in Float16 FMA kernel with -XX:-UseFMA (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32671/head:pull/32671` \
`$ git checkout pull/32671`

Update a local copy of the PR: \
`$ git checkout pull/32671` \
`$ git pull https://git.openjdk.org/jdk.git pull/32671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32671`

View PR using the GUI difftool: \
`$ git pr show -t 32671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32671.diff">https://git.openjdk.org/jdk/pull/32671.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32671#issuecomment-5522004546)
</details>
