### PR TITLE
8391751: JFR: Acquire JfrStacktrace_lock on reverse lookup for leak profiler

### DIFF
--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -212,6 +212,7 @@ traceid JfrStackTraceRepository::add_trace(const JfrStackTrace& stacktrace) {
 
 // invariant is that the entry to be resolved actually exists in the table
 const JfrStackTrace* JfrStackTraceRepository::lookup_for_leak_profiler(traceid hash, traceid id) {
+  MutexLocker lock(JfrStacktrace_lock, Mutex::_no_safepoint_check_flag);
   const size_t index = (hash % TABLE_SIZE);
   const JfrStackTrace* trace = leak_profiler_instance()._table[index];
   while (trace != nullptr && trace->id() != id) {


### PR DESCRIPTION
Greetings,

[JDK-8225797](https://bugs.openjdk.org/browse/JDK-8225797) moved leak-profiler stacktrace repository insertion ahead of ObjectSampler acquisition in ObjectSampler::sample(), unintentionally breaking the invariant that owning ObjectSampler also implied exclusive access to the leak profiler stack trace repository instance.

A producer can therefore modify the repository while the JFR Recorder Thread performs a reverse lookup.

Acquire JfrStacktrace_lock inside lookup_for_leak_profiler() to make repository insertion and lookup mutually exclusive again.

Testing: jdk_jfr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391751](https://bugs.openjdk.org/browse/JDK-8391751): JFR: Acquire JfrStacktrace_lock on reverse lookup for leak profiler (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32680/head:pull/32680` \
`$ git checkout pull/32680`

Update a local copy of the PR: \
`$ git checkout pull/32680` \
`$ git pull https://git.openjdk.org/jdk.git pull/32680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32680`

View PR using the GUI difftool: \
`$ git pr show -t 32680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32680.diff">https://git.openjdk.org/jdk/pull/32680.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32680#issuecomment-5525860392)
</details>
