### PR TITLE
Implement a jump table using branch instructions

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
 // Copyright (c) 2014, 2024, Red Hat, Inc. All rights reserved.
-// Copyright 2025 Arm Limited and/or its affiliates.
+// Copyright 2025, 2026 Arm Limited and/or its affiliates.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -8585,6 +8585,34 @@ instruct cmpL3_reg_imm(iRegINoSp dst, iRegL src1, immLAddSub src2, rFlagsReg fla
     __ subs(zr, $src1$$Register, (int32_t)$src2$$constant);
     __ csetw($dst$$Register, Assembler::NE);
     __ cnegw($dst$$Register, $dst$$Register, Assembler::LT);
+  %}
+
+  ins_pipe(pipe_class_default);
+%}
+
+instruct jumptable_switch_offset(iRegIorL2I switch_val) %{
+  match(Jump (ConvI2L switch_val));
+
+  format %{
+    "jump_table_switch $switch_val\n\t"
+  %}
+
+  ins_encode %{
+    __ jump_table_switch($switch_val$$Register, _index2label);
+  %}
+
+  ins_pipe(pipe_class_default);
+%}
+
+instruct jumptable_switch(iRegL switch_val) %{
+  match(Jump switch_val);
+
+  format %{
+    "jump_table_switch $switch_val\n\t"
+  %}
+
+  ins_encode %{
+    __ jump_table_switch($switch_val$$Register, _index2label);
   %}
 
   ins_pipe(pipe_class_default);

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -3018,3 +3018,35 @@ void C2_MacroAssembler::sve_sdiv_short(FloatRegister dst_src1, FloatRegister src
   // Narrow the two INT result halves back to SHORT.
   sve_uzp1(dst_src1, H, vtmp1, src1);
 }
+
+void C2_MacroAssembler::jump_table_switch(Register switch_val,
+                                          const GrowableArray<Label*>& labels) {
+  assert(Matcher::use_branch_jump_table,
+         "jump_table_switch should only be used with branch jump tables");
+
+  const bool scratch_emit = in_scratch_emit_size();
+  assert(scratch_emit || labels.is_nonempty(), "must be");
+
+  const int table_size = scratch_emit ? 0 : labels.length() * instruction_size;
+  if (!scratch_emit &&
+      code()->insts()->maybe_expand_to_ensure_remaining(3 * instruction_size + table_size) &&
+      code()->blob() == nullptr) {
+    Compile::current()->record_failure("CodeCache is full");
+    return;
+  }
+
+  Label jump_table;
+  adr(rscratch1, jump_table);
+  lea(rscratch1, Address(rscratch1, switch_val,
+                        Address::uxtw(exact_log2(instruction_size))));
+  br(rscratch1);
+  bind(jump_table);
+
+  if (scratch_emit) {
+    return;
+  }
+
+  for (GrowableArrayIterator<Label*> iter = labels.begin(); iter != labels.end(); ++iter) {
+    b(**iter);
+  }
+}

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -260,4 +260,5 @@
                      FloatRegister vtmp2, FloatRegister vtmp3, FloatRegister vtmp4);
   void sve_sdiv_short(FloatRegister dst_src1, FloatRegister src2,
                       FloatRegister vtmp1, FloatRegister vtmp2);
+  void jump_table_switch(Register switch_val, const GrowableArray<Label*>& labels);
 #endif // CPU_AARCH64_C2_MACROASSEMBLER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
@@ -33,6 +33,8 @@
   // Whether this platform implements the scalable vector feature
   static const bool implements_scalable_vector = true;
 
+  static const bool use_branch_jump_table = true;
+
   static bool supports_scalable_vector() {
     return UseSVE > 0;
   }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -279,6 +279,11 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(AlwaysMergeDMB)) {
       FLAG_SET_DEFAULT(AlwaysMergeDMB, false);
     }
