### PR TITLE
8391865: JFR: JfrEventThrottler::_disabled needs unadorned atomic loads and stores

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEventThrottler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Datadog, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,6 +26,7 @@
 #include "jfr/recorder/service/jfrEventThrottler.hpp"
 #include "jfrfiles/jfrEventIds.hpp"
 #include "logging/log.hpp"
+#include "runtime/atomicAccess.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/spinCriticalSection.hpp"
@@ -89,7 +90,7 @@ JfrEventThrottler::JfrEventThrottler(JfrEventId event_id) :
 bool JfrEventThrottler::create() {
   bool rc = _throttler_table.initialize();
   if (rc) {
-    _throttler_table.at(JfrCPUTimeSampleEvent)->_disabled = true; // CPU time sampler disabled
+    AtomicAccess::store(&_throttler_table.at(JfrCPUTimeSampleEvent)->_disabled, true); // CPU time sampler disabled
   }
   return rc;
 }
@@ -139,7 +140,7 @@ void JfrEventThrottler::configure(int64_t sample_size, int64_t period_ms) {
 bool JfrEventThrottler::accept(JfrEventId event_id, int64_t timestamp /* 0 */) {
   JfrEventThrottler* const throttler = for_event(event_id);
   assert(throttler != nullptr, "invariant");
-  return throttler->_disabled ? true : throttler->sample(timestamp);
+  return AtomicAccess::load(&throttler->_disabled) ? true : throttler->sample(timestamp);
 }
 
 /*
@@ -243,8 +244,9 @@ inline bool is_disabled(int64_t event_sample_size) {
 }
 
 const JfrSamplerParams& JfrEventThrottler::update_params(const JfrSamplerWindow* expired) {
-  _disabled = is_disabled(_sample_size);
-  if (_disabled) {
+  const bool disabled = is_disabled(_sample_size);
+  AtomicAccess::store(&_disabled, disabled);
+  if (disabled) {
     return _disabled_params;
   }
   normalize(&_sample_size, &_period_ms);
@@ -317,5 +319,5 @@ const JfrSamplerParams& JfrEventThrottler::next_window_params(const JfrSamplerWi
   if (_update) {
     return update_params(expired); // Updates _last_params in-place.
   }
-  return _disabled ? _disabled_params : _last_params;
+  return AtomicAccess::load(&_disabled) ? _disabled_params : _last_params;
 }


### PR DESCRIPTION
Greetings,

JfrEventThrottler::_disabled is read without the sampler lock by event-producing threads, while it may be updated by a thread holding the lock.

Because readers don't participate in that lock protocol, the accesses race. Use unadorned atomic loads and stores because the flag controls only the fast path and does not publish other sampler state. 

Testing: jdk_jfr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391865](https://bugs.openjdk.org/browse/JDK-8391865): JFR: JfrEventThrottler::_disabled needs unadorned atomic loads and stores (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32713/head:pull/32713` \
`$ git checkout pull/32713`

Update a local copy of the PR: \
`$ git checkout pull/32713` \
`$ git pull https://git.openjdk.org/jdk.git pull/32713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32713`

View PR using the GUI difftool: \
`$ git pr show -t 32713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32713.diff">https://git.openjdk.org/jdk/pull/32713.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32713#issuecomment-5546291440)
</details>
