### PR TITLE
8391761: Emit FillerElement[] instead of int[] in heap dump

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -786,11 +786,14 @@ class DumperSupport : AllStatic {
   static void dump_object_array(AbstractDumpWriter* writer, objArrayOop array, DumperFlatObjectList* flat_elements);
   // creates HPROF_GC_PRIM_ARRAY_DUMP record for the given type array
   static void dump_prim_array(AbstractDumpWriter* writer, typeArrayOop array);
+  // creates HPROF_GC_OBJ_ARRAY_DUMP record for the given filler array
+  static void dump_filler_array(AbstractDumpWriter* writer, typeArrayOop array);
   // create HPROF_FRAME record for the given method and bci
   static void dump_stack_frame(AbstractDumpWriter* writer, int frame_serial_num, int class_serial_num, Method* m, int bci);
 
   // check if we need to truncate an array
   static int calculate_array_max_length(AbstractDumpWriter* writer, arrayOop array, short header_size);
+  static int calculate_array_max_length(AbstractDumpWriter* writer, BasicType type, int length, short header_size);
 
   // fixes up the current dump record and writes HPROF_HEAP_DUMP_END record
   static void end_of_dump(AbstractDumpWriter* writer);
@@ -1433,14 +1436,15 @@ void DumperSupport::dump_array_class(AbstractDumpWriter* writer, Klass* k) {
 
 }
 
-// Hprof uses an u4 as record length field,
-// which means we need to truncate arrays that are too long.
 int DumperSupport::calculate_array_max_length(AbstractDumpWriter* writer, arrayOop array, short header_size) {
   BasicType type = ArrayKlass::cast(array->klass())->element_type();
   assert((type >= T_BOOLEAN && type <= T_OBJECT) || type == T_FLAT_ELEMENT, "invalid array element type");
+  return calculate_array_max_length(writer, type, array->length(), header_size);
+}
 
-  int length = array->length();
-
+// Hprof uses an u4 as record length field,
+// which means we need to truncate arrays that are too long.
+int DumperSupport::calculate_array_max_length(AbstractDumpWriter* writer, BasicType type, int length, short header_size) {
   int type_size;
   if (type == T_OBJECT || type == T_FLAT_ELEMENT) {
     type_size = sizeof(address);
@@ -1452,11 +1456,12 @@ int DumperSupport::calculate_array_max_length(AbstractDumpWriter* writer, arrayO
   uint max_bytes = max_juint - header_size;
 
   if (length_in_bytes > max_bytes) {
+    int orig_length = length;
     length = max_bytes / type_size;
     length_in_bytes = (size_t)length * type_size;
 
     warning("cannot dump array of type %s[] with length %d; truncating to length %d",
-            type2name_tab[type], array->length(), length);
+            type2name_tab[type], orig_length, length);
   }
   return length;
 }
@@ -1601,6 +1606,31 @@ void DumperSupport::dump_prim_array(AbstractDumpWriter* writer, typeArrayOop arr
       break;
     }
     default : ShouldNotReachHere();
+  }
+
+  writer->end_sub_record();
+}
+
+// Creates HPROF_GC_OBJ_ARRAY_DUMP record for the given filler array.
+//
+// Filler arrays are int typeArrays internally, but if we dump them as int[] they are not
+// identifiable as filler. So, dump as object array (FillerElement[]) with null elements.
+void DumperSupport::dump_filler_array(AbstractDumpWriter* writer, typeArrayOop array) {
+  // sizeof(u1) + 2 * sizeof(u4) + sizeof(objectID) + sizeof(classID)
+  short header_size = 1 + 2 * 4 + 2 * sizeof(address);
+  int length = calculate_array_max_length(writer, T_OBJECT, array->length(), header_size);
+  u4 size = checked_cast<u4>(header_size + length * sizeof(address));
+
+  writer->start_sub_record(HPROF_GC_OBJ_ARRAY_DUMP, size);
+  writer->write_objectID(array);
+  writer->write_u4(STACK_TRACE_ID);
+  writer->write_u4(length);
+
+  // array class ID
+  writer->write_classID(array->klass());
+
+  for (int index = 0; index < length; index++) {
+    writer->write_objectID(oop(nullptr));
   }
 
   writer->end_sub_record();
@@ -2231,8 +2261,13 @@ void HeapObjectDumper::do_object(oop o) {
       _flat_dumper->dump_flat_objects(writer(), o, &_class_cache, &flat_elements);
     }
   } else if (o->is_typeArray()) {
-    // create a HPROF_GC_PRIM_ARRAY_DUMP record for each type array
-    DumperSupport::dump_prim_array(writer(), typeArrayOop(o));
+    if (o->klass() == Universe::fillerArrayKlass()) {
+      // create a HPROF_GC_OBJ_ARRAY_DUMP record for each filler array
+      DumperSupport::dump_filler_array(writer(), typeArrayOop(o));
+    } else {
+      // create a HPROF_GC_PRIM_ARRAY_DUMP record for each type array
+      DumperSupport::dump_prim_array(writer(), typeArrayOop(o));
+    }
   }
 }
 


### PR DESCRIPTION
(See also https://bugs.openjdk.org/browse/JDK-8372389, which proposed to omit these entirely)

Heap filler arrays are stored internally as int typearrays, and currently dumped as `int[]` in heap dumps. This is confusing for users, as these filler arrays are not distinguishable from real user int arrays.

To distinguish them, dump them as `FillerElement[]` instead with null elements.

This also removes the security issue of dumping random heap data in filler arrays.

Implementation note: I have kept the length of the emitted object array the same as the underlying type array. That means the array lengths in the dump will be 'correct', but tools like MAT which estimate the array footprint based on heap size/compressed oops enablement will estimate double the true size for JVMs with uncompressed oops (`int[100]`, 400 bytes of data, becomes `FillerElement[100]`, 800 estimated bytes of data). We *could* instead adjust the length to give a better size estimate, if desired.

Using Eclipse MAT, before:
```
before.hprof - 2.6GB

Class Name | Objects | Shallow Heap
=====================================
     int[]    5,542     1.40GB
```

After:
```
after.hprof - 3.7GB

Class Name                     | Objects | Shallow Heap
============================================================
jdk.internal.vm.FillerElement[]        69   1.10GB
                          int[]     5,482   1.50MB
```

Performance seems to be similar, but dumps with lots of filler elements are bigger because elements take 8 bytes instead of 4. Very compressible, though.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391761](https://bugs.openjdk.org/browse/JDK-8391761): Emit FillerElement[] instead of int[] in heap dump (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32687/head:pull/32687` \
`$ git checkout pull/32687`

Update a local copy of the PR: \
`$ git checkout pull/32687` \
`$ git pull https://git.openjdk.org/jdk.git pull/32687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32687`

View PR using the GUI difftool: \
`$ git pr show -t 32687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32687.diff">https://git.openjdk.org/jdk/pull/32687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32687#issuecomment-5527224549)
</details>
