### PR TITLE
8391679: G1: Rename G1CSetCandidateGroup* to G1CardSetGroup*

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -498,7 +498,7 @@ void G1CardSet::release_and_must_free_container(ContainerPtr container) {
   free_mem_object(container);
 }
 
-class G1ReleaseCardsets : public StackObj {
+class G1ReleaseCardSets : public StackObj {
   G1CardSet* _card_set;
   using ContainerPtr = G1CardSet::ContainerPtr;
 
@@ -520,7 +520,7 @@ class G1ReleaseCardsets : public StackObj {
   }
 
 public:
-  explicit G1ReleaseCardsets(G1CardSet* card_set) : _card_set(card_set) { }
+  explicit G1ReleaseCardSets(G1CardSet* card_set) : _card_set(card_set) { }
 
   void operator ()(Atomic<ContainerPtr>* container_addr) {
     coarsen_to_full(container_addr);
@@ -650,7 +650,7 @@ bool G1CardSet::coarsen_container(Atomic<ContainerPtr>* container_addr,
     assert(!should_free, "must have had more than one reference");
     // Free containers if cur_container is ContainerHowl
     if (container_type(cur_container) == ContainerHowl) {
-      G1ReleaseCardsets rel(this);
+      G1ReleaseCardSets rel(this);
       container_ptr<G1CardSetHowl>(cur_container)->iterate(rel, _config->num_buckets_in_howl());
     }
     return true;

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -242,9 +242,9 @@ class G1CardSetHashTable : public CHeapObj<mtGCCardSet> {
   using CHTScanTask = CardSetHash::ScanTask;
 
   const static uint BucketClaimSize = 16;
-  // The claim size for group cardsets should be smaller to facilitate
-  // better work distribution. The group cardsets should be larger than
-  // the per region cardsets.
+  // The claim size for multi-region card set groups should be smaller to
+  // improve work distribution. The card set groups should contain more
+  // entries than the single-region card set groups.
   const static uint GroupBucketClaimSize = 4;
   // Did we insert at least one card in the table?
   Atomic<bool> _inserted_card;
@@ -782,8 +782,8 @@ G1AddCardResult G1CardSet::add_card(uintptr_t card) {
   {
     uint region_idx = card_region >> config()->log2_card_regions_per_heap_region();
     G1HeapRegion* r = G1CollectedHeap::heap()->region_at(region_idx);
-    assert(!r->rem_set()->has_cset_group() ||
-           r->rem_set()->cset_group()->card_set() != this, "Should not be sharing a cardset");
+    assert(!r->rem_set()->has_card_set_group() ||
+           r->rem_set()->card_set_group()->card_set() != this, "Should not be sharing a card set");
   }
 #endif
 

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -243,8 +243,8 @@ class G1CardSetHashTable : public CHeapObj<mtGCCardSet> {
 
   const static uint BucketClaimSize = 16;
   // The claim size for multi-region card set groups should be smaller to
-  // improve work distribution. The card set groups should contain more
-  // entries than the single-region card set groups.
+  // improve work distribution. The multi-region card set groups' card set
+  // should contain more entries than the single-region card set groups'.
   const static uint GroupBucketClaimSize = 4;
   // Did we insert at least one card in the table?
   Atomic<bool> _inserted_card;

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -82,7 +82,7 @@ public:
                          double cards_in_bitmap_threshold_percent,
                          uint max_buckets_in_howl,
                          double cards_in_howl_threshold_percent,
-                         uint max_cards_in_cardset,
+                         uint max_cards_in_card_set,
                          uint log2_card_region_per_region);
 
   ~G1CardSetConfiguration();
@@ -188,7 +188,7 @@ class G1CardSet : public CHeapObj<mtGCCardSet> {
   friend class G1CardSetMtTestTask;
   friend class G1CardSetTest;
   friend class G1CheckCardClosure;
-  friend class G1ReleaseCardsets;
+  friend class G1ReleaseCardSets;
   friend class G1TransferCard;
 
   // When splitting addresses into region and card within that region, the logical

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -264,7 +264,7 @@ private:
   // Iterates over the given ContainerPtr with at index in this Howl card set,
   // applying a CardOrRangeVisitor on it.
   template <class CardOrRangeVisitor>
-  void iterate_cardset(ContainerPtr const container, uint index, CardOrRangeVisitor& found, G1CardSetConfiguration* config);
+  void iterate_card_set(ContainerPtr const container, uint index, CardOrRangeVisitor& found, G1CardSetConfiguration* config);
 
   ContainerPtr at(EntryCountType index) const;
 

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -335,7 +335,7 @@ inline bool G1CardSetHowl::contains(uint card_idx, G1CardSetConfiguration* confi
 template <class CardOrRangeVisitor>
 inline void G1CardSetHowl::iterate(CardOrRangeVisitor& found, G1CardSetConfiguration* config) {
   for (uint i = 0; i < config->num_buckets_in_howl(); ++i) {
-    iterate_cardset(at(i), i, found, config);
+    iterate_card_set(at(i), i, found, config);
   }
 }
 
@@ -347,7 +347,7 @@ inline void G1CardSetHowl::iterate(ContainerPtrVisitor& found, uint num_card_set
 }
 
 template <class CardOrRangeVisitor>
-inline void G1CardSetHowl::iterate_cardset(ContainerPtr const container, uint index, CardOrRangeVisitor& found, G1CardSetConfiguration* config) {
+inline void G1CardSetHowl::iterate_card_set(ContainerPtr const container, uint index, CardOrRangeVisitor& found, G1CardSetConfiguration* config) {
   switch (G1CardSet::container_type(container)) {
     case G1CardSet::ContainerInlinePtr: {
       if (found.start_iterate(G1GCPhaseTimes::MergeRSHowlInline)) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1321,7 +1321,7 @@ G1CollectedHeap::G1CollectedHeap() :
   _rem_set(nullptr),
   _card_set_config(),
   _card_set_freelist_pool(G1CardSetConfiguration::num_mem_object_types()),
-  _young_regions_cset_group(card_set_config(), &_card_set_freelist_pool, G1CSetCandidateGroup::YoungId),
+  _young_regions_card_set_group(card_set_config(), &_card_set_freelist_pool, G1CardSetGroup::YoungId),
   _cm(nullptr),
   _cr(nullptr),
   _task_queues(nullptr),
@@ -3176,16 +3176,16 @@ G1HeapRegion* G1CollectedHeap::new_gc_alloc_region(size_t word_size, G1HeapRegio
     if (type.is_survivor()) {
       new_alloc_region->set_survivor();
       _survivor.add(new_alloc_region);
-      // The remembered set/group cardset for this region will be installed at the
+      // The card set group for this region will be installed at the
       // end of GC. Cannot do that right now because we still need the current young
-      // gen cardset group.
+      // gen card set group.
       // However, register with the attribute table to collect remembered set entries
-      // immediately as it is the only source for determining the need for remembered
+      // immediately as it is the definitive source for determining the need for remembered
       // set tracking during GC.
       register_new_survivor_region_with_region_attr(new_alloc_region);
     } else {
       new_alloc_region->set_old();
-      // Update remembered set/cardset.
+      // Update remembered set state.
       _policy->remset_tracker()->update_at_allocate(new_alloc_region);
       // Synchronize with region attribute table.
       update_region_attr(new_alloc_region);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -790,13 +790,13 @@ private:
 
   G1MonotonicArenaFreePool _card_set_freelist_pool;
 
-  // Group cardsets
-  G1CSetCandidateGroup _young_regions_cset_group;
+  // Young-region card set group
+  G1CardSetGroup _young_regions_card_set_group;
 
 public:
   G1CardSetConfiguration* card_set_config() { return &_card_set_config; }
 
-  G1CSetCandidateGroup* young_regions_cset_group() { return &_young_regions_cset_group; }
+  G1CardSetGroup* young_regions_card_set_group() { return &_young_regions_card_set_group; }
 
   // After a collection pause, reset eden and the collection set.
   void clear_eden();

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -36,13 +36,13 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-uint G1CollectionSet::num_groups() const {
+uint G1CollectionSet::num_selected_groups() const {
   assert(_inc_build_state == CSetBuildType::Inactive, "must be");
-  return _groups.length();
+  return _selected_groups.length();
 }
 
-uint G1CollectionSet::num_groups_in_increment() const {
-  return num_groups() - _groups_inc_part_start;
+uint G1CollectionSet::num_selected_groups_in_increment() const {
+  return num_selected_groups() - _selected_groups_inc_part_start;
 }
 
 G1CollectorState* G1CollectionSet::collector_state() const {
@@ -60,14 +60,14 @@ G1CollectionSet::G1CollectionSet(G1CollectedHeap* g1h, G1Policy* policy) :
   _regions(nullptr),
   _max_num_regions(0),
   _num_regions(0),
-  _groups(),
+  _selected_groups(),
   _num_eden_regions(0),
   _num_survivor_regions(0),
   _num_initial_old_regions(0),
   _optional_groups(),
   DEBUG_ONLY(_inc_build_state(CSetBuildType::Inactive) COMMA)
   _regions_inc_part_start(0),
-  _groups_inc_part_start(0) {
+  _selected_groups_inc_part_start(0) {
 }
 
 G1CollectionSet::~G1CollectionSet() {
@@ -113,7 +113,7 @@ void G1CollectionSet::abandon_all_candidates() {
 
 void G1CollectionSet::prepare_for_scan () {
   _g1h->young_regions_card_set_group()->card_set()->reset_table_scanner_for_groups();
-  _groups.prepare_for_scan();
+  _selected_groups.prepare_for_scan();
 }
 
 void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
@@ -139,7 +139,7 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
 void G1CollectionSet::start() {
   assert(num_regions() == 0, "Collection set must be empty before starting a new collection set.");
-  assert(num_groups() == 0, "Card set groups must be empty before starting a new collection set.");
+  assert(num_selected_groups() == 0, "Card set groups must be empty before starting a new collection set.");
   assert(_optional_groups.length() == 0,
          "Optional card set groups must be empty before starting a new collection set.");
 
@@ -153,7 +153,7 @@ void G1CollectionSet::continue_incremental_building() {
   assert(_inc_build_state == CSetBuildType::Inactive, "Precondition");
 
   _regions_inc_part_start = num_regions();
-  _groups_inc_part_start = num_groups();
+  _selected_groups_inc_part_start = num_selected_groups();
 
   DEBUG_ONLY(_inc_build_state = CSetBuildType::Active;)
 }
@@ -165,7 +165,7 @@ void G1CollectionSet::stop_incremental_building() {
 void G1CollectionSet::clear() {
   assert_at_safepoint_on_vm_thread();
   _num_regions.store_relaxed(0);
-  _groups.clear();
+  _selected_groups.clear();
   assert(_optional_groups.length() == 0, "must be");
 }
 
@@ -218,7 +218,6 @@ void G1CollectionSet::add_young_region_common(G1HeapRegion* hr) {
   assert(hr->is_young(), "invariant");
   assert(_inc_build_state == CSetBuildType::Active, "Precondition");
 
-  // Add to remembered set/card set group.
   _g1h->policy()->remset_tracker()->update_at_allocate(hr);
   _g1h->young_regions_card_set_group()->add(hr);
 
@@ -438,7 +437,7 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
   bool make_first_group_optional = G1ForceOptionalEvacuation;
 
   log_debug(gc, ergo, cset)("Start adding marking candidates to collection set. "
-                            "Min %u regions, max %u regions, available %u regions (%u groups), "
+                            "Min %u regions, max %u regions, available %u regions (%u card set groups), "
                             "time remaining %1.2fms, optional threshold %1.2fms",
                             min_num_old_cset_regions, max_num_old_cset_regions, from_marking_groups->num_regions(), from_marking_groups->length(),
                             time_remaining_ms, optional_threshold_ms);
@@ -695,7 +694,7 @@ void G1CollectionSet::add_group_to_collection_set(G1CardSetGroup* gr) {
     assert(r->rem_set()->is_complete(), "must be");
     add_region_to_collection_set(r);
   }
-  _groups.append(gr);
+  _selected_groups.append(gr);
 }
 
 void G1CollectionSet::add_region_to_collection_set(G1HeapRegion* r) {
@@ -706,7 +705,7 @@ void G1CollectionSet::add_region_to_collection_set(G1HeapRegion* r) {
 
 void G1CollectionSet::finalize_initial_collection_set(double target_pause_time_ms, G1SurvivorRegions* survivor) {
   assert(_regions_inc_part_start == 0, "must be");
-  assert(_groups_inc_part_start == 0, "must be");
+  assert(_selected_groups_inc_part_start == 0, "must be");
 
   double time_remaining_ms = finalize_young_part(target_pause_time_ms, survivor);
   finalize_old_part(time_remaining_ms);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -99,7 +99,7 @@ void G1CollectionSet::initialize(uint max_num_regions) {
 }
 
 void G1CollectionSet::abandon() {
-  _g1h->young_regions_cset_group()->clear(true /* uninstall_cset_group */);
+  _g1h->young_regions_card_set_group()->clear(true /* uninstall_card_set_group */);
   clear();
   abandon_all_candidates();
 
@@ -112,7 +112,7 @@ void G1CollectionSet::abandon_all_candidates() {
 }
 
 void G1CollectionSet::prepare_for_scan () {
-  _g1h->young_regions_cset_group()->card_set()->reset_table_scanner_for_groups();
+  _g1h->young_regions_card_set_group()->card_set()->reset_table_scanner_for_groups();
   _groups.prepare_for_scan();
 }
 
@@ -123,7 +123,7 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
          "Precondition, actively building cset or adding optional later on");
   assert(hr->is_old(), "the region should be old");
 
-  assert(!hr->rem_set()->has_cset_group(), "Should have already uninstalled group remset");
+  assert(!hr->rem_set()->has_card_set_group(), "Should have already uninstalled card set group");
 
   _g1h->register_old_collection_set_region_with_region_attr(hr);
 
@@ -139,13 +139,13 @@ void G1CollectionSet::add_old_region(G1HeapRegion* hr) {
 
 void G1CollectionSet::start() {
   assert(num_regions() == 0, "Collection set must be empty before starting a new collection set.");
-  assert(num_groups() == 0, "Collection set groups must be empty before starting a new collection set.");
+  assert(num_groups() == 0, "Card set groups must be empty before starting a new collection set.");
   assert(_optional_groups.length() == 0,
-         "Collection set optional groups must be empty before starting a new collection set.");
+         "Optional card set groups must be empty before starting a new collection set.");
 
   continue_incremental_building();
 
-  G1CSetCandidateGroup* young_group = _g1h->young_regions_cset_group();
+  G1CardSetGroup* young_group = _g1h->young_regions_card_set_group();
   young_group->clear();
 }
 
@@ -218,9 +218,9 @@ void G1CollectionSet::add_young_region_common(G1HeapRegion* hr) {
   assert(hr->is_young(), "invariant");
   assert(_inc_build_state == CSetBuildType::Active, "Precondition");
 
-  // Add to remembered set/cset group.
+  // Add to remembered set/card set group.
   _g1h->policy()->remset_tracker()->update_at_allocate(hr);
-  _g1h->young_regions_cset_group()->add(hr);
+  _g1h->young_regions_card_set_group()->add(hr);
 
   // Synchronize with the region attribute table.
   _g1h->register_young_region_with_region_attr(hr);
@@ -363,16 +363,16 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
   return remaining_time_ms;
 }
 
-// The current mechanism for evacuating pinned old regions is as below:
-// * pinned regions in the marking collection set candidate list (available during mixed gc) are evacuated like
-//   pinned young regions to avoid the complexity of dealing with pinned regions that are part of a
-//   collection group sharing a single cardset. These regions will be partially evacuated and added to the
-//   retained collection set by the evacuation failure handling mechanism.
-// * evacuating pinned regions out of retained collection set candidates would also just take up time
-//   with no actual space freed in old gen. Better to concentrate on others. So we skip over pinned
-//   regions in retained collection set candidates. Retained collection set candidates are aged out, ie.
-//   made to regular old regions without remembered sets after a few attempts to save computation costs
-//   of keeping them candidates for very long living pinned regions.
+// Handling of pinned regions within groups during selection:
+// * card set groups in the _from_marking_groups that contain pinned regions are selected as if there
+//   were no pinned regions in them.
+//   These pinned regions will simply cause an evacuation failure that is handled as normal.
+// * pinned regions within card set groups in the _retained_groups are skipped during selection.
+//   Since currently card set groups from this list only ever contain one region, trying to evacuate
+//   them will just waste time (everything but potentially pinned objects were already evacuated).
+//   These card set groups are aged out, i.e. turned to regular old regions without a card set group
+//   after a few attempts to select them to save computation costs keeping them in this list for a
+//   long time.
 void G1CollectionSet::finalize_old_part(double time_remaining_ms) {
   Ticks start_time = Ticks::now();
 
@@ -406,7 +406,7 @@ static void print_finish_message(const char* reason, bool from_marking) {
                             from_marking ? "marking" : "retained", reason);
 }
 
-void G1CollectionSet::add_optional_group(G1CSetCandidateGroup* group,
+void G1CollectionSet::add_optional_group(G1CardSetGroup* group,
                                          uint& num_optional_regions,
                                          double& predicted_optional_time_ms,
                                          double predicted_time_ms) {
@@ -433,7 +433,7 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
   uint max_num_old_cset_regions = MAX2(min_num_old_cset_regions, _policy->calc_max_old_cset_length());
   bool check_time_remaining = _policy->use_adaptive_num_young_regions();
 
-  G1CSetCandidateGroupList* from_marking_groups = &candidates()->from_marking_groups();
+  G1CardSetGroupList* from_marking_groups = &candidates()->from_marking_groups();
 
   bool make_first_group_optional = G1ForceOptionalEvacuation;
 
@@ -443,9 +443,9 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
                             min_num_old_cset_regions, max_num_old_cset_regions, from_marking_groups->num_regions(), from_marking_groups->length(),
                             time_remaining_ms, optional_threshold_ms);
 
-  G1CSetCandidateGroupList selected_groups;
+  G1CardSetGroupList selected_groups;
 
-  for (G1CSetCandidateGroup* group : *from_marking_groups) {
+  for (G1CardSetGroup* group : *from_marking_groups) {
     if (num_initial_regions + num_optional_regions >= max_num_old_cset_regions) {
       // Added maximum number of old regions to the CSet.
       print_finish_message("Maximum number of regions reached", true);
@@ -496,7 +496,7 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
     }
   }
 
-  // Remove selected groups from list of candidate groups.
+  // Remove selected groups from the collection set candidates.
   if (num_initial_groups > 0) {
     candidates()->remove(&selected_groups);
   }
@@ -539,7 +539,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
   double optional_time_remaining_ms = _policy->max_time_for_retaining();
   time_remaining_ms = MIN2(time_remaining_ms, optional_time_remaining_ms);
 
-  G1CSetCandidateGroupList* retained_groups = &candidates()->retained_groups();
+  G1CardSetGroupList* retained_groups = &candidates()->retained_groups();
 
   log_debug(gc, ergo, cset)("Start adding retained candidates to collection set. "
                             "Min %u regions, available %u regions (%u groups), "
@@ -547,17 +547,17 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
                             min_num_regions, retained_groups->num_regions(), retained_groups->length(),
                             time_remaining_ms, optional_time_remaining_ms);
 
-  G1CSetCandidateGroupList remove_from_retained;
-  G1CSetCandidateGroupList groups_to_abandon;
+  G1CardSetGroupList remove_from_retained;
+  G1CardSetGroupList groups_to_abandon;
 
-  for (G1CSetCandidateGroup* group : *retained_groups) {
+  for (G1CardSetGroup* group : *retained_groups) {
     assert(group->length() == 1, "Retained groups should have only 1 region");
 
     double predicted_time_ms = group->predict_group_total_time_ms();
 
     bool fits_in_remaining_time = predicted_time_ms <= time_remaining_ms;
 
-    G1CollectionSetCandidateInfo* ci = group->at(0); // We only have one region in the group.
+    G1CardSetGroupItem* ci = group->at(0); // We only have one region in the group.
     G1HeapRegion* r = ci->_r;
 
     // If we can't reclaim that region ignore it for now.
@@ -614,7 +614,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
   // for the regions in these groups.
   candidates()->remove(&remove_from_retained);
 
-  groups_to_abandon.clear(true /* uninstall_cset_group */);
+  groups_to_abandon.clear(true /* uninstall_card_set_group */);
 
   assert(num_optional_regions >= prev_num_optional_regions, "Sanity");
   uint selected_optional_regions = num_optional_regions - prev_num_optional_regions;
@@ -632,8 +632,8 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
          "Should only be called when there are optional regions");
 
   double total_prediction_ms = 0.0;
-  G1CSetCandidateGroupList selected;
-  for (G1CSetCandidateGroup* group : _optional_groups) {
+  G1CardSetGroupList selected;
+  for (G1CardSetGroup* group : _optional_groups) {
     double predicted_time_ms = group->predict_group_total_time_ms();
 
     if (predicted_time_ms > time_remaining_ms) {
@@ -651,9 +651,9 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
     selected.append(group);
   }
 
-  log_debug(gc, ergo, cset)("Completed with groups, selected %u region in %u groups",
+  log_debug(gc, ergo, cset)("Selected %u regions in %u card set groups",
                             num_regions_selected, selected.length());
-  // Remove selected groups from candidate list.
+  // Remove selected groups from collection set candidates and optional groups.
   if (selected.length() > 0) {
     _optional_groups.remove(&selected);
     candidates()->remove(&selected);
@@ -676,8 +676,8 @@ uint G1CollectionSet::select_optional_groups(double time_remaining_ms) {
   return num_regions_selected;
 }
 
-void G1CollectionSet::prepare_optional_group(G1CSetCandidateGroup* gr, uint cur_index) {
-  for (G1CollectionSetCandidateInfo ci : *gr) {
+void G1CollectionSet::prepare_optional_group(G1CardSetGroup* gr, uint cur_index) {
+  for (G1CardSetGroupItem ci : *gr) {
     G1HeapRegion* r = ci._r;
 
     assert(r->is_old(), "the region should be old");
@@ -688,10 +688,10 @@ void G1CollectionSet::prepare_optional_group(G1CSetCandidateGroup* gr, uint cur_
   }
 }
 
-void G1CollectionSet::add_group_to_collection_set(G1CSetCandidateGroup* gr) {
-  for (G1CollectionSetCandidateInfo ci : *gr) {
+void G1CollectionSet::add_group_to_collection_set(G1CardSetGroup* gr) {
+  for (G1CardSetGroupItem ci : *gr) {
     G1HeapRegion* r = ci._r;
-    r->uninstall_cset_group();
+    r->uninstall_card_set_group();
     assert(r->rem_set()->is_complete(), "must be");
     add_region_to_collection_set(r);
   }
@@ -738,7 +738,7 @@ void G1CollectionSet::abandon_optional_collection_set(G1ParScanThreadStateSet* p
     };
 
     _optional_groups.iterate(reset);
-    // Remove groups from list without deleting the groups or clearing the associated cardsets.
+    // Remove all card set groups from the list without deleting the groups or clearing the associated card sets.
     _optional_groups.remove_selected(_optional_groups.length(), _optional_groups.num_regions());
   }
 

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -42,11 +42,11 @@ class G1HeapRegionClosure;
 
 // The collection set.
 //
-// The set of regions and candidate groups that were evacuated during an
-// evacuation pause.
+// The set of regions with their corresponding card set groups that are evacuated during the
+// next evacuation pause.
 //
 // At the end of a collection, before freeing it, this set contains all regions
-// and collection set groups that were evacuated during this collection:
+// with their card set groups that were evacuated during this collection:
 //
 // - survivor regions from the last collection (if any)
 // - eden regions allocated by the mutator
@@ -130,7 +130,7 @@ class G1HeapRegionClosure;
 // ||                              ... after step b6)
 // |SSS|                           ... after step 7), with three survivor regions
 //
-// Candidate groups are kept in sync with the contents of the collection set regions.
+// Card set groups are kept in sync with the contents of the collection set regions.
 class G1CollectionSet {
   G1CollectedHeap* _g1h;
   G1Policy* _policy;
@@ -138,7 +138,7 @@ class G1CollectionSet {
   // All old gen collection set candidate regions.
   G1CollectionSetCandidates _candidates;
 
-  // The actual collection set as a set of region indices.
+  // The actual collection set as an array of region indices.
   //
   // All regions in _regions below _num_regions are assumed to be part of the
   // collection set.
@@ -146,14 +146,17 @@ class G1CollectionSet {
   // concurrent readers. This means synchronization using release and acquire
   // on the writer and reader respectively only are sufficient.
   //
-  // This corresponds to the regions referenced by the candidate groups further below.
+  // These regions correspond to the regions referenced by the card set groups
+  // in the current collection set.
+  //
+  // Keeping the regions in an array allows efficient parallelization of work.
   uint* _regions;
   uint _max_num_regions;
 
   Atomic<uint> _num_regions;
 
   // Old gen groups selected for evacuation.
-  G1CSetCandidateGroupList _groups;
+  G1CardSetGroupList _groups;
 
   uint num_groups() const;
 
@@ -164,7 +167,7 @@ class G1CollectionSet {
   // When doing mixed collections we can add old regions to the collection set, which
   // will be collected only if there is enough time. We call these optional (old)
   // groups. Regions are reachable via this list as well.
-  G1CSetCandidateGroupList _optional_groups;
+  G1CardSetGroupList _optional_groups;
 
 #ifdef ASSERT
   enum class CSetBuildType {
@@ -192,9 +195,9 @@ class G1CollectionSet {
   void prepare_for_collection(uint num_eden_cset_regions,
                               uint num_survivor_cset_regions);
 
-  void prepare_optional_group(G1CSetCandidateGroup* gr, uint cur_index);
+  void prepare_optional_group(G1CardSetGroup* gr, uint cur_index);
 
-  void add_group_to_collection_set(G1CSetCandidateGroup* gr);
+  void add_group_to_collection_set(G1CardSetGroup* gr);
 
   void add_region_to_collection_set(G1HeapRegion* r);
 
@@ -227,7 +230,7 @@ class G1CollectionSet {
 
   // Adds the given group to the optional groups list (_optional_groups)
   // and updates all related bookkeeping.
-  void add_optional_group(G1CSetCandidateGroup* group,
+  void add_optional_group(G1CardSetGroup* group,
                           uint& num_optional_regions,
                           double& predicted_optional_time_ms,
                           double predicted_time_ms);
@@ -263,7 +266,7 @@ public:
   bool only_contains_young_regions() const { return (num_initial_old_regions() + num_optional_regions()) == 0; }
 
   template <class CardOrRangeVisitor>
-  inline void merge_cardsets_for_collection_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers);
+  inline void merge_collection_set_card_set_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers);
 
   uint num_groups_in_increment() const;
 

--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -155,10 +155,10 @@ class G1CollectionSet {
 
   Atomic<uint> _num_regions;
 
-  // Old gen groups selected for evacuation.
-  G1CardSetGroupList _groups;
+  // Card set groups selected for evacuation.
+  G1CardSetGroupList _selected_groups;
 
-  uint num_groups() const;
+  uint num_selected_groups() const;
 
   uint _num_eden_regions;
   uint _num_survivor_regions;
@@ -179,8 +179,8 @@ class G1CollectionSet {
 #endif
   // Index into the _regions indicating the start of the current collection set increment.
   uint _regions_inc_part_start;
-  // Index into the _groups indicating the start of the current collection set increment.
-  uint _groups_inc_part_start;
+  // Index into the _selected_groups indicating the start of the current collection set increment.
+  uint _selected_groups_inc_part_start;
 
   G1CollectorState* collector_state() const;
   G1GCPhaseTimes* phase_times();
@@ -268,7 +268,7 @@ public:
   template <class CardOrRangeVisitor>
   inline void merge_collection_set_card_set_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers);
 
-  uint num_groups_in_increment() const;
+  uint num_selected_groups_in_increment() const;
 
   // Reset the contents of the collection set.
   void clear();

--- a/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
@@ -31,22 +31,22 @@
 
 template <class CardOrRangeVisitor>
 inline void G1CollectionSet::merge_collection_set_card_set_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers) {
-  uint offset = _groups_inc_part_start;
+  uint offset = _selected_groups_inc_part_start;
   if (offset == 0) {
     G1HeapRegionRemSet::iterate_for_merge(_g1h->young_regions_card_set_group()->card_set(), cl);
   }
 
-  const uint next_group_increment = num_groups_in_increment();
-  if (next_group_increment == 0) {
+  const uint next_selected_group_increment = num_selected_groups_in_increment();
+  if (next_selected_group_increment == 0) {
     return;
   }
 
-  uint start_pos = (worker_id * next_group_increment) / num_workers;
+  uint start_pos = (worker_id * next_selected_group_increment) / num_workers;
   uint cur_pos = start_pos;
   do {
-    G1HeapRegionRemSet::iterate_for_merge(_groups.at(offset + cur_pos)->card_set(), cl);
+    G1HeapRegionRemSet::iterate_for_merge(_selected_groups.at(offset + cur_pos)->card_set(), cl);
     cur_pos++;
-    if (cur_pos == next_group_increment) {
+    if (cur_pos == next_selected_group_increment) {
       cur_pos = 0;
     }
   } while (cur_pos != start_pos);

--- a/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.inline.hpp
@@ -30,10 +30,10 @@
 #include "gc/g1/g1HeapRegionRemSet.hpp"
 
 template <class CardOrRangeVisitor>
-inline void G1CollectionSet::merge_cardsets_for_collection_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers) {
+inline void G1CollectionSet::merge_collection_set_card_set_groups(CardOrRangeVisitor& cl, uint worker_id, uint num_workers) {
   uint offset = _groups_inc_part_start;
   if (offset == 0) {
-    G1HeapRegionRemSet::iterate_for_merge(_g1h->young_regions_cset_group()->card_set(), cl);
+    G1HeapRegionRemSet::iterate_for_merge(_g1h->young_regions_card_set_group()->card_set(), cl);
   }
 
   const uint next_group_increment = num_groups_in_increment();

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -127,9 +127,9 @@ double G1CardSetGroup::predict_group_total_time_ms() const {
   return total_time_ms;
 }
 
-int G1CSetCandidateGroup::compare_gc_efficiency(G1CardSetGroup** gr1, G1CardSetGroup** gr2) {
-  G1CSetCandidateGroup* group_1 = *gr1;
-  G1CSetCandidateGroup* group_2 = *gr2;
+int G1CardSetGroup::compare_gc_efficiency(G1CardSetGroup** gr1, G1CardSetGroup** gr2) {
+  G1CardSetGroup* group_1 = *gr1;
+  G1CardSetGroup* group_2 = *gr2;
   double gc_eff1 = group_1->gc_efficiency();
   double gc_eff2 = group_2->gc_efficiency();
 

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -113,7 +113,7 @@ double G1CardSetGroup::predict_group_total_time_ms() const {
                          predicted_copy_time_ms +
                          non_young_other_time_ms;
 
-  log_trace(gc, ergo, cset) ("Prediction for group %u (%u regions): total_time %.2fms card_rs_length %zu merge_scan_time %.2fms code_root_scan_time_ms %.2fms evac_time_ms %.2fms other_time %.2fms bytes_to_copy %zu",
+  log_trace(gc, ergo, cset) ("Prediction for card set group %u (%u regions): total_time %.2fms card_rs_length %zu merge_scan_time %.2fms code_root_scan_time_ms %.2fms evac_time_ms %.2fms other_time %.2fms bytes_to_copy %zu",
                              group_id(),
                              length(),
                              total_time_ms,
@@ -319,7 +319,7 @@ void G1CollectionSetCandidates::set_candidates_from_marking(GrowableArrayCHeap<G
 }
 
 void G1CollectionSetCandidates::sort_by_efficiency() {
-  // From marking regions must always be sorted so no reason to actually sort
+  // From marking card set groups must always be sorted so no reason to actually sort
   // them.
   _from_marking_groups.verify();
   _retained_groups.sort_by_efficiency();
@@ -329,7 +329,7 @@ void G1CollectionSetCandidates::sort_by_efficiency() {
 void G1CollectionSetCandidates::remove(G1CardSetGroupList* other) {
   // During removal, we exploit the fact that elements in the _from_marking_groups,
   // _retained_groups and other list are sorted by gc_efficiency. Furthermore,
-  // all regions in the passed other list are in one of the two other lists.
+  // all card set groups in the passed other list are in one of the two other lists.
   //
   // Split original list into elements for the marking list and elements from the
   // retained list.

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -27,8 +27,8 @@
 #include "gc/g1/g1HeapRegionRemSet.inline.hpp"
 #include "utilities/growableArray.hpp"
 
-G1CSetCandidateGroup::G1CSetCandidateGroup(G1CardSetConfiguration* config, G1MonotonicArenaFreePool* card_set_freelist_pool, uint group_id) :
-  _candidates(4, mtGCCardSet),
+G1CardSetGroup::G1CardSetGroup(G1CardSetConfiguration* config, G1MonotonicArenaFreePool* card_set_freelist_pool, uint group_id) :
+  _items(4, mtGCCardSet),
   _card_set_mm(config, card_set_freelist_pool),
   _card_set(config, &_card_set_mm),
   _reclaimable_bytes(size_t(0)),
@@ -36,67 +36,67 @@ G1CSetCandidateGroup::G1CSetCandidateGroup(G1CardSetConfiguration* config, G1Mon
   _group_id(group_id)
 { }
 
-G1CSetCandidateGroup::G1CSetCandidateGroup() :
-  G1CSetCandidateGroup(G1CollectedHeap::heap()->card_set_config(), G1CollectedHeap::heap()->card_set_freelist_pool(), InvalidId)
+G1CardSetGroup::G1CardSetGroup() :
+  G1CardSetGroup(G1CollectedHeap::heap()->card_set_config(), G1CollectedHeap::heap()->card_set_freelist_pool(), InvalidId)
 { }
 
-void G1CSetCandidateGroup::add(G1HeapRegion* hr) {
+void G1CardSetGroup::add(G1HeapRegion* hr) {
   precond(hr->is_young() == (_group_id == YoungId));
 
-  if (_candidates.is_empty() && _group_id != YoungId) {
+  if (_items.is_empty() && _group_id != YoungId) {
     precond(_group_id == InvalidId);
     _group_id = FirstNonYoungId + hr->hrm_index();
   }
-  G1CollectionSetCandidateInfo c(hr);
-  _candidates.append(c);
-  hr->install_cset_group(this);
+  G1CardSetGroupItem c(hr);
+  _items.append(c);
+  hr->install_card_set_group(this);
 }
 
-void G1CSetCandidateGroup::calculate_efficiency() {
+void G1CardSetGroup::calculate_efficiency() {
   _reclaimable_bytes = 0;
-  uint num_candidates = _candidates.length();
-  for (uint i = 0; i < num_candidates; i++) {
+  uint num_items = _items.length();
+  for (uint i = 0; i < num_items; i++) {
     G1HeapRegion* hr = region_at(i);
     _reclaimable_bytes += hr->reclaimable_bytes();
   }
   _gc_efficiency = _reclaimable_bytes / predict_group_total_time_ms();
 }
 
-double G1CSetCandidateGroup::liveness_percent() const {
+double G1CardSetGroup::liveness_percent() const {
   assert(length() > 0, "must be");
   size_t capacity = length() * G1HeapRegion::GrainBytes;
   return ((capacity - _reclaimable_bytes) * 100.0) / capacity;
 }
 
-void G1CSetCandidateGroup::clear(bool uninstall_cset_group) {
+void G1CardSetGroup::clear(bool uninstall_card_set_group) {
   clear_card_set();
-  if (uninstall_cset_group) {
-    for (G1CollectionSetCandidateInfo ci : _candidates) {
+  if (uninstall_card_set_group) {
+    for (G1CardSetGroupItem ci : _items) {
       G1HeapRegion* r = ci._r;
-      r->uninstall_cset_group();
+      r->uninstall_card_set_group();
       r->rem_set()->set_state_untracked();
     }
   }
-  _candidates.clear();
+  _items.clear();
   if (_group_id != YoungId) {
     _group_id = InvalidId;
   }
 }
 
-void G1CSetCandidateGroup::clear_card_set() {
+void G1CardSetGroup::clear_card_set() {
   _card_set.clear();
 }
 
-double G1CSetCandidateGroup::predict_group_total_time_ms() const {
+double G1CardSetGroup::predict_group_total_time_ms() const {
   G1Policy* p = G1CollectedHeap::heap()->policy();
 
   double predicted_copy_time_ms = 0.0;
   double predict_code_root_scan_time_ms = 0.0;
   size_t predict_bytes_to_copy = 0.0;
 
-  for (G1CollectionSetCandidateInfo ci : _candidates) {
+  for (G1CardSetGroupItem ci : _items) {
     G1HeapRegion* r = ci._r;
-    assert(r->rem_set()->cset_group() == this, "Must be!");
+    assert(r->rem_set()->card_set_group() == this, "Must be!");
 
     predict_bytes_to_copy += p->predict_bytes_to_copy(r);
     predicted_copy_time_ms += p->predict_region_copy_time_ms(r, false /* for_young_only_phase */);
@@ -127,7 +127,7 @@ double G1CSetCandidateGroup::predict_group_total_time_ms() const {
   return total_time_ms;
 }
 
-int G1CSetCandidateGroup::compare_gc_efficiency(G1CSetCandidateGroup** gr1, G1CSetCandidateGroup** gr2) {
+int G1CSetCandidateGroup::compare_gc_efficiency(G1CardSetGroup** gr1, G1CardSetGroup** gr2) {
   G1CSetCandidateGroup* group_1 = *gr1;
   G1CSetCandidateGroup* group_2 = *gr2;
   double gc_eff1 = group_1->gc_efficiency();
@@ -148,40 +148,40 @@ int G1CSetCandidateGroup::compare_gc_efficiency(G1CSetCandidateGroup** gr1, G1CS
   return 0;
 }
 
-G1CSetCandidateGroupList::G1CSetCandidateGroupList() : _groups(8, mtGC), _num_regions(0) { }
+G1CardSetGroupList::G1CardSetGroupList() : _groups(8, mtGC), _num_regions(0) { }
 
-void G1CSetCandidateGroupList::append(G1CSetCandidateGroup* group) {
+void G1CardSetGroupList::append(G1CardSetGroup* group) {
   assert(group->length() > 0, "Do not add empty groups");
   assert(!_groups.contains(group), "Already added to list");
   _groups.append(group);
   _num_regions.store_relaxed(num_regions() + group->length());
 }
 
-G1CSetCandidateGroup* G1CSetCandidateGroupList::at(uint index) {
+G1CardSetGroup* G1CardSetGroupList::at(uint index) {
   return _groups.at(index);
 }
 
-void G1CSetCandidateGroupList::clear(bool uninstall_cset_group) {
-  for (G1CSetCandidateGroup* gr : _groups) {
-    gr->clear(uninstall_cset_group);
+void G1CardSetGroupList::clear(bool uninstall_card_set_group) {
+  for (G1CardSetGroup* gr : _groups) {
+    gr->clear(uninstall_card_set_group);
     delete gr;
   }
   _groups.clear();
   _num_regions.store_relaxed(0);
 }
 
-void G1CSetCandidateGroupList::prepare_for_scan() {
-  for (G1CSetCandidateGroup* gr : _groups) {
+void G1CardSetGroupList::prepare_for_scan() {
+  for (G1CardSetGroup* gr : _groups) {
     gr->card_set()->reset_table_scanner_for_groups();
   }
 }
 
-void G1CSetCandidateGroupList::remove_selected(uint count, uint num_regions_to_remove) {
+void G1CardSetGroupList::remove_selected(uint count, uint num_regions_to_remove) {
   _groups.remove_till(count);
   _num_regions.store_relaxed(num_regions() - num_regions_to_remove);
 }
 
-void G1CSetCandidateGroupList::remove(G1CSetCandidateGroupList* other) {
+void G1CardSetGroupList::remove(G1CardSetGroupList* other) {
   guarantee((uint)_groups.length() >= other->length(), "Other should be a subset of this list");
 
   if (other->length() == 0) {
@@ -189,14 +189,14 @@ void G1CSetCandidateGroupList::remove(G1CSetCandidateGroupList* other) {
     return;
   }
 
-  // Create a list from scratch, copying over the elements from the candidate
+  // Create a list from scratch, copying over the elements from the original
   // list not in the other list. Finally deallocate and overwrite the old list.
   int new_length = _groups.length() - other->length();
   _num_regions.store_relaxed(num_regions() - other->num_regions());
-  GrowableArray<G1CSetCandidateGroup*> new_list(new_length, mtGC);
+  GrowableArray<G1CardSetGroup*> new_list(new_length, mtGC);
 
   uint other_idx = 0;
-  for (G1CSetCandidateGroup* gr : _groups) {
+  for (G1CardSetGroup* gr : _groups) {
     if (other_idx == other->length() || gr != other->at(other_idx)) {
       new_list.append(gr);
     } else {
@@ -209,15 +209,15 @@ void G1CSetCandidateGroupList::remove(G1CSetCandidateGroupList* other) {
   assert(_groups.length() == new_length, "Must be");
 }
 
-void G1CSetCandidateGroupList::sort_by_efficiency() {
-  _groups.sort(G1CSetCandidateGroup::compare_gc_efficiency);
+void G1CardSetGroupList::sort_by_efficiency() {
+  _groups.sort(G1CardSetGroup::compare_gc_efficiency);
 }
 
 #ifndef PRODUCT
-void G1CSetCandidateGroupList::verify() const {
-  G1CSetCandidateGroup* prev = nullptr;
+void G1CardSetGroupList::verify() const {
+  G1CardSetGroup* prev = nullptr;
 
-  for (G1CSetCandidateGroup* gr : _groups) {
+  for (G1CardSetGroup* gr : _groups) {
     assert(prev == nullptr || prev->gc_efficiency() >= gr->gc_efficiency(),
            "Stored gc efficiency must be descending");
     prev = gr;
@@ -252,8 +252,8 @@ void G1CollectionSetCandidates::initialize(uint max_regions) {
 }
 
 void G1CollectionSetCandidates::clear() {
-  _retained_groups.clear(true /* uninstall_cset_group */);
-  _from_marking_groups.clear(true /* uninstall_cset_group */);
+  _retained_groups.clear(true /* uninstall_card_set_group */);
+  _from_marking_groups.clear(true /* uninstall_card_set_group */);
   for (uint i = 0; i < _max_regions; i++) {
     _contains_map[i] = CandidateOrigin::Invalid;
   }
@@ -261,7 +261,7 @@ void G1CollectionSetCandidates::clear() {
 }
 
 void G1CollectionSetCandidates::sort_marking_by_efficiency() {
-  for (G1CSetCandidateGroup* gr : _from_marking_groups) {
+  for (G1CardSetGroup* gr : _from_marking_groups) {
     gr->calculate_efficiency();
   }
   _from_marking_groups.sort_by_efficiency();
@@ -283,13 +283,13 @@ void G1CollectionSetCandidates::set_candidates_from_marking(GrowableArrayCHeap<G
   G1Policy* p = G1CollectedHeap::heap()->policy();
   // During each Mixed GC, we must collect at least G1Policy::calc_min_old_cset_length regions to meet
   // the G1MixedGCCountTarget. For the first collection in a Mixed GC cycle, we can add all regions
-  // required to meet this threshold to the same remset group. We are certain these will be collected in
+  // required to meet this threshold to the same card set group. We are certain these will be collected in
   // the same Mixed GC.
   uint group_limit = p->calc_min_old_cset_length(num_candidates);
 
-  G1CSetCandidateGroup* current = nullptr;
+  G1CardSetGroup* current = nullptr;
 
-  current = new G1CSetCandidateGroup();
+  current = new G1CardSetGroup();
 
   for (uint i = 0; i < num_candidates; i++) {
     G1HeapRegion* r = candidates->at(i);
@@ -297,13 +297,13 @@ void G1CollectionSetCandidates::set_candidates_from_marking(GrowableArrayCHeap<G
     _contains_map[r->hrm_index()] = CandidateOrigin::Marking;
 
     if (current->length() == group_limit) {
-      if (group_limit != G1OldCSetGroupSize) {
-        group_limit = G1OldCSetGroupSize;
+      if (group_limit != G1OldCardSetGroupSize) {
+        group_limit = G1OldCardSetGroupSize;
       }
 
       _from_marking_groups.append(current);
 
-      current = new G1CSetCandidateGroup();
+      current = new G1CardSetGroup();
     }
     current->add(r);
   }
@@ -312,7 +312,7 @@ void G1CollectionSetCandidates::set_candidates_from_marking(GrowableArrayCHeap<G
 
   assert(_from_marking_groups.num_regions() == num_candidates, "Must be!");
 
-  log_debug(gc, ergo, cset) ("Finished creating %u collection groups from %u regions", _from_marking_groups.length(), num_candidates);
+  log_debug(gc, ergo, cset) ("Finished creating %u card set groups from %u regions", _from_marking_groups.length(), num_candidates);
   _last_marking_candidates_length = num_candidates;
 
   verify();
@@ -326,17 +326,17 @@ void G1CollectionSetCandidates::sort_by_efficiency() {
   _retained_groups.verify();
 }
 
-void G1CollectionSetCandidates::remove(G1CSetCandidateGroupList* other) {
-  // During removal, we exploit the fact that elements in the marking_regions,
-  // retained_regions and other list are sorted by gc_efficiency. Furthermore,
+void G1CollectionSetCandidates::remove(G1CardSetGroupList* other) {
+  // During removal, we exploit the fact that elements in the _from_marking_groups,
+  // _retained_groups and other list are sorted by gc_efficiency. Furthermore,
   // all regions in the passed other list are in one of the two other lists.
   //
   // Split original list into elements for the marking list and elements from the
   // retained list.
-  G1CSetCandidateGroupList other_marking_groups;
-  G1CSetCandidateGroupList other_retained_groups;
+  G1CardSetGroupList other_marking_groups;
+  G1CardSetGroupList other_retained_groups;
 
-  for (G1CSetCandidateGroup* group : *other) {
+  for (G1CardSetGroup* group : *other) {
     assert(group->length() > 0, "Should not have empty groups");
     // Regions in the same group have the same source (i.e from_marking or retained).
     G1HeapRegion* r = group->region_at(0);
@@ -362,7 +362,7 @@ void G1CollectionSetCandidates::add_retained_region_unsorted(G1HeapRegion* r) {
   assert(!contains(r), "Must not already contain region %u", r->hrm_index());
   _contains_map[r->hrm_index()] = CandidateOrigin::Retained;
 
-  G1CSetCandidateGroup* gr = new G1CSetCandidateGroup();
+  G1CardSetGroup* gr = new G1CardSetGroup();
   gr->add(r);
   gr->calculate_efficiency();
 
@@ -386,11 +386,11 @@ uint G1CollectionSetCandidates::retained_regions_length() const {
 }
 
 #ifndef PRODUCT
-void G1CollectionSetCandidates::verify_helper(G1CSetCandidateGroupList* list, uint& from_marking, CandidateOrigin* verify_map) {
+void G1CollectionSetCandidates::verify_helper(G1CardSetGroupList* list, uint& from_marking, CandidateOrigin* verify_map) {
   list->verify();
 
-  for (G1CSetCandidateGroup* gr : *list) {
-    for (G1CollectionSetCandidateInfo ci : *gr) {
+  for (G1CardSetGroup* gr : *list) {
+    for (G1CardSetGroupItem ci : *gr) {
       G1HeapRegion* r = ci._r;
 
       if (is_from_marking(r)) {

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -34,16 +34,16 @@
 #include "utilities/growableArray.hpp"
 
 class G1CollectionSetCandidates;
-class G1CSetCandidateGroupList;
+class G1CardSetGroupList;
 class G1HeapRegion;
 class G1HeapRegionClosure;
 
-struct G1CollectionSetCandidateInfo {
+struct G1CardSetGroupItem {
   G1HeapRegion* _r;
   uint _num_unreclaimed;          // Number of GCs this region has been found unreclaimable.
 
-  G1CollectionSetCandidateInfo() : G1CollectionSetCandidateInfo(nullptr) { }
-  G1CollectionSetCandidateInfo(G1HeapRegion* r) : _r(r), _num_unreclaimed(0) { }
+  G1CardSetGroupItem() : G1CardSetGroupItem(nullptr) { }
+  G1CardSetGroupItem(G1HeapRegion* r) : _r(r), _num_unreclaimed(0) { }
 
   bool update_num_unreclaimed() {
     ++_num_unreclaimed;
@@ -51,31 +51,31 @@ struct G1CollectionSetCandidateInfo {
   }
 };
 
-using G1CSetCandidateGroupIterator = GrowableArrayIterator<G1CollectionSetCandidateInfo>;
+using G1CardSetGroupIterator = GrowableArrayIterator<G1CardSetGroupItem>;
 
-// G1CSetCandidateGroup groups candidate regions that will be selected for evacuation at the same time.
-// Grouping occurs both for candidates from marking or regions retained during evacuation failure, but a group
-// can not contain regions from both types of regions.
+// G1CardSetGroup groups regions that share a single G1CardSet.
 //
-// Humongous objects are excluded from the candidate groups because regions associated with these
-// objects are never selected for evacuation.
+// Applications of this grouping are
+// * all young gen regions
+// * candidate regions determined by marking
+// * regions retained due to evacuation failure
+// * regions covered by humongous start regions
 //
-// All regions in the group share a G1CardSet instance, which tracks remembered set entries for the
-// regions in the group. We do not have track to cross-region references for regions that are in the
-// same group saving memory.
-class G1CSetCandidateGroup : public CHeapObj<mtGCCardSet>{
-  GrowableArray<G1CollectionSetCandidateInfo> _candidates;
+// The shared card set records remembered set entries for all regions in the group
+// as a whole. No references between these regions are recorded. This saves memory,
+// but requires reclamation of multi-region groups together as a single unit.
+class G1CardSetGroup : public CHeapObj<mtGCCardSet>{
+  GrowableArray<G1CardSetGroupItem> _items;
 
   G1CardSetMemoryManager _card_set_mm;
 
-  // The set of cards in the Java heap
+  // The set of cards in the Java heap for this card set group.
   G1CardSet _card_set;
 
   size_t _reclaimable_bytes;
   double _gc_efficiency;
-  // The _group_id identifies a candidate group in logging and in the
-  // FromCardCache. A group id must be assigned to at most one cset group
-  // at any time.
+  // The _group_id identifies the card set group for logging and for use in the
+  // FromCardCache. A group id must be unique among all currently used card set groups.
   uint _group_id;
 
 public:
@@ -84,15 +84,15 @@ public:
   static constexpr uint FirstNonYoungId = YoungId + 1;
   static constexpr uint InvalidId = UINT_MAX;
 
-  G1CSetCandidateGroup();
-  G1CSetCandidateGroup(G1CardSetConfiguration* config, G1MonotonicArenaFreePool* card_set_freelist_pool, uint group_id);
-  ~G1CSetCandidateGroup() {
+  G1CardSetGroup();
+  G1CardSetGroup(G1CardSetConfiguration* config, G1MonotonicArenaFreePool* card_set_freelist_pool, uint group_id);
+  ~G1CardSetGroup() {
     assert(length() == 0, "post condition!");
   }
 
   void add(G1HeapRegion* hr);
 
-  uint length() const { return (uint)_candidates.length(); }
+  uint length() const { return (uint)_items.length(); }
 
   G1CardSet* card_set() { return &_card_set; }
   const G1CardSet* card_set() const { return &_card_set; }
@@ -100,16 +100,16 @@ public:
   void calculate_efficiency();
 
   double liveness_percent() const;
-  // Comparison function to order regions in decreasing GC efficiency order. This
-  // will cause regions with a lot of live objects and large remembered sets to end
+  // Comparison function to order card set groups in decreasing GC efficiency order. This
+  // will cause card set groups with a lot of live objects and large card sets to end
   // up at the end of the list.
-  static int compare_gc_efficiency(G1CSetCandidateGroup** gr1, G1CSetCandidateGroup** gr2);
+  static int compare_gc_efficiency(G1CardSetGroup** gr1, G1CardSetGroup** gr2);
 
   double gc_efficiency() const { return _gc_efficiency; }
 
-  G1HeapRegion* region_at(uint i) const { return _candidates.at(i)._r; }
+  G1HeapRegion* region_at(uint i) const { return _items.at(i)._r; }
 
-  G1CollectionSetCandidateInfo* at(uint i) { return &_candidates.at(i); }
+  G1CardSetGroupItem* at(uint i) { return &_items.at(i); }
 
   double predict_group_total_time_ms() const;
 
@@ -124,14 +124,14 @@ public:
   // Clear the group-owned card set.
   void clear_card_set();
 
-  void clear(bool uninstall_cset_group = false);
+  void clear(bool uninstall_card_set_group = false);
 
-  G1CSetCandidateGroupIterator begin() const {
-    return _candidates.begin();
+  G1CardSetGroupIterator begin() const {
+    return _items.begin();
   }
 
-  G1CSetCandidateGroupIterator end() const {
-    return _candidates.end();
+  G1CardSetGroupIterator end() const {
+    return _items.end();
   }
 
   uint group_id() const {
@@ -140,23 +140,24 @@ public:
   }
 };
 
-using G1CSetCandidateGroupListIterator = GrowableArrayIterator<G1CSetCandidateGroup*>;
+using G1CardSetGroupListIterator = GrowableArrayIterator<G1CardSetGroup*>;
 
-class G1CSetCandidateGroupList {
-  GrowableArray<G1CSetCandidateGroup*> _groups;
+class G1CardSetGroupList {
+  GrowableArray<G1CardSetGroup*> _groups;
   Atomic<uint> _num_regions;
 
 public:
-  G1CSetCandidateGroupList();
-  void append(G1CSetCandidateGroup* group);
+  G1CardSetGroupList();
+  void append(G1CardSetGroup* group);
 
-  // Delete all groups from the list. The card set cleanup for regions within
+  // Delete all groups from the list. The card set group uninstall for regions within
   // the groups could have been done elsewhere (e.g. when adding groups to the
-  // collection set or to retained regions). The uninstall_cset_group is set to
-  // true if cleanup needs to happen as we clear the groups from the list.
-  void clear(bool uninstall_cset_group = false);
+  // collection set or to retained regions). The uninstall_card_set_group parameter
+  // should be set to true if the card set groups must be uninstalled from
+  // the regions, and their state set to Untracked.
+  void clear(bool uninstall_card_set_group = false);
 
-  G1CSetCandidateGroup* at(uint index);
+  G1CardSetGroup* at(uint index);
 
   uint length() const { return (uint)_groups.length(); }
 
@@ -164,28 +165,28 @@ public:
 
   void remove_selected(uint count, uint num_regions);
 
-  // Removes any candidate groups stored in this list and also in the other list. The other
-  // list may only contain candidate groups in this list, sorted by gc efficiency. It need
-  // not be a prefix of this list.
+  // Removes any card set groups stored in this and in the other list. The other
+  // list may only contain card set groups in this list, sorted by gc efficiency. The
+  // other list need not be a prefix of this list.
   // E.g. if this list is "A B G H", the other list may be "A G H", but not "F" (not in
   // this list) or "A H G" (wrong order).
-  void remove(G1CSetCandidateGroupList* other);
+  void remove(G1CardSetGroupList* other);
 
   void prepare_for_scan();
 
   void sort_by_efficiency();
 
-  GrowableArray<G1CSetCandidateGroup*>*  groups() {
+  GrowableArray<G1CardSetGroup*>*  groups() {
     return &_groups;
   }
 
   void verify() const PRODUCT_RETURN;
 
-  G1CSetCandidateGroupListIterator begin() const {
+  G1CardSetGroupListIterator begin() const {
     return _groups.begin();
   }
 
-  G1CSetCandidateGroupListIterator end() const {
+  G1CardSetGroupListIterator end() const {
     return _groups.end();
   }
 
@@ -193,35 +194,33 @@ public:
   void iterate(Func&& f) const;
 };
 
-// Tracks all collection set candidates, i.e. region groups that could/should be evacuated soon.
+// Tracks collection set candidate regions organized in two card set group lists. Their
+// groups are sorted by decreasing gc efficiency.
 //
-// These candidate groups are tracked in two list of region groups, sorted by decreasing
-// "gc efficiency".
-//
-// * from_marking_groups: the set of region groups selected by concurrent marking to be
+// * from_marking_groups: the set of card set groups selected by the concurrent cycle to be
 //                        evacuated to keep overall heap occupancy stable.
 //                        They are guaranteed to be evacuated and cleared out during
 //                        the mixed phase.
 //
-// * retained_groups: set of region groups selected for evacuation during evacuation
-//                    failure.
+// * retained_groups: contains the card set groups from regions whose evacuation in
+//                    previous garbage collections failed.
 //                    Any young collection will try to evacuate them.
 //
 class G1CollectionSetCandidates : public CHeapObj<mtGC> {
 
   enum class CandidateOrigin : uint8_t {
     Invalid,
-    Marking,                   // This region has been determined as candidate by concurrent marking.
+    Marking,                   // This region has been determined as candidate by the concurrent cycle.
     Retained,                  // This region has been added because it has been retained after evacuation.
     Verify                     // Special value for verification.
   };
 
   CandidateOrigin* _contains_map;
-  G1CSetCandidateGroupList _from_marking_groups; // Set of regions selected by concurrent marking.
+  G1CardSetGroupList _from_marking_groups; // Set of groups selected by the concurrent cycle.
   // Set of regions retained due to evacuation failure. Groups added to this list
   // should contain only one region each, making it easier to evacuate retained regions
   // in any young collection.
-  G1CSetCandidateGroupList _retained_groups;
+  G1CardSetGroupList _retained_groups;
   uint _max_regions;
 
   // The number of regions from the last merge of candidates from the marking.
@@ -233,8 +232,8 @@ public:
   G1CollectionSetCandidates();
   ~G1CollectionSetCandidates();
 
-  G1CSetCandidateGroupList& from_marking_groups() { return _from_marking_groups; }
-  G1CSetCandidateGroupList& retained_groups() { return _retained_groups; }
+  G1CardSetGroupList& from_marking_groups() { return _from_marking_groups; }
+  G1CardSetGroupList& retained_groups() { return _retained_groups; }
 
   void initialize(uint max_regions);
 
@@ -257,7 +256,7 @@ public:
   void add_retained_region_unsorted(G1HeapRegion* r);
   // Remove the given groups from the candidates. All given regions must be part
   // of the candidates.
-  void remove(G1CSetCandidateGroupList* other);
+  void remove(G1CardSetGroupList* other);
 
   bool contains(const G1HeapRegion* r) const;
 
@@ -270,7 +269,7 @@ public:
   uint retained_regions_length() const;
 
 private:
-  void verify_helper(G1CSetCandidateGroupList* list, uint& from_marking, CandidateOrigin* verify_map) PRODUCT_RETURN;
+  void verify_helper(G1CardSetGroupList* list, uint& from_marking, CandidateOrigin* verify_map) PRODUCT_RETURN;
 
 public:
   void verify() PRODUCT_RETURN;

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -152,8 +152,8 @@ public:
 
   // Delete all groups from the list. The card set group uninstall for regions within
   // the groups could have been done elsewhere (e.g. when adding groups to the
-  // collection set or to retained regions). The uninstall_card_set_group parameter
-  // should be set to true if the card set groups must be uninstalled from
+  // collection set or to the retained card set group list). The uninstall_card_set_group
+  // parameter should be set to true if the card set groups must be uninstalled from
   // the regions, and their state set to Untracked.
   void clear(bool uninstall_card_set_group = false);
 
@@ -239,8 +239,8 @@ public:
 
   void clear();
 
-  // Merge collection set candidates from marking into the current marking candidates
-  // (which needs to be empty).
+  // Merge collection set candidate regions from marking into the current from_marking candidate
+  // group list (which needs to be empty).
   void set_candidates_from_marking(GrowableArrayCHeap<G1HeapRegion*, mtGC>* selected);
   // The most recent length of the list that had been merged last via
   // set_candidates_from_marking(). Used for calculating minimum collection set
@@ -254,7 +254,7 @@ public:
   // Add the given region to the set of retained regions without regards to the
   // gc efficiency sorting. The retained regions must be re-sorted manually later.
   void add_retained_region_unsorted(G1HeapRegion* r);
-  // Remove the given groups from the candidates. All given regions must be part
+  // Remove the given groups from this list. All given card set groups must be part
   // of the candidates.
   void remove(G1CardSetGroupList* other);
 

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -63,7 +63,7 @@ using G1CardSetGroupIterator = GrowableArrayIterator<G1CardSetGroupItem>;
 //
 // The shared card set records remembered set entries for all regions in the group
 // as a whole. No references between these regions are recorded. This saves memory,
-// but requires reclamation of multi-region groups together as a single unit.
+// but requires reclamation of multi-region card set groups together as a single unit.
 class G1CardSetGroup : public CHeapObj<mtGCCardSet>{
   GrowableArray<G1CardSetGroupItem> _items;
 

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,9 @@
 #include "utilities/growableArray.hpp"
 
 template<typename Func>
-void G1CSetCandidateGroupList::iterate(Func&& f) const {
-  for (G1CSetCandidateGroup* group : _groups) {
-    for (G1CollectionSetCandidateInfo ci : *group) {
+void G1CardSetGroupList::iterate(Func&& f) const {
+  for (G1CardSetGroup* group : _groups) {
+    for (G1CardSetGroupItem ci : *group) {
       G1HeapRegion* r = ci._r;
       f(r);
     }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3231,7 +3231,7 @@ void G1PrintRegionLivenessInfoClosure::log_card_set_group_add_total(G1CardSetGro
   _total_remset_bytes += group->card_set()->mem_size();
 }
 
-void G1PrintRegionLivenessInfoClosure::log_card_set_grouplist(G1CardSetGroupList& gl, const char* type) {
+void G1PrintRegionLivenessInfoClosure::log_card_set_group_list(G1CardSetGroupList& gl, const char* type) {
   for (G1CardSetGroup* group : gl) {
     log_card_set_group_add_total(group, type);
   }
@@ -3268,6 +3268,6 @@ void G1PrintRegionLivenessInfoClosure::log_card_set_groups() {
   log_card_set_group_add_total(g1h->young_regions_card_set_group(), "Y");
 
   G1CollectionSetCandidates* candidates = g1h->policy()->candidates();
-  log_card_set_grouplist(candidates->from_marking_groups(), "M");
-  log_card_set_grouplist(candidates->retained_groups(), "R");
+  log_card_set_group_list(candidates->from_marking_groups(), "M");
+  log_card_set_group_list(candidates->retained_groups(), "R");
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3157,9 +3157,9 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(G1HeapRegion* r) {
   size_t remset_bytes    = r->rem_set()->mem_size();
   size_t code_roots_bytes = r->rem_set()->code_roots_mem_size();
   const char* remset_type = r->rem_set()->get_short_state_str();
-  uint cset_group_id     = r->rem_set()->has_cset_group()
-                         ? r->rem_set()->cset_group_id()
-                         : G1CSetCandidateGroup::NoGroupId;
+  uint card_set_group_id  = r->rem_set()->has_card_set_group()
+                          ? r->rem_set()->card_set_group_id()
+                          : G1CardSetGroup::NoGroupId;
 
   _total_used_bytes      += used_bytes;
   _total_capacity_bytes  += capacity_bytes;
@@ -3179,7 +3179,7 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(G1HeapRegion* r) {
                         type, p2i(bottom), p2i(end),
                         used_bytes, live_bytes,
                         remset_type, code_roots_bytes,
-                        cset_group_id);
+                        card_set_group_id);
 
   return false;
 }
@@ -3194,7 +3194,7 @@ G1PrintRegionLivenessInfoClosure::~G1PrintRegionLivenessInfoClosure() {
   // add static memory usages to remembered set sizes
   _total_remset_bytes += G1HeapRegionRemSet::static_mem_size();
 
-  log_cset_candidate_groups();
+  log_card_set_groups();
 
   // Print the footer of the output.
   log_trace(gc, liveness)(G1PPRL_LINE_PREFIX);
@@ -3214,7 +3214,7 @@ G1PrintRegionLivenessInfoClosure::~G1PrintRegionLivenessInfoClosure() {
                          bytes_to_mb(_total_code_roots_bytes));
 }
 
-void G1PrintRegionLivenessInfoClosure::log_cset_candidate_group_add_total(G1CSetCandidateGroup* group, const char* type) {
+void G1PrintRegionLivenessInfoClosure::log_card_set_group_add_total(G1CardSetGroup* group, const char* type) {
   log_trace(gc, liveness)(G1PPRL_LINE_PREFIX
                           G1PPRL_GID_FORMAT
                           G1PPRL_LEN_FORMAT
@@ -3231,15 +3231,15 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_group_add_total(G1CSet
   _total_remset_bytes += group->card_set()->mem_size();
 }
 
-void G1PrintRegionLivenessInfoClosure::log_cset_candidate_grouplist(G1CSetCandidateGroupList& gl, const char* type) {
-  for (G1CSetCandidateGroup* group : gl) {
-    log_cset_candidate_group_add_total(group, type);
+void G1PrintRegionLivenessInfoClosure::log_card_set_grouplist(G1CardSetGroupList& gl, const char* type) {
+  for (G1CardSetGroup* group : gl) {
+    log_card_set_group_add_total(group, type);
   }
 }
 
-void G1PrintRegionLivenessInfoClosure::log_cset_candidate_groups() {
+void G1PrintRegionLivenessInfoClosure::log_card_set_groups() {
   log_trace(gc, liveness)(G1PPRL_LINE_PREFIX);
-  log_trace(gc, liveness)(G1PPRL_LINE_PREFIX" Collection Set Candidate Groups");
+  log_trace(gc, liveness)(G1PPRL_LINE_PREFIX " Card Set Groups");
   log_trace(gc, liveness)(G1PPRL_LINE_PREFIX " Types: Y=Young, M=From Marking Regions, R=Retained Regions");
   log_trace(gc, liveness)(G1PPRL_LINE_PREFIX
                           G1PPRL_GID_H_FORMAT
@@ -3265,9 +3265,9 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_groups() {
 
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-  log_cset_candidate_group_add_total(g1h->young_regions_cset_group(), "Y");
+  log_card_set_group_add_total(g1h->young_regions_card_set_group(), "Y");
 
   G1CollectionSetCandidates* candidates = g1h->policy()->candidates();
-  log_cset_candidate_grouplist(candidates->from_marking_groups(), "M");
-  log_cset_candidate_grouplist(candidates->retained_groups(), "R");
+  log_card_set_grouplist(candidates->from_marking_groups(), "M");
+  log_card_set_grouplist(candidates->retained_groups(), "R");
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -1027,7 +1027,7 @@ class G1PrintRegionLivenessInfoClosure : public G1HeapRegionClosure {
   }
 
   void log_card_set_group_add_total(G1CardSetGroup* gr, const char* type);
-  void log_card_set_grouplist(G1CardSetGroupList& gl, const char* type);
+  void log_card_set_group_list(G1CardSetGroupList& gl, const char* type);
   void log_card_set_groups();
 
 public:

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -45,8 +45,8 @@
 
 class ConcurrentGCTimer;
 class G1CollectedHeap;
-class G1CSetCandidateGroup;
-class G1CSetCandidateGroupList;
+class G1CardSetGroup;
+class G1CardSetGroupList;
 class G1ConcurrentMark;
 class G1ConcurrentMarkThread;
 class G1CMOopClosure;
@@ -1026,9 +1026,9 @@ class G1PrintRegionLivenessInfoClosure : public G1HeapRegionClosure {
     return (double) val / (double) M;
   }
 
-  void log_cset_candidate_group_add_total(G1CSetCandidateGroup* gr, const char* type);
-  void log_cset_candidate_grouplist(G1CSetCandidateGroupList& gl, const char* type);
-  void log_cset_candidate_groups();
+  void log_card_set_group_add_total(G1CardSetGroup* gr, const char* type);
+  void log_card_set_grouplist(G1CardSetGroupList& gl, const char* type);
+  void log_card_set_groups();
 
 public:
   // The header and footer are printed in the constructor and

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkRemarkTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkRemarkTasks.cpp
@@ -209,7 +209,7 @@ void G1UpdateRegionLivenessAndSelectForRebuildTask::prune(GrowableArrayCHeap<G1H
       wasted_bytes + reclaimable > allowed_waste) {
       break;
     }
-    assert(!r->rem_set()->has_cset_group(), "must not have a cset group");
+    assert(!r->rem_set()->has_card_set_group(), "must not have a card set group");
     r->rem_set()->set_state_untracked();
 
     wasted_bytes += reclaimable;

--- a/src/hotspot/share/gc/g1/g1FromCardCache.hpp
+++ b/src/hotspot/share/gc/g1/g1FromCardCache.hpp
@@ -29,40 +29,40 @@
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-// G1FromCardCache remembers which destination cset groups have been
+// G1FromCardCache remembers which destination card set groups have been
 // encountered while a worker scans the current from_card.
 //
 // Refinement and remembered set rebuild scan the heap linearly, visiting
 // references from a card consecutively. Therefore, the cache only tracks
-// the destination cset groups found while scanning the current card. The
+// the destination card set groups found while scanning the current card. The
 // cache state is discarded when advancing to the next card.
 //
 // A scan can be suspended at a yield point. A GC may run while it is
-// suspended and change the cset group assignments. Therefore, the cache
+// suspended and change the card set group assignments. Therefore, the cache
 // must be reset before the scan resumes after every yield.
 class G1FromCardCache {
-  // Worst case: each reference in a card targets a different cset group.
+  // Worst case: each reference in a card targets a different card set group.
   static constexpr uint MaxGroupsPerCard = MaxGCCardSizeInBytes / sizeof(narrowOop);
 
   uintptr_t _from_card;
-  uint _num_cset_groups;
-  uint _cset_group_ids[MaxGroupsPerCard];
+  uint _num_card_set_groups;
+  uint _card_set_group_ids[MaxGroupsPerCard];
 
   NONCOPYABLE(G1FromCardCache);
 
 public:
   G1FromCardCache()
     : _from_card(0),
-      _num_cset_groups(0) {}
+      _num_card_set_groups(0) {}
 
   // Discard the state associated with the _from_card.
   void reset() {
-    _num_cset_groups = 0;
+    _num_card_set_groups = 0;
   }
 
-  // Returns true if cset_group_id has already been encountered while
+  // Returns true if card_set_group_id has already been encountered while
   // scanning from_card. Otherwise, records the id and returns false.
-  inline bool contains_or_add(uintptr_t from_card, uint cset_group_id);
+  inline bool contains_or_add(uintptr_t from_card, uint card_set_group_id);
 };
 
 #endif // SHARE_GC_G1_G1FROMCARDCACHE_HPP

--- a/src/hotspot/share/gc/g1/g1FromCardCache.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FromCardCache.inline.hpp
@@ -27,21 +27,21 @@
 
 #include "gc/g1/g1FromCardCache.hpp"
 
-bool G1FromCardCache::contains_or_add(uintptr_t from_card, uint cset_group_id) {
+bool G1FromCardCache::contains_or_add(uintptr_t from_card, uint card_set_group_id) {
   if (_from_card != from_card) {
     _from_card = from_card;
-    _num_cset_groups = 0;
+    _num_card_set_groups = 0;
   }
 
-  for (uint i = 0; i < _num_cset_groups; i++) {
-    if (_cset_group_ids[i] == cset_group_id) {
+  for (uint i = 0; i < _num_card_set_groups; i++) {
+    if (_card_set_group_ids[i] == card_set_group_id) {
       return true;
     }
   }
 
-  assert(_num_cset_groups < MaxGroupsPerCard, "from_card has too many destination cset groups");
+  assert(_num_card_set_groups < MaxGroupsPerCard, "from_card has too many destination card set groups");
 
-  _cset_group_ids[_num_cset_groups++] = cset_group_id;
+  _card_set_group_ids[_num_card_set_groups++] = card_set_group_id;
   return false;
 }
 

--- a/src/hotspot/share/gc/g1/g1FullGCResetMetadataTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCResetMetadataTask.cpp
@@ -31,12 +31,12 @@ G1FullGCResetMetadataTask::G1ResetMetadataClosure::G1ResetMetadataClosure(G1Full
   _collector(collector) { }
 
 void G1FullGCResetMetadataTask::G1ResetMetadataClosure::reset_region_metadata(G1HeapRegion* hr) {
-  if (hr->rem_set()->has_cset_group()) {
-    assert(hr->is_starts_humongous(), "Only humongous regions can retain a cset group");
-    assert(hr->rem_set()->cset_group()->length() == 1,
-           "Humongous region cset group must contain exactly one region");
+  if (hr->rem_set()->has_card_set_group()) {
+    assert(hr->is_starts_humongous(), "Only humongous start regions can retain a card set group");
+    assert(hr->rem_set()->card_set_group()->length() == 1,
+           "Humongous region card set group must contain exactly one region");
 
-    hr->rem_set()->cset_group()->clear_card_set();
+    hr->rem_set()->card_set_group()->clear_card_set();
   }
 
   hr->rem_set()->clear();

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -109,7 +109,7 @@ void G1HeapRegion::handle_evacuation_failure(bool retain) {
   move_to_old();
 
   _rem_set->clean_code_roots(this);
-  assert(!_rem_set->has_cset_group(), "must not have a cset group");
+  assert(!_rem_set->has_card_set_group(), "must not have a card set group");
   if (retain) {
     assert(_rem_set->is_tracked(), "must be");
   } else {
@@ -128,7 +128,7 @@ void G1HeapRegion::hr_clear(bool clear_space) {
   clear_young_index_in_cset();
   clear_index_in_opt_cset();
   uninstall_surv_rate_group();
-  uninstall_cset_group();
+  uninstall_card_set_group();
   set_free();
   reset_pre_dummy_top();
 
@@ -198,8 +198,8 @@ void G1HeapRegion::set_starts_humongous(HeapWord* obj_top, size_t fill_size) {
   _type.set_starts_humongous();
   _humongous_start_region = this;
 
-  G1CSetCandidateGroup* cset_group = new G1CSetCandidateGroup();
-  cset_group->add(this);
+  G1CardSetGroup* card_set_group = new G1CardSetGroup();
+  card_set_group->add(this);
 
   _bot->update_for_block(bottom(), obj_top);
   if (fill_size > 0) {
@@ -222,18 +222,18 @@ void G1HeapRegion::clear_humongous() {
 
   assert(capacity() == G1HeapRegion::GrainBytes, "pre-condition");
   if (is_starts_humongous()) {
-    G1CSetCandidateGroup* cset_group = _rem_set->cset_group();
-    assert(cset_group != nullptr, "pre-condition %u missing cardset", hrm_index());
-    uninstall_cset_group();
-    cset_group->clear();
-    delete cset_group;
+    G1CardSetGroup* card_set_group = _rem_set->card_set_group();
+    assert(card_set_group != nullptr, "pre-condition %u missing card set group", hrm_index());
+    uninstall_card_set_group();
+    card_set_group->clear();
+    delete card_set_group;
   }
   _humongous_start_region = nullptr;
 }
 
 void G1HeapRegion::prepare_remset_for_scan() {
   if (is_young()) {
-    uninstall_cset_group();
+    uninstall_card_set_group();
   }
   _rem_set->reset_table_scanner();
 }
@@ -629,7 +629,7 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
     bool failed() const {
       if (_from != _to && !_from->is_young() &&
           _to->rem_set()->is_complete() &&
-          _from->rem_set()->cset_group() != _to->rem_set()->cset_group()) {
+          _from->rem_set()->card_set_group() != _to->rem_set()->card_set_group()) {
         const CardValue clean = G1CardTable::clean_card_val();
         return !(_to->rem_set()->contains_reference(this->_p) ||
                  (this->_containing_obj->is_objArray() ?

--- a/src/hotspot/share/gc/g1/g1HeapRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.hpp
@@ -41,7 +41,7 @@ class G1CardSet;
 class G1CardSetConfiguration;
 class G1CollectedHeap;
 class G1CMBitMap;
-class G1CSetCandidateGroup;
+class G1CardSetGroup;
 class G1Predictions;
 class G1HeapRegionRemSet;
 class G1HeapRegionSetBase;
@@ -518,8 +518,8 @@ public:
   void install_surv_rate_group(G1SurvRateGroup* surv_rate_group);
   void uninstall_surv_rate_group();
 
-  void install_cset_group(G1CSetCandidateGroup* cset_group);
-  void uninstall_cset_group();
+  void install_card_set_group(G1CardSetGroup* card_set_group);
+  void uninstall_card_set_group();
 
   void record_surv_words_in_group(size_t words_survived);
 

--- a/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
@@ -534,12 +534,12 @@ inline void G1HeapRegion::add_pinned_object_count(size_t value) {
   _pinned_object_count.add_then_fetch(value, memory_order_relaxed);
 }
 
-inline void G1HeapRegion::install_cset_group(G1CSetCandidateGroup* cset_group) {
-  _rem_set->install_cset_group(cset_group);
+inline void G1HeapRegion::install_card_set_group(G1CardSetGroup* card_set_group) {
+  _rem_set->install_card_set_group(card_set_group);
 }
 
-inline void G1HeapRegion::uninstall_cset_group() {
-  _rem_set->uninstall_cset_group();
+inline void G1HeapRegion::uninstall_card_set_group() {
+  _rem_set->uninstall_card_set_group();
 }
 
 #endif // SHARE_GC_G1_G1HEAPREGION_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.cpp
@@ -35,17 +35,17 @@ void G1HeapRegionRemSet::initialize(MemRegion reserved) {
   _heap_base_address = reserved.start();
 }
 
-void G1HeapRegionRemSet::uninstall_cset_group() {
-  _cset_group = nullptr;
+void G1HeapRegionRemSet::uninstall_card_set_group() {
+  _card_set_group = nullptr;
 }
 
 G1HeapRegionRemSet::G1HeapRegionRemSet() :
   _code_roots(),
-  _cset_group(nullptr),
+  _card_set_group(nullptr),
   _state(Untracked) { }
 
 G1HeapRegionRemSet::~G1HeapRegionRemSet() {
-  assert(!has_cset_group(), "Still assigned to a CSet group");
+  assert(!has_card_set_group(), "Still assigned to a card set group");
 }
 
 void G1HeapRegionRemSet::clear() {
@@ -60,14 +60,14 @@ void G1HeapRegionRemSet::reset_code_root_table_scanner() {
 
 void G1HeapRegionRemSet::reset_table_scanner() {
   reset_code_root_table_scanner();
-  if (has_cset_group()) {
+  if (has_card_set_group()) {
     card_set()->reset_table_scanner();
   }
 }
 
 G1MonotonicArenaMemoryStats G1HeapRegionRemSet::card_set_memory_stats() const {
-  assert(has_cset_group(), "pre-condition");
-  return cset_group()->card_set_memory_stats();
+  assert(has_card_set_group(), "pre-condition");
+  return card_set_group()->card_set_memory_stats();
 }
 
 void G1HeapRegionRemSet::print_static_mem_size(outputStream* out) {

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.hpp
@@ -38,53 +38,53 @@ class G1HeapRegionRemSet : public CHeapObj<mtGC> {
   // the region that owns this RSet.
   G1CodeRootSet _code_roots;
 
-  G1CSetCandidateGroup* _cset_group;
+  G1CardSetGroup* _card_set_group;
 
   // Cached value of heap base address.
   static HeapWord* _heap_base_address;
 
   G1CardSet* card_set() {
-    assert(has_cset_group(), "pre-condition");
-    return cset_group()->card_set();
+    assert(has_card_set_group(), "pre-condition");
+    return card_set_group()->card_set();
   }
 
   const G1CardSet* card_set() const {
-    assert(has_cset_group(), "pre-condition");
-    return cset_group()->card_set();
+    assert(has_card_set_group(), "pre-condition");
+    return card_set_group()->card_set();
   }
 
   bool card_set_is_empty() const {
-    return !has_cset_group() || card_set()->is_empty();
+    return !has_card_set_group() || card_set()->is_empty();
   }
 
 public:
   G1HeapRegionRemSet();
   ~G1HeapRegionRemSet();
 
-  void install_cset_group(G1CSetCandidateGroup* cset_group) {
-    assert(cset_group != nullptr, "pre-condition");
-    assert(_cset_group == nullptr, "pre-condition");
+  void install_card_set_group(G1CardSetGroup* card_set_group) {
+    assert(card_set_group != nullptr, "pre-condition");
+    assert(_card_set_group == nullptr, "pre-condition");
 
-    _cset_group = cset_group;
+    _card_set_group = card_set_group;
   }
 
-  void uninstall_cset_group();
+  void uninstall_card_set_group();
 
-  bool has_cset_group() const {
-    return _cset_group != nullptr;
+  bool has_card_set_group() const {
+    return _card_set_group != nullptr;
   }
 
-  G1CSetCandidateGroup* cset_group() {
-    return _cset_group;
+  G1CardSetGroup* card_set_group() {
+    return _card_set_group;
   }
 
-  const G1CSetCandidateGroup* cset_group() const {
-    return _cset_group;
+  const G1CardSetGroup* card_set_group() const {
+    return _card_set_group;
   }
 
-  uint cset_group_id() const {
-    assert(has_cset_group(), "pre-condition");
-    return cset_group()->group_id();
+  uint card_set_group_id() const {
+    assert(has_card_set_group(), "pre-condition");
+    return card_set_group()->group_id();
   }
 
   bool is_empty() const {
@@ -105,7 +105,7 @@ public:
   inline static void iterate_for_merge(G1CardSet* card_set, CardOrRangeVisitor& cl);
 
   size_t occupied() {
-    assert(has_cset_group(), "pre-condition");
+    assert(has_card_set_group(), "pre-condition");
     return card_set()->occupied();
   }
 

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.inline.hpp
@@ -122,12 +122,12 @@ uintptr_t G1HeapRegionRemSet::to_card(OopOrNarrowOopStar from) const {
 }
 
 void G1HeapRegionRemSet::add_reference(OopOrNarrowOopStar from, G1FromCardCache& from_card_cache) {
-  precond(has_cset_group());
+  precond(has_card_set_group());
   precond(_state != Untracked);
 
   uintptr_t from_card = uintptr_t(from) >> CardTable::card_shift();
 
-  if (from_card_cache.contains_or_add(from_card, cset_group()->group_id())) {
+  if (from_card_cache.contains_or_add(from_card, card_set_group()->group_id())) {
     // We can't check whether the card is in the remembered set - the card container
     // may be coarsened just now.
     return;

--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -163,7 +163,7 @@ inline void G1ConcurrentRefineOopClosure::do_oop_work(T* p) {
   if (to_rem_set->is_tracked()) {
     G1HeapRegion* from = _g1h->heap_region_containing(p);
 
-    if (from->rem_set()->cset_group() != to_rem_set->cset_group()) {
+    if (from->rem_set()->card_set_group() != to_rem_set->card_set_group()) {
       to_rem_set->add_reference(p, _from_card_cache);
       _has_ref_to_old = true;
     }
@@ -290,7 +290,7 @@ template <class T> void G1RebuildRemSetClosure::do_oop_work(T* p) {
     if (!to->is_young()) {
       G1HeapRegion* from = _g1h->heap_region_containing(p);
 
-      if (from->rem_set()->cset_group() != rem_set->cset_group()) {
+      if (from->rem_set()->card_set_group() != rem_set->card_set_group()) {
         rem_set->add_reference(p, _from_card_cache);
       }
     }

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -512,7 +512,7 @@ uint G1Policy::calculate_desired_num_eden_regions_before_mixed(double base_time_
                                      candidates()->from_marking_groups().num_regions());
   double predicted_region_evac_time_ms = base_time_ms;
   uint selected_candidates = 0;
-  for (G1CSetCandidateGroup* gr : candidates()->from_marking_groups()) {
+  for (G1CardSetGroup* gr : candidates()->from_marking_groups()) {
     if (selected_candidates >= min_marking_candidates) {
       break;
     }
@@ -540,11 +540,11 @@ double G1Policy::predict_retained_regions_evac_time() const {
 
   double result = 0.0;
 
-  G1CSetCandidateGroupList* retained_groups = &candidates()->retained_groups();
+  G1CardSetGroupList* retained_groups = &candidates()->retained_groups();
   uint min_regions_left = MIN2(min_retained_old_cset_length(),
                                retained_groups->num_regions());
 
-  for (G1CSetCandidateGroup* group : *retained_groups) {
+  for (G1CardSetGroup* group : *retained_groups) {
     assert(group->length() == 1, "We should only have one region in a retained group");
     G1HeapRegion* r = group->region_at(0); // We only have one region per group.
     // We optimistically assume that any of these marking candidate regions will

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -547,8 +547,8 @@ double G1Policy::predict_retained_regions_evac_time() const {
   for (G1CardSetGroup* group : *retained_groups) {
     assert(group->length() == 1, "We should only have one region in a retained group");
     G1HeapRegion* r = group->region_at(0); // We only have one region per group.
-    // We optimistically assume that any of these marking candidate regions will
-    // be reclaimable the next gc, so just consider them as normal.
+    // We optimistically assume that any regions of these card set groups that contain pinned
+    // regions can be evacuated the next gc, so just consider them like normal.
     if (r->has_pinned_objects()) {
       num_pinned_regions++;
     }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1077,9 +1077,9 @@ class G1MergeHeapRootsTask : public WorkerTask {
         // remembered sets for this region.
         // We want to continue collecting remembered set entries for humongous regions
         // that were not reclaimed.
-        G1CSetCandidateGroup* group = r->rem_set()->cset_group();
-        assert(group != nullptr, "must have a cset group");
-        assert(group->length() == 1, "humongous regions cset group must have a single entry");
+        G1CardSetGroup* group = r->rem_set()->card_set_group();
+        assert(group != nullptr, "must have a card set group");
+        assert(group->length() == 1, "Card set groups containing humongous regions must have a single entry");
         group->clear_card_set();
       }
 
@@ -1148,7 +1148,7 @@ public:
         // 2. collection set
         G1MergeCardSetClosure merge(_scan_state);
 
-        g1h->collection_set()->merge_cardsets_for_collection_groups(merge, worker_id, _num_workers);
+        g1h->collection_set()->merge_collection_set_card_set_groups(merge, worker_id, _num_workers);
 
         G1MergeCardSetStats stats = merge.stats();
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1211,14 +1211,14 @@ void G1RemSet::merge_heap_roots(bool initial_evacuation) {
   {
     WorkerThreads* workers = g1h->workers();
 
-    uint const num_groups_in_increment = g1h->collection_set()->num_groups_in_increment();
+    uint const num_selected_groups_in_increment = g1h->collection_set()->num_selected_groups_in_increment();
 
     uint const num_workers = initial_evacuation ? workers->active_workers() :
-                                                  MIN2(workers->active_workers(), num_groups_in_increment);
+                                                  MIN2(workers->active_workers(), num_selected_groups_in_increment);
 
     G1MergeHeapRootsTask cl(_scan_state, num_workers, initial_evacuation);
-    log_debug(gc, ergo)("Running %s using %u workers for %u groups",
-                        cl.name(), num_workers, num_groups_in_increment);
+    log_debug(gc, ergo)("Running %s using %u workers for %u card set groups",
+                        cl.name(), num_workers, num_selected_groups_in_increment);
     workers->run_task(&cl, num_workers);
   }
 

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -216,8 +216,8 @@ class G1HeapRegionStatsClosure: public G1HeapRegionClosure {
   size_t _max_code_root_mem_sz;
   G1HeapRegion* _max_code_root_mem_sz_region;
 
-  size_t _max_group_cardset_mem_sz;
-  G1CardSetGroup* _max_cardset_mem_sz_group;
+  size_t _max_group_card_set_mem_sz;
+  G1CardSetGroup* _max_card_set_mem_sz_group;
 
   size_t total_rs_unused_mem_sz() const     { return _all.rs_unused_mem_size(); }
   size_t total_rs_mem_sz() const            { return _all.rs_mem_size(); }
@@ -226,8 +226,8 @@ class G1HeapRegionStatsClosure: public G1HeapRegionClosure {
   size_t max_rs_mem_sz() const              { return _max_rs_mem_sz; }
   G1HeapRegion* max_rs_mem_sz_region() const  { return _max_rs_mem_sz_region; }
 
-  size_t max_group_cardset_mem_sz() const                 { return _max_group_cardset_mem_sz; }
-  G1CardSetGroup* max_cardset_mem_sz_group() const  { return _max_cardset_mem_sz_group; }
+  size_t max_group_card_set_mem_sz() const                 { return _max_group_card_set_mem_sz; }
+  G1CardSetGroup* max_card_set_mem_sz_group() const  { return _max_card_set_mem_sz_group; }
 
   size_t total_code_root_mem_sz() const     { return _all.code_root_mem_size(); }
   size_t total_code_root_elems() const      { return _all.code_root_elems(); }
@@ -240,7 +240,7 @@ public:
     _free("Free"), _old("Old"), _all("All"),
     _max_rs_mem_sz(0), _max_rs_mem_sz_region(nullptr),
     _max_code_root_mem_sz(0), _max_code_root_mem_sz_region(nullptr),
-    _max_group_cardset_mem_sz(0), _max_cardset_mem_sz_group(nullptr)
+    _max_group_card_set_mem_sz(0), _max_card_set_mem_sz_group(nullptr)
   {}
 
   bool do_heap_region(G1HeapRegion* r) {
@@ -301,9 +301,9 @@ public:
       size_t rs_unused_mem_sz = card_set->unused_mem_size();
       size_t occupied_cards = card_set->occupied();
 
-      if (rs_mem_sz > _max_group_cardset_mem_sz) {
-        _max_group_cardset_mem_sz = rs_mem_sz;
-        _max_cardset_mem_sz_group = group;
+      if (rs_mem_sz > _max_group_card_set_mem_sz) {
+        _max_group_card_set_mem_sz = rs_mem_sz;
+        _max_card_set_mem_sz_group = group;
       }
 
       gen_counter->add(rs_unused_mem_sz, rs_mem_sz, occupied_cards, 0, 0, false);
@@ -356,8 +356,8 @@ public:
                     rem_set->occupied());
     }
 
-    if (max_cardset_mem_sz_group() != nullptr) {
-      G1CardSetGroup* card_set_group = max_cardset_mem_sz_group();
+    if (max_card_set_mem_sz_group() != nullptr) {
+      G1CardSetGroup* card_set_group = max_card_set_mem_sz_group();
       out->print_cr("    Card Set Group with largest card set = %u:(%u regions), "
                     "size = %zu occupied = %zu",
                     card_set_group->group_id(), card_set_group->length(),

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -249,8 +249,8 @@ public:
     size_t rs_unused_mem_sz = 0;
     size_t occupied_cards = 0;
 
-    // Accumulate card set details for regions that are assigned to single region
-    // groups. G1HeapRegionRemSet::mem_size() includes the size of the code roots
+    // Accumulate card set details for regions that are assigned to single-region
+    // card set groups. G1HeapRegionRemSet::mem_size() includes the size of the code roots
     if (hrrs->has_card_set_group() && hrrs->card_set_group()->length() == 1) {
       G1CardSet* card_set = hrrs->card_set_group()->card_set();
 

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -217,7 +217,7 @@ class G1HeapRegionStatsClosure: public G1HeapRegionClosure {
   G1HeapRegion* _max_code_root_mem_sz_region;
 
   size_t _max_group_cardset_mem_sz;
-  G1CSetCandidateGroup* _max_cardset_mem_sz_group;
+  G1CardSetGroup* _max_cardset_mem_sz_group;
 
   size_t total_rs_unused_mem_sz() const     { return _all.rs_unused_mem_size(); }
   size_t total_rs_mem_sz() const            { return _all.rs_mem_size(); }
@@ -227,7 +227,7 @@ class G1HeapRegionStatsClosure: public G1HeapRegionClosure {
   G1HeapRegion* max_rs_mem_sz_region() const  { return _max_rs_mem_sz_region; }
 
   size_t max_group_cardset_mem_sz() const                 { return _max_group_cardset_mem_sz; }
-  G1CSetCandidateGroup* max_cardset_mem_sz_group() const  { return _max_cardset_mem_sz_group; }
+  G1CardSetGroup* max_cardset_mem_sz_group() const  { return _max_cardset_mem_sz_group; }
 
   size_t total_code_root_mem_sz() const     { return _all.code_root_mem_size(); }
   size_t total_code_root_elems() const      { return _all.code_root_elems(); }
@@ -251,8 +251,8 @@ public:
 
     // Accumulate card set details for regions that are assigned to single region
     // groups. G1HeapRegionRemSet::mem_size() includes the size of the code roots
-    if (hrrs->has_cset_group() && hrrs->cset_group()->length() == 1) {
-      G1CardSet* card_set = hrrs->cset_group()->card_set();
+    if (hrrs->has_card_set_group() && hrrs->card_set_group()->length() == 1) {
+      G1CardSet* card_set = hrrs->card_set_group()->card_set();
 
       rs_mem_sz = hrrs->mem_size() + card_set->mem_size();
       rs_unused_mem_sz = card_set->unused_mem_size();
@@ -291,7 +291,7 @@ public:
     return false;
   }
 
-  void accumulate_stats_for_group(G1CSetCandidateGroup* group, G1PerRegionTypeRemSetCounters* gen_counter) {
+  void accumulate_stats_for_group(G1CardSetGroup* group, G1PerRegionTypeRemSetCounters* gen_counter) {
     // If the group has only a single region, then stats were accumulated
     // during region iteration. Skip these.
     if (group->length() > 1) {
@@ -311,18 +311,18 @@ public:
     }
   }
 
-  void do_cset_groups() {
+  void do_card_set_groups() {
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-    accumulate_stats_for_group(g1h->young_regions_cset_group(), &_young);
+    accumulate_stats_for_group(g1h->young_regions_card_set_group(), &_young);
 
     G1CollectionSetCandidates* candidates = g1h->policy()->candidates();
-    for (G1CSetCandidateGroup* group : candidates->from_marking_groups()) {
+    for (G1CardSetGroup* group : candidates->from_marking_groups()) {
       accumulate_stats_for_group(group, &_old);
     }
     // Skip gathering statistics for retained regions. Just verify that they have
     // the expected amount of regions.
-    for (G1CSetCandidateGroup* group : candidates->retained_groups()) {
+    for (G1CardSetGroup* group : candidates->retained_groups()) {
       assert(group->length() == 1, "must be");
     }
   }
@@ -357,12 +357,12 @@ public:
     }
 
     if (max_cardset_mem_sz_group() != nullptr) {
-      G1CSetCandidateGroup* cset_group = max_cardset_mem_sz_group();
-      out->print_cr("    Collectionset Candidate Group with largest cardset = %u:(%u regions), "
+      G1CardSetGroup* card_set_group = max_cardset_mem_sz_group();
+      out->print_cr("    Card Set Group with largest card set = %u:(%u regions), "
                     "size = %zu occupied = %zu",
-                    cset_group->group_id(), cset_group->length(),
-                    cset_group->card_set()->mem_size(),
-                    cset_group->card_set()->occupied());
+                    card_set_group->group_id(), card_set_group->length(),
+                    card_set_group->card_set()->mem_size(),
+                    card_set_group->card_set()->occupied());
     }
 
     G1HeapRegionRemSet::print_static_mem_size(out);
@@ -408,6 +408,6 @@ void G1RemSetSummary::print_on(outputStream* out, bool show_thread_times) {
   }
   G1HeapRegionStatsClosure blk;
   G1CollectedHeap::heap()->heap_region_iterate(&blk);
-  blk.do_cset_groups();
+  blk.do_card_set_groups();
   blk.print_summary_on(out);
 }

--- a/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
@@ -118,7 +118,7 @@ void G1RemSetTrackingPolicy::update_after_rebuild(G1HeapRegion* r) {
 
     size_t remset_bytes = r->rem_set()->mem_size();
     size_t occupied = 0;
-    // Per-region card set group details only valid if group contains a single region.
+    // Per-region card set group statistics are only valid if group contains a single region.
     if (r->rem_set()->has_card_set_group() &&
         r->rem_set()->card_set_group()->length() == 1 ) {
         G1CardSet *card_set = r->rem_set()->card_set_group()->card_set();

--- a/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
@@ -102,9 +102,9 @@ void G1RemSetTrackingPolicy::update_after_rebuild(G1HeapRegion* r) {
     // cycle as e.g. remembered set entries will always be added.
     if (r->is_starts_humongous() && !g1h->is_potential_eager_reclaim_candidate(r)) {
       // Handle HC regions with the HS region.
-      G1CSetCandidateGroup* group = r->rem_set()->cset_group();
+      G1CardSetGroup* group = r->rem_set()->card_set_group();
 
-      assert(group != nullptr, "humongous start must have a cset group");
+      assert(group != nullptr, "humongous start must have a card set group");
       assert(group->length() == 1, "humongous group must have only one region");
 
       group->clear_card_set();
@@ -118,10 +118,10 @@ void G1RemSetTrackingPolicy::update_after_rebuild(G1HeapRegion* r) {
 
     size_t remset_bytes = r->rem_set()->mem_size();
     size_t occupied = 0;
-    // per region cardset details only valid if group contains a single region.
-    if (r->rem_set()->has_cset_group() &&
-        r->rem_set()->cset_group()->length() == 1 ) {
-        G1CardSet *card_set = r->rem_set()->cset_group()->card_set();
+    // Per-region card set group details only valid if group contains a single region.
+    if (r->rem_set()->has_card_set_group() &&
+        r->rem_set()->card_set_group()->length() == 1 ) {
+        G1CardSet *card_set = r->rem_set()->card_set_group()->card_set();
         remset_bytes += card_set->mem_size();
         occupied = card_set->occupied();
     }

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -556,7 +556,7 @@ void G1YoungCollector::pre_evacuate_collection_set(G1EvacInfo* evacuation_info) 
     Tickspan task_time = run_task_timed(&g1_prep_task);
 
     G1MonotonicArenaMemoryStats sampled_card_set_stats = g1_prep_task.all_card_set_stats();
-    sampled_card_set_stats.add(_g1h->young_regions_cset_group()->card_set_memory_stats());
+    sampled_card_set_stats.add(_g1h->young_regions_card_set_group()->card_set_memory_stats());
     _g1h->set_young_gen_card_set_stats(sampled_card_set_stats);
     _g1h->set_humongous_stats(g1_prep_task.humongous_total(), g1_prep_task.humongous_candidates());
 

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -108,11 +108,11 @@ public:
 
     G1MonotonicArenaMemoryStats _total;
     G1CollectionSetCandidates* candidates = g1h->collection_set()->candidates();
-    for (G1CSetCandidateGroup* gr : candidates->from_marking_groups()) {
+    for (G1CardSetGroup* gr : candidates->from_marking_groups()) {
       _total.add(gr->card_set_memory_stats());
     }
 
-    for (G1CSetCandidateGroup* gr : candidates->retained_groups()) {
+    for (G1CardSetGroup* gr : candidates->retained_groups()) {
       _total.add(gr->card_set_memory_stats());
     }
     g1h->set_collection_set_candidates_stats(_total);

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -316,16 +316,16 @@
           "Chunk size used for rebuilding the remembered set.")             \
           range(4 * K, 32 * M)                                              \
                                                                             \
-  product(uint, G1OldCSetRegionThresholdPercent, 10, EXPERIMENTAL,         \
+  product(uint, G1OldCSetRegionThresholdPercent, 10, EXPERIMENTAL,          \
           "An upper bound for the number of old CSet regions expressed "    \
           "as a percentage of the heap size.")                              \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, G1OldCSetGroupSize, 5, EXPERIMENTAL,                        \
-          "The maximum number of old CSet regions in a collection group. "  \
-          "All regions in a group will be evacuated in the same GC pause."  \
-          "The first group calculated after marking from marking "          \
-          "candidates may exceed this limit as it is calculated based on "  \
+  product(uint, G1OldCardSetGroupSize, 5, EXPERIMENTAL,                     \
+          "The maximum number of old regions in a card set group. "         \
+          "All regions in a group will be evacuated in the same GC pause. " \
+          "The first group calculated in the concurrent cycle  "            \
+          "may exceed this limit as it is calculated based on "             \
           "G1MixedGCCountTarget.")                                          \
           range(1, 256)                                                     \
                                                                             \

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -392,8 +392,8 @@
   develop(bool, G1ForceOptionalEvacuation, false,                           \
           "Force optional evacuation for all GCs where there are old gen "  \
           "collection set candidates."                                      \
-          "Also schedule all available optional groups for evacuation "     \
-          "regardless of timing.")                                          \
+          "Also schedule all available optional card setgroups for "        \
+          "evacuation regardless of timing.")                               \
                                                                             \
   GC_G1_EVACUATION_FAILURE_FLAGS(develop,                                   \
                     develop_pd,                                             \

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -392,7 +392,7 @@
   develop(bool, G1ForceOptionalEvacuation, false,                           \
           "Force optional evacuation for all GCs where there are old gen "  \
           "collection set candidates."                                      \
-          "Also schedule all available optional card setgroups for "        \
+          "Also schedule all available optional card set groups for "       \
           "evacuation regardless of timing.")                               \
                                                                             \
   GC_G1_EVACUATION_FAILURE_FLAGS(develop,                                   \

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -324,7 +324,7 @@
   product(uint, G1OldCardSetGroupSize, 5, EXPERIMENTAL,                     \
           "The maximum number of old regions in a card set group. "         \
           "All regions in a group will be evacuated in the same GC pause. " \
-          "The first group calculated in the concurrent cycle  "            \
+          "The first group calculated in the concurrent cycle "             \
           "may exceed this limit as it is calculated based on "             \
           "G1MixedGCCountTarget.")                                          \
           range(1, 256)                                                     \

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -89,8 +89,8 @@ public:
     return (seed % i);
   }
 
-  static void cardset_basic_test();
-  static void cardset_mt_test();
+  static void card_set_basic_test();
+  static void card_set_mt_test();
 
   static void add_cards(G1CardSet* card_set, uint cards_per_region, uint* cards, uint num_cards, G1AddCardResult* results);
   static void contains_cards(G1CardSet* card_set, uint cards_per_region, uint* cards, uint num_cards);
@@ -215,7 +215,7 @@ void G1CardSetTest::check_iteration(G1CardSet* card_set, const size_t expected, 
   }
 }
 
-void G1CardSetTest::cardset_basic_test() {
+void G1CardSetTest::card_set_basic_test() {
 
   const uint CardsPerRegion = 2048;
   const double FullCardSetThreshold = 0.8;
@@ -435,7 +435,7 @@ public:
   size_t found() const { return _found.load_relaxed(); }
 };
 
-void G1CardSetTest::cardset_mt_test() {
+void G1CardSetTest::card_set_mt_test() {
   const uint CardsPerRegion = 16384;
   const double FullCardSetThreshold = 1.0;
   const uint BitmapCoarsenThreshold = 1.0;
@@ -492,10 +492,10 @@ void G1CardSetTest::cardset_mt_test() {
   ASSERT_TRUE(count_cards._num_cards <= cl.added());
 }
 
-TEST_VM(G1CardSetTest, basic_cardset_test) {
-  G1CardSetTest::cardset_basic_test();
+TEST_VM(G1CardSetTest, basic_card_set_test) {
+  G1CardSetTest::card_set_basic_test();
 }
 
-TEST_VM(G1CardSetTest, mt_cardset_test) {
-  G1CardSetTest::cardset_mt_test();
+TEST_VM(G1CardSetTest, mt_card_set_test) {
+  G1CardSetTest::card_set_mt_test();
 }

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -456,7 +456,7 @@ void G1CardSetTest::cardset_mt_test() {
   G1CardSetMtTestTask cl(&card_set);
 
   {
-    GCTraceTime(Error, gc) x("Cardset test");
+    GCTraceTime(Error, gc) x("G1CardSet test");
     _workers->run_task(&cl, num_workers);
   }
 

--- a/test/hotspot/gtest/gc/g1/test_g1CardSetContainers.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSetContainers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/gc/g1/test_g1CardSetContainers.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSetContainers.cpp
@@ -39,9 +39,9 @@ public:
     return G1CardSetInlinePtr::max_cards_in_inline_ptr(bits_per_card);
   }
 
-  static void cardset_inlineptr_test(uint bits_per_card);
-  static void cardset_array_test(uint cards_per_array);
-  static void cardset_bitmap_test(uint threshold, uint size_in_bits);
+  static void card_set_inlineptr_test(uint bits_per_card);
+  static void card_set_array_test(uint cards_per_array);
+  static void card_set_bitmap_test(uint threshold, uint size_in_bits);
 };
 
 class G1FindCardsInRange : public StackObj {
@@ -78,7 +78,7 @@ public:
   }
 };
 
-void G1CardSetContainersTest::cardset_inlineptr_test(uint bits_per_card) {
+void G1CardSetContainersTest::card_set_inlineptr_test(uint bits_per_card) {
   const uint CardsPerSet = cards_per_inlineptr_set(bits_per_card);
 
   G1AddCardResult res;
@@ -138,7 +138,7 @@ void G1CardSetContainersTest::cardset_inlineptr_test(uint bits_per_card) {
   }
 }
 
-void G1CardSetContainersTest::cardset_array_test(uint cards_per_array) {
+void G1CardSetContainersTest::card_set_array_test(uint cards_per_array) {
   uint8_t* cardset_data = NEW_C_HEAP_ARRAY(uint8_t, G1CardSetArray::size_in_bytes(cards_per_array), mtGC);
   G1CardSetArray* cards = new (cardset_data) G1CardSetArray(1, cards_per_array);
 
@@ -188,7 +188,7 @@ void G1CardSetContainersTest::cardset_array_test(uint cards_per_array) {
   FREE_C_HEAP_ARRAY(cardset_data);
 }
 
-void G1CardSetContainersTest::cardset_bitmap_test(uint threshold, uint size_in_bits) {
+void G1CardSetContainersTest::card_set_bitmap_test(uint threshold, uint size_in_bits) {
   uint8_t* cardset_data = NEW_C_HEAP_ARRAY(uint8_t, G1CardSetBitMap::size_in_bytes(size_in_bits), mtGC);
   G1CardSetBitMap* cards = new (cardset_data) G1CardSetBitMap(1, size_in_bits);
 
@@ -235,29 +235,29 @@ void G1CardSetContainersTest::cardset_bitmap_test(uint threshold, uint size_in_b
   FREE_C_HEAP_ARRAY(cardset_data);
 }
 
-TEST_VM_F(G1CardSetContainersTest, basic_cardset_inptr_test) {
+TEST_VM_F(G1CardSetContainersTest, basic_card_set_inptr_test) {
   uint const min = (uint)log2i(G1HeapRegionBounds::min_size());
   uint const max = (uint)log2i(G1HeapRegionBounds::max_size());
 
   for (uint i = min; i <= max; i++) {
-    G1CardSetContainersTest::cardset_inlineptr_test(i - CardTable::card_shift());
+    G1CardSetContainersTest::card_set_inlineptr_test(i - CardTable::card_shift());
   }
 }
 
-TEST_VM_F(G1CardSetContainersTest, basic_cardset_array_test) {
+TEST_VM_F(G1CardSetContainersTest, basic_card_set_array_test) {
   uint array_sizes[] = { 5, 9, 63, 77, 127 };
 
   for (uint i = 0; i < ARRAY_SIZE(array_sizes); i++) {
     size_t const max_cards_in_set = ARRAY_SIZE(array_sizes);
-    G1CardSetContainersTest::cardset_array_test(max_cards_in_set);
+    G1CardSetContainersTest::card_set_array_test(max_cards_in_set);
   }
 }
 
-TEST_VM_F(G1CardSetContainersTest, basic_cardset_bitmap_test) {
+TEST_VM_F(G1CardSetContainersTest, basic_card_set_bitmap_test) {
   uint bit_sizes[] = { 64, 2048 };
   uint threshold_sizes[] = { 17, 330 };
 
   for (uint i = 0; i < ARRAY_SIZE(bit_sizes); i++) {
-    G1CardSetContainersTest::cardset_bitmap_test(threshold_sizes[i], bit_sizes[i]);
+    G1CardSetContainersTest::card_set_bitmap_test(threshold_sizes[i], bit_sizes[i]);
   }
 }

--- a/test/hotspot/gtest/gc/g1/test_g1CardSetContainers.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSetContainers.cpp
@@ -139,8 +139,8 @@ void G1CardSetContainersTest::card_set_inlineptr_test(uint bits_per_card) {
 }
 
 void G1CardSetContainersTest::card_set_array_test(uint cards_per_array) {
-  uint8_t* cardset_data = NEW_C_HEAP_ARRAY(uint8_t, G1CardSetArray::size_in_bytes(cards_per_array), mtGC);
-  G1CardSetArray* cards = new (cardset_data) G1CardSetArray(1, cards_per_array);
+  uint8_t* card_set_data = NEW_C_HEAP_ARRAY(uint8_t, G1CardSetArray::size_in_bytes(cards_per_array), mtGC);
+  G1CardSetArray* cards = new (card_set_data) G1CardSetArray(1, cards_per_array);
 
   ASSERT_TRUE(cards->contains(1)); // Added during initialization
   ASSERT_TRUE(cards->num_entries() == 1); // Check it's the only one.
@@ -185,12 +185,12 @@ void G1CardSetContainersTest::card_set_array_test(uint cards_per_array) {
     found.verify_all_found();
   }
 
-  FREE_C_HEAP_ARRAY(cardset_data);
+  FREE_C_HEAP_ARRAY(card_set_data);
 }
 
 void G1CardSetContainersTest::card_set_bitmap_test(uint threshold, uint size_in_bits) {
-  uint8_t* cardset_data = NEW_C_HEAP_ARRAY(uint8_t, G1CardSetBitMap::size_in_bytes(size_in_bits), mtGC);
-  G1CardSetBitMap* cards = new (cardset_data) G1CardSetBitMap(1, size_in_bits);
+  uint8_t* card_set_data = NEW_C_HEAP_ARRAY(uint8_t, G1CardSetBitMap::size_in_bytes(size_in_bits), mtGC);
+  G1CardSetBitMap* cards = new (card_set_data) G1CardSetBitMap(1, size_in_bits);
 
   ASSERT_TRUE(cards->contains(1, size_in_bits)); // Added during initialization
   ASSERT_TRUE(cards->num_bits_set() == 1); // Should be the only one.
@@ -232,7 +232,7 @@ void G1CardSetContainersTest::card_set_bitmap_test(uint threshold, uint size_in_
     found.verify_part_found(threshold);
   }
 
-  FREE_C_HEAP_ARRAY(cardset_data);
+  FREE_C_HEAP_ARRAY(card_set_data);
 }
 
 TEST_VM_F(G1CardSetContainersTest, basic_card_set_inptr_test) {

--- a/test/hotspot/gtest/gc/g1/test_g1FromCardCache.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1FromCardCache.cpp
@@ -26,54 +26,54 @@
 
 TEST(G1FromCardCache, hit_and_miss) {
   const uintptr_t from_card = 64;
-  const uint cset_group_a = 3;
-  const uint cset_group_b = 13;
-  const uint cset_group_high = 1024;
+  const uint card_set_group_a = 3;
+  const uint card_set_group_b = 13;
+  const uint card_set_group_high = 1024;
 
   G1FromCardCache cache;
 
-  EXPECT_FALSE(cache.contains_or_add(from_card, cset_group_a));
-  EXPECT_TRUE(cache.contains_or_add(from_card, cset_group_a));
+  EXPECT_FALSE(cache.contains_or_add(from_card, card_set_group_a));
+  EXPECT_TRUE(cache.contains_or_add(from_card, card_set_group_a));
 
-  // Retain multiple cset groups for the same from_card.
-  EXPECT_FALSE(cache.contains_or_add(from_card, cset_group_b));
-  EXPECT_TRUE(cache.contains_or_add(from_card, cset_group_a));
-  EXPECT_TRUE(cache.contains_or_add(from_card, cset_group_b));
+  // Retain multiple card set groups for the same from_card.
+  EXPECT_FALSE(cache.contains_or_add(from_card, card_set_group_b));
+  EXPECT_TRUE(cache.contains_or_add(from_card, card_set_group_a));
+  EXPECT_TRUE(cache.contains_or_add(from_card, card_set_group_b));
 
   // A group id is not an array index.
-  EXPECT_FALSE(cache.contains_or_add(from_card, cset_group_high));
-  EXPECT_TRUE(cache.contains_or_add(from_card, cset_group_high));
+  EXPECT_FALSE(cache.contains_or_add(from_card, card_set_group_high));
+  EXPECT_TRUE(cache.contains_or_add(from_card, card_set_group_high));
 }
 
 TEST(G1FromCardCache, from_card_transition) {
   const uintptr_t from_card_a = 2;
   const uintptr_t from_card_b = 3;
-  const uint cset_group_id = 17;
+  const uint card_set_group_id = 17;
 
   G1FromCardCache cache;
 
-  EXPECT_FALSE(cache.contains_or_add(from_card_a, cset_group_id));
-  EXPECT_TRUE(cache.contains_or_add(from_card_a, cset_group_id));
+  EXPECT_FALSE(cache.contains_or_add(from_card_a, card_set_group_id));
+  EXPECT_TRUE(cache.contains_or_add(from_card_a, card_set_group_id));
 
   // Discard previous from_card data.
-  EXPECT_FALSE(cache.contains_or_add(from_card_b, cset_group_id));
-  EXPECT_TRUE(cache.contains_or_add(from_card_b, cset_group_id));
+  EXPECT_FALSE(cache.contains_or_add(from_card_b, card_set_group_id));
+  EXPECT_TRUE(cache.contains_or_add(from_card_b, card_set_group_id));
 
   // Verify that it was discarded before.
-  EXPECT_FALSE(cache.contains_or_add(from_card_a, cset_group_id));
+  EXPECT_FALSE(cache.contains_or_add(from_card_a, card_set_group_id));
 }
 
 TEST(G1FromCardCache, cache_reset) {
   const uintptr_t from_card = 17;
-  const uint cset_group_id = 17;
+  const uint card_set_group_id = 17;
 
   G1FromCardCache cache;
 
-  EXPECT_FALSE(cache.contains_or_add(from_card, cset_group_id));
-  EXPECT_TRUE(cache.contains_or_add(from_card, cset_group_id));
+  EXPECT_FALSE(cache.contains_or_add(from_card, card_set_group_id));
+  EXPECT_TRUE(cache.contains_or_add(from_card, card_set_group_id));
 
   cache.reset();
 
-  EXPECT_FALSE(cache.contains_or_add(from_card, cset_group_id));
-  EXPECT_TRUE(cache.contains_or_add(from_card, cset_group_id));
+  EXPECT_FALSE(cache.contains_or_add(from_card, card_set_group_id));
+  EXPECT_TRUE(cache.contains_or_add(from_card, card_set_group_id));
 }


### PR DESCRIPTION
Hi all,

  please review this renaming of G1CSetCandidateGroupList to g1CardSetGroup as the naming of the former has been causing quite a bit of confusion imo in the past.

The many fixes in the comments also indicate that.

There should be no semantic change in the code.

I plan to move out the G1CardSetGroup* classes into extra files separately.

Added naming rules:

 * ALWAYS spell out card set in some form, either "card set" in text, "_card_set" as part of variables, "CardSet" as part of types on so on.
* same for card set group (list), e.g. "card set group[ list]", "_card_set_group[_list]" and "CardSetGroup[List]" respectively

* do NOT use CSet in any form, reserved for collection set related names 

Testing: gha, local compilation

Thanks,
  Thomas

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391679](https://bugs.openjdk.org/browse/JDK-8391679): G1: Rename G1CSetCandidateGroup* to G1CardSetGroup* (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32672/head:pull/32672` \
`$ git checkout pull/32672`

Update a local copy of the PR: \
`$ git checkout pull/32672` \
`$ git pull https://git.openjdk.org/jdk.git pull/32672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32672`

View PR using the GUI difftool: \
`$ git pr show -t 32672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32672.diff">https://git.openjdk.org/jdk/pull/32672.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32672#issuecomment-5523111307)
</details>
