### PR TITLE
8386465: 4th argument in inline_dilithiumNttMult() is unused

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -9117,12 +9117,10 @@ bool LibraryCallKit::inline_dilithiumNttMult() {
   Node* result          = argument(0);
   Node* ntta            = argument(1);
   Node* nttb            = argument(2);
-  Node* zetas           = argument(3);
 
   result = must_be_not_null(result, true);
   ntta = must_be_not_null(ntta, true);
   nttb = must_be_not_null(nttb, true);
-  zetas = must_be_not_null(zetas, true);
 
   Node* result_start  = array_element_address(result, intcon(0), T_INT);
   assert(result_start, "result is null");


### PR DESCRIPTION
`inline_dilithiumNttMult()` reads a 4th `zetas` argument, but the Java intrinsic candidate `implDilithiumNttMult()` declares only 3 arguments.

This PR removes the invalid 4-argument access.

Sanity checked running `sun/security/provider/pqc/ML_DSA_Intrinsic_Test.java` test.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386465](https://bugs.openjdk.org/browse/JDK-8386465): 4th argument in inline_dilithiumNttMult() is unused (**Enhancement** - P4)


### Reviewers
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author) Review applies to [5c493afe](https://git.openjdk.org/jdk/pull/32700/files/5c493afe772cfb20a9bf5cc43a9a40a7e31587a7)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32700/head:pull/32700` \
`$ git checkout pull/32700`

Update a local copy of the PR: \
`$ git checkout pull/32700` \
`$ git pull https://git.openjdk.org/jdk.git pull/32700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32700`

View PR using the GUI difftool: \
`$ git pr show -t 32700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32700.diff">https://git.openjdk.org/jdk/pull/32700.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32700#issuecomment-5539086232)
</details>
