### PR TITLE
8391869: Jtreg failure handler in the JDK incorrectly determines core dump files

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/jtreg/GatherDiagnosticInfoObserver.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/jtreg/GatherDiagnosticInfoObserver.java
@@ -90,8 +90,8 @@ public class GatherDiagnosticInfoObserver implements Harness.Observer {
             List<Path> coreFiles;
             try (Stream<Path> paths = Files.walk(workDir)) {
                 coreFiles = paths.filter(Files::isRegularFile)
-                        .filter(f -> (f.getFileName().toString().contains("core")
-                                || f.getFileName().toString().contains("mdmp")))
+                        .filter(f -> (f.getFileName().toString().startsWith("core.")
+                                || f.getFileName().toString().endsWith(".mdmp")))
                         .toList();
             }
             gatherCoreInfo(workDir, name, coreFiles, log, gathererFactory.getCoreInfoGatherer());


### PR DESCRIPTION
Can I please get a review of this change which addresses the issue noted in https://bugs.openjdk.org/browse/JDK-8391869?

The change now reduces the chances of the jtreg failure handler in the JDK identifying an incorrect file as a core dump file. In theory, this check can be made much more stricter but I didn't want add that complexity.

I've verified that with this change `.mdmp` and `core.<xxx>` files continue to be considered as a core dump files and yet any JAR files that may have had "core" in their file names are no longer considered as core dump files.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391869](https://bugs.openjdk.org/browse/JDK-8391869): Jtreg failure handler in the JDK incorrectly determines core dump files (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32723/head:pull/32723` \
`$ git checkout pull/32723`

Update a local copy of the PR: \
`$ git checkout pull/32723` \
`$ git pull https://git.openjdk.org/jdk.git pull/32723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32723`

View PR using the GUI difftool: \
`$ git pr show -t 32723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32723.diff">https://git.openjdk.org/jdk/pull/32723.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32723#issuecomment-5566629219)
</details>
