### PR TITLE
8391881: RISC-V: jni_fast_Get<Primitive>Field registers the wrong pc for the speculative load

### DIFF
--- a/src/hotspot/cpu/riscv/jniFastGetField_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jniFastGetField_riscv.cpp
@@ -105,10 +105,10 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   bs->try_resolve_jobject_in_native(masm, c_rarg0, robj, t0, slow);
 
   __ srli(roffset, c_rarg2, jfieldIDWorkaround::offset_shift); // offset
+  __ add(roffset, robj, roffset);
 
   assert(count < LIST_CAPACITY, "LIST_CAPACITY too small");
   speculative_load_pclist[count] = __ pc();   // Used by the segfault handler
-  __ add(roffset, robj, roffset);
 
   switch (type) {
     case T_BOOLEAN: __ lbu(result, Address(roffset, 0)); break;


### PR DESCRIPTION
Hi, Please help review this small but consequential fix for the RISC-V port.
The `jni_fast_Get<Primitive>Field` stubs read the field speculatively, before they can know whether the object is still there. The address may already be unmapped — as the existing comment in `os_linux_riscv.cpp` notes, the stubs "can trap at certain pc's if a GC kicks in and the heap gets shrunk before the field access". Each stub therefore registers the address of its speculative load in `speculative_load_pclist[]`, and the signal handler turns a fault at that address into a jump to the slow-case entry.

`JNI_FastGetField::find_slowcase_pc()` compares pcs for exact equality, so the registered address must be the load's own address. On RISC-V it is off by one instruction, because `__ pc()` is captured before the address arithmetic is emitted:
https://github.com/openjdk/jdk/blob/ef54ca1c775881843f0710a8148f379a6e209816/src/hotspot/cpu/riscv/jniFastGetField_riscv.cpp#L109-L131

The registered pc points at the `add`, which can never trap, while the load that does trap is 4 bytes later — 2 bytes with `UseRVC`, where the `add` is compressed to `c.add`. Nothing matches, so the fault is not recognised and the VM dies with a fatal error instead of falling back to the slow path. All eight stubs are affected, as they share `generate_fast_get_int_field0()`.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391881](https://bugs.openjdk.org/browse/JDK-8391881): RISC-V: jni_fast_Get&lt;Primitive&gt;Field registers the wrong pc for the speculative load (**Bug** - P3)


### Reviewers
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32720/head:pull/32720` \
`$ git checkout pull/32720`

Update a local copy of the PR: \
`$ git checkout pull/32720` \
`$ git pull https://git.openjdk.org/jdk.git pull/32720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32720`

View PR using the GUI difftool: \
`$ git pr show -t 32720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32720.diff">https://git.openjdk.org/jdk/pull/32720.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32720#issuecomment-5559533407)
</details>
