### PR TITLE
8391662: Deadlock in UpcallContext dtor when called after JVM shutdown due to System.exit

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -75,6 +75,7 @@ else
   # java.lang.foreign tests
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncStackWalk := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncInvokers := -pthread
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libDetachAfterExit := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := -pthread

--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -31,6 +31,7 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "runtime/vmOperations.hpp"
 #include "utilities/checkedCast.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -49,6 +50,13 @@ struct UpcallContext {
   Thread* attachedThread;
 
   ~UpcallContext() {
+    if (VM_Exit::vm_exited()) {
+      // This thread terminated after VM exit
+      // and can't be detached anymore.
+      // Leaking it is preferable to deadlocking
+      // in DetachCurrentThread.
+      return;
+    }
     if (attachedThread != nullptr) {
       JavaVM_ *vm = (JavaVM *)(&main_vm);
       vm->functions->DetachCurrentThread(vm);

--- a/test/jdk/java/foreign/detachafterexit/TestDetachAfterExit.java
+++ b/test/jdk/java/foreign/detachafterexit/TestDetachAfterExit.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library ../ /test/lib
+ * @modules java.base/jdk.internal.ref java.base/jdk.internal.foreign
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED TestDetachAfterExit
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.foreign.*;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestDetachAfterExit extends NativeTestHelper  {
+
+    @Test
+    public void testDetachAtExit() throws IOException, InterruptedException {
+        try {
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                    "--enable-native-access=ALL-UNNAMED",
+                    "-Djava.library.path=" + System.getProperty("java.library.path"),
+                    Runner.class.getName());
+            // note that it's important to use ProcessTools.startProcess here since this makes sure output streams of the
+            // fork don't fill up, which could make the process stall while writing to stdout/stderr
+            Process process = ProcessTools.startProcess(Runner.class.getName(), pb, null, null, 1L, TimeUnit.MINUTES);
+            OutputAnalyzer output = new OutputAnalyzer(process);
+            output.outputTo(System.out);
+            output.errorTo(System.err);
+
+            output.shouldHaveExitValue(0)
+                    .stdoutShouldContain("[await_join] done joining");
+        } catch (TimeoutException e) {
+            fail("Timeout while waiting for forked process");
+        }
+    }
+
+    public static class Runner {
+        static {
+            System.loadLibrary("DetachAfterExit");
+        }
+
+        public static void main(String[] args) throws Throwable {
+            MethodHandle mhCreate = Linker.nativeLinker().downcallHandle(
+                    SymbolLookup.loaderLookup().findOrThrow("create_thread_and_register_atexit"),
+                    FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+            MethodHandle mhCB = MethodHandles.lookup().findStatic(Runner.class, "cb",
+                    MethodType.methodType(void.class, AtomicBoolean.class));
+            FunctionDescriptor fdCB = FunctionDescriptor.ofVoid();
+
+            AtomicBoolean flag = new AtomicBoolean();
+            try (Arena arena = Arena.ofShared()) {
+                MemorySegment cb = Linker.nativeLinker().upcallStub(mhCB.bindTo(flag), fdCB, arena);
+                mhCreate.invokeExact(cb);
+
+                System.out.println("[main] Waiting for callback...");
+                while (!flag.get()) {
+                    Thread.onSpinWait();
+                }
+                System.out.println("[main] done waiting for callback");
+            }
+
+            System.out.println("[main] VM shutting down");
+            System.exit(0);
+        }
+
+        private static void cb(AtomicBoolean flag) {
+            System.out.println("[cb] Inside cb");
+            flag.set(true);
+        }
+    }
+}

--- a/test/jdk/java/foreign/detachafterexit/TestDetachAfterExit.java
+++ b/test/jdk/java/foreign/detachafterexit/TestDetachAfterExit.java
@@ -35,14 +35,9 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestDetachAfterExit {
 

--- a/test/jdk/java/foreign/detachafterexit/TestDetachAfterExit.java
+++ b/test/jdk/java/foreign/detachafterexit/TestDetachAfterExit.java
@@ -60,7 +60,7 @@ public class TestDetachAfterExit extends NativeTestHelper  {
             output.errorTo(System.err);
 
             output.shouldHaveExitValue(0)
-                    .stdoutShouldContain("[await_join] done joining");
+                  .stdoutShouldContain("[await_join] done joining");
         } catch (TimeoutException e) {
             fail("Timeout while waiting for forked process");
         }

--- a/test/jdk/java/foreign/detachafterexit/TestDetachAfterExit.java
+++ b/test/jdk/java/foreign/detachafterexit/TestDetachAfterExit.java
@@ -41,63 +41,50 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class TestDetachAfterExit extends NativeTestHelper  {
+public class TestDetachAfterExit {
 
     @Test
     public void testDetachAtExit() throws IOException, InterruptedException {
-        try {
-            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                    "--enable-native-access=ALL-UNNAMED",
-                    "-Djava.library.path=" + System.getProperty("java.library.path"),
-                    Runner.class.getName());
-            // note that it's important to use ProcessTools.startProcess here since this makes sure output streams of the
-            // fork don't fill up, which could make the process stall while writing to stdout/stderr
-            Process process = ProcessTools.startProcess(Runner.class.getName(), pb, null, null, 1L, TimeUnit.MINUTES);
-            OutputAnalyzer output = new OutputAnalyzer(process);
-            output.outputTo(System.out);
-            output.errorTo(System.err);
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "--enable-native-access=ALL-UNNAMED",
+                "-Djava.library.path=" + System.getProperty("java.library.path"),
+                Runner.class.getName());
+        // note that it's important to use ProcessTools.startProcess here since this makes sure output streams of the
+        // fork don't fill up, which could make the process stall while writing to stdout/stderr
+        Process process = ProcessTools.startProcess(Runner.class.getName(), pb);
+        assertTrue(process.waitFor(1L, TimeUnit.MINUTES));
+        OutputAnalyzer output = new OutputAnalyzer(process);
+        output.outputTo(System.out);
+        output.errorTo(System.err);
 
-            output.shouldHaveExitValue(0)
-                  .stdoutShouldContain("[await_join] done joining");
-        } catch (TimeoutException e) {
-            fail("Timeout while waiting for forked process");
-        }
+        output.shouldHaveExitValue(0)
+              .stdoutShouldContain("[await_join] done joining");
     }
 
-    public static class Runner {
+    public static class Runner extends NativeTestHelper  {
         static {
             System.loadLibrary("DetachAfterExit");
         }
 
         public static void main(String[] args) throws Throwable {
-            MethodHandle mhCreate = Linker.nativeLinker().downcallHandle(
-                    SymbolLookup.loaderLookup().findOrThrow("create_thread_and_register_atexit"),
-                    FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
-            MethodHandle mhCB = MethodHandles.lookup().findStatic(Runner.class, "cb",
-                    MethodType.methodType(void.class, AtomicBoolean.class));
-            FunctionDescriptor fdCB = FunctionDescriptor.ofVoid();
+            MethodHandle mhCreate = downcallHandle("create_thread_and_register_atexit",
+                    FunctionDescriptor.ofVoid(C_POINTER));
 
-            AtomicBoolean flag = new AtomicBoolean();
             try (Arena arena = Arena.ofShared()) {
-                MemorySegment cb = Linker.nativeLinker().upcallStub(mhCB.bindTo(flag), fdCB, arena);
+                MemorySegment cb = upcallStub(Runner.class, "cb", FunctionDescriptor.ofVoid(), arena);
+                // will block until callback has finished executing
                 mhCreate.invokeExact(cb);
-
-                System.out.println("[main] Waiting for callback...");
-                while (!flag.get()) {
-                    Thread.onSpinWait();
-                }
-                System.out.println("[main] done waiting for callback");
             }
 
             System.out.println("[main] VM shutting down");
             System.exit(0);
         }
 
-        private static void cb(AtomicBoolean flag) {
+        public static void cb() {
             System.out.println("[cb] Inside cb");
-            flag.set(true);
         }
     }
 }

--- a/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
+++ b/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
@@ -47,7 +47,6 @@ static void await_join() {
 extern "C"
 EXPORT void create_thread_and_register_atexit(void (*callback)(void)) {
     puts("[create_thread_and_register_atexit] creating native thread");
-    THREAD = TestThread(proc, (void*) callback);
-    THREAD.start();
+    THREAD = TestThread::start(proc, (void*) callback);
     atexit(&await_join);
 }

--- a/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
+++ b/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "export.h"
+#include "testlib_threads.hpp"
+
+#include <stdbool.h>
+
+static ThreadHelper THREAD_HELPER;
+static volatile bool FLAG = false;
+
+static void proc(void* ctxt) {
+    void (*callback)(void) = (void (*)(void)) ctxt;
+    callback();
+    puts("[proc] waiting for flag...");
+    while (!FLAG) {} // keep the thread alive until we can call join
+    puts("[proc] done waiting for flag");
+}
+
+static void await_join() {
+    puts("[await_join] joining...");
+    FLAG = true;
+    join_thread(&THREAD_HELPER);
+    puts("[await_join] done joining");
+}
+
+extern "C"
+EXPORT void create_thread_and_register_atexit(void (*callback)(void)) {
+    puts("[create_thread_and_register_atexit] creating native thread");
+    THREAD_HELPER.proc = proc;
+    THREAD_HELPER.context = (void*) callback;
+
+    create_thread(&THREAD_HELPER);
+
+    atexit(&await_join);
+}

--- a/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
+++ b/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
@@ -26,7 +26,7 @@
 
 #include <stdbool.h>
 
-static ThreadHelper THREAD_HELPER;
+static TestThread THREAD;
 static volatile bool FLAG = false;
 
 static void proc(void* ctxt) {
@@ -40,17 +40,14 @@ static void proc(void* ctxt) {
 static void await_join() {
     puts("[await_join] joining...");
     FLAG = true;
-    join_thread(&THREAD_HELPER);
+    THREAD.join();
     puts("[await_join] done joining");
 }
 
 extern "C"
 EXPORT void create_thread_and_register_atexit(void (*callback)(void)) {
     puts("[create_thread_and_register_atexit] creating native thread");
-    THREAD_HELPER.proc = proc;
-    THREAD_HELPER.context = (void*) callback;
-
-    create_thread(&THREAD_HELPER);
-
+    THREAD = TestThread(proc, (void*) callback);
+    THREAD.start();
     atexit(&await_join);
 }

--- a/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
+++ b/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
@@ -24,22 +24,25 @@
 #include "export.h"
 #include "testlib_threads.hpp"
 
+#include <atomic>
 #include <stdbool.h>
 
 static TestThread THREAD;
-static volatile bool FLAG = false;
+static std::atomic<bool> FLAG_WAITING;
+static std::atomic<bool> FLAG_JOINING;
 
 static void proc(void* ctxt) {
     void (*callback)(void) = (void (*)(void)) ctxt;
     callback();
     puts("[proc] waiting for flag...");
-    while (!FLAG) {} // keep the thread alive until we can call join
+    FLAG_WAITING.store(true);
+    while (!FLAG_JOINING.load()) {} // keep the thread alive until we can call join
     puts("[proc] done waiting for flag");
 }
 
 static void await_join() {
     puts("[await_join] joining...");
-    FLAG = true;
+    FLAG_JOINING.store(true);
     THREAD.join();
     puts("[await_join] done joining");
 }
@@ -49,4 +52,8 @@ EXPORT void create_thread_and_register_atexit(void (*callback)(void)) {
     puts("[create_thread_and_register_atexit] creating native thread");
     THREAD = TestThread::start(proc, (void*) callback);
     atexit(&await_join);
+    // wait for the thread to finish executing the callback
+    // so that we don't terminate the VM while it's still
+    // in progress
+    while (!FLAG_WAITING.load()) {}
 }

--- a/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
+++ b/test/jdk/java/foreign/detachafterexit/libDetachAfterExit.cpp
@@ -36,7 +36,8 @@ static void proc(void* ctxt) {
     callback();
     puts("[proc] waiting for flag...");
     FLAG_WAITING.store(true);
-    while (!FLAG_JOINING.load()) {} // keep the thread alive until we can call join
+    // keep this thread alive until after we've shut down the VM
+    while (!FLAG_JOINING.load()) {}
     puts("[proc] done waiting for flag");
 }
 

--- a/test/lib/native/testlib_threads.hpp
+++ b/test/lib/native/testlib_threads.hpp
@@ -37,20 +37,8 @@
 #endif
 
 extern "C" {
-
-typedef void(*PROCEDURE)(void*);
-
-#ifdef _WIN32
-typedef HANDLE THREAD;
-#else
-typedef pthread_t THREAD;
-#endif
-
-struct ThreadHelper {
-    THREAD _thread;
-    PROCEDURE proc;
-    void* context;
-};
+    typedef void(*PROCEDURE)(void*);
+}
 
 static void fatal(const char* message, int code) {
     fputs(message, stderr);
@@ -58,61 +46,82 @@ static void fatal(const char* message, int code) {
     exit(code);
 }
 
-// Adapt from the callback type the OS API expects to
-// our OS-independent PROCEDURE type.
+class TestThread {
+private:
+    using proc_t = PROCEDURE;
 #ifdef _WIN32
-DWORD WINAPI procedure(_In_ LPVOID ctxt) {
+    using thread_t = HANDLE;
 #else
-void* procedure(void* ctxt) {
+    using thread_t = pthread_t;
 #endif
-    ThreadHelper* helper = (ThreadHelper*)ctxt;
-    helper->proc(helper->context);
-    return 0;
-}
+    thread_t _thread;
+    proc_t _proc;
+    void* _context;
+public:
+    TestThread()
+            : _proc(nullptr), _context(nullptr) { }
 
-void create_thread(ThreadHelper* helper) {
-#ifdef _WIN32
-    helper->_thread = CreateThread(nullptr, 0, procedure, helper, 0, nullptr);
-    if (helper->_thread == nullptr) {
-        fatal("failed to create thread", GetLastError());
-    }
-#else
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    size_t stack_size = 0x100000;
-    pthread_attr_setstacksize(&attr, stack_size);
-    int result = pthread_create(&helper->_thread, &attr, procedure, helper);
-    if (result != 0) {
-        fatal("failed to create thread", result);
-    }
-    pthread_attr_destroy(&attr);
-#endif
-}
+    TestThread(proc_t proc, void* context = nullptr)
+            : _proc(proc), _context(context) { }
 
-void join_thread(ThreadHelper* helper) {
+    void start() {
 #ifdef _WIN32
-    if (WaitForSingleObject(helper->_thread, INFINITE) != WAIT_OBJECT_0) {
-        // Should be WAIT_FAILED, since this is not a mutex, and
-        // we set no timeout.
-        fatal("failed to join thread", GetLastError());
-    }
+        _thread = CreateThread(nullptr, 0, TestThread::procedure, this, 0, nullptr);
+        if (_thread == nullptr) {
+            fatal("failed to create thread", GetLastError());
+        }
 #else
-    int result = pthread_join(helper->_thread, nullptr);
-    if (result != 0) {
-        fatal("failed to join thread", result);
-    }
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        size_t stack_size = 0x100000;
+        pthread_attr_setstacksize(&attr, stack_size);
+        int result = pthread_create(&_thread, &attr, TestThread::procedure, this);
+        if (result != 0) {
+            fatal("failed to create thread", result);
+        }
+        pthread_attr_destroy(&attr);
 #endif
-}
+    }
+
+    void join() {
+#ifdef _WIN32
+        if (WaitForSingleObject(_thread, INFINITE) != WAIT_OBJECT_0) {
+            // Should be WAIT_FAILED, since this is not a mutex, and
+            // we set no timeout.
+            fatal("failed to join thread", GetLastError());
+        }
+#else
+        int result = pthread_join(_thread, nullptr);
+        if (result != 0) {
+            fatal("failed to join thread", result);
+        }
+#endif
+    }
+
+private:
+
+    // Adapt from the callback type the OS API expects to
+    // our OS-independent PROCEDURE type.
+    static
+    #ifdef _WIN32
+    DWORD WINAPI procedure(_In_ LPVOID ctxt) {
+    #else
+    void* procedure(void* ctxt) {
+    #endif
+        TestThread* helper = (TestThread*)ctxt;
+        helper->_proc(helper->_context);
+        return 0;
+    }
+};
+
+extern "C" {
 
 // Run 'proc' in a newly started thread, passing 'context' to it
 // as an argument, and then join that thread.
 void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
-    struct ThreadHelper helper;
-    helper.proc = proc;
-    helper.context = context;
-
-    create_thread(&helper);
-    join_thread(&helper);
+    TestThread thread(proc, context);
+    thread.start();
+    thread.join();
 }
 
 }

--- a/test/lib/native/testlib_threads.hpp
+++ b/test/lib/native/testlib_threads.hpp
@@ -28,6 +28,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <memory>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -55,18 +56,21 @@ private:
     using thread_t = pthread_t;
 #endif
     thread_t _thread;
-    proc_t _proc;
-    void* _context;
-public:
-    TestThread()
-            : _proc(nullptr), _context(nullptr) { }
+    struct CallbackData {
+        proc_t _proc;
+        void* _context;
+        CallbackData(proc_t proc, void* context)
+                : _proc(proc), _context(context) {}
+    };
+    // Keep the data the callback needs out-of-line
+    // so that if this TestThread object is copied,
+    // the pointer remains valid
+    std::shared_ptr<CallbackData> _data;
 
-    TestThread(proc_t proc, void* context = nullptr)
-            : _proc(proc), _context(context) { }
-
-    void start() {
+    TestThread(proc_t proc, void* context)
+            : _data(std::make_shared<CallbackData>(proc, context)) {
 #ifdef _WIN32
-        _thread = CreateThread(nullptr, 0, TestThread::procedure, this, 0, nullptr);
+        _thread = CreateThread(nullptr, 0, TestThread::procedure, _data.get(), 0, nullptr);
         if (_thread == nullptr) {
             fatal("failed to create thread", GetLastError());
         }
@@ -75,15 +79,24 @@ public:
         pthread_attr_init(&attr);
         size_t stack_size = 0x100000;
         pthread_attr_setstacksize(&attr, stack_size);
-        int result = pthread_create(&_thread, &attr, TestThread::procedure, this);
+        int result = pthread_create(&_thread, &attr, TestThread::procedure, _data.get());
         if (result != 0) {
             fatal("failed to create thread", result);
         }
         pthread_attr_destroy(&attr);
 #endif
     }
+public:
+    TestThread() { }
 
-    void join() {
+    static TestThread start(proc_t proc, void* context) {
+        return TestThread(proc, context);
+    }
+
+    void join() const {
+        if (_data.get() == nullptr) {
+            fatal("Joining TestThread that is not initialized", 1);
+        }
 #ifdef _WIN32
         if (WaitForSingleObject(_thread, INFINITE) != WAIT_OBJECT_0) {
             // Should be WAIT_FAILED, since this is not a mutex, and
@@ -108,8 +121,8 @@ private:
     #else
     void* procedure(void* ctxt) {
     #endif
-        TestThread* helper = (TestThread*)ctxt;
-        helper->_proc(helper->_context);
+        CallbackData* data = (CallbackData*)ctxt;
+        data->_proc(data->_context);
         return 0;
     }
 };
@@ -119,8 +132,7 @@ extern "C" {
 // Run 'proc' in a newly started thread, passing 'context' to it
 // as an argument, and then join that thread.
 void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
-    TestThread thread(proc, context);
-    thread.start();
+    TestThread thread = TestThread::start(proc, context);
     thread.join();
 }
 

--- a/test/lib/native/testlib_threads.hpp
+++ b/test/lib/native/testlib_threads.hpp
@@ -37,10 +37,6 @@
 #include <pthread.h>
 #endif
 
-extern "C" {
-    typedef void(*PROCEDURE)(void*);
-}
-
 static void fatal(const char* message, int code) {
     fputs(message, stderr);
     // exit the test with a non-zero exit code to avoid accidental false positives
@@ -48,14 +44,17 @@ static void fatal(const char* message, int code) {
 }
 
 class TestThread {
+public:
+    using proc_t = void(*)(void*);
 private:
-    using proc_t = PROCEDURE;
 #ifdef _WIN32
     using thread_t = HANDLE;
 #else
     using thread_t = pthread_t;
 #endif
+
     thread_t _thread;
+
     struct CallbackData {
         proc_t _proc;
         void* _context;
@@ -112,7 +111,6 @@ public:
     }
 
 private:
-
     // Adapt from the callback type the OS API expects to
     // our OS-independent PROCEDURE type.
     static
@@ -127,15 +125,11 @@ private:
     }
 };
 
-extern "C" {
-
 // Run 'proc' in a newly started thread, passing 'context' to it
 // as an argument, and then join that thread.
-void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
+void run_in_new_thread_and_join(TestThread::proc_t proc, void* context) {
     TestThread thread = TestThread::start(proc, context);
     thread.join();
-}
-
 }
 
 #endif // TEST_LIB_NATIVE_THREAD_HPP

--- a/test/lib/native/testlib_threads.hpp
+++ b/test/lib/native/testlib_threads.hpp
@@ -40,7 +40,14 @@ extern "C" {
 
 typedef void(*PROCEDURE)(void*);
 
-struct Helper {
+#ifdef _WIN32
+typedef HANDLE THREAD;
+#else
+typedef pthread_t THREAD;
+#endif
+
+struct ThreadHelper {
+    THREAD _thread;
     PROCEDURE proc;
     void* context;
 };
@@ -58,43 +65,54 @@ DWORD WINAPI procedure(_In_ LPVOID ctxt) {
 #else
 void* procedure(void* ctxt) {
 #endif
-    Helper* helper = (Helper*)ctxt;
+    ThreadHelper* helper = (ThreadHelper*)ctxt;
     helper->proc(helper->context);
     return 0;
 }
 
-// Run 'proc' in a newly started thread, passing 'context' to it
-// as an argument, and then join that thread.
-void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
-    struct Helper helper;
-    helper.proc = proc;
-    helper.context = context;
+void create_thread(ThreadHelper* helper) {
 #ifdef _WIN32
-    HANDLE thread = CreateThread(nullptr, 0, procedure, &helper, 0, nullptr);
-    if (thread == nullptr) {
+    helper->_thread = CreateThread(nullptr, 0, procedure, helper, 0, nullptr);
+    if (helper->_thread == nullptr) {
         fatal("failed to create thread", GetLastError());
     }
-    if (WaitForSingleObject(thread, INFINITE) != WAIT_OBJECT_0) {
+#else
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    size_t stack_size = 0x100000;
+    pthread_attr_setstacksize(&attr, stack_size);
+    int result = pthread_create(&helper->_thread, &attr, procedure, helper);
+    if (result != 0) {
+        fatal("failed to create thread", result);
+    }
+    pthread_attr_destroy(&attr);
+#endif
+}
+
+void join_thread(ThreadHelper* helper) {
+#ifdef _WIN32
+    if (WaitForSingleObject(helper->_thread, INFINITE) != WAIT_OBJECT_0) {
         // Should be WAIT_FAILED, since this is not a mutex, and
         // we set no timeout.
         fatal("failed to join thread", GetLastError());
     }
 #else
-    pthread_t thread;
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    size_t stack_size = 0x100000;
-    pthread_attr_setstacksize(&attr, stack_size);
-    int result = pthread_create(&thread, &attr, procedure, &helper);
-    if (result != 0) {
-        fatal("failed to create thread", result);
-    }
-    pthread_attr_destroy(&attr);
-    result = pthread_join(thread, nullptr);
+    int result = pthread_join(helper->_thread, nullptr);
     if (result != 0) {
         fatal("failed to join thread", result);
     }
 #endif
+}
+
+// Run 'proc' in a newly started thread, passing 'context' to it
+// as an argument, and then join that thread.
+void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
+    struct ThreadHelper helper;
+    helper.proc = proc;
+    helper.context = context;
+
+    create_thread(&helper);
+    join_thread(&helper);
 }
 
 }


### PR DESCRIPTION
See the JBS issue for the extended problem description.

Native threads that were attached to the JVM through an FFM upcall are automatically detached from the VM when they join/terminate. However, if a native thread tries to terminate after the VM has exited without going through `DestroyJavaVm` (e.g. as a result of calling `System.exit`), they will block in `VM_Exit::block_if_vm_exited` inside `DetachCurrentThread`. This may happen for instance when they try to join after the JVM has exited in an `atexit` handler.

This patch adds a check before trying to detach the thread to see if the VM has exited and bails out if it has. This does not prevent issues as a result of a race between the VM exiting and the thread joining, but it does prevent issues in the more comment case where a thread simply outlives the VM.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391662](https://bugs.openjdk.org/browse/JDK-8391662): Deadlock in UpcallContext dtor when called after JVM shutdown due to System.exit (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32686/head:pull/32686` \
`$ git checkout pull/32686`

Update a local copy of the PR: \
`$ git checkout pull/32686` \
`$ git pull https://git.openjdk.org/jdk.git pull/32686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32686`

View PR using the GUI difftool: \
`$ git pr show -t 32686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32686.diff">https://git.openjdk.org/jdk/pull/32686.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32686#issuecomment-5542274732)
</details>
