### PR TITLE
8391861: JFR: JfrThreadLocal::_dead termination condition has a data race

### DIFF
--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,7 +225,7 @@ void JfrThreadLocal::release(JfrThreadLocal* tl, Thread* t) {
   assert(Thread::current() == t, "invariant");
   assert(!tl->is_dead(), "invariant");
   assert(tl->shelved_buffer() == nullptr, "invariant");
-  tl->_dead = true;
+  AtomicAccess::release_store(&tl->_dead, true);
   tl->release(t);
 }
 

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -225,7 +225,7 @@ void JfrThreadLocal::release(JfrThreadLocal* tl, Thread* t) {
   assert(Thread::current() == t, "invariant");
   assert(!tl->is_dead(), "invariant");
   assert(tl->shelved_buffer() == nullptr, "invariant");
-  AtomicAccess::release_store(&tl->_dead, true);
+  AtomicAccess::store(&tl->_dead, true);
   tl->release(t);
 }
 

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -341,7 +341,7 @@ class JfrThreadLocal {
   }
 
   bool is_dead() const {
-    return _dead;
+    return AtomicAccess::load_acquire(&_dead);
   }
 
   bool in_sampling_critical_section() const {

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -341,7 +341,7 @@ class JfrThreadLocal {
   }
 
   bool is_dead() const {
-    return AtomicAccess::load_acquire(&_dead);
+    return AtomicAccess::load(&_dead);
   }
 
   bool in_sampling_critical_section() const {


### PR DESCRIPTION
Greetings,

The JfrThreadLocal::_dead is a general JFR iterator exclusion flag that both Java and non-Java thread iterators read, while the terminating thread writes it.

That is a data race that requires atomic access. 

Testing: jdk_Jfr

Thanks
Markus

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391861](https://bugs.openjdk.org/browse/JDK-8391861): JFR: JfrThreadLocal::_dead termination condition has a data race (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32711/head:pull/32711` \
`$ git checkout pull/32711`

Update a local copy of the PR: \
`$ git checkout pull/32711` \
`$ git pull https://git.openjdk.org/jdk.git pull/32711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32711`

View PR using the GUI difftool: \
`$ git pr show -t 32711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32711.diff">https://git.openjdk.org/jdk/pull/32711.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32711#issuecomment-5544070810)
</details>
