### PR TITLE
8391790: JFR: MethodTracer should inspect the union of unload sets

### DIFF
--- a/src/hotspot/share/jfr/support/methodtracer/jfrClassFilterClosure.cpp
+++ b/src/hotspot/share/jfr/support/methodtracer/jfrClassFilterClosure.cpp
@@ -113,7 +113,7 @@ void JfrFilterClassClosure::iterate_all_classes(GrowableArray<JfrInstrumentedCla
   // We, therefore, put these klasses directly into the classes_to_modify set.
   if (instrumented_klasses->is_nonempty()) {
     for (int i = 0; i < instrumented_klasses->length(); ++i) {
-      if (JfrKlassUnloading::is_unloaded(instrumented_klasses->at(i).trace_id())) {
+      if (JfrKlassUnloading::is_unloaded(instrumented_klasses->at(i).trace_id(), true)) {
         continue;
       }
       add(instrumented_klasses->at(i).instance_klass());


### PR DESCRIPTION
Greetings,

MethodTracer keeps instrumented classes across epochs. When updating filters, one site accidentally only consults the current unload set before using the Klass pointer. The traceid of that class may already be in the previous unload set, so the site should check both sets, as the other MethodTracer paths do.

[JDK-8387756](https://bugs.openjdk.org/browse/JDK-8387756) added the do_entry(), co-located next to the problematic site, making the asymmetry stand out.

Testing: jdk_jfr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391790](https://bugs.openjdk.org/browse/JDK-8391790): JFR: MethodTracer should inspect the union of unload sets (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32692/head:pull/32692` \
`$ git checkout pull/32692`

Update a local copy of the PR: \
`$ git checkout pull/32692` \
`$ git pull https://git.openjdk.org/jdk.git pull/32692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32692`

View PR using the GUI difftool: \
`$ git pr show -t 32692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32692.diff">https://git.openjdk.org/jdk/pull/32692.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32692#issuecomment-5533200928)
</details>
