### PR TITLE
8391750: Disable StressVerifyMeetJoin in CTW until JDK-8391748 is fixed

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -323,7 +323,6 @@ public class CtwRunner {
                 "-XX:+StressMacroExpansion",
                 "-XX:+StressMacroElimination",
                 "-XX:+StressIncrementalInlining",
-                "-XX:+StressVerifyMeetJoin",
                 // StressSeed is uint
                 "-XX:StressSeed=" + rng.nextInt(Integer.MAX_VALUE),
                 // Do not fail on huge methods where StressGCM makes register


### PR DESCRIPTION
Reverting (parts of) [JDK-8391452](https://bugs.openjdk.org/browse/JDK-8391452) because it causes frequent timeouts. Will be investigated with [JDK-8391748](https://bugs.openjdk.org/browse/JDK-8391748).

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391750](https://bugs.openjdk.org/browse/JDK-8391750): Disable StressVerifyMeetJoin in CTW until JDK-8391748 is fixed (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32676/head:pull/32676` \
`$ git checkout pull/32676`

Update a local copy of the PR: \
`$ git checkout pull/32676` \
`$ git pull https://git.openjdk.org/jdk.git pull/32676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32676`

View PR using the GUI difftool: \
`$ git pr show -t 32676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32676.diff">https://git.openjdk.org/jdk/pull/32676.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32676#issuecomment-5524853230)
</details>
