### PR TITLE
8391824: JFR: wrong field lookup for JVM.getEventWriter() slow path

### DIFF
--- a/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
+++ b/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
@@ -101,7 +101,7 @@ static bool setup_event_writer_offsets(TRAPS) {
   assert(valid_offset != invalid_offset, "invariant");
 
   const char pin_name[] = "pinVirtualThread";
-  Symbol* const pin_sym = SymbolTable::new_symbol(valid_name);
+  Symbol* const pin_sym = SymbolTable::new_symbol(pin_name);
   assert(pin_sym != nullptr, "invariant");
   assert(invalid_offset == pin_offset, "invariant");
   JfrJavaSupport::compute_field_offset(pin_offset, klass, pin_sym, vmSymbols::bool_signature());


### PR DESCRIPTION
Greetings,

The JVM.getEventWriter() slow path attempts to look up the field offset for field "pinVirtualThread", but is doing so incorrectly; it is using the field name "valid" instead - a copy-paste error. Since both fields are booleans, all seems fine to the compiler. This went relatively unnoticed because an eventWriter is constructed with the correct parameters, but more importantly, JVM.getEventWriter() has a C2 intrinsic that does the correct thing. Since JVM.getEventWriter() is on the hot path for all JFR events, the correct C2 executions dominate and hide this issue (including intrinsification before virtual threads are mounted).

Use the pin_name string for the Symbol* lookup.

Testing: jdk_jfr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391824](https://bugs.openjdk.org/browse/JDK-8391824): JFR: wrong field lookup for JVM.getEventWriter() slow path (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32705/head:pull/32705` \
`$ git checkout pull/32705`

Update a local copy of the PR: \
`$ git checkout pull/32705` \
`$ git pull https://git.openjdk.org/jdk.git pull/32705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32705`

View PR using the GUI difftool: \
`$ git pr show -t 32705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32705.diff">https://git.openjdk.org/jdk/pull/32705.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32705#issuecomment-5541000663)
</details>
