### PR TITLE
7184956: [macosx] JPopupMenu.setDefaultLightPopupEnable(true) doesn't work correctly

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -538,7 +538,6 @@ javax/swing/JTree/4633594/JTreeFocusTest.java 7105441 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
 javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8327236 windows-all
-javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
 javax/swing/JFileChooser/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all

--- a/test/jdk/javax/swing/JPopupMenu/6800513/bug6800513.java
+++ b/test/jdk/javax/swing/JPopupMenu/6800513/bug6800513.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012 Red Hat, Inc.  All Rights Reserved.
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,6 +143,8 @@ public class bug6800513 {
         robot = new Robot();
         testFrame(false, "javax.swing.PopupFactory$HeavyWeightPopup");
 
-        testFrame(true, "javax.swing.PopupFactory$LightWeightPopup");
+        if (!((UIManager.getLookAndFeel().getID()).equals("Aqua"))) {
+            testFrame(true, "javax.swing.PopupFactory$LightWeightPopup");
+        }
     }
 }


### PR DESCRIPTION
Test fails citing

```
java.lang.Exception: popup class is: javax.swing.PopupFactory$HeavyWeightPopup, expected: javax.swing.PopupFactory$LightWeightPopup
        at bug6800513.testFrame(bug6800513.java:78)
        at bug6800513.main(bug6800513.java:146)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:583)
        at com.sun.javatest.regtest.agent.MainMethodHelper.executeModernMainClass(MainMethodHelper.java:56)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:140)
        at java.base/java.lang.Thread.run(Thread.java:1527)
JavaTest Message: Test threw exception: java.lang.Exception: popup class is: javax.swing.PopupFactory$HeavyWeightPopup, expected: javax.swing.PopupFactory$LightWeightPopup

```

On macOS, Aqua installs `com.apple.laf.ScreenPopupFactory` as Swing’s shared PopupFactory. While Aqua is active, its getPopup(...) explicitly [calls the internal “get heavy-weight popup [accessor]"](https://github.com/openjdk/jdk/blob/f0952f6ce6cc43db4326eda0e397711d36c31fc6/src/java.desktop/macosx/classes/com/apple/laf/ScreenPopupFactory.java#L58-L60) 
It does this so that menu popups can have native [Aqua-specific translucency, shadow, rounded-corner](https://github.com/openjdk/jdk/blob/f0952f6ce6cc43db4326eda0e397711d36c31fc6/src/java.desktop/macosx/classes/com/apple/laf/ScreenPopupFactory.java#L40). Therefore it intentionally ignores JPopupMenu.setDefaultLightWeightPopupEnabled(true).

Also the spec supports that L&F can choose to always choose heavy weight popups 
https://docs.oracle.com/en/java/javase/25/docs/api/java.desktop/javax/swing/JPopupMenu.html#setLightWeightPopupEnabled(boolean)

> Some look and feels might always use heavyweight popups, no matter what the value of this property.

so fix is made to ignore the subtest for Aqua L&F




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-7184956](https://bugs.openjdk.org/browse/JDK-7184956): [macosx] JPopupMenu.setDefaultLightPopupEnable(true) doesn't work correctly (**Enhancement** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32696/head:pull/32696` \
`$ git checkout pull/32696`

Update a local copy of the PR: \
`$ git checkout pull/32696` \
`$ git pull https://git.openjdk.org/jdk.git pull/32696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32696`

View PR using the GUI difftool: \
`$ git pr show -t 32696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32696.diff">https://git.openjdk.org/jdk/pull/32696.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32696#issuecomment-5536699129)
</details>
