### PR TITLE
8386318: The Java compiler allows a Pair<Object,?> to be assigned to a Pair<Object,Object>

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -888,6 +888,15 @@ public class Infer {
          * Is source type 's' compatible with target type 't' given source and target bound kinds?
          */
         boolean checkBound(Type s, Type t, InferenceBound ib_s, InferenceBound ib_t, Warner warn, InferenceContext ic) {
+            // An inference variable bounded by a wildcard must not be instantiated
+            // to an unrelated concrete type (e.g. Pair<Object,?> must not become
+            // Pair<Object,Object>).
+            if (s.hasTag(WILDCARD) != t.hasTag(WILDCARD) &&
+                    (ib_s == InferenceBound.EQ || ib_t == InferenceBound.EQ)) {
+                if (!isSameType(s, t, ic)) {
+                    return false;
+                }
+            }
             if (ib_s.lessThan(ib_t)) {
                 return isSubtype(s, t, warn, ic);
             } else if (ib_t.lessThan(ib_s)) {

--- a/test/langtools/tools/javac/generics/inference/WildcardChainedInference.java
+++ b/test/langtools/tools/javac/generics/inference/WildcardChainedInference.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test /nodynamiccopyright/
+ * @summary Inference must not widen wildcard type arguments to Object
+ * @compile/fail WildcardChainedInference.java
+ */
+
+class Pair<A,B>{
+    A left;
+    B right;
+    static <X,Y> Pair<X,Y> change(Pair<X,Y> a){ return a;}
+    static <A> Pair<A,?> left(Pair<A,Integer> p){return p;}
+
+    public static void main(String[] args){
+        Pair<Object,Integer> p1 = new Pair<Object,Integer>();
+        p1.left = "1";
+        p1.right = 2;
+        Pair<Object,Object> p = change(left(p1));
+        p.right = p.left;
+        System.out.println(p1.right + p1.right);
+    }
+}


### PR DESCRIPTION
## Problem

javac incorrectly accepts chained generic inference that widens a wildcard type argument to a concrete type.

**Reproducer:**

    class Pair<A,B>{
        A left;
        B right;
        static <X,Y> Pair<X,Y> change(Pair<X,Y> a){ return a; }
        static <A> Pair<A,?> left(Pair<A,Integer> p){ return p; }

        public static void main(String[] args){
            Pair<Object,Integer> p1 = new Pair<>();
            p1.left = "1";
            p1.right = 2;
            Pair<Object,Object> p = change(left(p1)); // invalid
            p.right = p.left;
        }
    }

`left(p1)` has type `Pair<Object,?>`, but inference for `change(...)` incorrectly instantiates the second type argument as `Object`. This allows an unsound assignment to `Pair<Object,Object>` and can cause `ClassCastException` at runtime.

JDK 8 rejects this program. The unsound behavior is a regression since JDK 9.

## JBS Issue

https://bugs.openjdk.org/browse/JDK-8386318

## Root Cause

During inference, an inference variable may receive:

- an upper bound from a wildcard in an argument type (`?`), and
- an equality bound from the target type (`Object`).

`Infer.CheckBounds.checkBound()` accepted this using subtyping alone (`Object <: ?`), which is not sufficient for sound inference.

## Solution

Reject bound combinations where one side is a wildcard and the other is an equality bound to a non-equivalent concrete type.

## Changes

- `src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java`
- `test/langtools/tools/javac/generics/inference/WildcardChainedInference.java`

## Testing

Added regression test with `@compile/fail`:

    make test TEST="tools/javac/generics/inference/WildcardChainedInference.java"
    make test TEST="tools/javac/generics/inference"

## Risk Assessment

- Fixes unsound code that previously compiled
- Scope is limited to inference bound checking
- Well-typed code should be unaffected

## Checklist

- [x] JBS issue filed: JDK-8386318
- [x] Regression test added
- [x] OCA signed
- [x ] `make test` run locally

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8386318](https://bugs.openjdk.org/browse/JDK-8386318): The Java compiler allows a Pair&lt;Object,?&gt; to be assigned to a Pair&lt;Object,Object&gt; (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32719/head:pull/32719` \
`$ git checkout pull/32719`

Update a local copy of the PR: \
`$ git checkout pull/32719` \
`$ git pull https://git.openjdk.org/jdk.git pull/32719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32719`

View PR using the GUI difftool: \
`$ git pr show -t 32719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32719.diff">https://git.openjdk.org/jdk/pull/32719.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32719#issuecomment-5553569265)
</details>
