### PR TITLE
8391765: C2: allow KILL effect with non bound registers in ad file

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -16172,15 +16172,15 @@ instruct string_equalsL(iRegP_R1 str1, iRegP_R3 str2, iRegI_R4 cnt,
   ins_pipe(pipe_class_memory);
 %}
 
-instruct array_equalsB(iRegP_R1 ary1, iRegP_R2 ary2, iRegI_R0 result,
-                       iRegP_R3 tmp1, iRegP_R4 tmp2, iRegP_R5 tmp3,
-                       vRegD_V0 vtmp0, vRegD_V1 vtmp1, vRegD_V2 vtmp2, vRegD_V3 vtmp3,
-                       vRegD_V4 vtmp4, vRegD_V5 vtmp5, vRegD_V6 vtmp6, vRegD_V7 vtmp7,
-                       iRegP_R10 tmp, rFlagsReg cr)
+instruct array_equalsB(iRegPNoSp ary1, iRegPNoSp ary2, iRegINoSp result,
+                       iRegPNoSp tmp1, iRegPNoSp tmp2, iRegPNoSp tmp3,
+                       vRegD vtmp0, vRegD vtmp1, vRegD vtmp2, vRegD vtmp3,
+                       vRegD vtmp4, vRegD vtmp5, vRegD vtmp6, vRegD vtmp7,
+                       iRegPNoSp tmp, rFlagsReg cr)
 %{
   predicate(((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (AryEq ary1 ary2));
-  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP tmp1, TEMP tmp2, TEMP tmp3,
+  effect(TEMP_DEF result, TEMP tmp, USE_KILL ary1, USE_KILL ary2, TEMP tmp1, TEMP tmp2, TEMP tmp3,
          TEMP vtmp0, TEMP vtmp1, TEMP vtmp2, TEMP vtmp3, TEMP vtmp4, TEMP vtmp5,
          TEMP vtmp6, TEMP vtmp7, KILL cr);
 
@@ -16197,15 +16197,15 @@ instruct array_equalsB(iRegP_R1 ary1, iRegP_R2 ary2, iRegI_R0 result,
   ins_pipe(pipe_class_memory);
 %}
 
-instruct array_equalsC(iRegP_R1 ary1, iRegP_R2 ary2, iRegI_R0 result,
-                       iRegP_R3 tmp1, iRegP_R4 tmp2, iRegP_R5 tmp3,
-                       vRegD_V0 vtmp0, vRegD_V1 vtmp1, vRegD_V2 vtmp2, vRegD_V3 vtmp3,
-                       vRegD_V4 vtmp4, vRegD_V5 vtmp5, vRegD_V6 vtmp6, vRegD_V7 vtmp7,
-                       iRegP_R10 tmp, rFlagsReg cr)
+instruct array_equalsC(iRegPNoSp ary1, iRegPNoSp ary2, iRegINoSp result,
+                       iRegPNoSp tmp1, iRegPNoSp tmp2, iRegPNoSp tmp3,
+                       vRegD vtmp0, vRegD vtmp1, vRegD vtmp2, vRegD vtmp3,
+                       vRegD vtmp4, vRegD vtmp5, vRegD vtmp6, vRegD vtmp7,
+                       iRegPNoSp tmp, rFlagsReg cr)
 %{
   predicate(((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (AryEq ary1 ary2));
-  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP tmp1, TEMP tmp2, TEMP tmp3,
+  effect(TEMP_DEF result, TEMP tmp, USE_KILL ary1, USE_KILL ary2, TEMP tmp1, TEMP tmp2, TEMP tmp3,
          TEMP vtmp0, TEMP vtmp1, TEMP vtmp2, TEMP vtmp3, TEMP vtmp4, TEMP vtmp5,
          TEMP vtmp6, TEMP vtmp7, KILL cr);
 
@@ -16264,13 +16264,15 @@ instruct count_positives(iRegP_R1 ary1, iRegI_R2 len, iRegI_R0 result, rFlagsReg
 %}
 
 // fast char[] to byte[] compression
-instruct string_compress(iRegP_R2 src, iRegP_R1 dst, iRegI_R3 len,
+// NB: vtmp0...vtmp3 and vtmp4...vtmp5 are hard registers because
+// we're going to use them in blocks with ld1 and st1.
+instruct string_compress(iRegPNoSp src, iRegPNoSp dst, iRegINoSp len,
                          vRegD_V0 vtmp0, vRegD_V1 vtmp1, vRegD_V2 vtmp2,
                          vRegD_V3 vtmp3, vRegD_V4 vtmp4, vRegD_V5 vtmp5,
-                         iRegI_R0 result, rFlagsReg cr)
+                         iRegINoSp result, rFlagsReg cr)
 %{
   match(Set result (StrCompressedCopy src (Binary dst len)));
-  effect(TEMP vtmp0, TEMP vtmp1, TEMP vtmp2, TEMP vtmp3, TEMP vtmp4, TEMP vtmp5,
+  effect(TEMP_DEF result, TEMP vtmp0, TEMP vtmp1, TEMP vtmp2, TEMP vtmp3, TEMP vtmp4, TEMP vtmp5,
          USE_KILL src, USE_KILL dst, USE len, KILL cr);
 
   format %{ "String Compress $src,$dst,$len -> $result # KILL $src $dst V0-V5 cr" %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -15281,12 +15281,12 @@ instruct string_compareL(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI c
   ins_pipe( pipe_slow );
 %}
 
-instruct string_compareL_evex(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
+instruct string_compareL_evex(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI cnt2,
                               rax_RegI result, legRegD tmp1, kReg ktmp, rFlagsReg cr)
 %{
   predicate(VM_Version::supports_avx512vlbw() && ((StrCompNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP tmp1, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
   format %{ "String Compare byte[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL $tmp1" %}
   ins_encode %{
@@ -15313,12 +15313,12 @@ instruct string_compareU(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI c
   ins_pipe( pipe_slow );
 %}
 
-instruct string_compareU_evex(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
+instruct string_compareU_evex(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI cnt2,
                               rax_RegI result, legRegD tmp1, kReg ktmp, rFlagsReg cr)
 %{
   predicate(VM_Version::supports_avx512vlbw() && ((StrCompNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP tmp1, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
   format %{ "String Compare char[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL $tmp1" %}
   ins_encode %{
@@ -15345,12 +15345,12 @@ instruct string_compareLU(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI 
   ins_pipe( pipe_slow );
 %}
 
-instruct string_compareLU_evex(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
+instruct string_compareLU_evex(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI cnt2,
                                rax_RegI result, legRegD tmp1, kReg ktmp, rFlagsReg cr)
 %{
   predicate(VM_Version::supports_avx512vlbw() && ((StrCompNode*)n)->encoding() == StrIntrinsicNode::LU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP tmp1, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
   format %{ "String Compare byte[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL $tmp1" %}
   ins_encode %{
@@ -15377,12 +15377,12 @@ instruct string_compareUL(rsi_RegP str1, rdx_RegI cnt1, rdi_RegP str2, rcx_RegI 
   ins_pipe( pipe_slow );
 %}
 
-instruct string_compareUL_evex(rsi_RegP str1, rdx_RegI cnt1, rdi_RegP str2, rcx_RegI cnt2,
+instruct string_compareUL_evex(rRegP str1, rdx_RegI cnt1, rRegP str2, rcx_RegI cnt2,
                                rax_RegI result, legRegD tmp1, kReg ktmp, rFlagsReg cr)
 %{
   predicate(VM_Version::supports_avx512vlbw() && ((StrCompNode*)n)->encoding() == StrIntrinsicNode::UL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP tmp1, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
   format %{ "String Compare byte[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL $tmp1" %}
   ins_encode %{
@@ -15560,12 +15560,12 @@ instruct stringL_indexof_char(rdi_RegP str1, rdx_RegI cnt1, rax_RegI ch,
 %}
 
 // fast string equals
-instruct string_equals(rdi_RegP str1, rsi_RegP str2, rcx_RegI cnt, rax_RegI result,
-                       legRegD tmp1, legRegD tmp2, rbx_RegI tmp3, rFlagsReg cr)
+instruct string_equals(rRegP str1, rRegP str2, rRegI cnt, rRegI result,
+                       legRegD tmp1, legRegD tmp2, rRegI tmp3, rFlagsReg cr)
 %{
   predicate(!VM_Version::supports_avx512vlbw());
   match(Set result (StrEquals (Binary str1 str2) cnt));
-  effect(TEMP tmp1, TEMP tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt, KILL tmp3, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP tmp3, KILL cr);
 
   format %{ "String Equals $str1,$str2,$cnt -> $result    // KILL $tmp1, $tmp2, $tmp3" %}
   ins_encode %{
@@ -15576,12 +15576,12 @@ instruct string_equals(rdi_RegP str1, rsi_RegP str2, rcx_RegI cnt, rax_RegI resu
   ins_pipe( pipe_slow );
 %}
 
-instruct string_equals_evex(rdi_RegP str1, rsi_RegP str2, rcx_RegI cnt, rax_RegI result,
-                           legRegD tmp1, legRegD tmp2, kReg ktmp, rbx_RegI tmp3, rFlagsReg cr)
+instruct string_equals_evex(rRegP str1, rRegP str2, rRegI cnt, rRegI result,
+                           legRegD tmp1, legRegD tmp2, kReg ktmp, rRegI tmp3, rFlagsReg cr)
 %{
   predicate(VM_Version::supports_avx512vlbw());
   match(Set result (StrEquals (Binary str1 str2) cnt));
-  effect(TEMP tmp1, TEMP tmp2, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt, KILL tmp3, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP tmp2, TEMP ktmp, USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP tmp3, KILL cr);
 
   format %{ "String Equals $str1,$str2,$cnt -> $result    // KILL $tmp1, $tmp2, $tmp3" %}
   ins_encode %{

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -15265,12 +15265,12 @@ instruct rep_stos_im(immL cnt, rRegP base, regD tmp, immL0 zero, rRegI val, kReg
   ins_pipe(pipe_slow);
 %}
 
-instruct string_compareL(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
+instruct string_compareL(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI cnt2,
                          rax_RegI result, legRegD tmp1, rFlagsReg cr)
 %{
   predicate(!VM_Version::supports_avx512vlbw() && ((StrCompNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP tmp1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
   format %{ "String Compare byte[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL $tmp1" %}
   ins_encode %{
@@ -15297,12 +15297,12 @@ instruct string_compareL_evex(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI cn
   ins_pipe( pipe_slow );
 %}
 
-instruct string_compareU(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
+instruct string_compareU(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI cnt2,
                          rax_RegI result, legRegD tmp1, rFlagsReg cr)
 %{
   predicate(!VM_Version::supports_avx512vlbw() && ((StrCompNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP tmp1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
   format %{ "String Compare char[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL $tmp1" %}
   ins_encode %{
@@ -15329,12 +15329,12 @@ instruct string_compareU_evex(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI cn
   ins_pipe( pipe_slow );
 %}
 
-instruct string_compareLU(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
+instruct string_compareLU(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI cnt2,
                           rax_RegI result, legRegD tmp1, rFlagsReg cr)
 %{
   predicate(!VM_Version::supports_avx512vlbw() && ((StrCompNode*)n)->encoding() == StrIntrinsicNode::LU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP tmp1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
   format %{ "String Compare byte[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL $tmp1" %}
   ins_encode %{
@@ -15361,12 +15361,12 @@ instruct string_compareLU_evex(rRegP str1, rcx_RegI cnt1, rRegP str2, rdx_RegI c
   ins_pipe( pipe_slow );
 %}
 
-instruct string_compareUL(rsi_RegP str1, rdx_RegI cnt1, rdi_RegP str2, rcx_RegI cnt2,
+instruct string_compareUL(rRegP str1, rdx_RegI cnt1, rRegP str2, rcx_RegI cnt2,
                           rax_RegI result, legRegD tmp1, rFlagsReg cr)
 %{
   predicate(!VM_Version::supports_avx512vlbw() && ((StrCompNode*)n)->encoding() == StrIntrinsicNode::UL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP tmp1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
+  effect(TEMP_DEF result, TEMP tmp1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
   format %{ "String Compare byte[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL $tmp1" %}
   ins_encode %{

--- a/src/hotspot/share/adlc/archDesc.hpp
+++ b/src/hotspot/share/adlc/archDesc.hpp
@@ -310,6 +310,8 @@ public:
 
   // Generator for Expand methods for instructions with expand rules
   void defineExpand      (FILE *fp, InstructForm *node);
+  void defineIsKilledInput      (FILE *fp, InstructForm *node);
+  
   // Generator for Peephole methods for instructions with peephole rules
   void definePeephole    (FILE *fp, InstructForm *node);
   // Generator for Size methods for instructions

--- a/src/hotspot/share/adlc/archDesc.hpp
+++ b/src/hotspot/share/adlc/archDesc.hpp
@@ -311,7 +311,7 @@ public:
   // Generator for Expand methods for instructions with expand rules
   void defineExpand      (FILE *fp, InstructForm *node);
   void defineIsKilledInput (FILE *fp, InstructForm *node);
-  
+
   // Generator for Peephole methods for instructions with peephole rules
   void definePeephole    (FILE *fp, InstructForm *node);
   // Generator for Size methods for instructions

--- a/src/hotspot/share/adlc/archDesc.hpp
+++ b/src/hotspot/share/adlc/archDesc.hpp
@@ -310,7 +310,7 @@ public:
 
   // Generator for Expand methods for instructions with expand rules
   void defineExpand      (FILE *fp, InstructForm *node);
-  void defineIsKilledInput      (FILE *fp, InstructForm *node);
+  void defineIsKilledInput (FILE *fp, InstructForm *node);
   
   // Generator for Peephole methods for instructions with peephole rules
   void definePeephole    (FILE *fp, InstructForm *node);

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -119,16 +119,37 @@ bool InstructForm::sets_result() const {
   return (_matrule != nullptr && _matrule->sets_result());
 }
 
-bool InstructForm::needs_projections() {
+bool InstructForm::needs_projections(ArchDesc& AD) {
   _components.reset();
   for( Component *comp; (comp = _components.iter()) != nullptr; ) {
     if (comp->isa(Component::KILL)) {
-      return true;
+      Form *form = (Form*)AD.globalNames()[comp->_type];
+      assert(form, "component type must be a defined form");
+      OperandForm *op = form->is_operand();
+      assert(op, "Support additional KILLS for base operands");
+      if (op->is_bound_register()) {
+        return true;
+      }
     }
   }
   return false;
 }
 
+bool InstructForm::kills_some_inputs(ArchDesc& AD) {
+  _components.reset();
+  for( Component *comp; (comp = _components.iter()) != nullptr; ) {
+    if (comp->isa(Component::KILL)) {
+      Form *form = (Form*)AD.globalNames()[comp->_type];
+      assert(form, "component type must be a defined form");
+      OperandForm *op = form->is_operand();
+      assert(op, "Support additional KILLS for base operands");
+      if (!op->is_bound_register()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 bool InstructForm::has_temps() {
   if (_matrule) {

--- a/src/hotspot/share/adlc/formssel.hpp
+++ b/src/hotspot/share/adlc/formssel.hpp
@@ -132,7 +132,8 @@ public:
   // This instruction sets a result
   virtual bool        sets_result() const;
   // This instruction needs projections for additional DEFs or KILLs
-  virtual bool        needs_projections();
+  virtual bool        needs_projections(ArchDesc& AD);
+  bool        kills_some_inputs(ArchDesc &AD);
   // This instruction needs extra nodes for temporary inputs
   virtual bool        has_temps();
   // This instruction defines or kills more than one object

--- a/src/hotspot/share/adlc/formssel.hpp
+++ b/src/hotspot/share/adlc/formssel.hpp
@@ -133,7 +133,7 @@ public:
   virtual bool        sets_result() const;
   // This instruction needs projections for additional DEFs or KILLs
   virtual bool        needs_projections(ArchDesc& AD);
-  bool        kills_some_inputs(ArchDesc &AD);
+          bool        kills_some_inputs(ArchDesc &AD);
   // This instruction needs extra nodes for temporary inputs
   virtual bool        has_temps();
   // This instruction defines or kills more than one object

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1701,7 +1701,7 @@ void ArchDesc::defineExpand(FILE *fp, InstructForm *node) {
   } // done generating expand rule
 
   // Generate projections for instruction's additional DEFs and KILLs
-  if( ! node->expands() && (node->needs_projections() || node->has_temps())) {
+  if( ! node->expands() && (node->needs_projections(*this) || node->has_temps())) {
     // Get string representing the MachNode that projections point at
     const char *machNode = "this";
     // Generate the projections
@@ -1757,8 +1757,9 @@ void ArchDesc::defineExpand(FILE *fp, InstructForm *node) {
         const char *ideal_type = op->ideal_type(_globalNames, _register);
 
         if (!op->is_bound_register()) {
-          syntax_err(node->_linenum, "In %s only bound registers can be killed: %s %s\n",
-                     node->_ident, comp->_type, comp->_name);
+          continue;
+          // syntax_err(node->_linenum, "In %s only bound registers can be killed: %s %s\n",
+          //            node->_ident, comp->_type, comp->_name);
         }
 
         fprintf(fp,"  kill = ");
@@ -1857,6 +1858,41 @@ void ArchDesc::defineExpand(FILE *fp, InstructForm *node) {
   fprintf(fp, "\n");
 }
 
+void ArchDesc::defineIsKilledInput(FILE* fp, InstructForm* node) {
+  if (node->expands() || !node->kills_some_inputs(*this)) {
+    return;
+  }
+  fprintf(fp, "bool %sNode::is_killed_input(uint idx) const {\n", node->_ident);
+  node->_components.reset();
+  Component* comp = nullptr;
+
+  int index = node->oper_input_base(_globalNames) - 1;
+  while ((comp = node->_components.iter()) != nullptr) {
+    // printf("XXX %d %s\n", index, comp->isa(Component::KILL) ? "kill" : "");
+           
+    if (comp->isa(Component::KILL)) {
+      // instr->oper_input_base(_globalNames)
+      //  const char *opcode = machOperEnum(comp->_type);
+      // oper->num_edges(_globalNames);
+
+      Form *form = (Form*)_globalNames[comp->_type];
+      assert(form, "component type must be a defined form");
+      OperandForm *op = form->is_operand();
+      assert(op, "Support additional KILLS for base operands");
+      if (!op->is_bound_register()) {
+        fprintf(fp, "  assert(operand_index(%d) == %d, \"\");\n", node->_components.operand_position(comp->_name), index);
+        fprintf(fp, "  if (operand_index(%d) == (int)idx) {\n", node->_components.operand_position(comp->_name));
+        fprintf(fp, "    return true;\n");
+        fprintf(fp, "  }\n");
+      }
+    }
+    index += _globalNames[comp->_type]->is_operand()->num_edges(_globalNames);
+  }
+
+  fprintf(fp, "  return false;\n");
+  fprintf(fp, "}\n");
+  fprintf(fp, "\n");
+}
 
 //------------------------------Emit Routines----------------------------------
 // Special classes and routines for defining node emit routines which output
@@ -3155,6 +3191,7 @@ void ArchDesc::defineClasses(FILE *fp) {
     if ( instr->ideal_only() ) continue;
 
     defineOut_RegMask(_CPP_MISC_file._fp, instr->_ident, reg_mask(*instr));
+    defineIsKilledInput(_CPP_MISC_file._fp, instr);
   }
 
   // Output the definitions for expand rules & peephole rules
@@ -3163,7 +3200,7 @@ void ArchDesc::defineClasses(FILE *fp) {
     // Ensure this is a machine-world instruction
     if ( instr->ideal_only() ) continue;
     // If there are multiple defs/kills, or an explicit expand rule, build rule
-    if( instr->expands() || instr->needs_projections() ||
+    if( instr->expands() || instr->needs_projections(*this) ||
         instr->has_temps() ||
         instr->is_mach_constant() ||
         instr->needs_constant_base() ||

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1866,7 +1866,7 @@ void ArchDesc::defineIsKilledInput(FILE* fp, InstructForm* node) {
 
   int index = node->oper_input_base(_globalNames) - 1;
   while ((comp = node->_components.iter()) != nullptr) {
-           
+
     if (comp->isa(Component::KILL)) {
 
       Form *form = (Form*)_globalNames[comp->_type];

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1875,7 +1875,7 @@ void ArchDesc::defineIsKilledInput(FILE* fp, InstructForm* node) {
       assert(op, "Support additional KILLS for base operands");
       if (!op->is_bound_register()) {
         fprintf(fp, "  assert(operand_index(%d) == %d, \"\");\n", node->_components.operand_position(comp->_name), index);
-        fprintf(fp, "  if (%d == (int)idx) {\n", index, node->_components.operand_position(comp->_name));
+        fprintf(fp, "  if (%d == (int)idx) {\n", index);
         fprintf(fp, "    return true;\n");
         fprintf(fp, "  }\n");
       }

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1875,7 +1875,7 @@ void ArchDesc::defineIsKilledInput(FILE* fp, InstructForm* node) {
       assert(op, "Support additional KILLS for base operands");
       if (!op->is_bound_register()) {
         fprintf(fp, "  assert(operand_index(%d) == %d, \"\");\n", node->_components.operand_position(comp->_name), index);
-        fprintf(fp, "  if (operand_index(%d) == (int)idx) {\n", node->_components.operand_position(comp->_name));
+        fprintf(fp, "  if (%d == (int)idx) {\n", index, node->_components.operand_position(comp->_name));
         fprintf(fp, "    return true;\n");
         fprintf(fp, "  }\n");
       }

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1701,7 +1701,7 @@ void ArchDesc::defineExpand(FILE *fp, InstructForm *node) {
   } // done generating expand rule
 
   // Generate projections for instruction's additional DEFs and KILLs
-  if( ! node->expands() && (node->needs_projections(*this) || node->has_temps())) {
+  if (! node->expands() && (node->needs_projections(*this) || node->has_temps())) {
     // Get string representing the MachNode that projections point at
     const char *machNode = "this";
     // Generate the projections
@@ -1758,8 +1758,6 @@ void ArchDesc::defineExpand(FILE *fp, InstructForm *node) {
 
         if (!op->is_bound_register()) {
           continue;
-          // syntax_err(node->_linenum, "In %s only bound registers can be killed: %s %s\n",
-          //            node->_ident, comp->_type, comp->_name);
         }
 
         fprintf(fp,"  kill = ");
@@ -1868,12 +1866,8 @@ void ArchDesc::defineIsKilledInput(FILE* fp, InstructForm* node) {
 
   int index = node->oper_input_base(_globalNames) - 1;
   while ((comp = node->_components.iter()) != nullptr) {
-    // printf("XXX %d %s\n", index, comp->isa(Component::KILL) ? "kill" : "");
            
     if (comp->isa(Component::KILL)) {
-      // instr->oper_input_base(_globalNames)
-      //  const char *opcode = machOperEnum(comp->_type);
-      // oper->num_edges(_globalNames);
 
       Form *form = (Form*)_globalNames[comp->_type];
       assert(form, "component type must be a defined form");

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -1700,7 +1700,7 @@ void ArchDesc::declareClasses(FILE *fp) {
     if ( instr->oper_input_base(_globalNames) != 1 ||
          strcmp("MachNode", instr->mach_base_class(_globalNames)) != 0 ) {
       fprintf(fp,"  virtual uint           oper_input_base() const { return %d; }\n",
-            instr->oper_input_base(_globalNames));
+             instr->oper_input_base(_globalNames));
     }
 
     // Make the constructor and following methods 'public:'
@@ -1803,7 +1803,7 @@ void ArchDesc::declareClasses(FILE *fp) {
     fprintf(fp, " }\n");
 
     // Virtual methods which are only generated to override base class
-    if( instr->expands() || instr->needs_projections() ||
+    if( instr->expands() || instr->needs_projections(*this) ||
         instr->has_temps() ||
         instr->is_mach_constant() ||
         instr->needs_constant_base() ||
@@ -1889,6 +1889,11 @@ void ArchDesc::declareClasses(FILE *fp) {
         fprintf(fp,"  virtual const TypePtr *adr_type() const;\n");
       }
       fprintf(fp,"  virtual const MachOper *memory_operand() const;\n");
+    }
+
+    if (!instr->expands() && instr->kills_some_inputs(*this)) {
+      fprintf(fp,"  virtual bool has_killed_inputs() const { return true; }\n");
+      fprintf(fp,"  virtual bool is_killed_input(uint i) const;\n");
     }
 
     fprintf(fp, "#ifndef PRODUCT\n");

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -754,6 +754,58 @@ void PhaseChaitin::Register_Allocate() {
     }
   }
 
+  {
+    bool failed = false;
+    live.compute(_lrg_map.max_lrg_id());
+    for (uint i = 0; i < _cfg.number_of_blocks(); i++) {
+      Block *block = _cfg.get_block(i);
+      IndexSet liveout(live.live(block));
+      uint last_inst = block->end_idx();
+      for (uint location = last_inst; location > 0; location--) {
+        Node *n = block->get_node(location);
+        uint lid = _lrg_map.live_range_id(n);
+
+        if (n->is_Mach() && n->as_Mach()->has_killed_inputs()) {
+          const MachNode* mach = n->as_Mach();
+          for (uint i = 1; i < n->req(); i++) {
+            if (mach->is_killed_input(i)) {
+              uint lidx = _lrg_map.live_range_id(n->in(i));
+              assert(lidx != 0, "");
+              if (liveout.member(lidx)) {
+                tty->print("input %d of", i); DEBUG_ONLY(n->dump();)
+                failed = true;
+              }
+              // assert(!liveout.member(lidx), "");
+            }
+          }
+        }
+        if (lid) {
+          liveout.remove(lid);
+        }
+        if (!n->is_Phi()) {
+          for (uint k = ((n->Opcode() == Op_SCMemProj) ? 0 : 1); k < n->req(); k++) {
+            Node *def = n->in(k);
+            uint lid = _lrg_map.live_range_id(def);
+            if (lid) {
+              liveout.insert(lid);
+            }
+          }
+        }
+      }
+    }
+    if (failed) {
+      for (uint i = 0; i < _cfg.number_of_blocks(); i++) {
+        Block* block = _cfg.get_block(i);
+        for (uint j = 0; j < block->number_of_nodes(); j++) {
+          Node* n = block->get_node(j);
+          OptoReg::Name reg = C->regalloc()->get_reg_first(n);
+          tty->print(" %-6s ", reg >= 0 && reg < REG_COUNT ? Matcher::regName[reg] : "");
+          DEBUG_ONLY(n->dump("\n", false, tty);)
+        }
+      }
+    }
+    assert(!failed, "");
+  }
   // Done!
   _live = nullptr;
   _ifg = nullptr;

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -775,7 +775,6 @@ void PhaseChaitin::Register_Allocate() {
                 tty->print("input %d of", i); DEBUG_ONLY(n->dump();)
                 failed = true;
               }
-              // assert(!liveout.member(lidx), "");
             }
           }
         }

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -767,12 +767,12 @@ void PhaseChaitin::Register_Allocate() {
 
         if (n->is_Mach() && n->as_Mach()->has_killed_inputs()) {
           const MachNode* mach = n->as_Mach();
-          for (uint i = 1; i < n->req(); i++) {
-            if (mach->is_killed_input(i)) {
-              uint lidx = _lrg_map.live_range_id(n->in(i));
+          for (uint j = 1; j < n->req(); j++) {
+            if (mach->is_killed_input(j)) {
+              uint lidx = _lrg_map.live_range_id(n->in(j));
               assert(lidx != 0, "");
               if (liveout.member(lidx)) {
-                tty->print("input %d of", i); DEBUG_ONLY(n->dump();)
+                tty->print("input %d of", j); DEBUG_ONLY(n->dump();)
                 failed = true;
               }
             }

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -353,6 +353,59 @@ void PhaseChaitin::compact() {
   _lrg_map.reset_uf_map(j);
 }
 
+#ifdef ASSERT
+void PhaseChaitin::verify_killed_inputs(PhaseLive& live) {
+  bool failed = false;
+  live.compute(_lrg_map.max_lrg_id());
+  for (uint i = 0; i < _cfg.number_of_blocks(); i++) {
+    Block *block = _cfg.get_block(i);
+    IndexSet liveout(live.live(block));
+    uint last_inst = block->end_idx();
+    for (uint location = last_inst; location > 0; location--) {
+      Node *n = block->get_node(location);
+      uint lid = _lrg_map.live_range_id(n);
+
+      if (n->is_Mach() && n->as_Mach()->has_killed_inputs()) {
+        const MachNode* mach = n->as_Mach();
+        for (uint j = 1; j < n->req(); j++) {
+          if (mach->is_killed_input(j)) {
+            uint lidx = _lrg_map.live_range_id(n->in(j));
+            assert(lidx != 0, "");
+            if (liveout.member(lidx)) {
+              tty->print("input %d of", j); DEBUG_ONLY(n->dump();)
+              failed = true;
+            }
+          }
+        }
+      }
+      if (lid) {
+        liveout.remove(lid);
+      }
+      if (!n->is_Phi()) {
+        for (uint k = ((n->Opcode() == Op_SCMemProj) ? 0 : 1); k < n->req(); k++) {
+          Node *def = n->in(k);
+          uint lid = _lrg_map.live_range_id(def);
+          if (lid) {
+            liveout.insert(lid);
+          }
+        }
+      }
+    }
+  }
+  if (failed) {
+    for (uint i = 0; i < _cfg.number_of_blocks(); i++) {
+      Block* block = _cfg.get_block(i);
+      for (uint j = 0; j < block->number_of_nodes(); j++) {
+        Node* n = block->get_node(j);
+        OptoReg::Name reg = C->regalloc()->get_reg_first(n);
+        tty->print(" %-6s ", reg >= 0 && reg < REG_COUNT ? Matcher::regName[reg] : "");
+        DEBUG_ONLY(n->dump("\n", false, tty);)
+      }
+    }
+  }
+  assert(!failed, "");
+}
+#endif
 void PhaseChaitin::Register_Allocate() {
 
   // Above the OLD FP (and in registers) are the incoming arguments.  Stack
@@ -754,57 +807,7 @@ void PhaseChaitin::Register_Allocate() {
     }
   }
 
-  {
-    bool failed = false;
-    live.compute(_lrg_map.max_lrg_id());
-    for (uint i = 0; i < _cfg.number_of_blocks(); i++) {
-      Block *block = _cfg.get_block(i);
-      IndexSet liveout(live.live(block));
-      uint last_inst = block->end_idx();
-      for (uint location = last_inst; location > 0; location--) {
-        Node *n = block->get_node(location);
-        uint lid = _lrg_map.live_range_id(n);
-
-        if (n->is_Mach() && n->as_Mach()->has_killed_inputs()) {
-          const MachNode* mach = n->as_Mach();
-          for (uint j = 1; j < n->req(); j++) {
-            if (mach->is_killed_input(j)) {
-              uint lidx = _lrg_map.live_range_id(n->in(j));
-              assert(lidx != 0, "");
-              if (liveout.member(lidx)) {
-                tty->print("input %d of", j); DEBUG_ONLY(n->dump();)
-                failed = true;
-              }
-            }
-          }
-        }
-        if (lid) {
-          liveout.remove(lid);
-        }
-        if (!n->is_Phi()) {
-          for (uint k = ((n->Opcode() == Op_SCMemProj) ? 0 : 1); k < n->req(); k++) {
-            Node *def = n->in(k);
-            uint lid = _lrg_map.live_range_id(def);
-            if (lid) {
-              liveout.insert(lid);
-            }
-          }
-        }
-      }
-    }
-    if (failed) {
-      for (uint i = 0; i < _cfg.number_of_blocks(); i++) {
-        Block* block = _cfg.get_block(i);
-        for (uint j = 0; j < block->number_of_nodes(); j++) {
-          Node* n = block->get_node(j);
-          OptoReg::Name reg = C->regalloc()->get_reg_first(n);
-          tty->print(" %-6s ", reg >= 0 && reg < REG_COUNT ? Matcher::regName[reg] : "");
-          DEBUG_ONLY(n->dump("\n", false, tty);)
-        }
-      }
-    }
-    assert(!failed, "");
-  }
+  verify_killed_inputs(live);
   // Done!
   _live = nullptr;
   _ifg = nullptr;

--- a/src/hotspot/share/opto/chaitin.hpp
+++ b/src/hotspot/share/opto/chaitin.hpp
@@ -442,6 +442,8 @@ class PhaseChaitin : public PhaseRegAlloc {
   // Compact live ranges, removing unused ones.  Return new maxlrg.
   void compact();
 
+  void verify_killed_inputs(PhaseLive& live) PRODUCT_RETURN;
+
   uint _lo_degree;              // Head of lo-degree LRGs list
   uint _lo_stk_degree;          // Head of lo-stk-degree LRGs list
   uint _hi_degree;              // Head of hi-degree LRGs list

--- a/src/hotspot/share/opto/ifg.cpp
+++ b/src/hotspot/share/opto/ifg.cpp
@@ -28,12 +28,9 @@
 #include "opto/addnode.hpp"
 #include "opto/block.hpp"
 #include "opto/callnode.hpp"
-#include "opto/cfgnode.hpp"
 #include "opto/chaitin.hpp"
-#include "opto/coalesce.hpp"
 #include "opto/indexSet.hpp"
 #include "opto/machnode.hpp"
-#include "opto/memnode.hpp"
 #include "opto/opcodes.hpp"
 
 #include <fenv.h>
@@ -892,6 +889,22 @@ uint PhaseChaitin::build_ifg_physical( ResourceArea *a ) {
       Node* n = block->get_node(location);
       uint lid = _lrg_map.live_range_id(n);
 
+      if (n->is_Mach() && n->as_Mach()->has_killed_inputs()) {
+        const MachNode* mach = n->as_Mach();
+        for (uint i = 1; i < n->req(); i++) {
+          if (mach->is_killed_input(i)) {
+            uint lidx = _lrg_map.live_range_id(n->in(i));
+            assert(lidx != 0, "");
+            if (liveout.member(lidx)) {
+              LRG &lrg = lrgs(lidx);
+              must_spill++;
+              lrg._must_spill = 1;
+              lrg.set_reg(OptoReg::Name(LRG::SPILL_REG));
+            }
+          }
+        }
+      }
+
       if (lid) {
         LRG& lrg = lrgs(lid);
 
@@ -937,6 +950,16 @@ uint PhaseChaitin::build_ifg_physical( ResourceArea *a ) {
           remove_bound_register_from_interfering_live_ranges(lrg, &liveout, must_spill);
         }
         interfere_with_live(lid, &liveout);
+        if (n->is_Mach() && n->as_Mach()->has_killed_inputs()) {
+          const MachNode* mach = n->as_Mach();
+          for (uint i = 1; i < n->req(); i++) {
+            if (mach->is_killed_input(i)) {
+              uint lidx = _lrg_map.live_range_id(n->in(i));
+              assert(lidx != 0, "");
+              interfere_with_live(lidx, &liveout);
+            }
+          }
+        }
         if (C->failing()) {
           return 0;
         }

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -283,6 +283,12 @@ public:
   // output have choices - but they must use the same choice.
   virtual uint two_adr( ) const { return 0; }
 
+  virtual bool has_killed_inputs() const { return false; }
+  virtual bool is_killed_input(uint i) const {
+    ShouldNotReachHere();
+    return false;
+  }
+
   // Capture the type of the matched ideal node
   const Type* _bottom_type;
 

--- a/src/hotspot/share/opto/postaloc.cpp
+++ b/src/hotspot/share/opto/postaloc.cpp
@@ -694,7 +694,23 @@ void PhaseChaitin::post_allocate_copy_removal() {
 
       // Remove copies along input edges
       for (k = 1; k < n->req(); k++) {
-        j -= elide_copy(n, k, block, &value, &regnd, two_adr != k);
+        j -= elide_copy(n, k, block, &value, &regnd, (two_adr != k) && !(n->is_Mach() && n->as_Mach()->has_killed_inputs() && n->as_Mach()->is_killed_input(k)));
+      }
+      if (n->is_Mach() && n->as_Mach()->has_killed_inputs()) {
+        for (k = 1; k < n->req(); k++) {
+          if (n->as_Mach()->is_killed_input(k)) {
+            Node* in = n->in(k);
+            uint lidx = _lrg_map.live_range_id(in);
+            OptoReg::Name inreg = lrgs(lidx).reg();
+            uint in_ideal_reg = in->ideal_reg();
+            int in_regs = RegMask::num_registers(in_ideal_reg, lrgs(lidx));
+            assert(in_regs == 1 || RegMask::is_vector(in_ideal_reg) || lrgs(lidx).mask().member(OptoReg::add(inreg,-1)), "");
+            for (int l = 0; l < in_regs; l++) {
+              regnd.map(OptoReg::add(inreg,-l), nullptr);
+              value.map(OptoReg::add(inreg,-l), nullptr);
+            }
+          }
+        }
       }
 
       // Unallocated Nodes define no registers

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -1037,8 +1037,8 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
             // Need special logic to handle bound USES. Insert a split at this
             // bound use if we can't rematerialize the def, or if we need the
             // split to form a misaligned pair.
-            if (!umask.is_infinite_stack() &&
-                (int)umask.size() <= lrgs(useidx).num_regs() &&
+            if (((!umask.is_infinite_stack() &&
+                (int)umask.size() <= lrgs(useidx).num_regs()) || (mach && mach->has_killed_inputs() && mach->is_killed_input(inpidx))) &&
                 (!def->rematerialize() ||
                  (!is_vect && umask.is_misaligned_pair()))) {
               // These need a Split regardless of overlap or pressure


### PR DESCRIPTION
XXXX

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391765](https://bugs.openjdk.org/browse/JDK-8391765): C2: allow KILL effect with non bound registers in ad file (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32685/head:pull/32685` \
`$ git checkout pull/32685`

Update a local copy of the PR: \
`$ git checkout pull/32685` \
`$ git pull https://git.openjdk.org/jdk.git pull/32685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32685`

View PR using the GUI difftool: \
`$ git pr show -t 32685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32685.diff">https://git.openjdk.org/jdk/pull/32685.diff</a>

</details>
