### PR TITLE
8391868: disable java/foreign/TestConfinedSegmentPoolDefensiveRelease.java with zero

### DIFF
--- a/test/jdk/java/foreign/TestConfinedSegmentPoolDefensiveRelease.java
+++ b/test/jdk/java/foreign/TestConfinedSegmentPoolDefensiveRelease.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires vm.flavor != "zero"
  * @modules java.base/jdk.internal.foreign:+open java.base/java.lang:+open java.base/jdk.internal.access
  * @library /test/lib
  * @build TestConfinedSegmentPoolUtils


### PR DESCRIPTION
A trivial fix to disable java/foreign/TestConfinedSegmentPoolDefensiveRelease.java with zero.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8391868: disable java/foreign/TestConfinedSegmentPoolDefensiveRelease.java with zero`

### Issue
 * [JDK-8391868](https://bugs.openjdk.org/browse/JDK-8391868): disable java/foreign/TestConfinedSegmentPoolDefensiveRelease.java with zero (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32714/head:pull/32714` \
`$ git checkout pull/32714`

Update a local copy of the PR: \
`$ git checkout pull/32714` \
`$ git pull https://git.openjdk.org/jdk.git pull/32714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32714`

View PR using the GUI difftool: \
`$ git pr show -t 32714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32714.diff">https://git.openjdk.org/jdk/pull/32714.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32714#issuecomment-5547863743)
</details>
