### PR TITLE
8391891: RISC-V: CheckLargePages.java failed on riscv

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -76,8 +76,8 @@ public class CheckLargePages {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-XX:+UseLargePages",
                 "-XX:+SegmentedCodeCache",
-                "-XX:InitialCodeCacheSize=2g",
-                "-XX:ReservedCodeCacheSize=2g",
+                "-XX:InitialCodeCacheSize=1900m",
+                "-XX:ReservedCodeCacheSize=1900m",
                 "-XX:LargePageSizeInBytes=1g",
                 "-Xlog:pagesize=info",
                 "-version");

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -76,6 +76,7 @@ public class CheckLargePages {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-XX:+UseLargePages",
                 "-XX:+SegmentedCodeCache",
+                // For architecture like riscv, code cache limit is below 2g, so use a close value 1900m instead.
                 "-XX:InitialCodeCacheSize=1900m",
                 "-XX:ReservedCodeCacheSize=1900m",
                 "-XX:LargePageSizeInBytes=1g",


### PR DESCRIPTION
I found test/hotspot/compiler/codecache/CheckLargePages.java failed on riscv machine.

```
[2026-09-07T03:52:31.323729600Z] Gathering output for process 2772077
[2026-09-07T03:52:31.931522640Z] Waiting for completion for process 2772077
[2026-09-07T03:52:31.932322380Z] Waiting for completion finished for process 2772077
STDERR:
 stdout: [];
 stderr: [Invalid ReservedCodeCacheSize=2048M. Must be at most 2047M.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
]
 exitValue = 1
```

The failure reason is code cache limit is set as 2g-2k in globalsDefinitions_riscv.hpp
```c++
// auipc useable for all cc -> cc calls and jumps
#define CODE_CACHE_SIZE_LIMIT ((2*G)-(2*K))
```

So I changed the code cache size in test from `2g` to `1900m`, and it is passed on my test machine.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391891](https://bugs.openjdk.org/browse/JDK-8391891): RISC-V: CheckLargePages.java failed on riscv (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32721/head:pull/32721` \
`$ git checkout pull/32721`

Update a local copy of the PR: \
`$ git checkout pull/32721` \
`$ git pull https://git.openjdk.org/jdk.git pull/32721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32721`

View PR using the GUI difftool: \
`$ git pr show -t 32721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32721.diff">https://git.openjdk.org/jdk/pull/32721.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32721#issuecomment-5565934621)
</details>
