### PR TITLE
8391831: MemorySegment.asOverlappingSlice() fails for enclosed segment

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -245,10 +245,18 @@ public abstract sealed class AbstractMemorySegmentImpl
     @Override
     public final Optional<MemorySegment> asOverlappingSlice(MemorySegment other) {
         final AbstractMemorySegmentImpl that = (AbstractMemorySegmentImpl)Objects.requireNonNull(other);
-        if (overlaps(that)) {
-            final long offsetToThat = that.address() - this.address();
-            final long newOffset = offsetToThat >= 0 ? offsetToThat : 0;
-            return Optional.of(asSlice(newOffset, Math.min(this.byteSize() - newOffset, that.byteSize() + offsetToThat)));
+        if (unsafeGetBase() == that.unsafeGetBase()) { // both either native or the same heap segment
+            final long thisStart = this.unsafeGetOffset();
+            final long thatStart = that.unsafeGetOffset();
+            final long thisEnd = thisStart + this.byteSize();
+            final long thatEnd = thatStart + that.byteSize();
+            // Memory segments denote half-open intervals [start, end).
+            if (thisStart < thatEnd && thisEnd > thatStart) {
+                // The intersection is [max(starts), min(ends)).
+                final long overlapStart = Math.max(thisStart, thatStart);
+                final long overlapEnd = Math.min(thisEnd, thatEnd);
+                return Optional.of(asSlice(overlapStart - thisStart, overlapEnd - overlapStart));
+            }
         }
         return Optional.empty();
     }

--- a/test/jdk/java/foreign/TestSegmentOverlap.java
+++ b/test/jdk/java/foreign/TestSegmentOverlap.java
@@ -135,6 +135,17 @@ public class TestSegmentOverlap {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("segmentFactories")
+    public void testContainedSlice(Supplier<MemorySegment> segmentSupplier) {
+        MemorySegment segment = segmentSupplier.get();
+        // Select an inner slice whose end precedes the end of the enclosing segment.
+        MemorySegment slice = segment.asSlice(1, 2);
+
+        // The overlap is limited by both segment ends, so it must not extend past the slice.
+        assertEquals(slice.byteSize(), segment.asOverlappingSlice(slice).orElseThrow().byteSize());
+    }
+
     enum OtherSegmentFactory {
         NATIVE(() -> Arena.ofAuto().allocate(16, 1)),
         HEAP(() -> MemorySegment.ofArray(new byte[]{16}));


### PR DESCRIPTION
This PR proposes to fix a bug in the `MemorySegment::asOverlapingSlice` which incorrectly computes the size of the overlapping region. 

A parameterized test is also proposed via this PR

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391831](https://bugs.openjdk.org/browse/JDK-8391831): MemorySegment.asOverlappingSlice() fails for enclosed segment (**Sub-task** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32707/head:pull/32707` \
`$ git checkout pull/32707`

Update a local copy of the PR: \
`$ git checkout pull/32707` \
`$ git pull https://git.openjdk.org/jdk.git pull/32707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32707`

View PR using the GUI difftool: \
`$ git pr show -t 32707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32707.diff">https://git.openjdk.org/jdk/pull/32707.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32707#issuecomment-5541657262)
</details>
