### PR TITLE
8391454: [Valhalla][AArch64] C2 stack-repair fails with PAC-RET branch protection enabled

### DIFF
--- a/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
@@ -63,12 +63,13 @@ inline frame FreezeBase::sender(const frame& f) {
   frame::CompiledFramePointers cfp = f.compiled_frame_details();
 
   int slot = 0;
-  CodeBlob* sender_cb = CodeCache::find_blob_and_oopmap(*cfp.sender_pc_addr, slot);
+  address sender_pc = ContinuationHelper::return_address_at((intptr_t*)cfp.sender_pc_addr);
+  CodeBlob* sender_cb = CodeCache::find_blob_and_oopmap(sender_pc, slot);
 
   return sender_cb != nullptr
-    ? frame(cfp.sender_sp, cfp.sender_sp, *cfp.saved_fp_addr, *cfp.sender_pc_addr, sender_cb,
-            slot == -1 ? nullptr : sender_cb->oop_map_for_slot(slot, *cfp.sender_pc_addr), false)
-    : frame(cfp.sender_sp, cfp.sender_sp, *cfp.saved_fp_addr, *cfp.sender_pc_addr);
+    ? frame(cfp.sender_sp, cfp.sender_sp, *cfp.saved_fp_addr, sender_pc, sender_cb,
+            slot == -1 ? nullptr : sender_cb->oop_map_for_slot(slot, sender_pc), false)
+    : frame(cfp.sender_sp, cfp.sender_sp, *cfp.saved_fp_addr, sender_pc);
 }
 
 template<typename FKind>

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -632,7 +632,9 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
       ret_pc_loc = (intptr_t*)cfp.sender_pc_addr;
       fp_loc = (intptr_t*)cfp.saved_fp_addr;
     }
-    address ret_pc = *(address*)ret_pc_loc;
+    // Strip without authenticating: describe may see unsigned or broken LRs,
+    // and is_return_barrier_entry() compares against a raw stub address.
+    address ret_pc = pauth_strip_pointer(*(address*)ret_pc_loc);
     values.describe(frame_no, ret_pc_loc,
       Continuation::is_return_barrier_entry(ret_pc) ? "return address (return barrier)" : "return address");
     values.describe(-1, fp_loc, "saved fp", 0); // "unowned" as value belongs to sender

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -6041,6 +6041,7 @@ void MacroAssembler::remove_frame(int initial_framesize, bool needs_stack_repair
     ldr(rscratch1, Address(sp, sp_inc_offset));
     add(sp, sp, rscratch1);
     ldp(rfp, lr, Address(post(sp, 2 * wordSize)));
+    authenticate_return_address();
   } else {
     remove_frame(initial_framesize);
   }
@@ -7182,8 +7183,17 @@ int MacroAssembler::extend_stack_for_inline_args(int args_on_stack) {
   sp_inc = align_up(sp_inc, StackAlignmentInBytes);
   assert(sp_inc > 0, "sanity");
 
-  // Save a copy of the FP and LR here for deoptimization patching and frame walking
+  // Save a copy of the FP and LR here for deoptimization patching and frame
+  // walking. See remove_frame(). Sign LR #1 before spilling. Strip afterwards
+  // so build_frame() can use its normal path (it expects a raw LR and signs
+  // before spilling LR #2). Signing LR #2 is not strictly necessary. Reusing
+  // the signed LR #1 (PACIAZ, modifier zero) or storing a raw LR #2 (layout
+  // placeholder) would both work, but would need a special build_frame() path
+  // for stack repair, which adds code complexity. Current approach (strip +
+  // re-sign) keeps one generic build_frame().
+  protect_return_address();
   stp(rfp, lr, Address(pre(sp, -2 * wordSize)));
+  strip_return_address();
 
   // Adjust the stack pointer. This will be repaired on return by MacroAssembler::remove_frame
   if (sp_inc < (1 << 9)) {


### PR DESCRIPTION
About 600 "hotspot" and "jdk" jtreg tests fail on AArch64 with PAC-RET.

- Env: Linux (Ubuntu 26.04), Neoverse-V1 and Neoverse-V2
- JDK configure: --enable-branch-protection
- JDK runtime option: -XX:UseBranchProtection=pac-ret

1. Valhalla may spill two LR copies (`LR #1` and `LR #2`). Sign and authenticate were missing.

Sign `LR #1` before the store, then strip the live LR so build_frame can sign it again as `LR #2`:

```
  pac LR
  store signed LR
  strip signed LR
  ...
  use raw LR later (build_frame signs it as LR #2)
```

An alternative is to pac a temp and leave LR raw:

```
  mov LR, rscratch1
  pac rscratch1
  store rscratch1
  ...
  use raw LR later
```

"pac+strip" has about the same latency as "mov+pac". The temp-register sequence has less dependence on LR, but must branch on PAC-RET: spill raw LR when PAC-RET is off, and spill rscratch1 when it is on.

```
  PAC-RET on:
    mov LR, rscratch1
    pac rscratch1
    store rscratch1
  PAC-RET off:
    store LR
```

We keep "pac-store-strip" on LR: protect_return_address() already no-ops when PAC-RET is off and we suppose LR is usually not on the critical path.

2. Valhalla introduces helper compiled_frame_details() to handle many stack repair details. However, in FreezeBase::sender(), the sender PC is not authenticated before it's passed to
CodeCache::find_blob_and_oopmap().

3. The usage in frame::describe_pd() is low risk.

Test: Ran "hotspot jdk langtools" on Neoverse-V1 and Neoverse-V2 with the following test configs. No PAC-RET regressions.

- test config 1: build JDK with --enable-branch-protection and run test with the default option
- test config 2: build JDK with --enable-branch-protection and run test with -XX:UseBranchProtection=standard option
- test config 3: config 2 plus --enable-preview




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391454](https://bugs.openjdk.org/browse/JDK-8391454): [Valhalla][AArch64] C2 stack-repair fails with PAC-RET branch protection enabled (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32703/head:pull/32703` \
`$ git checkout pull/32703`

Update a local copy of the PR: \
`$ git checkout pull/32703` \
`$ git pull https://git.openjdk.org/jdk.git pull/32703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32703`

View PR using the GUI difftool: \
`$ git pr show -t 32703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32703.diff">https://git.openjdk.org/jdk/pull/32703.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32703#issuecomment-5539181046)
</details>