+#ifdef COMPILER2
+    if (model_is(CPU_MODEL_ARM_NEOVERSE_V1) && FLAG_IS_DEFAULT(MinJumpTableSize)) {
+      FLAG_SET_DEFAULT(MinJumpTableSize, 72);
+    }
+#endif
   }
 
   if (supports_feature(CPU_FP) || supports_feature(CPU_ASIMD)) {

--- a/src/hotspot/cpu/arm/matcher_arm.hpp
+++ b/src/hotspot/cpu/arm/matcher_arm.hpp
@@ -33,6 +33,8 @@
   // Whether this platform implements the scalable vector feature
   static const bool implements_scalable_vector = false;
 
+  static const bool use_branch_jump_table = false;
+
   static constexpr bool supports_scalable_vector() {
     return false;
   }

--- a/src/hotspot/cpu/ppc/matcher_ppc.hpp
+++ b/src/hotspot/cpu/ppc/matcher_ppc.hpp
@@ -34,6 +34,8 @@
   // Whether this platform implements the scalable vector feature
   static const bool implements_scalable_vector = false;
 
+  static const bool use_branch_jump_table = false;
+
   static constexpr bool supports_scalable_vector() {
     return false;
   }

--- a/src/hotspot/cpu/riscv/matcher_riscv.hpp
+++ b/src/hotspot/cpu/riscv/matcher_riscv.hpp
@@ -34,6 +34,8 @@
   // Whether this platform implements the scalable vector feature
   static const bool implements_scalable_vector = true;
 
+  static const bool use_branch_jump_table = false;
+
   static bool supports_scalable_vector() {
     return UseRVV;
   }

--- a/src/hotspot/cpu/s390/matcher_s390.hpp
+++ b/src/hotspot/cpu/s390/matcher_s390.hpp
@@ -35,6 +35,8 @@
   // Whether this platform implements the scalable vector feature
   static const bool implements_scalable_vector = false;
 
+  static const bool use_branch_jump_table = false;
+
   static constexpr bool supports_scalable_vector() {
     return false;
   }

--- a/src/hotspot/cpu/x86/matcher_x86.hpp
+++ b/src/hotspot/cpu/x86/matcher_x86.hpp
@@ -33,6 +33,8 @@
   // Whether this platform implements the scalable vector feature
   static const bool implements_scalable_vector = false;
 
+  static const bool use_branch_jump_table = false;
+
   static constexpr bool supports_scalable_vector() {
     return false;
   }

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -2653,7 +2653,9 @@ void ArchDesc::defineEmit(FILE* fp, InstructForm& inst) {
 
   // For MachConstantNodes which are ideal jump nodes, fill the jump table.
   if (inst.is_mach_constant() && inst.is_ideal_jump()) {
-    fprintf(fp, "  ra_->C->output()->constant_table().fill_jump_table(masm, (MachConstantNode*) this, _index2label);\n");
+    fprintf(fp, "  if (!Matcher::use_branch_jump_table) {\n");
+    fprintf(fp, "    ra_->C->output()->constant_table().fill_jump_table(masm, (MachConstantNode*) this, _index2label);\n");
+    fprintf(fp, "  }\n");
   }
 
   // Output each operand's offset into the array of registers.
@@ -2727,7 +2729,9 @@ void ArchDesc::defineEvalConstant(FILE* fp, InstructForm& inst) {
 
   // For ideal jump nodes, add a jump-table entry.
   if (inst.is_ideal_jump()) {
-    fprintf(fp, "  _constant = C->output()->constant_table().add_jump_table(this);\n");
+    fprintf(fp, "  if (!Matcher::use_branch_jump_table) {\n");
+    fprintf(fp, "    _constant = C->output()->constant_table().add_jump_table(this);\n");
+    fprintf(fp, "  }\n");
   }
 
   // If user did not define an encode section,

--- a/src/hotspot/share/opto/constantTable.cpp
+++ b/src/hotspot/share/opto/constantTable.cpp
@@ -188,6 +188,8 @@ bool ConstantTable::emit(C2_MacroAssembler* masm) const {
       // We use T_VOID as marker for jump-table entries (labels) which
       // need an internal word relocation.
       case T_VOID: {
+        assert(!Matcher::use_branch_jump_table,
+               "branch jump tables do not go through the constant table");
         MachConstantNode* n = (MachConstantNode*) con.get_jobject();
         // Fill the jump-table with a dummy word.  The real value is
         // filled in later in fill_jump_table.
@@ -297,6 +299,8 @@ ConstantTable::Constant ConstantTable::add(MachConstantNode* n, MachOper* oper) 
 }
 
 ConstantTable::Constant ConstantTable::add_jump_table(MachConstantNode* n) {
+  assert(!Matcher::use_branch_jump_table,
+         "branch jump tables do not go through the constant table");
   jvalue value;
   // We can use the node pointer here to identify the right jump-table
   // as this method is called from Compile::Fill_buffer right before
@@ -309,6 +313,9 @@ ConstantTable::Constant ConstantTable::add_jump_table(MachConstantNode* n) {
 }
 
 void ConstantTable::fill_jump_table(C2_MacroAssembler* masm, MachConstantNode* n, GrowableArray<Label*> labels) const {
+  assert(!Matcher::use_branch_jump_table,
+         "branch jump tables do not go through the constant table");
+
   // If called from Compile::scratch_emit_size do nothing.
   if (Compile::current()->output()->in_scratch_emit_size())  return;
 

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -157,6 +157,14 @@ uint MachNode::emit_size(PhaseRegAlloc *ra_) const {
   return ra_->C->output()->scratch_emit_size(this);
 }
 
+uint MachJumpNode::size(PhaseRegAlloc* ra_) const {
+  uint size = MachNode::emit_size(ra_);
+  if (Matcher::use_branch_jump_table) {
+    size += outcnt() * Pipeline::instr_unit_size();
+  }
+  return size;
+}
+
 
 
 //------------------------------hash-------------------------------------------

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -841,6 +841,14 @@ public:
   MachJumpNode() : MachConstantNode() {
     init_class_id(Class_MachJump);
   }
+  virtual void eval_constant(Compile* C) {
+    assert(Matcher::use_branch_jump_table, "branch jump table expected");
+  }
+  virtual uint mach_constant_base_node_input() const {
+    return Matcher::use_branch_jump_table ?
+           (uint)-1 : MachConstantNode::mach_constant_base_node_input();
+  }
+  virtual uint size(PhaseRegAlloc* ra_) const;
   virtual uint size_of() const { return sizeof(MachJumpNode); }
 };
 

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1212,6 +1212,11 @@ bool Parse::create_jump_tables(Node* key_val, SwitchRange* lo, SwitchRange* hi) 
   // Don't create table if: too large, too small, or too sparse.
   if (num_cases > MaxJumpTableSize)
     return false;
+
+  if (Matcher::use_branch_jump_table && num_cases < MinJumpTableSize) {
+    return false;
+  }
+
   if (UseSwitchProfiling) {
     // MinJumpTableSize is set so with a well balanced binary tree,
     // when the number of ranges is MinJumpTableSize, it's cheaper to
@@ -1264,10 +1269,12 @@ bool Parse::create_jump_tables(Node* key_val, SwitchRange* lo, SwitchRange* hi) 
   key_val = C->constrained_convI2L(&_gvn, key_val, TypeInt::INT, control(), true /* carry_dependency */);
 #endif
 
-  // Shift the value by wordsize so we have an index into the table, rather
-  // than a switch value
-  Node *shiftWord = _gvn.MakeConX(wordSize);
-  key_val = _gvn.transform( new MulXNode( key_val, shiftWord));
+  if (!Matcher::use_branch_jump_table) {
+    // Shift the value by wordsize so we have an index into the table, rather
+    // than a switch value
+    Node *shiftWord = _gvn.MakeConX(wordSize);
+    key_val = _gvn.transform( new MulXNode( key_val, shiftWord));
+  }
 
   // Create the JumpNode
   Arena* arena = C->comp_arena();


### PR DESCRIPTION
This patch implements the jump table as a sequence of ordinary AArch64 branch instructions. Each jump table entry is a b instruction targeting the corresponding switch case.

adr  rscratch1, jump_table
add  rscratch1, rscratch1, switch_index, uxtw #2
br   rscratch1
jump_table:
    b case_0
    b case_1
    b case_2
    ...




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32702/head:pull/32702` \
`$ git checkout pull/32702`

Update a local copy of the PR: \
`$ git checkout pull/32702` \
`$ git pull https://git.openjdk.org/jdk.git pull/32702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32702`

View PR using the GUI difftool: \
`$ git pr show -t 32702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32702.diff">https://git.openjdk.org/jdk/pull/32702.diff</a>

</details>
