### PR TITLE
8371851: Build tool GenModuleInfoSource does not report duplicate targets of export

### DIFF
--- a/make/jdk/src/classes/build/tools/module/GenModuleInfoSource.java
+++ b/make/jdk/src/classes/build/tools/module/GenModuleInfoSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -449,9 +450,14 @@ public class GenModuleInfoSource {
                     String lookAhead = lookAhead(parser);
                     if (lookAhead.equals(statement.qualifier)) {
                         parser.nextToken(); // skip qualifier
+                        Set<String> targets = new HashSet<>();
                         while ((lookAhead = parser.peekToken()) != null) {
                             // add target name
                             name = nextIdentifier(parser);
+                            if (!targets.add(name)) {
+                                throw parser.newError("duplicate target " + name +
+                                    " in " + keyword + " " + statement.name);
+                            }
                             statement.addTarget(name);
                             lookAhead = lookAhead(parser);
                             if (lookAhead.equals(",") || lookAhead.equals(";")) {

--- a/make/jdk/src/classes/build/tools/module/GenModuleInfoSource.java
+++ b/make/jdk/src/classes/build/tools/module/GenModuleInfoSource.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -450,15 +449,13 @@ public class GenModuleInfoSource {
                     String lookAhead = lookAhead(parser);
                     if (lookAhead.equals(statement.qualifier)) {
                         parser.nextToken(); // skip qualifier
-                        Set<String> targets = new HashSet<>();
                         while ((lookAhead = parser.peekToken()) != null) {
                             // add target name
                             name = nextIdentifier(parser);
-                            if (!targets.add(name)) {
+                            if (!statement.addTarget(name)) {
                                 throw parser.newError("duplicate target " + name +
                                     " in " + keyword + " " + statement.name);
                             }
-                            statement.addTarget(name);
                             lookAhead = lookAhead(parser);
                             if (lookAhead.equals(",") || lookAhead.equals(";")) {
                                 parser.nextToken();
@@ -566,11 +563,10 @@ public class GenModuleInfoSource {
             this.ordered = ordered;
         }
 
-        Statement addTarget(String mn) {
+        boolean addTarget(String mn) {
             if (mn.isEmpty())
                 throw new IllegalArgumentException("empty module name");
-            targets.add(mn);
-            return this;
+            return targets.add(mn);
         }
 
         boolean isQualified() {

--- a/make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java
+++ b/make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,7 +185,12 @@ public class ModuleInfoExtraTest {
             "   exports p1 to m1;",
             "   exports p1 to m2;",
             "}"
-        },                      ".*, line .*, multiple exports p1.*"
+        },                      ".*, line .*, multiple exports p1.*",
+        new String[] {
+            "module x {",
+            "   exports p1 to m1, m2, m1;",
+            "}"
+        },                      ".*, line .*, duplicate target m1 in exports p1.*"
     );
 
     final Map<String[], String> badExtraFiles = Map.of(
@@ -234,7 +239,13 @@ public class ModuleInfoExtraTest {
             new String[] {
                 "   provides s with impl1;",
                 "   provides s with impl2, impl3;"
-            },                      ".*, line .*, multiple provides s.*"
+            },                      ".*, line .*, multiple provides s.*",
+            new String[] {
+                "   opens p1 to m1, m1;"
+            },                      ".*, line .*, duplicate target m1 in opens p1.*",
+            new String[] {
+                "   provides s with impl1, impl1;"
+            },                      ".*, line .*, duplicate target impl1 in provides s.*"
     );
 
     void errorCases() {


### PR DESCRIPTION
Please review this small fix.

**Problem:**

`Statement.targets` is a `LinkedHashSet`, so duplicate targets in directives such as `exports p1 to m1, m2, m1;` are silently ignored. As a result, `GenModuleInfoSource` accepts invalid input instead of reporting an error.

**Fix:**

Use a local `HashSet` while parsing each directive and report an error when `add()` returns `false`.

**Testing:**

- Added tests for duplicate targets in `exports`, `opens`, and `provides`
- `ModuleInfoExtraTest`: passed
- `make test-make`: passed



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8371851](https://bugs.openjdk.org/browse/JDK-8371851): Build tool GenModuleInfoSource does not report duplicate targets of export (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32698/head:pull/32698` \
`$ git checkout pull/32698`

Update a local copy of the PR: \
`$ git checkout pull/32698` \
`$ git pull https://git.openjdk.org/jdk.git pull/32698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32698`

View PR using the GUI difftool: \
`$ git pr show -t 32698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32698.diff">https://git.openjdk.org/jdk/pull/32698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32698#issuecomment-5537875845)
</details>
