### PR TITLE
8391760: [windows] libjaas nt.c seems to have some handle leaks

### DIFF
--- a/src/jdk.security.auth/windows/native/libjaas/nt.c
+++ b/src/jdk.security.auth/windows/native/libjaas/nt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,21 +106,21 @@ Java_com_sun_security_auth_module_NTSystem_getCurrent
     }
     if (getUser
         (tokenHandle, &userName, &domainName, &userSid, &domainSid) == FALSE) {
-        return;
+        goto cleanup;
     }
 
     if (debug) {
         printf("getting primary group\n");
     }
     if (getPrimaryGroup(tokenHandle, &primaryGroup) == FALSE) {
-        return;
+        goto cleanup;
     }
 
     if (debug) {
         printf("getting supplementary groups\n");
     }
     if (getGroups(tokenHandle, &numGroups, &groups) == FALSE) {
-        return;
+        goto cleanup;
     }
 
     // then set values into NTSystem
@@ -578,6 +578,7 @@ BOOL getImpersonationToken(PHANDLE impersonationToken) {
                 GetLastError());
             DisplayErrorText(GetLastError());
         }
+        CloseHandle(dupToken);
         return FALSE;
     }
     CloseHandle(dupToken);


### PR DESCRIPTION
In the libjaas nt.c coding the OpenProcessToken ( https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocesstoken ) function is used.
But this needs handle close operations ("To close the access token handle returned through the TokenHandle parameter, call CloseHandle.") and they are missing at some code location(s).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391760](https://bugs.openjdk.org/browse/JDK-8391760): [windows] libjaas nt.c seems to have some handle leaks (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32689/head:pull/32689` \
`$ git checkout pull/32689`

Update a local copy of the PR: \
`$ git checkout pull/32689` \
`$ git pull https://git.openjdk.org/jdk.git pull/32689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32689`

View PR using the GUI difftool: \
`$ git pr show -t 32689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32689.diff">https://git.openjdk.org/jdk/pull/32689.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32689#issuecomment-5528458514)
</details>
