### PR TITLE
8391841: MemorySegment.copy does not throw for zero-sized segments

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,8 +112,10 @@ public final class SegmentBulkOperations {
         src.checkAccess(srcOffset, size, true);
         dst.checkAccess(dstOffset, size, false);
 
-        if (size <= 0) {
-            // Do nothing
+        if (size == 0) {
+            // No memory access occurs below, so the segments' states must be checked explicitly.
+            src.sessionImpl().checkValidState();
+            dst.sessionImpl().checkValidState();
         } else if (size < NATIVE_THRESHOLD_COPY && !src.overlaps(dst)) {
             // 0 < size < FILL_NATIVE_LIMIT : 0...0X...XXXX
             //

--- a/test/jdk/java/foreign/TestSegmentCopy.java
+++ b/test/jdk/java/foreign/TestSegmentCopy.java
@@ -186,6 +186,17 @@ public class TestSegmentCopy {
     }
 
     @Test
+    public void testClosedZeroLengthCopy() {
+        MemorySegment closed;
+        try (Arena arena = Arena.ofConfined()) {
+            closed = arena.allocate(4, 1);
+        }
+        var alive = MemorySegment.ofArray(new byte[4]);
+        assertThrows(IllegalStateException.class, () -> MemorySegment.copy(closed, 0, alive, 0, 0));
+        assertThrows(IllegalStateException.class, () -> MemorySegment.copy(alive, 0, closed, 0, 0));
+    }
+
+    @Test
     public void badCopy6Arg() {
         try (Arena scope = Arena.ofConfined()) {
             MemorySegment dest = scope.allocate(ValueLayout.JAVA_INT).asReadOnly();


### PR DESCRIPTION
This PR proposes adding a missing liveness check for `SegmentBulkOperation::copy` if the `size` is zero.

It also proposes to add a small test.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391841](https://bugs.openjdk.org/browse/JDK-8391841): MemorySegment.copy does not throw for zero-sized segments (**Sub-task** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32710/head:pull/32710` \
`$ git checkout pull/32710`

Update a local copy of the PR: \
`$ git checkout pull/32710` \
`$ git pull https://git.openjdk.org/jdk.git pull/32710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32710`

View PR using the GUI difftool: \
`$ git pr show -t 32710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32710.diff">https://git.openjdk.org/jdk/pull/32710.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32710#issuecomment-5542754161)
</details>
