### PR TITLE
8391442: Test compiler/c1/CanonicalizeArrayLength.java is timing out with VerifyOops

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2045,7 +2045,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
   stp(rscratch2, lr, Address(pre(sp, -2 * wordSize)));
 
   mov(r0, reg);
-  lea(rscratch1, ExternalAddress((address)b));
+  lea(rscratch1, Address((address)b, external_word_Relocation::spec_for_immediate()));
 
   // call indirectly to solve generation ordering problem
   lea(rscratch2, RuntimeAddress(StubRoutines::verify_oop_subroutine_entry_address()));
@@ -2096,7 +2096,7 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
   } else {
     ldr(r0, addr);
   }
-  lea(rscratch1, ExternalAddress((address)b));
+  lea(rscratch1, Address((address)b, external_word_Relocation::spec_for_immediate()));
 
   // call indirectly to solve generation ordering problem
   lea(rscratch2, RuntimeAddress(StubRoutines::verify_oop_subroutine_entry_address()));

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -541,7 +541,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
   // The length of the instruction sequence emitted should not depend
   // on the address of the char buffer so that the size of mach nodes for
   // scratch emit and normal emit matches.
-  la(t0, ExternalAddress((address)b));
+  la(t0, Address((address)b, external_word_Relocation::spec_for_immediate()));
 
   // Call indirectly to solve generation ordering problem
   ld(t1, RuntimeAddress(StubRoutines::verify_oop_subroutine_entry_address()));
@@ -738,7 +738,7 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
   // The length of the instruction sequence emitted should not depend
   // on the address of the char buffer so that the size of mach nodes for
   // scratch emit and normal emit matches.
-  la(t0, ExternalAddress((address)b));
+  la(t0, Address((address)b, external_word_Relocation::spec_for_immediate()));
 
   // Call indirectly to solve generation ordering problem
   ld(t1, RuntimeAddress(StubRoutines::verify_oop_subroutine_entry_address()));

--- a/test/hotspot/jtreg/compiler/c1/CanonicalizeArrayLength.java
+++ b/test/hotspot/jtreg/compiler/c1/CanonicalizeArrayLength.java
@@ -28,21 +28,21 @@
  *
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileThreshold=100 -XX:+TieredCompilation -XX:TieredStopAtLevel=1
- *                   -XX:-BackgroundCompilation -XX:-VerifyOops
+ *                   -XX:-BackgroundCompilation
  *                   compiler.c1.CanonicalizeArrayLength
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileThreshold=100 -XX:+TieredCompilation -XX:TieredStopAtLevel=3
- *                   -XX:-BackgroundCompilation -XX:-VerifyOops
+ *                   -XX:-BackgroundCompilation
  *                   -XX:+PatchALot
  *                   compiler.c1.CanonicalizeArrayLength
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileThreshold=100 -XX:+TieredCompilation -XX:TieredStopAtLevel=1
- *                   -XX:-BackgroundCompilation -XX:-VerifyOops
+ *                   -XX:-BackgroundCompilation
  *                   -XX:ScavengeRootsInCode=0
  *                   compiler.c1.CanonicalizeArrayLength
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:CompileThreshold=100 -XX:+TieredCompilation -XX:TieredStopAtLevel=1
- *                   -XX:-BackgroundCompilation -XX:ScavengeRootsInCode=1 -XX:-VerifyOops
+ *                   -XX:-BackgroundCompilation -XX:ScavengeRootsInCode=1
  *                   compiler.c1.CanonicalizeArrayLength
  */
 


### PR DESCRIPTION
After adding relocation to string address in `verify_oop*()` by [JDK-8390914](https://bugs.openjdk.org/browse/JDK-8390914) the test `CanonicalizeArrayLength.java` hits timeout on linux-aarch64 with fastdebug VM when run with `-Xcomp -XX:+VerifyOops` flags because a lot of strings were generated and processing relocations took long time.

There was similar issue with this test on x86 which was fixed in JDK 24: https://github.com/openjdk/jdk/commit/6682305ee21cf595ec953d95bea594734a2982a8

You can see fix explanation in old PR: https://github.com/openjdk/jdk/pull/19871

I did the same change for Aarch64 and RISC-V (which was also updated by JDK-8390914) to fix the issue.
And rolled back changes in the test done by [JDK-8391749](https://bugs.openjdk.org/browse/JDK-8391749)

Testing shows that the test run 3x faster with this fix and not time out.

Testing: tier1, and several iterations with `-Xcomp -XX:+VerifyOops`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391442](https://bugs.openjdk.org/browse/JDK-8391442): Test compiler/c1/CanonicalizeArrayLength.java is timing out with VerifyOops (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32693/head:pull/32693` \
`$ git checkout pull/32693`

Update a local copy of the PR: \
`$ git checkout pull/32693` \
`$ git pull https://git.openjdk.org/jdk.git pull/32693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32693`

View PR using the GUI difftool: \
`$ git pr show -t 32693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32693.diff">https://git.openjdk.org/jdk/pull/32693.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32693#issuecomment-5534344322)
</details>
