### PR TITLE
8391611: Remove old NT 4.0 code from src/java.base/windows/native/libjava/TimeZone_md.c

### DIFF
--- a/src/java.base/windows/native/libjava/TimeZone_md.c
+++ b/src/java.base/windows/native/libjava/TimeZone_md.c
@@ -318,15 +318,6 @@ static int getWinTimeZone(char *winZoneName, size_t winZoneNameBufSize)
             ret = getValueInRegistry(hSubKey, STD_NAME, &valueType,
                                      szValue, &size);
             if (ret != ERROR_SUCCESS) {
-                /*
-                 * NT 4.0 SP3 fails here since it doesn't have the "Std"
-                 * entry in the Time Zones registry.
-                 */
-                RegCloseKey(hSubKey);
-                ret = RegOpenKeyExW(hKey, stdNamePtr, 0, KEY_READ, (PHKEY)&hSubKey);
-                if (ret != ERROR_SUCCESS) {
-                    goto err;
-                }
                 RegCloseKey(hSubKey);
                 break;
             }


### PR DESCRIPTION
TimeZone_md.c still contains some old NT 4.0 coding, this seems to be a leftover of older changes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391611](https://bugs.openjdk.org/browse/JDK-8391611): Remove old NT 4.0 code from src/java.base/windows/native/libjava/TimeZone_md.c (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32679/head:pull/32679` \
`$ git checkout pull/32679`

Update a local copy of the PR: \
`$ git checkout pull/32679` \
`$ git pull https://git.openjdk.org/jdk.git pull/32679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32679`

View PR using the GUI difftool: \
`$ git pr show -t 32679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32679.diff">https://git.openjdk.org/jdk/pull/32679.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32679#issuecomment-5525367012)
</details>
