### PR TITLE
8391724: C2: Hoist expensive nodes explicitly to make get_early_ctrl not mutate the graph

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -93,68 +93,70 @@ bool LoopNode::is_valid_counted_loop(BasicType bt) const {
   return false;
 }
 
+// Keep the deepest of 'early' and the controls of n's inputs, starting at input 'start'.
+Node *PhaseIdealLoop::deepest_ctrl_of_inputs(Node *n, Node *early, uint start) {
+  assert(early != nullptr, "no starting control");
+  uint e_d = dom_depth(early);
+  for (uint i = start; i < n->req(); i++) {
+    Node *cin = get_ctrl(n->in(i));
+    assert(cin != nullptr, "");
+    uint c_d = dom_depth(cin);
+    if (c_d > e_d) {
+      // Keep deepest found
+      early = cin;
+      e_d = c_d;
+    } else if (c_d == e_d && early != cin) {
+      // Same depth but not equal, we want the deeper one.
+      Node *n1 = early;
+      Node *n2 = cin;
+      while (1) {
+        n1 = idom(n1);
+        n2 = idom(n2);
+        if (n1 == cin || dom_depth(n2) < c_d) {
+          break; // we keep early
+        }
+        if (n2 == early || dom_depth(n1) < c_d) {
+          early = cin; // cin is deeper
+          break;
+        }
+      }
+      e_d = dom_depth(early); // reset depth register cache
+    }
+  }
+
+  assert(early == find_non_split_ctrl(early), "unexpected early control");
+  return early;
+}
+
 //------------------------------get_early_ctrl---------------------------------
 // Compute earliest legal control
