### PR TITLE
8391789: Collector for ListFormat

### DIFF
--- a/src/java.base/share/classes/java/text/ListFormat.java
+++ b/src/java.base/share/classes/java/text/ListFormat.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import sun.util.locale.provider.LocaleProviderAdapter;
 
@@ -378,6 +380,21 @@ public final class ListFormat extends Format {
 
         return format(input, StringBufFactory.of(),
                 DontCareFieldPosition.INSTANCE).toString();
+    }
+
+    /**
+     * {@return a {@code Collector} that concatenates the input elements into a
+     * string with the patterns of this {@code ListFormat}, in encounter order}
+     *
+     * <p>The returned Collector requires at least one input element.
+     * It will throw {@link IllegalArgumentException} if there are no input elements.
+     *
+     * @since 28
+     */
+    public Collector<CharSequence, ?, String> toCollector() {
+        return Collectors.collectingAndThen(
+                Collectors.mapping(String::valueOf, Collectors.toList()),
+                this::format);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -354,6 +354,7 @@ public final class Collectors {
      * @param delimiter the delimiter to be used between each element
      * @return A {@code Collector} which concatenates CharSequence elements,
      * separated by the specified delimiter, in encounter order
+     * @see java.text.ListFormat#toCollector
      */
     public static Collector<CharSequence, ?, String> joining(CharSequence delimiter) {
         return joining(delimiter, "", "");

--- a/test/jdk/java/text/Format/ListFormat/TestListFormat.java
+++ b/test/jdk/java/text/Format/ListFormat/TestListFormat.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8041488 8316974 8318569 8306116 8385736 8385834 8386200
+ * @bug 8041488 8316974 8318569 8306116 8385736 8385834 8386200 8391789
  * @summary Tests for ListFormat class
  * @run junit TestListFormat
  */
@@ -35,6 +35,10 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -441,6 +445,27 @@ public class TestListFormat {
             ListFormat [locale: "%s", start: "{0}, {1}", middle: "{0}, {1}", end: "{0} and {1}", two: "{0} and {1}", three: "{0}, {1} and {2}"]
             """.formatted(world.getDisplayName()),
             ListFormat.getInstance(world, ListFormat.Type.STANDARD, ListFormat.Style.FULL).toString());
+    }
+
+    @Test
+    void toCollector() {
+        ListFormat format = ListFormat.getInstance(Locale.ENGLISH, ListFormat.Type.STANDARD, ListFormat.Style.FULL);
+        Collector<CharSequence, ?, String> collector = format.toCollector();
+        assertThrows(IllegalArgumentException.class, () -> Stream.<CharSequence>empty().collect(collector));
+        assertEquals("a",
+                Stream.of("a").collect(collector));
+        assertEquals("a and b",
+                Stream.of("a", "b").collect(collector));
+        assertEquals("a, b, and c",
+                Stream.of("a", "b", "c").collect(collector));
+        assertEquals("a, b, and c",
+                Stream.of(new StringBuilder("a"), "b", new StringBuffer("c")).collect(collector));
+        assertEquals("a, b, c, and null",
+                Stream.of(new StringBuilder("a"), "b", new StringBuffer("c"), null).collect(collector));
+        assertEquals("1, 2, 3, 4, 5, 6, 7, 8, and 9",
+                IntStream.range(1, 10).mapToObj(String::valueOf).collect(collector));
+        assertEquals("1, 2, 3, 4, 5, 6, 7, 8, and 9",
+                IntStream.range(1, 10).parallel().mapToObj(String::valueOf).collect(collector));
     }
 
     private static void compareResult(ListFormat f, List<String> input, String expected, boolean roundTrip) throws ParseException {


### PR DESCRIPTION
Three options were suggested about the new API:
- ListFormat.formatting()
- ListFormat.toCollector()
- Collectors.listFormatting(ListFormat) static method
I feel it should belong to ListFormat, but I'm open to discussions.

For testing, I tested a couple of scenarios and a few corner cases (empty stream, null element, parallel stream) in a simple non-parameterized JUnit test. I believe that it's enough, given that the implementation is trivial, and ListFormat itself, as well as Stream API is already thoroughly tested by other tests. Tell me if you feel that some testing scenarios are missing, I'll happily add them.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change requires CSR request [JDK-8391870](https://bugs.openjdk.org/browse/JDK-8391870) to be approved

### Issues
 * [JDK-8391789](https://bugs.openjdk.org/browse/JDK-8391789): Collector for ListFormat (**Enhancement** - P4)
 * [JDK-8391870](https://bugs.openjdk.org/browse/JDK-8391870): Collector for ListFormat (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32716/head:pull/32716` \
`$ git checkout pull/32716`

Update a local copy of the PR: \
`$ git checkout pull/32716` \
`$ git pull https://git.openjdk.org/jdk.git pull/32716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32716`

View PR using the GUI difftool: \
`$ git pr show -t 32716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32716.diff">https://git.openjdk.org/jdk/pull/32716.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32716#issuecomment-5551105438)
</details>
