### PR TITLE
8391835: JFR: Clarify deprecated event level helper name

### DIFF
--- a/src/hotspot/share/jfr/support/jfrDeprecationEventWriter.cpp
+++ b/src/hotspot/share/jfr/support/jfrDeprecationEventWriter.cpp
@@ -48,7 +48,7 @@ void JfrDeprecatedEventWriterState::on_level_setting_update(int64_t new_level) {
   _current_level_setting = new_level;
 }
 
-static inline bool level() {
+static inline bool previous_epoch_level() {
   assert(_current_level_setting != uninitialized, "invariant");
   return _previous_level_setting == uninitialized ? _current_level_setting : _previous_level_setting;
 }
@@ -56,7 +56,7 @@ static inline bool level() {
 static inline bool only_for_removal() {
   assert(JfrEventSetting::is_enabled(JfrDeprecatedInvocationEvent), "invariant");
   // level 0: forRemoval, level 1: = all
-  return level() == 0;
+  return previous_epoch_level() == 0;
 }
 
 void JfrDeprecatedStackTraceWriter::install_stacktrace_blob(JfrDeprecatedEdge* edge, JfrCheckpointWriter& writer, JavaThread* jt) {


### PR DESCRIPTION
Greetings,

Rename the local level() helper to previous_epoch_level() to better describe the value used when serializing the previous epoch.

This is a naming-only change. 

Testing: jdk_jfr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391835](https://bugs.openjdk.org/browse/JDK-8391835): JFR: Clarify deprecated event level helper name (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32709/head:pull/32709` \
`$ git checkout pull/32709`

Update a local copy of the PR: \
`$ git checkout pull/32709` \
`$ git pull https://git.openjdk.org/jdk.git pull/32709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32709`

View PR using the GUI difftool: \
`$ git pr show -t 32709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32709.diff">https://git.openjdk.org/jdk/pull/32709.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32709#issuecomment-5542153269)
</details>
