### PR TITLE
8391756: SegmentAllocator string methods promise to return native segments which it should not

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -91,7 +91,7 @@ public interface SegmentAllocator {
      *}
      *
      * @param str the Java string to be converted into a C string
-     * @return a new native segment containing the converted C string
+     * @return a new segment containing the converted C string
      */
     @ForceInline
     default MemorySegment allocateFrom(String str) {
@@ -117,7 +117,7 @@ public interface SegmentAllocator {
      * @param str     the Java string to be converted into a C string
      * @param charset the charset used to {@linkplain Charset#newEncoder() encode} the
      *                string bytes
-     * @return a new native segment containing the converted C string
+     * @return a new segment containing the converted C string
      * @throws IllegalArgumentException if {@code charset} is not a
      *         {@linkplain StandardCharsets standard charset}
      * @implSpec The default implementation for this method copies the contents of the
@@ -174,7 +174,7 @@ public interface SegmentAllocator {
      *                 string bytes
      * @param srcIndex the starting index of the source string
      * @param numChars the number of characters to be copied
-     * @return a new native segment containing the encoded string
+     * @return a new segment containing the encoded string
      * @throws IndexOutOfBoundsException if either {@code srcIndex} or {@code numChars} are {@code < 0}
      * @throws IndexOutOfBoundsException if {@code srcIndex > str.length() - numChars}
      *


### PR DESCRIPTION
This PR proposes removing an erroneous claim that `SegmentAllocator` string operations return *native* segments.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change requires CSR request [JDK-8391764](https://bugs.openjdk.org/browse/JDK-8391764) to be approved
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8391756](https://bugs.openjdk.org/browse/JDK-8391756): SegmentAllocator string methods promise to return native segments which it should not (**Bug** - P3)
 * [JDK-8391764](https://bugs.openjdk.org/browse/JDK-8391764): SegmentAllocator string methods promise to return native segments which it should not (**CSR**)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32683/head:pull/32683` \
`$ git checkout pull/32683`

Update a local copy of the PR: \
`$ git checkout pull/32683` \
`$ git pull https://git.openjdk.org/jdk.git pull/32683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32683`

View PR using the GUI difftool: \
`$ git pr show -t 32683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32683.diff">https://git.openjdk.org/jdk/pull/32683.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32683#issuecomment-5526580098)
</details>
