### PR TITLE
8391871: AArch64: Prevent non-acquire CAS patterns from matching nodes that need acquire

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_atomic.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic.ad
@@ -40,6 +40,7 @@
 
 
 instruct compareAndExchangeB(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
+  predicate(!needs_acquiring_load_exclusive(n));
   match(Set res (CompareAndExchangeB mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(TEMP_DEF res, KILL cr);
@@ -55,6 +56,7 @@ instruct compareAndExchangeB(iRegINoSp res, indirect mem, iRegI oldval, iRegI ne
 %}
 
 instruct compareAndExchangeS(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
+  predicate(!needs_acquiring_load_exclusive(n));
   match(Set res (CompareAndExchangeS mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(TEMP_DEF res, KILL cr);
@@ -70,6 +72,7 @@ instruct compareAndExchangeS(iRegINoSp res, indirect mem, iRegI oldval, iRegI ne
 %}
 
 instruct compareAndExchangeI(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
+  predicate(!needs_acquiring_load_exclusive(n));
   match(Set res (CompareAndExchangeI mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(TEMP_DEF res, KILL cr);
@@ -84,6 +87,7 @@ instruct compareAndExchangeI(iRegINoSp res, indirect mem, iRegI oldval, iRegI ne
 %}
 
 instruct compareAndExchangeL(iRegLNoSp res, indirect mem, iRegL oldval, iRegL newval, rFlagsReg cr) %{
+  predicate(!needs_acquiring_load_exclusive(n));
   match(Set res (CompareAndExchangeL mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(TEMP_DEF res, KILL cr);
@@ -98,7 +102,7 @@ instruct compareAndExchangeL(iRegLNoSp res, indirect mem, iRegL oldval, iRegL ne
 %}
 
 instruct compareAndExchangeN(iRegNNoSp res, indirect mem, iRegN oldval, iRegN newval, rFlagsReg cr) %{
-  predicate(n->as_LoadStore()->barrier_data() == 0);
+  predicate(!needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);
   match(Set res (CompareAndExchangeN mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(TEMP_DEF res, KILL cr);
@@ -113,7 +117,7 @@ instruct compareAndExchangeN(iRegNNoSp res, indirect mem, iRegN oldval, iRegN ne
 %}
 
 instruct compareAndExchangeP(iRegPNoSp res, indirect mem, iRegP oldval, iRegP newval, rFlagsReg cr) %{
-  predicate(n->as_LoadStore()->barrier_data() == 0);
+  predicate(!needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));
   match(Set res (CompareAndExchangeP mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(TEMP_DEF res, KILL cr);
@@ -316,6 +320,7 @@ instruct compareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP new
 %}
 
 instruct weakCompareAndSwapB(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
+  predicate(!needs_acquiring_load_exclusive(n));
   match(Set res (WeakCompareAndSwapB mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(KILL cr);
@@ -331,6 +336,7 @@ instruct weakCompareAndSwapB(iRegINoSp res, indirect mem, iRegI oldval, iRegI ne
 %}
 
 instruct weakCompareAndSwapS(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
+  predicate(!needs_acquiring_load_exclusive(n));
   match(Set res (WeakCompareAndSwapS mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(KILL cr);
@@ -346,6 +352,7 @@ instruct weakCompareAndSwapS(iRegINoSp res, indirect mem, iRegI oldval, iRegI ne
 %}
 
 instruct weakCompareAndSwapI(iRegINoSp res, indirect mem, iRegI oldval, iRegI newval, rFlagsReg cr) %{
+  predicate(!needs_acquiring_load_exclusive(n));
   match(Set res (WeakCompareAndSwapI mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(KILL cr);
@@ -361,6 +368,7 @@ instruct weakCompareAndSwapI(iRegINoSp res, indirect mem, iRegI oldval, iRegI ne
 %}
 
 instruct weakCompareAndSwapL(iRegINoSp res, indirect mem, iRegL oldval, iRegL newval, rFlagsReg cr) %{
+  predicate(!needs_acquiring_load_exclusive(n));
   match(Set res (WeakCompareAndSwapL mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(KILL cr);
@@ -376,7 +384,7 @@ instruct weakCompareAndSwapL(iRegINoSp res, indirect mem, iRegL oldval, iRegL ne
 %}
 
 instruct weakCompareAndSwapN(iRegINoSp res, indirect mem, iRegN oldval, iRegN newval, rFlagsReg cr) %{
-  predicate(n->as_LoadStore()->barrier_data() == 0);
+  predicate(!needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);
   match(Set res (WeakCompareAndSwapN mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(KILL cr);
@@ -392,7 +400,7 @@ instruct weakCompareAndSwapN(iRegINoSp res, indirect mem, iRegN oldval, iRegN ne
 %}
 
 instruct weakCompareAndSwapP(iRegINoSp res, indirect mem, iRegP oldval, iRegP newval, rFlagsReg cr) %{
-  predicate(n->as_LoadStore()->barrier_data() == 0);
+  predicate(!needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));
   match(Set res (WeakCompareAndSwapP mem (Binary oldval newval)));
   ins_cost(2*VOLATILE_REF_COST);
   effect(KILL cr);

--- a/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_atomic_ad.m4
@@ -49,7 +49,8 @@ dnl
 define(`CAE_INSN1',
 `
 instruct compareAndExchange$1$7(iReg$2NoSp res, indirect mem, iReg$2 oldval, iReg$2 newval, rFlagsReg cr) %{
-ifelse($7,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),`dnl')
+ifelse($7,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
+       INDENT(predicate(!needs_acquiring_load_exclusive(n));))
   match(Set res (CompareAndExchange$1 mem (Binary oldval newval)));
   ins_cost(`'ifelse($7,Acq,,2*)VOLATILE_REF_COST);
   effect(TEMP_DEF res, KILL cr);
@@ -68,10 +69,10 @@ define(`CAE_INSN2',
 instruct compareAndExchange$1$6(iReg$2NoSp res, indirect mem, iReg$2 oldval, iReg$2 newval, rFlagsReg cr) %{
 ifelse($1$6,PAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));),
        $1$6,NAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);),
-       $1,P,INDENT(predicate(n->as_LoadStore()->barrier_data() == 0);),
-       $1,N,INDENT(predicate(n->as_LoadStore()->barrier_data() == 0);),
+       $1,P,INDENT(predicate(!needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));),
+       $1,N,INDENT(predicate(!needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);),
        $6,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
-       `dnl')
+       INDENT(predicate(!needs_acquiring_load_exclusive(n));))
   match(Set res (CompareAndExchange$1 mem (Binary oldval newval)));
   ins_cost(`'ifelse($6,Acq,,2*)VOLATILE_REF_COST);
   effect(TEMP_DEF res, KILL cr);
@@ -106,7 +107,8 @@ dnl
 define(`CAS_INSN1',
 `
 instruct ifelse($7,Weak,'weakCompare`,'compare`)AndSwap$1$6(iRegINoSp res, indirect mem, iReg$2 oldval, iReg$2 newval, rFlagsReg cr) %{
-ifelse($6,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),`dnl')
+ifelse($6,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
+       INDENT(predicate(!needs_acquiring_load_exclusive(n));))
   match(Set res ($7CompareAndSwap$1 mem (Binary oldval newval)));
   ins_cost(`'ifelse($6,Acq,,2*)VOLATILE_REF_COST);
   effect(KILL cr);
@@ -126,10 +128,10 @@ define(`CAS_INSN2',
 instruct ifelse($7,Weak,'weakCompare`,'compare`)AndSwap$1$6(iRegINoSp res, indirect mem, iReg$2 oldval, iReg$2 newval, rFlagsReg cr) %{
 ifelse($1$6,PAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));),
        $1$6,NAcq,INDENT(predicate(needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);),
-       $1,P,INDENT(predicate(n->as_LoadStore()->barrier_data() == 0);),
-       $1,N,INDENT(predicate(n->as_LoadStore()->barrier_data() == 0);),
+       $1,P,INDENT(predicate(!needs_acquiring_load_exclusive(n) && (n->as_LoadStore()->barrier_data() == 0));),
+       $1,N,INDENT(predicate(!needs_acquiring_load_exclusive(n) && n->as_LoadStore()->barrier_data() == 0);),
        $6,Acq,INDENT(predicate(needs_acquiring_load_exclusive(n));),
-       `dnl')
+       INDENT(predicate(!needs_acquiring_load_exclusive(n));))
   match(Set res ($7CompareAndSwap$1 mem (Binary oldval newval)));
   ins_cost(`'ifelse($6,Acq,,2*)VOLATILE_REF_COST);
   effect(KILL cr);


### PR DESCRIPTION
Hi, please consider.
The non-acquiring `CompareAndExchangeX` and `WeakCompareAndSwapX` match rules carry no `needs_acquiring_load_exclusive()` condition, for a sequentially consistent node both they and their `*Acq` counterparts match and the choice is settled by `ins_cost` (`VOLATILE_REF_COST` vs `2*VOLATILE_REF_COST`). This adds the negated predicate to the 12 non-acquiring rules, making each pair mutually exclusive.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391871](https://bugs.openjdk.org/browse/JDK-8391871): AArch64: Prevent non-acquire CAS patterns from matching nodes that need acquire (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32717/head:pull/32717` \
`$ git checkout pull/32717`

Update a local copy of the PR: \
`$ git checkout pull/32717` \
`$ git pull https://git.openjdk.org/jdk.git pull/32717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32717`

View PR using the GUI difftool: \
`$ git pr show -t 32717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32717.diff">https://git.openjdk.org/jdk/pull/32717.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32717#issuecomment-5552580765)
</details>
