### PR TITLE
8318233: RISC-V: C2 OverflowAdd/Sub/Mul I/L

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2021,9 +2021,11 @@ void C2_MacroAssembler::enc_cmpUEqNeLeGt_imm0_branch(int cmpFlag, Register op1, 
 void C2_MacroAssembler::enc_cmpEqNe_imm0_branch(int cmpFlag, Register op1, Label& L, bool is_far) {
   switch (cmpFlag) {
     case BoolTest::eq:
+    case BoolTest::no_overflow:
       beqz(op1, L, is_far);
       break;
     case BoolTest::ne:
+    case BoolTest::overflow:
       bnez(op1, L, is_far);
       break;
     default:

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3756,6 +3756,28 @@ operand cmpOpEqNe()
   %}
 %}
 
+operand cmpOpEqNeOverflow()
+%{
+  match(Bool);
+  op_cost(0);
+  predicate(n->as_Bool()->_test._test == BoolTest::ne ||
+            n->as_Bool()->_test._test == BoolTest::eq ||
+            n->as_Bool()->_test._test == BoolTest::overflow ||
+            n->as_Bool()->_test._test == BoolTest::no_overflow);
+
+  format %{ "" %}
+  interface(COND_INTER) %{
+    equal(0x0, "eq");
+    greater(0x1, "gt");
+    overflow(0x2, "overflow");
+    less(0x3, "lt");
+    not_equal(0x4, "ne");
+    less_equal(0x5, "le");
+    no_overflow(0x6, "no_overflow");
+    greater_equal(0x7, "ge");
+  %}
+%}
+
 operand cmpOpULtGe()
 %{
   match(Bool);
@@ -6610,6 +6632,355 @@ instruct umulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2)
   ins_pipe(lmul_reg_reg);
 %}
 
