### PR TITLE
8391786: ProblemList java/awt/FullScreen/SetFSWindow/FSFrame.java#default on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -224,6 +224,7 @@ sun/java2d/SunGraphics2D/SimplePrimQuality.java 6992007 generic-all
 sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196185 generic-all
 
 java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469,8273617 windows-all,macosx-aarch64
+java/awt/FullScreen/SetFSWindow/FSFrame.java#default 8390445 macosx-aarch64
 java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java 8273617 macosx-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList java/awt/FullScreen/SetFSWindow/FSFrame.java#default on macosx-aarch64.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391786](https://bugs.openjdk.org/browse/JDK-8391786): ProblemList java/awt/FullScreen/SetFSWindow/FSFrame.java#default on macosx-aarch64 (**Sub-task** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32691/head:pull/32691` \
`$ git checkout pull/32691`

Update a local copy of the PR: \
`$ git checkout pull/32691` \
`$ git pull https://git.openjdk.org/jdk.git pull/32691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32691`

View PR using the GUI difftool: \
`$ git pr show -t 32691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32691.diff">https://git.openjdk.org/jdk/pull/32691.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32691#issuecomment-5531009842)
</details>
