### PR TITLE
8250677: ModuleDescriptor.Version parsing treats pre-release identically to build

### DIFF
--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -1102,7 +1102,8 @@ public final class ModuleDescriptor
             if (c == '-' && i >= n)
                 throw new IllegalArgumentException(v + ": Empty pre-release");
 
-            while (i < n) {
+            boolean parsePreRelease = c == '-';
+            while (parsePreRelease && i < n) {
                 c = v.charAt(i);
                 if (c == '.' || c == '-') {
                     i++;

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -1102,21 +1102,22 @@ public final class ModuleDescriptor
             if (c == '-' && i >= n)
                 throw new IllegalArgumentException(v + ": Empty pre-release");
 
-            boolean parsePreRelease = c == '-';
-            while (parsePreRelease && i < n) {
-                c = v.charAt(i);
-                if (c == '.' || c == '-') {
-                    i++;
-                    continue;
+            if (c == '-') {
+                while (i < n) {
+                    c = v.charAt(i);
+                    if (c == '.' || c == '-') {
+                        i++;
+                        continue;
+                    }
+                    if (c == '+') {
+                        i++;
+                        break;
+                    }
+                    if (c >= '0' && c <= '9')
+                        i = takeNumber(v, i, pre);
+                    else
+                        i = takeString(v, i, pre);
                 }
-                if (c == '+') {
-                    i++;
-                    break;
-                }
-                if (c >= '0' && c <= '9')
-                    i = takeNumber(v, i, pre);
-                else
-                    i = takeString(v, i, pre);
             }
 
             if (c == '+' && i >= n)

--- a/test/jdk/java/lang/module/VersionTest.java
+++ b/test/jdk/java/lang/module/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8250677
  * @run testng VersionTest
  * @summary Basic tests for java.lang.module.ModuleDescriptor.Version.
  */
@@ -117,7 +118,12 @@ public class VersionTest {
             { "1.2.3-ea+104", "1.2.3-ea+105" },
             { "1.2.3-ea+104-4084552", "1.2.3-ea+104-4084552+8849330" },
             { "1+104", "1+105" },
-            { "1.0-alpha1", "1.0-alpha2" }
+            { "1.0-alpha1", "1.0-alpha2" },
+            { "1", "1+1" },
+            { "1-1", "1+1" },
+            { "1-foo", "1+foo" },
+            { "1-foo+bar", "1+foo+bar" },
+            { "1-foo+bar", "1+foo-bar" },
 
         };
     }

--- a/test/jdk/java/lang/module/VersionTest.java
+++ b/test/jdk/java/lang/module/VersionTest.java
@@ -70,6 +70,8 @@ public class VersionTest {
             { "",              null },
             { "A1",            null },  // does not start with number
             { "1.0-",          null },  // empty branch
+            { "1+",            null },  // empty build
+            { "1-a+",          null },  // empty build
 
         };
     }


### PR DESCRIPTION
Please review this small fix.

**Problem:**

After parsing the version number, the parser enters the pre-release parsing loop regardless of whether the delimiter was `-` or `+`. As a result, build-only versions such as `1+1` are parsed as pre-release versions, causing `1+1` to compare equal to `1-1`.

**Fix:**

Record whether the version number ended with `-`, and only parse the pre-release component in that case. If it ended with `+`, proceed directly to the build component.

**Testing:**

- Added regression cases to `VersionTest.java`.
- `make test TEST=test/jdk/java/lang/module`: 17 passed, 0 failed.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8250677](https://bugs.openjdk.org/browse/JDK-8250677): ModuleDescriptor.Version parsing treats pre-release identically to build (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32715/head:pull/32715` \
`$ git checkout pull/32715`

Update a local copy of the PR: \
`$ git checkout pull/32715` \
`$ git pull https://git.openjdk.org/jdk.git pull/32715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32715`

View PR using the GUI difftool: \
`$ git pr show -t 32715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32715.diff">https://git.openjdk.org/jdk/pull/32715.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32715#issuecomment-5549161184)
</details>
