### PR TITLE
8266312: java/awt/font/TextLayout/LigatureCaretTest.java fails with "Error: Left hit failed.  Hit:TextHitInfo[1L]"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -318,7 +318,6 @@ java/awt/Modal/ToBack/ToBackNonModal3Test.java 8196441 linux-all
 java/awt/Modal/ToBack/ToBackNonModal4Test.java 8196441 linux-all
 javax/print/PrintSEUmlauts/PrintSEUmlauts.java 8135174 generic-all
 java/awt/font/Rotate/RotatedTextTest.java 8219641 linux-all
-java/awt/font/TextLayout/LigatureCaretTest.java 8266312  generic-all
 java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-all
 java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all


### PR DESCRIPTION
Test used to fail in WIndows server 2012 in CI but after upgrading to Windows Server 2025 this test has not failed..
Tried several iterations in all platforms and whole jdk_desktop too without issue (jobs in JBS) so we can deproblemlist




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8266312](https://bugs.openjdk.org/browse/JDK-8266312): java/awt/font/TextLayout/LigatureCaretTest.java fails with "Error: Left hit failed.  Hit:TextHitInfo[1L]" (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32694/head:pull/32694` \
`$ git checkout pull/32694`

Update a local copy of the PR: \
`$ git checkout pull/32694` \
`$ git pull https://git.openjdk.org/jdk.git pull/32694/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32694`

View PR using the GUI difftool: \
`$ git pr show -t 32694`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32694.diff">https://git.openjdk.org/jdk/pull/32694.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32694#issuecomment-5536443597)
</details>
