### PR TITLE
8391766: JFR: Reset JfrSet element count when clearing

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrSet.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrSet.hpp
@@ -119,6 +119,7 @@ class JfrSetStorage : public AnyObj {
         ::new (&_table[i]) K{};
       }
     }
+    _elements = 0;
   }
 };
 


### PR DESCRIPTION
Greetings,

In [JDK-8365199](https://bugs.openjdk.org/browse/JDK-8365199), a new class, JfrSet, was introduced, but clear() only cleared the table slots and did not reset the element count. A cleared set therefore continued to report itself as non-empty, and subsequent insertions could trigger premature resizing.

Reset _elements after clearing the slots so the set’s bookkeeping again reflects its contents.

Testing: jdk_jfr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391766](https://bugs.openjdk.org/browse/JDK-8391766): JFR: Reset JfrSet element count when clearing (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32688/head:pull/32688` \
`$ git checkout pull/32688`

Update a local copy of the PR: \
`$ git checkout pull/32688` \
`$ git pull https://git.openjdk.org/jdk.git pull/32688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32688`

View PR using the GUI difftool: \
`$ git pr show -t 32688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32688.diff">https://git.openjdk.org/jdk/pull/32688.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32688#issuecomment-5527320172)
</details>
