### PR TITLE
8391495: Apply JDK-8370201 to serviceability/sa/sadebugd/DebugdConnectTest.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -115,7 +115,7 @@ containers/docker/ShareTmpDir.java 8390823 linux-all
 # :hotspot_serviceability
 
 # 8239062 and 8270326 only affects macosx-x64,macosx-aarch64
-serviceability/sa/sadebugd/DebugdConnectTest.java 8239062,8270326 generic-all
+serviceability/sa/sadebugd/DebugdConnectTest.java 8239062,8270326 macosx-x64,macosx-aarch64
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 
 serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java 8318090,8318729 generic-all

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/DebugdConnectTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/DebugdConnectTest.java
@@ -65,7 +65,8 @@ public class DebugdConnectTest {
         System.out.println(out.getStdout());
         System.err.println(out.getStderr());
 
-        return out;
+        return new OutputAnalyzer(out.getStdout(),
+                out.getStderrNoDeprecatedWarnings(), out.getExitValue());
     }
 
     private static void runJSTACK(String serverID) throws IOException, InterruptedException {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/DebugdConnectTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/DebugdConnectTest.java
@@ -72,7 +72,7 @@ public class DebugdConnectTest {
         OutputAnalyzer out = runJHSDB("jstack", serverID);
 
         out.shouldContain("LingeredApp");
-        out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
+        out.stderrShouldBeEmptyIgnoreVMWarnings();
         out.shouldHaveExitValue(0);
     }
 
@@ -80,7 +80,7 @@ public class DebugdConnectTest {
         OutputAnalyzer out = runJHSDB("jmap", serverID);
 
         out.shouldContain("JVM version is");
-        out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
+        out.stderrShouldBeEmptyIgnoreVMWarnings();
         out.shouldHaveExitValue(0);
     }
 
@@ -88,7 +88,7 @@ public class DebugdConnectTest {
         OutputAnalyzer out = runJHSDB("jinfo", serverID);
 
         out.shouldContain("Java System Properties:");
-        out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
+        out.stderrShouldBeEmptyIgnoreVMWarnings();
         out.shouldHaveExitValue(0);
     }
 
@@ -96,7 +96,7 @@ public class DebugdConnectTest {
         OutputAnalyzer out = runJHSDB("jsnap", serverID);
 
         out.shouldContain("java.vm.name=");
-        out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
+        out.stderrShouldBeEmptyIgnoreVMWarnings();
         out.shouldHaveExitValue(0);
     }
 


### PR DESCRIPTION
8391495: Apply JDK-8370201 to serviceability/sa/sadebugd/DebugdConnectTest.java




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391495](https://bugs.openjdk.org/browse/JDK-8391495): Apply JDK-8370201 to serviceability/sa/sadebugd/DebugdConnectTest.java (**Bug** - P5)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32690/head:pull/32690` \
`$ git checkout pull/32690`

Update a local copy of the PR: \
`$ git checkout pull/32690` \
`$ git pull https://git.openjdk.org/jdk.git pull/32690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32690`

View PR using the GUI difftool: \
`$ git pr show -t 32690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32690.diff">https://git.openjdk.org/jdk/pull/32690.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32690#issuecomment-5530308887)
</details>