-Node *PhaseIdealLoop::get_early_ctrl( Node *n ) {
-  assert( !n->is_Phi() && !n->is_CFG(), "this code only handles data nodes" );
+Node *PhaseIdealLoop::get_early_ctrl(Node *n) {
+  assert(!n->is_Phi() && !n->is_CFG(), "this code only handles data nodes");
   uint i;
   Node *early;
-  // During verification we also get early control for expensive nodes here,
-  // as get_early_ctrl_for_expensive is skipped because it modifies the graph.
-  if (n->in(0) != nullptr && (!n->is_expensive() || _verify_me != nullptr || _verify_only)) {
+  if (n->in(0) != nullptr) {
     early = n->in(0);
-    if (!early->is_CFG()) // Might be a non-CFG multi-def
-      early = get_ctrl(early);        // So treat input as a straight data input
+    if (!early->is_CFG()) { // Might be a non-CFG multi-def
+      early = get_ctrl(early); // So treat input as a straight data input
+    }
     i = 1;
   } else {
     early = get_ctrl(n->in(1));
     i = 2;
   }
-  uint e_d = dom_depth(early);
-  assert( early, "" );
-  for (; i < n->req(); i++) {
-    Node *cin = get_ctrl(n->in(i));
-    assert( cin, "" );
-    // Keep deepest dominator depth
-    uint c_d = dom_depth(cin);
-    if (c_d > e_d) {           // Deeper guy?
-      early = cin;              // Keep deepest found so far
-      e_d = c_d;
-    } else if (c_d == e_d &&    // Same depth?
-               early != cin) { // If not equal, must use slower algorithm
-      // If same depth but not equal, one _must_ dominate the other
-      // and we want the deeper (i.e., dominated) guy.
-      Node *n1 = early;
-      Node *n2 = cin;
-      while (1) {
-        n1 = idom(n1);          // Walk up until break cycle
-        n2 = idom(n2);
-        if (n1 == cin ||        // Walked early up to cin
-            dom_depth(n2) < c_d)
-          break;                // early is deeper; keep him
-        if (n2 == early ||      // Walked cin up to early
-            dom_depth(n1) < c_d) {
-          early = cin;          // cin is deeper; keep him
-          break;
-        }
-      }
-      e_d = dom_depth(early);   // Reset depth register cache
-    }
-  }
 
-  // Return earliest legal location
-  assert(early == find_non_split_ctrl(early), "unexpected early control");
+  return deepest_ctrl_of_inputs(n, early, i);
+}
 
-  if (n->is_expensive() && !_verify_only && !_verify_me) {
-    assert(n->in(0), "should have control input");
-    early = get_early_ctrl_for_expensive(n, early);
-  }
-
-  return early;
+// Earliest control ignoring the control input of n: the highest an expensive node may go.
+Node *PhaseIdealLoop::get_early_ctrl_of_data_inputs(Node *n) {
+  assert(!n->is_Phi() && !n->is_CFG(), "only handles data nodes");
+  assert(n->in(0) != nullptr, "only for nodes with a control input");
+  return deepest_ctrl_of_inputs(n, get_ctrl(n->in(1)), 2);
 }
 
 //------------------------------get_early_ctrl_for_expensive---------------------------------
-// Move node up the dominator tree as high as legal while still beneficial
+// How far up the dominator tree an expensive node may move.
 Node *PhaseIdealLoop::get_early_ctrl_for_expensive(Node *n, Node* earliest) {
   assert(n->in(0) && n->is_expensive(), "expensive node with control input here");
   assert(OptimizeExpensiveOps, "optimization off?");
@@ -169,7 +171,8 @@ Node *PhaseIdealLoop::get_early_ctrl_for_expensive(Node *n, Node* earliest) {
   }
 #endif
   if (dom_depth(ctl) < min_dom_depth) {
-    return earliest;
+    // cannot move, keep the current control input
+    return ctl;
   }
 
   while (true) {
@@ -237,18 +240,30 @@ Node *PhaseIdealLoop::get_early_ctrl_for_expensive(Node *n, Node* earliest) {
     ctl = next;
   }
 
+  return ctl;
+}
+
+// Move an expensive node up the dominator tree as high as legal while still beneficial.
+// Modifies the graph, so it must run before the early control of n is computed.
+void PhaseIdealLoop::hoist_expensive_node(Node *n) {
+  assert(n->is_expensive(), "only for expensive nodes");
+  assert(!_verify_only && _verify_me == nullptr, "must not modify the graph when verifying");
+  Node *ctl = get_early_ctrl_for_expensive(n, get_early_ctrl_of_data_inputs(n));
   if (ctl != n->in(0)) {
     _igvn.replace_input_of(n, 0, ctl);
     _igvn.hash_insert(n);
   }
-
-  return ctl;
 }
 
 
 //------------------------------set_early_ctrl---------------------------------
 // Set earliest legal control
 void PhaseIdealLoop::set_early_ctrl(Node* n, bool update_body) {
+  if (n->is_expensive() && !_verify_only && _verify_me == nullptr) {
+    // Changes in(0), so it has to run before get_early_ctrl().
+    hoist_expensive_node(n);
+  }
+
   Node *early = get_early_ctrl(n);
 
   // Record earliest legal location

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1049,8 +1049,11 @@ public:
   }
   // check if transform created new nodes that need _ctrl recorded
   Node *get_late_ctrl( Node *n, Node *early );
+  Node *deepest_ctrl_of_inputs(Node *n, Node *early, uint start);
+  Node *get_early_ctrl_of_data_inputs(Node *n);
   Node *get_early_ctrl( Node *n );
   Node *get_early_ctrl_for_expensive(Node *n, Node* earliest);
+  void hoist_expensive_node(Node *n);
   void set_early_ctrl(Node* n, bool update_body);
   void set_subtree_ctrl(Node* n, bool update_body);
   void set_ctrl( Node *n, Node *ctrl ) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestExpensiveNodeHoisting.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestExpensiveNodeHoisting.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8391724
+ * @summary Expensive nodes are now hoisted by an explicit step instead of by
+ *          get_early_ctrl(). Check that they still end up in the right place.
+ *
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyLoopOptimizations
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::*
+ *                   ${test.main.class}
+ * @run main ${test.main.class}
+ */
+
+/*
+ * Math.sqrt() is the only expensive node left in C2. Each method below is one
+ * of the shapes hoist_expensive_node() has to get right: a Sqrt that can move
+ * above the loop, one that cannot move at all, and two identical ones that are
+ * commoned by process_expensive_nodes(). A wrong placement either fails loop
+ * verification on a debug VM or changes the result.
+ */
+
+package compiler.loopopts;
+
+public class TestExpensiveNodeHoisting {
+
+    static final double[] VALUES = new double[100];
+
+    static {
+        for (int i = 0; i < VALUES.length; i++) {
+            VALUES[i] = i;
+        }
+    }
+
+    // Loop invariant, the Sqrt is hoisted above the loop.
+    static double invariant(double x) {
+        double sum = 0;
+        for (int i = 0; i < 100; i++) {
+            sum += Math.sqrt(x);
+        }
+        return sum;
+    }
+
+    // Depends on the loop body, the Sqrt stays where it is.
+    static double variant(double[] a) {
+        double sum = 0;
+        for (int i = 0; i < a.length; i++) {
+            sum += Math.sqrt(a[i]);
+        }
+        return sum;
+    }
+
+    // Same Sqrt in both branches, moved above the If.
+    static double bothBranches(double x) {
+        double sum = 0;
+        for (int i = 0; i < 100; i++) {
+            if ((i & 1) == 0) {
+                sum += Math.sqrt(x);
+            } else {
+                sum -= Math.sqrt(x);
+            }
+        }
+        return sum;
+    }
+
+    static void check(double result, double expected) {
+        if (result != expected) {
+            throw new RuntimeException("expected " + expected + " but got " + result);
+        }
+    }
+
+    public static void main(String[] args) {
+        double invariantResult = invariant(2.0);
+        double variantResult = variant(VALUES);
+        double bothBranchesResult = bothBranches(2.0);
+
+        for (int i = 0; i < 20_000; i++) {
+            check(invariant(2.0), invariantResult);
+            check(variant(VALUES), variantResult);
+            check(bothBranches(2.0), bothBranchesResult);
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to JDK-8388592, suggested by @merykitty in the review there.

get_early_ctrl() hoists expensive nodes by calling
get_early_ctrl_for_expensive(), which rewires their control input. A getter
that modifies the graph is easy to miss, and it is why JDK-8388592 needed a
verification opt-out. The hoisting now happens in hoist_expensive_node(),
called from set_early_ctrl() just before the node is placed, and
get_early_ctrl() treats every node the same with no special case. The order
matters: hoisting has to run before the early control is computed, otherwise
the node and its users keep the old position and verification recomputes
something else, so this cannot be a separate pass after build_loop_early().

Placement is unchanged. can_move_to_inner_loop() and split_thru_phi() no
longer hoist as a side effect, which is the point.

Testing:
- linux-x64-fastdebug build
- compiler/loopopts and compiler/loopstripmining
- hotspot tier1 on linux-x64-fastdebug, partial local runs, no failures

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391724](https://bugs.openjdk.org/browse/JDK-8391724): C2: Hoist expensive nodes explicitly to make get_early_ctrl not mutate the graph (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32712/head:pull/32712` \
`$ git checkout pull/32712`

Update a local copy of the PR: \
`$ git checkout pull/32712` \
`$ git pull https://git.openjdk.org/jdk.git pull/32712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32712`

View PR using the GUI difftool: \
`$ git pr show -t 32712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32712.diff">https://git.openjdk.org/jdk/pull/32712.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32712#issuecomment-5546151581)
</details>