+// ============================================================================
+// Overflow Math Instructions
+
+instruct overflowAddI_reg_sext(rFlagsReg cr, iRegI op1, iRegI op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowAddI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(3 * ALU_COST);
+  format %{ "add    $cr, $op1, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowAddI_reg_sext" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ add(cr, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowAddI_imm_sext(rFlagsReg cr, iRegI op1, immIAdd op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowAddI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(3 * ALU_COST);
+  format %{ "addi   $cr, $op1, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowAddI_imm_sext" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ addi(cr, as_Register($op1$$reg), $op2$$constant);
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowAddI_reg(rFlagsReg cr, iRegIorL2I op1, iRegIorL2I op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowAddI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(5 * ALU_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "sext.w $cr, $op2\n\t"
+            "add    $cr, $tmp, $cr\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowAddI_reg" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ sext_w(cr, as_Register($op2$$reg));
+    __ add(cr, tmp, cr);
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowAddI_imm(rFlagsReg cr, iRegIorL2I op1, immIAdd op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowAddI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(4 * ALU_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "addi   $cr, $tmp, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowAddI_imm" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ addi(cr, tmp, $op2$$constant);
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowSubI_reg_sext(rFlagsReg cr, iRegI op1, iRegI op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowSubI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(3 * ALU_COST);
+  format %{ "sub    $cr, $op1, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowSubI_reg_sext" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sub(cr, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowSubI_imm_sext(rFlagsReg cr, iRegI op1, immISub op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowSubI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(3 * ALU_COST);
+  format %{ "subi   $cr, $op1, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowSubI_imm_sext" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ subi(cr, as_Register($op1$$reg), $op2$$constant);
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowSubI_reg(rFlagsReg cr, iRegIorL2I op1, iRegIorL2I op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowSubI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(5 * ALU_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "sext.w $cr, $op2\n\t"
+            "sub    $cr, $tmp, $cr\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowSubI_reg" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ sext_w(cr, as_Register($op2$$reg));
+    __ sub(cr, tmp, cr);
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowSubI_imm(rFlagsReg cr, iRegIorL2I op1, immISub op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowSubI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(4 * ALU_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "subi   $cr, $tmp, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowSubI_imm" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ subi(cr, tmp, $op2$$constant);
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowNegI_sext(rFlagsReg cr, immI0 zero, iRegI op1, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowSubI zero op1));
+  effect(TEMP tmp);
+
+  ins_cost(3 * ALU_COST);
+  format %{ "neg    $cr, $op1\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowNegI_sext" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ neg(cr, as_Register($op1$$reg));
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowNegI(rFlagsReg cr, immI0 zero, iRegIorL2I op1, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowSubI zero op1));
+  effect(TEMP tmp);
+
+  ins_cost(4 * ALU_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "neg    $cr, $tmp\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowNegI" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ neg(cr, tmp);
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowAddL_reg(rFlagsReg cr, iRegL op1, iRegL op2, iRegLNoSp tmp1, iRegLNoSp tmp2)
+%{
+  match(Set cr (OverflowAddL op1 op2));
+  effect(TEMP tmp1, TEMP tmp2);
+
+  ins_cost(5 * ALU_COST);
+  format %{ "add    $tmp1, $op1, $op2\n\t"
+            "xor    $tmp2, $tmp1, $op1\n\t"
+            "xor    $cr, $tmp1, $op2\n\t"
+            "and    $cr, $cr, $tmp2\n\t"
+            "srli   $cr, $cr, 63\t# overflow check long, #@overflowAddL_reg" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ add(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(tmp2, tmp1, as_Register($op1$$reg));
+    __ xorr(cr, tmp1, as_Register($op2$$reg));
+    __ andr(cr, cr, tmp2);
+    __ srli(cr, cr, 63);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowSubL_reg(rFlagsReg cr, iRegL op1, iRegL op2, iRegLNoSp tmp1, iRegLNoSp tmp2)
+%{
+  match(Set cr (OverflowSubL op1 op2));
+  effect(TEMP tmp1, TEMP tmp2);
+
+  ins_cost(5 * ALU_COST);
+  format %{ "sub    $tmp1, $op1, $op2\n\t"
+            "xor    $tmp2, $op1, $op2\n\t"
+            "xor    $cr, $op1, $tmp1\n\t"
+            "and    $cr, $cr, $tmp2\n\t"
+            "srli   $cr, $cr, 63\t# overflow check long, #@overflowSubL_reg" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ sub(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(tmp2, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(cr, as_Register($op1$$reg), tmp1);
+    __ andr(cr, cr, tmp2);
+    __ srli(cr, cr, 63);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowNegL(rFlagsReg cr, immL0 zero, iRegL op1, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowSubL zero op1));
+  effect(TEMP tmp);
+
+  ins_cost(3 * ALU_COST);
+  format %{ "neg    $tmp, $op1\n\t"
+            "and    $cr, $tmp, $op1\n\t"
+            "srli   $cr, $cr, 63\t# overflow check long, #@overflowNegL" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ neg(tmp, as_Register($op1$$reg));
+    __ andr(cr, tmp, as_Register($op1$$reg));
+    __ srli(cr, cr, 63);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowMulI_reg(rFlagsReg cr, iRegIorL2I op1, iRegIorL2I op2, iRegLNoSp tmp)
+%{
+  match(Set cr (OverflowMulI op1 op2));
+  effect(TEMP tmp);
+
+  ins_cost(IMUL_COST + 3 * ALU_COST);
+  format %{ "sext.w $cr, $op1\n\t"
+            "sext.w $tmp, $op2\n\t"
+            "mul    $cr, $cr, $tmp\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "xor    $cr, $cr, $tmp\t# overflow check int, #@overflowMulI_reg" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(cr, as_Register($op1$$reg));
+    __ sext_w(tmp, as_Register($op2$$reg));
+    __ mul(cr, cr, tmp);
+    __ sext_w(tmp, cr);
+    __ xorr(cr, cr, tmp);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct overflowMulL_reg(rFlagsReg cr, iRegL op1, iRegL op2, iRegLNoSp tmp1, iRegLNoSp tmp2)
+%{
+  match(Set cr (OverflowMulL op1 op2));
+  effect(TEMP tmp1, TEMP tmp2);
+
+  ins_cost(2 * IMUL_COST + 2 * ALU_COST);
+  format %{ "mulh   $tmp1, $op1, $op2\n\t"
+            "mul    $cr, $op1, $op2\n\t"
+            "srai   $tmp2, $cr, 63\n\t"
+            "xor    $cr, $tmp1, $tmp2\t# overflow check long, #@overflowMulL_reg" %}
+
+  ins_encode %{
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ mulh(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ mul(cr, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ srai(tmp2, cr, 63);
+    __ xorr(cr, tmp1, tmp2);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
 // Integer Divide
 
 instruct divI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
@@ -9439,7 +9810,7 @@ instruct branch(label lbl)
 // Patterns for short (< 12KiB) variants
 
 // Compare flags and branch near instructions.
-instruct cmpFlag_branch(cmpOpEqNe cmp, rFlagsReg cr, label lbl) %{
+instruct cmpFlag_branch(cmpOpEqNeOverflow cmp, rFlagsReg cr, label lbl) %{
   match(If cmp cr);
   effect(USE lbl);
 
@@ -9450,6 +9821,337 @@ instruct cmpFlag_branch(cmpOpEqNe cmp, rFlagsReg cr, label lbl) %{
     __ enc_cmpEqNe_imm0_branch($cmp$$cmpcode, as_Register($cr$$reg), *($lbl$$label));
   %}
   ins_pipe(pipe_cmpz_branch);
+  ins_short_branch(1);
+%}
+
+instruct overflowAddI_branch(cmpOp cmp, iRegIorL2I op1, iRegIorL2I op2,
+                              label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowAddI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(4 * ALU_COST + BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "sext.w $cr, $op2\n\t"
+            "add    $cr, $tmp, $cr\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "b$cmp  $cr, $tmp, $lbl\t# overflow check int, #@overflowAddI_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ sext_w(cr, as_Register($op2$$reg));
+    __ add(cr, tmp, cr);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L);
+    } else {
+      __ beq(cr, tmp, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowAddI_imm_branch(cmpOp cmp, iRegIorL2I op1, immIAdd op2,
+                                  label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowAddI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(3 * ALU_COST + BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "addi   $cr, $tmp, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "b$cmp  $cr, $tmp, $lbl\t# overflow check int, #@overflowAddI_imm_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ addi(cr, tmp, $op2$$constant);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L);
+    } else {
+      __ beq(cr, tmp, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowSubI_branch(cmpOp cmp, iRegIorL2I op1, iRegIorL2I op2,
+                              label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(4 * ALU_COST + BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "sext.w $cr, $op2\n\t"
+            "sub    $cr, $tmp, $cr\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "b$cmp  $cr, $tmp, $lbl\t# overflow check int, #@overflowSubI_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ sext_w(cr, as_Register($op2$$reg));
+    __ sub(cr, tmp, cr);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L);
+    } else {
+      __ beq(cr, tmp, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowSubI_imm_branch(cmpOp cmp, iRegIorL2I op1, immISub op2,
+                                  label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(3 * ALU_COST + BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "subi   $cr, $tmp, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "b$cmp  $cr, $tmp, $lbl\t# overflow check int, #@overflowSubI_imm_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ subi(cr, tmp, $op2$$constant);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L);
+    } else {
+      __ beq(cr, tmp, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowNegI_branch(cmpOp cmp, immI0 zero, iRegIorL2I op1,
+                              label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubI zero op1));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(3 * ALU_COST + BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "neg    $cr, $tmp\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "b$cmp  $cr, $tmp, $lbl\t# overflow check int, #@overflowNegI_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ neg(cr, tmp);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L);
+    } else {
+      __ beq(cr, tmp, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowAddL_branch(cmpOpEqNeOverflow cmp, iRegL op1, iRegL op2,
+                              label lbl, iRegLNoSp tmp1, iRegLNoSp tmp2, rFlagsReg cr)
+%{
+  match(If cmp (OverflowAddL op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp1, TEMP tmp2, KILL cr);
+
+  ins_cost(4 * ALU_COST + BRANCH_COST);
+  format %{ "add    $tmp1, $op1, $op2\n\t"
+            "xor    $tmp2, $tmp1, $op1\n\t"
+            "xor    $cr, $tmp1, $op2\n\t"
+            "and    $cr, $cr, $tmp2\n\t"
+            "b$cmp  $cr, zr, $lbl\t# overflow check long, #@overflowAddL_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ add(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(tmp2, tmp1, as_Register($op1$$reg));
+    __ xorr(cr, tmp1, as_Register($op2$$reg));
+    __ andr(cr, cr, tmp2);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bltz(cr, *L);
+    } else {
+      __ bgez(cr, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowSubL_branch(cmpOpEqNeOverflow cmp, iRegL op1, iRegL op2,
+                              label lbl, iRegLNoSp tmp1, iRegLNoSp tmp2, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubL op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp1, TEMP tmp2, KILL cr);
+
+  ins_cost(4 * ALU_COST + BRANCH_COST);
+  format %{ "sub    $tmp1, $op1, $op2\n\t"
+            "xor    $tmp2, $op1, $op2\n\t"
+            "xor    $cr, $op1, $tmp1\n\t"
+            "and    $cr, $cr, $tmp2\n\t"
+            "b$cmp  $cr, zr, $lbl\t# overflow check long, #@overflowSubL_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ sub(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(tmp2, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(cr, as_Register($op1$$reg), tmp1);
+    __ andr(cr, cr, tmp2);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bltz(cr, *L);
+    } else {
+      __ bgez(cr, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowNegL_branch(cmpOpEqNeOverflow cmp, immL0 zero, iRegL op1,
+                              label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubL zero op1));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(2 * ALU_COST + BRANCH_COST);
+  format %{ "neg    $tmp, $op1\n\t"
+            "and    $cr, $tmp, $op1\n\t"
+            "b$cmp  $cr, zr, $lbl\t# overflow check long, #@overflowNegL_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ neg(tmp, as_Register($op1$$reg));
+    __ andr(cr, tmp, as_Register($op1$$reg));
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bltz(cr, *L);
+    } else {
+      __ bgez(cr, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowMulI_branch(cmpOp cmp, iRegIorL2I op1, iRegIorL2I op2,
+                            label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowMulI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(IMUL_COST + 2 * ALU_COST + BRANCH_COST);
+  format %{ "sext.w $cr, $op1\n\t"
+            "sext.w $tmp, $op2\n\t"
+            "mul    $cr, $cr, $tmp\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "b$cmp  $cr, $tmp, $lbl\t# overflow check int, #@overflowMulI_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(cr, as_Register($op1$$reg));
+    __ sext_w(tmp, as_Register($op2$$reg));
+    __ mul(cr, cr, tmp);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L);
+    } else {
+      __ beq(cr, tmp, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+  ins_short_branch(1);
+%}
+
+instruct overflowMulL_branch(cmpOp cmp, iRegL op1, iRegL op2,
+                            label lbl, iRegLNoSp tmp1, iRegLNoSp tmp2, rFlagsReg cr)
+%{
+  match(If cmp (OverflowMulL op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp1, TEMP tmp2, KILL cr);
+
+  ins_cost(2 * IMUL_COST + ALU_COST + BRANCH_COST);
+  format %{ "mulh   $tmp1, $op1, $op2\n\t"
+            "mul    $cr, $op1, $op2\n\t"
+            "srai   $tmp2, $cr, 63\n\t"
+            "b$cmp  $tmp1, $tmp2, $lbl\t# overflow check long, #@overflowMulL_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ mulh(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ mul(cr, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ srai(tmp2, cr, 63);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(tmp1, tmp2, *L);
+    } else {
+      __ beq(tmp1, tmp2, *L);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
   ins_short_branch(1);
 %}
 
@@ -9823,11 +10525,11 @@ instruct cmpP_narrowOop_imm0_branch(cmpOpEqNe cmp, iRegN op1, immP0 zero, label 
 
 // Patterns for far (20KiB) variants
 
-instruct far_cmpFlag_branch(cmpOp cmp, rFlagsReg cr, label lbl) %{
+instruct far_cmpFlag_branch(cmpOpEqNeOverflow cmp, rFlagsReg cr, label lbl) %{
   match(If cmp cr);
   effect(USE lbl);
 
-  ins_cost(BRANCH_COST);
+  ins_cost(2 * BRANCH_COST);
   format %{ "far_b$cmp $cr, zr, $lbl\t#@far_cmpFlag_branch"%}
 
   ins_encode %{
@@ -9835,6 +10537,327 @@ instruct far_cmpFlag_branch(cmpOp cmp, rFlagsReg cr, label lbl) %{
   %}
 
   ins_pipe(pipe_cmpz_branch);
+%}
+
+instruct far_overflowAddI_branch(cmpOp cmp, iRegIorL2I op1, iRegIorL2I op2,
+                                  label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowAddI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(4 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "sext.w $cr, $op2\n\t"
+            "add    $cr, $tmp, $cr\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "far_b$cmp $cr, $tmp, $lbl\t# overflow check int, #@far_overflowAddI_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ sext_w(cr, as_Register($op2$$reg));
+    __ add(cr, tmp, cr);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L, /* is_far */ true);
+    } else {
+      __ beq(cr, tmp, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowAddI_imm_branch(cmpOp cmp, iRegIorL2I op1, immIAdd op2,
+                                      label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowAddI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(3 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "addi   $cr, $tmp, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "far_b$cmp $cr, $tmp, $lbl\t# overflow check int, #@far_overflowAddI_imm_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ addi(cr, tmp, $op2$$constant);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L, /* is_far */ true);
+    } else {
+      __ beq(cr, tmp, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowSubI_branch(cmpOp cmp, iRegIorL2I op1, iRegIorL2I op2,
+                                  label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(4 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "sext.w $cr, $op2\n\t"
+            "sub    $cr, $tmp, $cr\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "far_b$cmp $cr, $tmp, $lbl\t# overflow check int, #@far_overflowSubI_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ sext_w(cr, as_Register($op2$$reg));
+    __ sub(cr, tmp, cr);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L, /* is_far */ true);
+    } else {
+      __ beq(cr, tmp, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowSubI_imm_branch(cmpOp cmp, iRegIorL2I op1, immISub op2,
+                                      label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(3 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "subi   $cr, $tmp, $op2\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "far_b$cmp $cr, $tmp, $lbl\t# overflow check int, #@far_overflowSubI_imm_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ subi(cr, tmp, $op2$$constant);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L, /* is_far */ true);
+    } else {
+      __ beq(cr, tmp, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowNegI_branch(cmpOp cmp, immI0 zero, iRegIorL2I op1,
+                                  label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubI zero op1));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(3 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "sext.w $tmp, $op1\n\t"
+            "neg    $cr, $tmp\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "far_b$cmp $cr, $tmp, $lbl\t# overflow check int, #@far_overflowNegI_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(tmp, as_Register($op1$$reg));
+    __ neg(cr, tmp);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L, /* is_far */ true);
+    } else {
+      __ beq(cr, tmp, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowAddL_branch(cmpOpEqNeOverflow cmp, iRegL op1, iRegL op2,
+                                  label lbl, iRegLNoSp tmp1, iRegLNoSp tmp2, rFlagsReg cr)
+%{
+  match(If cmp (OverflowAddL op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp1, TEMP tmp2, KILL cr);
+
+  ins_cost(4 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "add    $tmp1, $op1, $op2\n\t"
+            "xor    $tmp2, $tmp1, $op1\n\t"
+            "xor    $cr, $tmp1, $op2\n\t"
+            "and    $cr, $cr, $tmp2\n\t"
+            "far_b$cmp $cr, zr, $lbl\t# overflow check long, #@far_overflowAddL_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ add(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(tmp2, tmp1, as_Register($op1$$reg));
+    __ xorr(cr, tmp1, as_Register($op2$$reg));
+    __ andr(cr, cr, tmp2);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bltz(cr, *L, /* is_far */ true);
+    } else {
+      __ bgez(cr, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowSubL_branch(cmpOpEqNeOverflow cmp, iRegL op1, iRegL op2,
+                                  label lbl, iRegLNoSp tmp1, iRegLNoSp tmp2, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubL op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp1, TEMP tmp2, KILL cr);
+
+  ins_cost(4 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "sub    $tmp1, $op1, $op2\n\t"
+            "xor    $tmp2, $op1, $op2\n\t"
+            "xor    $cr, $op1, $tmp1\n\t"
+            "and    $cr, $cr, $tmp2\n\t"
+            "far_b$cmp $cr, zr, $lbl\t# overflow check long, #@far_overflowSubL_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ sub(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(tmp2, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ xorr(cr, as_Register($op1$$reg), tmp1);
+    __ andr(cr, cr, tmp2);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bltz(cr, *L, /* is_far */ true);
+    } else {
+      __ bgez(cr, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowNegL_branch(cmpOpEqNeOverflow cmp, immL0 zero, iRegL op1,
+                                  label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowSubL zero op1));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(2 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "neg    $tmp, $op1\n\t"
+            "and    $cr, $tmp, $op1\n\t"
+            "far_b$cmp $cr, zr, $lbl\t# overflow check long, #@far_overflowNegL_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ neg(tmp, as_Register($op1$$reg));
+    __ andr(cr, tmp, as_Register($op1$$reg));
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bltz(cr, *L, /* is_far */ true);
+    } else {
+      __ bgez(cr, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowMulI_branch(cmpOp cmp, iRegIorL2I op1, iRegIorL2I op2,
+                                label lbl, iRegLNoSp tmp, rFlagsReg cr)
+%{
+  match(If cmp (OverflowMulI op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp, KILL cr);
+
+  ins_cost(IMUL_COST + 2 * ALU_COST + 2 * BRANCH_COST);
+  format %{ "sext.w $cr, $op1\n\t"
+            "sext.w $tmp, $op2\n\t"
+            "mul    $cr, $cr, $tmp\n\t"
+            "sext.w $tmp, $cr\n\t"
+            "far_b$cmp $cr, $tmp, $lbl\t# overflow check int, #@far_overflowMulI_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp = as_Register($tmp$$reg);
+    __ sext_w(cr, as_Register($op1$$reg));
+    __ sext_w(tmp, as_Register($op2$$reg));
+    __ mul(cr, cr, tmp);
+    __ sext_w(tmp, cr);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(cr, tmp, *L, /* is_far */ true);
+    } else {
+      __ beq(cr, tmp, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
+%}
+
+instruct far_overflowMulL_branch(cmpOp cmp, iRegL op1, iRegL op2,
+                                label lbl, iRegLNoSp tmp1, iRegLNoSp tmp2, rFlagsReg cr)
+%{
+  match(If cmp (OverflowMulL op1 op2));
+  predicate(n->in(1)->as_Bool()->_test._test == BoolTest::overflow ||
+            n->in(1)->as_Bool()->_test._test == BoolTest::no_overflow);
+  effect(USE lbl, TEMP tmp1, TEMP tmp2, KILL cr);
+
+  ins_cost(2 * IMUL_COST + ALU_COST + 2 * BRANCH_COST);
+  format %{ "mulh   $tmp1, $op1, $op2\n\t"
+            "mul    $cr, $op1, $op2\n\t"
+            "srai   $tmp2, $cr, 63\n\t"
+            "far_b$cmp $tmp1, $tmp2, $lbl\t# overflow check long, #@far_overflowMulL_branch" %}
+
+  ins_encode %{
+    Label* L = $lbl$$label;
+    Register cr = as_Register($cr$$reg);
+    Register tmp1 = as_Register($tmp1$$reg);
+    Register tmp2 = as_Register($tmp2$$reg);
+    __ mulh(tmp1, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ mul(cr, as_Register($op1$$reg), as_Register($op2$$reg));
+    __ srai(tmp2, cr, 63);
+    if ($cmp$$cmpcode == BoolTest::overflow) {
+      __ bne(tmp1, tmp2, *L, /* is_far */ true);
+    } else {
+      __ beq(tmp1, tmp2, *L, /* is_far */ true);
+    }
+  %}
+
+  ins_pipe(pipe_serial);
 %}
 
 // Compare signed int and branch far instructions


### PR DESCRIPTION
Hi, please consider.
This change adds RISC-V C2 match rules for detecting signed arithmetic overflow for int and long operations.
The new rules cover:
  * OverflowAddI and OverflowAddL
  * OverflowSubI and OverflowSubL, including exact negation
  * OverflowMulI and OverflowMulL
  * Fused overflow-check-and-branch patterns
  * Both short and far branch variants

RISC-V has no arithmetic overflow flags, so overflow is detected explicitly.
For int operations, operands are sign-extended and the full-width result is compared with the sign extension of its low 32 bits.
For long addition and subtraction, overflow is detected using the sign bits of the operands and result. For long multiplication, the upper half of the 128-bit product is compared with the sign extension of the lower half.

### Performance Test
MathExact test without this patch on SG2042
```
Benchmark                                              (SIZE)  Mode  Cnt     Score      Error  Units
MathExact.C2.loopAddIOverflow                         1000000  avgt    3  7663.264 ±  340.357  ms/op
MathExact.C2.loopAddLOverflow                         1000000  avgt    3  7629.560 ±  474.764  ms/op
MathExact.C2.loopDecrementIOverflow                   1000000  avgt    3  7818.010 ±  764.360  ms/op
MathExact.C2.loopDecrementLOverflow                   1000000  avgt    3  7978.163 ±  360.275  ms/op
MathExact.C2.loopIncrementIOverflow                   1000000  avgt    3  7718.239 ±  715.300  ms/op
MathExact.C2.loopIncrementLOverflow                   1000000  avgt    3  7715.618 ±  353.413  ms/op
MathExact.C2.loopMultiplyIOverflow                    1000000  avgt    3  7086.752 ±  418.049  ms/op
MathExact.C2.loopMultiplyLOverflow                    1000000  avgt    3  7641.883 ± 1193.591  ms/op
MathExact.C2.loopNegateIOverflow                      1000000  avgt    3  7970.861 ± 1774.301  ms/op
MathExact.C2.loopNegateLOverflow                      1000000  avgt    3  7667.663 ±  490.901  ms/op
MathExact.C2.loopSubtractIOverflow                    1000000  avgt    3  7790.008 ±   60.770  ms/op
MathExact.C2.loopSubtractLOverflow                    1000000  avgt    3  7463.901 ±  338.620  ms/op
```
MathExact test with this patch on SG2042
```
Benchmark                                              (SIZE)  Mode  Cnt     Score      Error  Units
MathExact.C2.loopAddIOverflow                         1000000  avgt    3     8.088 ±   0.611  ms/op
MathExact.C2.loopAddLOverflow                         1000000  avgt    3     7.359 ±   0.793  ms/op
MathExact.C2.loopDecrementIOverflow                   1000000  avgt    3    13.257 ±   4.274  ms/op
MathExact.C2.loopDecrementLOverflow                   1000000  avgt    3    13.161 ±   1.140  ms/op
MathExact.C2.loopIncrementIOverflow                   1000000  avgt    3    13.194 ±   2.471  ms/op
MathExact.C2.loopIncrementLOverflow                   1000000  avgt    3    13.133 ±   0.567  ms/op
MathExact.C2.loopMultiplyIOverflow                    1000000  avgt    3     6.880 ±   0.582  ms/op
MathExact.C2.loopMultiplyLOverflow                    1000000  avgt    3     7.601 ±   1.971  ms/op
MathExact.C2.loopNegateIOverflow                      1000000  avgt    3    13.236 ±   3.987  ms/op
MathExact.C2.loopNegateLOverflow                      1000000  avgt    3    13.589 ±   1.343  ms/op
MathExact.C2.loopSubtractIOverflow                    1000000  avgt    3     8.032 ±   1.840  ms/op
MathExact.C2.loopSubtractLOverflow                    1000000  avgt    3     7.355 ±   0.627  ms/op
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8318233](https://bugs.openjdk.org/browse/JDK-8318233): RISC-V: C2 OverflowAdd/Sub/Mul I/L (**Sub-task** - P4) ⚠️ Issue is not open.


### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32722/head:pull/32722` \
`$ git checkout pull/32722`

Update a local copy of the PR: \
`$ git checkout pull/32722` \
`$ git pull https://git.openjdk.org/jdk.git pull/32722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32722`

View PR using the GUI difftool: \
`$ git pr show -t 32722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32722.diff">https://git.openjdk.org/jdk/pull/32722.diff</a>

</details>
