### PR TITLE
8391641: Unify *Handle type hierarchy with *oopDesc type hierarchy

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -587,7 +587,7 @@ void CodeBuffer::finalize_oop_references(const methodHandle& mh) {
   // Add any oops that we've found
   Thread* thread = Thread::current();
   for (int i = 0; i < oops.length(); i++) {
-    oop_recorder()->find_index((jobject)thread->handle_area()->allocate_handle(oops.at(i)));
+    oop_recorder()->find_index((jobject)thread->handle_area()->allocate_raw_handle(oops.at(i)));
   }
 }
 

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -45,8 +45,6 @@
 #include "utilities/macros.hpp"
 #include CPU_HEADER_INLINE(stackChunkOop)
 
-DEF_HANDLE_CONSTR(stackChunk, is_stackChunk_noinline)
-
 inline stackChunkOop stackChunkOopDesc::cast(oop obj) {
   assert(obj == nullptr || obj->is_stackChunk(), "Wrong type");
   return stackChunkOop(obj);

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -75,7 +75,7 @@ RegisterMap::RegisterMap(JavaThread *thread, UpdateMap update_map, ProcessFrames
   NOT_PRODUCT(_async = false;)
 
   if (walk_cont == WalkContinuation::include && thread != nullptr && thread->last_continuation() != nullptr) {
-    _chunk = stackChunkHandle(Thread::current()->handle_area()->allocate_null_handle(), true /* dummy */);
+    _chunk = stackChunkHandle::make_handle(Thread::current()->handle_area()->allocate_null_handle());
   }
   _chunk_index = -1;
 
@@ -94,7 +94,7 @@ RegisterMap::RegisterMap(oop continuation, UpdateMap update_map) {
   NOT_PRODUCT(_skip_missing = false;)
   NOT_PRODUCT(_async = false;)
 
-  _chunk = stackChunkHandle(Thread::current()->handle_area()->allocate_null_handle(), true /* dummy */);
+  _chunk = stackChunkHandle::make_handle(Thread::current()->handle_area()->allocate_null_handle());
   _chunk_index = -1;
 
 #ifndef PRODUCT

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -75,7 +75,7 @@ RegisterMap::RegisterMap(JavaThread *thread, UpdateMap update_map, ProcessFrames
   NOT_PRODUCT(_async = false;)
 
   if (walk_cont == WalkContinuation::include && thread != nullptr && thread->last_continuation() != nullptr) {
-    _chunk = stackChunkHandle::make_handle(Thread::current()->handle_area()->allocate_null_handle());
+    _chunk = stackChunkHandle::make(Thread::current()->handle_area()->allocate_raw_handle());
   }
   _chunk_index = -1;
 
@@ -94,7 +94,7 @@ RegisterMap::RegisterMap(oop continuation, UpdateMap update_map) {
   NOT_PRODUCT(_skip_missing = false;)
   NOT_PRODUCT(_async = false;)
 
-  _chunk = stackChunkHandle::make_handle(Thread::current()->handle_area()->allocate_null_handle());
+  _chunk = stackChunkHandle::make(Thread::current()->handle_area()->allocate_raw_handle());
   _chunk_index = -1;
 
 #ifndef PRODUCT

--- a/src/hotspot/share/runtime/handles.cpp
+++ b/src/hotspot/share/runtime/handles.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,15 +37,15 @@
   assert(_no_handle_mark_nesting == 0, "allocating handle inside NoHandleMark");         \
 
 
-oop* HandleArea::allocate_handle(oop obj) {
+oop* HandleArea::allocate_raw_handle(oop obj) {
   assert_handle_mark_nesting();
   assert(oopDesc::is_oop(obj), "not an oop: " INTPTR_FORMAT, p2i(obj));
-  return real_allocate_handle(obj);
+  return allocate_raw_handle_internal(obj);
 }
 
-oop* HandleArea::allocate_null_handle() {
+oop* HandleArea::allocate_raw_handle() {
   assert_handle_mark_nesting();
-  return real_allocate_handle(nullptr);
+  return allocate_raw_handle_internal(nullptr);
 }
 #endif
 

--- a/src/hotspot/share/runtime/handles.hpp
+++ b/src/hotspot/share/runtime/handles.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,8 @@ class Handle {
   oop     obj() const                            { return _handle == nullptr ? (oop)nullptr : *_handle; }
   oop     non_null_obj() const                   { assert(_handle != nullptr, "resolving null handle"); return *_handle; }
 
+  explicit Handle(oop *handle)                   { _handle = handle; }
+
  public:
   // Constructors
   Handle()                                       { _handle = nullptr; }
@@ -94,8 +96,7 @@ class Handle {
 
   // Direct interface, use very sparingly.
   // Used by JavaCalls to quickly convert handles and to create handles static data structures.
-  // Constructor takes a dummy argument to prevent unintentional type conversion in C++.
-  Handle(oop *handle, bool dummy)                { _handle = handle; }
+  static Handle make_handle(oop* handle)         { return Handle(handle); }
 
   // Raw handle access. Allows easy duplication of Handles. This can be very unsafe
   // since duplicates is only valid as long as original handle is alive.
@@ -104,33 +105,42 @@ class Handle {
 
   inline void replace(oop obj);
 };
-
 // Specific Handles for different oop types
-#define DEF_HANDLE(type, is_a)                   \
-  class type##Handle: public Handle {            \
-   protected:                                    \
-    type##Oop    obj() const                     { return (type##Oop)Handle::obj(); } \
-    type##Oop    non_null_obj() const            { return (type##Oop)Handle::non_null_obj(); } \
-                                                 \
-   public:                                       \
-    /* Constructors */                           \
-    type##Handle ()                              : Handle() {} \
-    inline type##Handle (Thread* thread, type##Oop obj); \
-    type##Handle (oop *handle, bool dummy)       : Handle(handle, dummy) {} \
-                                                 \
-    /* Operators for ease of use */              \
-    type##Oop    operator () () const            { return obj(); } \
-    type##Oop    operator -> () const            { return non_null_obj(); } \
+#define DEF_HANDLE_IMPL(HandleType, OopType, BaseType)                         \
+  class HandleType : public BaseType {                                         \
+  protected:                                                                   \
+    OopType obj() const { return (OopType)Handle::obj(); }                     \
+    OopType non_null_obj() const { return (OopType)Handle::non_null_obj(); }   \
+                                                                               \
+    explicit HandleType(oop *handle) : BaseType(handle) {}                     \
+                                                                               \
+  public:                                                                      \
+    /* Constructors */                                                         \
+    HandleType() : BaseType() {}                                               \
+    inline HandleType(Thread *thread, OopType obj);                            \
+                                                                               \
+    static HandleType make_handle(oop *handle) { return HandleType(handle); }  \
+                                                                               \
+    /* Operators for ease of use */                                            \
+    OopType operator()() const { return obj(); }                               \
+    OopType operator->() const { return non_null_obj(); }                      \
   };
 
+#define DEF_HANDLE_BASE(type, base)                                            \
+  DEF_HANDLE_IMPL(type##Handle, type##Oop, base##Handle)
+#define DEF_HANDLE(type) DEF_HANDLE_IMPL(type##Handle, type##Oop, Handle)
 
-DEF_HANDLE(instance         , is_instance_noinline         )
-DEF_HANDLE(stackChunk       , is_stackChunk_noinline       )
-DEF_HANDLE(array            , is_array_noinline            )
-DEF_HANDLE(objArray         , is_objArray_noinline         )
-DEF_HANDLE(typeArray        , is_typeArray_noinline        )
-DEF_HANDLE(flatArray        , is_flatArray_noinline        )
-DEF_HANDLE(refArray         , is_refArray_noinline         )
+DEF_HANDLE(instance)
+DEF_HANDLE_BASE(stackChunk, instance)
+DEF_HANDLE(array)
+DEF_HANDLE_BASE(objArray, array)
+DEF_HANDLE_BASE(typeArray, array)
+DEF_HANDLE_BASE(flatArray, objArray)
+DEF_HANDLE_BASE(refArray, objArray)
+
+#undef DEF_HANDLE
+#undef DEF_HANDLE_BASE
+#undef DEF_HANDLE_IMPL
 
 //------------------------------------------------------------------------------------------------------------------------
 
@@ -176,6 +186,8 @@ DEF_HANDLE(refArray         , is_refArray_noinline         )
 
 DEF_METADATA_HANDLE(method, Method)
 DEF_METADATA_HANDLE(constantPool, ConstantPool)
+
+#undef DEF_METADATA_HANDLE
 
 //------------------------------------------------------------------------------------------------------------------------
 // Thread local handle area

--- a/src/hotspot/share/runtime/handles.hpp
+++ b/src/hotspot/share/runtime/handles.hpp
@@ -65,17 +65,17 @@ class Thread;
 
 class Handle {
  private:
-  oop* _handle;
+  oop* _raw_handle;
 
  protected:
-  oop     obj() const                            { return _handle == nullptr ? (oop)nullptr : *_handle; }
-  oop     non_null_obj() const                   { assert(_handle != nullptr, "resolving null handle"); return *_handle; }
+  oop     obj() const                            { return _raw_handle == nullptr ? (oop)nullptr : *_raw_handle; }
+  oop     non_null_obj() const                   { assert(_raw_handle != nullptr, "resolving null handle"); return *_raw_handle; }
 
-  explicit Handle(oop *handle)                   { _handle = handle; }
+  explicit Handle(oop* raw_handle)               { _raw_handle = raw_handle; }
 
  public:
   // Constructors
-  Handle()                                       { _handle = nullptr; }
+  Handle()                                       { _raw_handle = nullptr; }
   inline Handle(Thread* thread, oop obj);
 
   // General access
@@ -88,20 +88,20 @@ class Handle {
   bool operator != (const Handle& h) const       { return obj() != h.obj(); }
 
   // Null checks
-  bool    is_null() const                        { return _handle == nullptr; }
-  bool    not_null() const                       { return _handle != nullptr; }
+  bool    is_null() const                        { return _raw_handle == nullptr; }
+  bool    not_null() const                       { return _raw_handle != nullptr; }
 
   // Debugging
   void    print()                                { obj()->print(); }
 
   // Direct interface, use very sparingly.
   // Used by JavaCalls to quickly convert handles and to create handles static data structures.
-  static Handle make_handle(oop* handle)         { return Handle(handle); }
+  static Handle make(oop* raw_handle)            { return Handle(raw_handle); }
 
   // Raw handle access. Allows easy duplication of Handles. This can be very unsafe
   // since duplicates is only valid as long as original handle is alive.
-  oop* raw_value() const                         { return _handle; }
-  static oop raw_resolve(oop *handle)            { return handle == nullptr ? (oop)nullptr : *handle; }
+  oop* raw_value() const                         { return _raw_handle; }
+  static oop raw_resolve(oop* raw_handle)        { return raw_handle == nullptr ? (oop)nullptr : *raw_handle; }
 
   inline void replace(oop obj);
 };
@@ -112,14 +112,14 @@ class Handle {
     OopType obj() const { return (OopType)Handle::obj(); }                     \
     OopType non_null_obj() const { return (OopType)Handle::non_null_obj(); }   \
                                                                                \
-    explicit HandleType(oop *handle) : BaseType(handle) {}                     \
+    explicit HandleType(oop* raw_handle) : BaseType(raw_handle) {}             \
                                                                                \
   public:                                                                      \
     /* Constructors */                                                         \
     HandleType() : BaseType() {}                                               \
-    inline HandleType(Thread *thread, OopType obj);                            \
+    inline HandleType(Thread* thread, OopType obj);                            \
                                                                                \
-    static HandleType make_handle(oop *handle) { return HandleType(handle); }  \
+    static HandleType make(oop* raw_handle) { return HandleType(raw_handle); } \
                                                                                \
     /* Operators for ease of use */                                            \
     OopType operator()() const { return obj(); }                               \
@@ -208,18 +208,18 @@ class HandleArea: public Arena {
 
   // Handle allocation
  private:
-  oop* real_allocate_handle(oop obj) {
-    oop* handle = (oop*)internal_amalloc(oopSize);
-    *handle = obj;
-    return handle;
+  oop* allocate_raw_handle_internal(oop obj) {
+    oop* raw_handle = (oop*)internal_amalloc(oopSize);
+    *raw_handle = obj;
+    return raw_handle;
   }
  public:
 #ifdef ASSERT
-  oop* allocate_handle(oop obj);
-  oop* allocate_null_handle();
+  oop* allocate_raw_handle(oop obj);
+  oop* allocate_raw_handle();
 #else
-  oop* allocate_handle(oop obj) { return real_allocate_handle(obj); }
-  oop* allocate_null_handle()   { return allocate_handle(nullptr); }
+  oop* allocate_raw_handle(oop obj) { return allocate_raw_handle_internal(obj); }
+  oop* allocate_raw_handle()   { return allocate_raw_handle_internal(nullptr); }
 #endif
 
   // Garbage collection support

--- a/src/hotspot/share/runtime/handles.inline.hpp
+++ b/src/hotspot/share/runtime/handles.inline.hpp
@@ -37,9 +37,9 @@
 inline Handle::Handle(Thread* thread, oop obj) {
   assert(thread == Thread::current(), "sanity check");
   if (obj == nullptr) {
-    _handle = nullptr;
+    _raw_handle = nullptr;
   } else {
-    _handle = thread->handle_area()->allocate_handle(obj);
+    _raw_handle = thread->handle_area()->allocate_raw_handle(obj);
   }
 }
 
@@ -47,8 +47,8 @@ inline void Handle::replace(oop obj) {
   // Unlike in OopHandle::replace, we shouldn't use a barrier here.
   // OopHandle has its storage in OopStorage, which is walked concurrently and uses barriers.
   // Handle is thread private, and iterated by Thread::oops_do, which is why it shouldn't have any barriers at all.
-  assert(_handle != nullptr, "should not use replace");
-  *_handle = obj;
+  assert(_raw_handle != nullptr, "should not use replace");
+  *_raw_handle = obj;
 }
 
 // Inline constructors for Specific Handles for different oop types

--- a/src/hotspot/share/runtime/handles.inline.hpp
+++ b/src/hotspot/share/runtime/handles.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,17 +52,31 @@ inline void Handle::replace(oop obj) {
 }
 
 // Inline constructors for Specific Handles for different oop types
-#define DEF_HANDLE_CONSTR(type, is_a)                   \
-inline type##Handle::type##Handle (Thread* thread, type##Oop obj) : Handle(thread, (oop)obj) { \
-  assert(is_null() || ((oop)obj)->is_a(), "illegal type");                \
-}
+#define DEF_HANDLE_CONSTR_IMPL(HandleType, OopType, BaseHandleType,            \
+                               BaseOopType, TypeCheckFn)                       \
+  inline HandleType::HandleType(Thread* thread, OopType obj)                   \
+      : BaseHandleType(thread, (BaseOopType)obj) {                             \
+    assert(is_null() || ((oop)obj)->TypeCheckFn(), "illegal type");            \
+  }
 
-DEF_HANDLE_CONSTR(instance , is_instance_noinline )
-DEF_HANDLE_CONSTR(array    , is_array_noinline    )
-DEF_HANDLE_CONSTR(objArray , is_objArray_noinline )
-DEF_HANDLE_CONSTR(typeArray, is_typeArray_noinline)
-DEF_HANDLE_CONSTR(flatArray, is_flatArray_noinline)
-DEF_HANDLE_CONSTR(refArray , is_refArray_noinline )
+#define DEF_HANDLE_CONSTR_BASE(type, base)                                     \
+  DEF_HANDLE_CONSTR_IMPL(type##Handle, type##Oop, base##Handle, base##Oop,     \
+                         is_##type##_noinline)
+#define DEF_HANDLE_CONSTR(type)                                                \
+  DEF_HANDLE_CONSTR_IMPL(type##Handle, type##Oop, Handle, oop,                 \
+                         is_##type##_noinline)
+
+DEF_HANDLE_CONSTR(instance)
+DEF_HANDLE_CONSTR_BASE(stackChunk, instance)
+DEF_HANDLE_CONSTR(array)
+DEF_HANDLE_CONSTR_BASE(objArray, array)
+DEF_HANDLE_CONSTR_BASE(typeArray, array)
+DEF_HANDLE_CONSTR_BASE(flatArray, objArray)
+DEF_HANDLE_CONSTR_BASE(refArray, objArray)
+
+#undef DEF_HANDLE_CONSTR
+#undef DEF_HANDLE_CONSTR_BASE
+#undef DEF_HANDLE_CONSTR_IMPL
 
 // Constructor for metadata handles
 #define DEF_METADATA_HANDLE_FN(name, type) \
@@ -77,6 +91,8 @@ inline name##Handle::name##Handle(Thread* thread, type* obj) : _value(obj), _thr
 
 DEF_METADATA_HANDLE_FN(method, Method)
 DEF_METADATA_HANDLE_FN(constantPool, ConstantPool)
+
+#undef DEF_METADATA_HANDLE_FN
 
 inline void HandleMark::push() {
   // This is intentionally a NOP. pop_and_restore will reset

--- a/src/hotspot/share/runtime/javaCalls.hpp
+++ b/src/hotspot/share/runtime/javaCalls.hpp
@@ -169,7 +169,7 @@ class JavaCallArguments : public StackObj {
     assert(_value_state[0] == value_state_handle,
            "first argument must be an oop");
     assert(_value[0] != 0, "receiver must be not-null");
-    return Handle::make_handle((oop*)_value[0]);
+    return Handle::make((oop*)_value[0]);
   }
 
   void set_receiver(Handle h) {

--- a/src/hotspot/share/runtime/javaCalls.hpp
+++ b/src/hotspot/share/runtime/javaCalls.hpp
@@ -169,7 +169,7 @@ class JavaCallArguments : public StackObj {
     assert(_value_state[0] == value_state_handle,
            "first argument must be an oop");
     assert(_value[0] != 0, "receiver must be not-null");
-    return Handle((oop*)_value[0], false);
+    return Handle::make_handle((oop*)_value[0]);
   }
 
   void set_receiver(Handle h) {


### PR DESCRIPTION
Similar to [JDK-8390299](https://bugs.openjdk.org/browse/JDK-8390299) but for our `<type>Handle` which right now all inherit from `Handle`.

I suggest we have the `<type>Handle` have the same type hierarchy as the `<type>OopDesc` type hierarchy.

Also cleanup the custom Handle constructor which is only used by JavaCalls and loom frame walking into its own explicit `make` function.

We currently do not have a `InlineHandle`. I will explore in a separate RFE the value of extending our Klass, Handle, Oop and OopDesc types to have a one to one correspondence. 

There are at least a handful of places in the code where we can avoid casting and/or have more explicit signatures if we had more precis Handle / oopDesc types.

Also prefixed the internal `oop*` handle with `raw` to better differentiate it from the typed `Handle`.

Testing:
* Tier 1-3 Oracle Supported platforms
* GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391641](https://bugs.openjdk.org/browse/JDK-8391641): Unify *Handle type hierarchy with *oopDesc type hierarchy (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32677/head:pull/32677` \
`$ git checkout pull/32677`

Update a local copy of the PR: \
`$ git checkout pull/32677` \
`$ git pull https://git.openjdk.org/jdk.git pull/32677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32677`

View PR using the GUI difftool: \
`$ git pr show -t 32677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32677.diff">https://git.openjdk.org/jdk/pull/32677.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32677#issuecomment-5525155637)
</details>
