### PR TITLE
8391811: (jdeps) Fix typos in man page and help output

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
      * Returns the target archives determined from the dependency analysis.
      *
      * Inverse transitive dependency will find all nodes that depend
-     * upon the returned set of archives directly and indirectly.
+     * upon the returned set of archives directly or indirectly.
      */
     public Set<Archive> targets() {
         return Collections.unmodifiableSet(targets);
@@ -167,8 +167,8 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
             trace("targets: %s%n", targets());
 
             // Traverse from the targets and find all paths
-            // rebuild a graph with all nodes that depends on targets
-            // targets directly and indirectly
+            // rebuild a graph with all nodes that depend on targets
+            // directly or indirectly
             return targets().stream()
                 .map(t -> findPaths(graph, t))
                 .flatMap(Set::stream)

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -882,7 +882,7 @@ class JdepsTask {
         /*
          * Returns true if --require is specified so that all modules are
          * analyzed to find all modules that depend on the modules specified in the
-         * --require option directly and indirectly
+         * --require option directly or indirectly
          */
         Set<String> addModules() {
             return options.requires.size() > 0 ? Set.of("ALL-SYSTEM") : Set.of();

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleExportsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleExportsAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
 
 /**
  * Analyze module dependences and any reference to JDK internal APIs.
- * It can apply transition reduction on the resulting module graph.
+ * It can apply transitive reduction on the resulting module graph.
  *
  * The result prints one line per module it depends on
  * one line per JDK internal API package it references:
@@ -153,7 +153,7 @@ public class ModuleExportsAnalyzer extends DepsAnalyzer {
             .forEach(m -> builder.addEdge(root, m));
 
         // build module dependence graph
-        // if reduced is set, apply transition reduction
+        // if reduced is set, apply transitive reduction
         Graph<Module> g = reduced ? builder.reduced() : builder.build();
         return g.adjacentNodes(root);
     }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/jdeps.properties
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/jdeps.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,11 @@
 jdeps.description=launch the Java class dependency analyzer
 
 main.usage.summary=\
-Usage: {0} <options> <path ...>]\n\
+Usage: {0} <options> <path ...>\n\
 use --help for a list of possible options
 
 main.usage=\
-Usage: {0} <options> <path ...>]\n\
+Usage: {0} <options> <path ...>\n\
 <path> can be a pathname to a .class file, a directory, a JAR file.\n\
 \n\
 Possible options include:
@@ -130,11 +130,11 @@ main.opt.I=\
 \  -I\n\
 \  --inverse                     Analyzes the dependences per other given options\n\
 \                                and then find all artifacts that directly\n\
-\                                and indirectly depend on the matching nodes.\n\
+\                                or indirectly depend on the matching nodes.\n\
 \                                This is equivalent to the inverse of\n\
 \                                compile-time view analysis and print\n\
-\                                dependency summary.  This option must use\n\
-\                                with --require, --package or --regex option.
+\                                dependency summary.  This option must be used\n\
+\                                with the --require, --package, or --regex option.
 
 main.opt.compile-time=\
 \  --compile-time                Compile-time view of transitive dependences\n\
@@ -175,7 +175,7 @@ main.opt.check=\
 \                                Analyze the dependence of the specified modules\n\
 \                                It prints the module descriptor, the resulting\n\
 \                                module dependences after analysis and the\n\
-\                                graph after transition reduction.  It also\n\
+\                                graph after transitive reduction.  It also\n\
 \                                identifies any unused qualified exports.
 
 main.opt.dotoutput=\

--- a/src/jdk.jdeps/share/man/jdeps.md
+++ b/src/jdk.jdeps/share/man/jdeps.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ dependencies in DOT language (see the `-dotoutput` option).
 
 `-dotoutput` *dir* or `--dot-output` *dir*
 :   Specifies the destination directory for DOT file output. If this option is
-    specified, then the `jdeps`command generates one `.dot` file for each
+    specified, then the `jdeps` command generates one `.dot` file for each
     analyzed archive named `archive-file-name.dot` that lists the dependencies,
     and also a summary file named `summary.dot` that lists the dependencies
     among the archive files.
@@ -119,7 +119,7 @@ dependencies in DOT language (see the `-dotoutput` option).
     should be an integer \>=9 or base.
 
 `-q` or `-quiet`
-:   Doesn't show missing dependencies from `-generate-module-info` output.
+:   Doesn't show missing dependencies from `--generate-module-info` output.
 
 `-version` or `--version`
 :   Prints version information.
@@ -143,7 +143,7 @@ dependencies in DOT language (see the `-dotoutput` option).
 `--check` *module-name* \[`,` *module-name*...\]
 :   Analyzes the dependence of the specified modules. It prints the module
     descriptor, the resulting module dependences after analysis and the graph
-    after transition reduction. It also identifies any unused qualified
+    after transitive reduction. It also identifies any unused qualified
     exports.
 
 `--list-deps`
@@ -220,7 +220,7 @@ dependencies in DOT language (see the `-dotoutput` option).
 
 `-I` or `--inverse`
 :   Analyzes the dependences per other given options and then finds all
-    artifacts that directly and indirectly depend on the matching nodes. This
+    artifacts that directly or indirectly depend on the matching nodes. This
     is equivalent to the inverse of the compile-time view analysis and the
     print dependency summary. This option must be used with the `--require`,
     `--package`, or `--regex` options.


### PR DESCRIPTION
I've been using jdeps recently, and I thought I could suggest some minor improvements to its documentation (and related code comments, for completeness and consistency). Please review.

Separately, I note that JDK tools inconsistently use CLI notation (i.e. {}, (), [], ... etc.) and verb forms ( 2nd person prescriptive (print) vs. 3rd person descriptive (prints) ). Sometimes verb forms are mixed within a single sentence. But that's a bigger issue, and I'm not trying to address it in this PR. Maybe it's something an LLM-assisted person could do once we're cleared to use LLMs in that way in OpenJDK.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391811](https://bugs.openjdk.org/browse/JDK-8391811): (jdeps) Fix typos in man page and help output (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32701/head:pull/32701` \
`$ git checkout pull/32701`

Update a local copy of the PR: \
`$ git checkout pull/32701` \
`$ git pull https://git.openjdk.org/jdk.git pull/32701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32701`

View PR using the GUI difftool: \
`$ git pr show -t 32701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32701.diff">https://git.openjdk.org/jdk/pull/32701.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32701#issuecomment-5538861772)
</details>
