### PR TITLE
8391808: Problemlist compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,6 +71,8 @@ compiler/escapeAnalysis/TestBCEscapeAnalyzerOverflow.java 8387392 windows-aarch6
 
 compiler/vectorapi/VectorStoreMaskIdentityTest.java 8388281 generic-all
 
+compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java 8391806 generic-aarch64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
This PR problemlists `compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java` on aarch64.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391808](https://bugs.openjdk.org/browse/JDK-8391808): Problemlist compiler/vectorapi/AllBitsSetVectorMatchRuleTest.java (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32697/head:pull/32697` \
`$ git checkout pull/32697`

Update a local copy of the PR: \
`$ git checkout pull/32697` \
`$ git pull https://git.openjdk.org/jdk.git pull/32697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32697`

View PR using the GUI difftool: \
`$ git pr show -t 32697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32697.diff">https://git.openjdk.org/jdk/pull/32697.diff</a>

</details>
