### PR TITLE
8391753: G1: Fix groud-id typo in remembered set size message

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3248,7 +3248,7 @@ void G1PrintRegionLivenessInfoClosure::log_cset_candidate_groups() {
                           G1PPRL_BYTE_H_FORMAT
                           G1PPRL_BYTE_H_FORMAT
                           G1PPRL_TYPE_H_FORMAT,
-                          "groud-id", "num-regions",
+                          "group-id", "num-regions",
                           "gc-eff", "liveness",
                           "remset", "type");
 


### PR DESCRIPTION
Hi all,

  please review this trival fix of a typo in a log message: "groud-id" should be written as "group-id".

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391753](https://bugs.openjdk.org/browse/JDK-8391753): G1: Fix groud-id typo in remembered set size message (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32678/head:pull/32678` \
`$ git checkout pull/32678`

Update a local copy of the PR: \
`$ git checkout pull/32678` \
`$ git pull https://git.openjdk.org/jdk.git pull/32678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32678`

View PR using the GUI difftool: \
`$ git pr show -t 32678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32678.diff">https://git.openjdk.org/jdk/pull/32678.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32678#issuecomment-5525183335)
</details>
