### PR TITLE
8391837: MemorySegment.mismatch does not throw for zero-sized segments

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -257,6 +257,9 @@ public final class SegmentBulkOperations {
         final boolean srcAndDstBytesDiffer = srcBytes != dstBytes;
 
         if (length == 0) {
+            // No memory access occurs below, so the segments' states must be checked explicitly.
+            src.sessionImpl().checkValidState();
+            dst.sessionImpl().checkValidState();
             return srcAndDstBytesDiffer ? 0 : -1;
         } else if (length < NATIVE_THRESHOLD_MISMATCH) {
             return mismatch(src, srcFromOffset, dst, dstFromOffset, 0, (int) length, srcAndDstBytesDiffer);

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -327,6 +327,17 @@ public class TestMismatch {
     }
 
     @Test
+    public void testClosedEmptyRange() {
+        MemorySegment closed;
+        try (Arena arena = Arena.ofConfined()) {
+            closed = arena.allocate(4, 1);
+        }
+        var alive = MemorySegment.ofArray(new byte[4]);
+        assertThrows(ISE, () -> MemorySegment.mismatch(closed, 0, 0, alive, 0, 0));
+        assertThrows(ISE, () -> MemorySegment.mismatch(alive, 0, 0, closed, 0, 0));
+    }
+
+    @Test
     public void testThreadAccess() throws Exception {
         try (Arena arena = Arena.ofConfined()) {
             var segment = arena.allocate(4, 1);;


### PR DESCRIPTION
This PR proposes to fix an error in `SegmentBulkOperations::mismatch` so it will throw `IllegalStateException` on closed zero-sized memory segments.

A new test is also proposed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391837](https://bugs.openjdk.org/browse/JDK-8391837): MemorySegment.mismatch does not throw for zero-sized segments (**Sub-task** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32708/head:pull/32708` \
`$ git checkout pull/32708`

Update a local copy of the PR: \
`$ git checkout pull/32708` \
`$ git pull https://git.openjdk.org/jdk.git pull/32708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32708`

View PR using the GUI difftool: \
`$ git pr show -t 32708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32708.diff">https://git.openjdk.org/jdk/pull/32708.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32708#issuecomment-5542116436)
</details>
