### PR TITLE
7003378: test/jdk/java/awt/print/print/PrinterJob/GlyphPositions.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -225,8 +225,6 @@ sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196
 
 java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469,8273617 windows-all,macosx-aarch64
 java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java 8273617 macosx-all
-java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
-java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all
 java/awt/Component/GetScreenLocTest/GetScreenLocTest.java 4753654 generic-all
 java/awt/Component/SetEnabledPerformance/SetEnabledPerformance.java 8165863 macosx-all
 java/awt/Clipboard/PasteNullToTextComponentsTest.java 8234140 macosx-all,windows-all


### PR DESCRIPTION
2 Tests are not failing in CI..Tried several iterations in all platforms (CI job in JBS) so deproblemlisting..




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-7003378](https://bugs.openjdk.org/browse/JDK-7003378): test/jdk/java/awt/print/print/PrinterJob/GlyphPositions.java fails (**Bug** - P4)
 * [JDK-7003376](https://bugs.openjdk.org/browse/JDK-7003376): test/jdk/java/awt/print/PrinterJob/PSQuestionMark.java fails (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32695/head:pull/32695` \
`$ git checkout pull/32695`

Update a local copy of the PR: \
`$ git checkout pull/32695` \
`$ git pull https://git.openjdk.org/jdk.git pull/32695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32695`

View PR using the GUI difftool: \
`$ git pr show -t 32695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32695.diff">https://git.openjdk.org/jdk/pull/32695.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32695#issuecomment-5536531213)
</details>
