### PR TITLE
8391749: Disable VerifyOops in compiler/c1/CanonicalizeArrayLength.java

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/CanonicalizeArrayLength.java
+++ b/test/hotspot/jtreg/compiler/c1/CanonicalizeArrayLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,21 +28,21 @@
  *
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileThreshold=100 -XX:+TieredCompilation -XX:TieredStopAtLevel=1
- *                   -XX:-BackgroundCompilation
+ *                   -XX:-BackgroundCompilation -XX:-VerifyOops
  *                   compiler.c1.CanonicalizeArrayLength
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileThreshold=100 -XX:+TieredCompilation -XX:TieredStopAtLevel=3
- *                   -XX:-BackgroundCompilation
+ *                   -XX:-BackgroundCompilation -XX:-VerifyOops
  *                   -XX:+PatchALot
  *                   compiler.c1.CanonicalizeArrayLength
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileThreshold=100 -XX:+TieredCompilation -XX:TieredStopAtLevel=1
- *                   -XX:-BackgroundCompilation
+ *                   -XX:-BackgroundCompilation -XX:-VerifyOops
  *                   -XX:ScavengeRootsInCode=0
  *                   compiler.c1.CanonicalizeArrayLength
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileThreshold=100 -XX:+TieredCompilation -XX:TieredStopAtLevel=1
- *                   -XX:-BackgroundCompilation -XX:ScavengeRootsInCode=1
+ *                   -XX:-BackgroundCompilation -XX:ScavengeRootsInCode=1 -XX:-VerifyOops
  *                   compiler.c1.CanonicalizeArrayLength
  */
 


### PR DESCRIPTION
In order to reduce the noise in our CI, we should disable `VerifyOops` in `compiler/c1/CanonicalizeArrayLength.java` until [JDK-8391442](https://bugs.openjdk.org/browse/JDK-8391442) is fixed. 

I've checked a few occurrences and it always seems to happen with `-XX:+PatchALot`. But as a conservative fix, I suggest to just disable `VerifyOops` in all runs.

Thanks,
Christian

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391749](https://bugs.openjdk.org/browse/JDK-8391749): Disable VerifyOops in compiler/c1/CanonicalizeArrayLength.java (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32675/head:pull/32675` \
`$ git checkout pull/32675`

Update a local copy of the PR: \
`$ git checkout pull/32675` \
`$ git pull https://git.openjdk.org/jdk.git pull/32675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32675`

View PR using the GUI difftool: \
`$ git pr show -t 32675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32675.diff">https://git.openjdk.org/jdk/pull/32675.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32675#issuecomment-5524743118)
</details>
