### PR TITLE
8391895: RISC-V: Add unsigned vector min/max reductions

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -3071,8 +3071,14 @@ void C2_MacroAssembler::reduce_integral_v(Register dst, Register src1,
     case Op_MaxReductionV:
       vredmax_vs(tmp, src2, tmp, vm);
       break;
+    case Op_UMaxReductionV:
+      vredmaxu_vs(tmp, src2, tmp, vm);
+      break;
     case Op_MinReductionV:
       vredmin_vs(tmp, src2, tmp, vm);
+      break;
+    case Op_UMinReductionV:
+      vredminu_vs(tmp, src2, tmp, vm);
       break;
     default:
       ShouldNotReachHere();

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -2813,6 +2813,138 @@ instruct vreduce_minL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v
   ins_pipe(pipe_slow);
 %}
 
+// vector integer unsigned max reduction
+
+instruct vreduce_umax(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
+  match(Set dst (UMaxReductionV src1 src2));
+  effect(TEMP tmp);
+  format %{ "vreduce_umax $dst, $src1, $src2\t# KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ reduce_integral_v($dst$$Register, $src1$$Register,
+                         as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vreduce_umaxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
+  match(Set dst (UMaxReductionV src1 src2));
+  effect(TEMP tmp);
+  format %{ "vreduce_umaxL $dst, $src1, $src2\t# KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ reduce_integral_v($dst$$Register, $src1$$Register,
+                         as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector integer unsigned max reduction - predicated
+
+instruct vreduce_umax_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
+  match(Set dst (UMaxReductionV (Binary src1 src2) v0));
+  effect(TEMP tmp);
+  format %{ "vreduce_umax_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ reduce_integral_v($dst$$Register, $src1$$Register,
+                         as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vreduce_umaxL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
+  match(Set dst (UMaxReductionV (Binary src1 src2) v0));
+  effect(TEMP tmp);
+  format %{ "vreduce_umaxL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ reduce_integral_v($dst$$Register, $src1$$Register,
+                         as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector integer unsigned min reduction
+
+instruct vreduce_umin(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
+  match(Set dst (UMinReductionV src1 src2));
+  effect(TEMP tmp);
+  format %{ "vreduce_umin $dst, $src1, $src2\t# KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ reduce_integral_v($dst$$Register, $src1$$Register,
+                         as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vreduce_uminL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
+  match(Set dst (UMinReductionV src1 src2));
+  effect(TEMP tmp);
+  format %{ "vreduce_uminL $dst, $src1, $src2\t# KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ reduce_integral_v($dst$$Register, $src1$$Register,
+                         as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector integer unsigned min reduction - predicated
+
+instruct vreduce_umin_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_SHORT ||
+            Matcher::vector_element_basic_type(n->in(2)) == T_INT);
+  match(Set dst (UMinReductionV (Binary src1 src2) v0));
+  effect(TEMP tmp);
+  format %{ "vreduce_umin_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ reduce_integral_v($dst$$Register, $src1$$Register,
+                         as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vreduce_uminL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegMask_V0 v0, vReg tmp) %{
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG);
+  match(Set dst (UMinReductionV (Binary src1 src2) v0));
+  effect(TEMP tmp);
+  format %{ "vreduce_uminL_masked $dst, $src1, $src2, $v0\t# KILL $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
+    __ reduce_integral_v($dst$$Register, $src1$$Register,
+                         as_VectorRegister($src2$$reg), as_VectorRegister($tmp$$reg),
+                         this->ideal_Opcode(), bt, Matcher::vector_length(this, $src2),
+                         Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // vector float max reduction
 
 instruct vreduce_maxF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{


### PR DESCRIPTION
Hi, please consider.
The unsigned min/max reduction nodes were introduced by JDK-8372980, but the RISC-V C2 backend does not currently provide matching rules for them. As a result, Vector API `UMIN` and `UMAX` reductions cannot be intrinsified on RISC-V.

Assembly before/after:

```asm
; before
; no RISC-V RVV unsigned reduction rule for UMinReductionV / UMaxReductionV;
; generated code did not lower to a single RVV unsigned reduction instruction.

; after
vredminu.vs   ...        ; UMinReductionV
vredmaxu.vs   ...        ; UMaxReductionV
vredminu.vs   ..., v0.t  ; masked UMinReductionV
vredmaxu.vs   ..., v0.t  ; masked UMaxReductionV
```

Local all-node PrintAssembly check confirmed the expected RVV instruction for:

- byte/short/int/long `UMinReductionV`
- byte/short/int/long `UMaxReductionV`
- all corresponding masked variants using `v0`

JMH on sg2044, `VectorUMinUMaxReductionBenchmark`, mode `thrpt`, unit `ops/ms`, higher is better:

| Benchmark                    | Before ops/ms | After ops/ms | Speedup |
| ---------------------------- | ------------: | -----------: | ------: |
| `byteUMaxReduction`        |     11340.965 |   379723.762 |  33.48x |
| `byteUMaxReductionMasked`  |      9902.595 |   382658.756 |  38.64x |
| `byteUMinReduction`        |     11501.150 |   384870.575 |  33.46x |
| `byteUMinReductionMasked`  |     10043.098 |   382499.723 |  38.09x |
| `shortUMaxReduction`       |      5889.466 |   200196.993 |  33.99x |
| `shortUMaxReductionMasked` |      5174.894 |   197171.503 |  38.10x |
| `shortUMinReduction`       |      6112.891 |   201654.500 |  32.99x |
| `shortUMinReductionMasked` |      5264.638 |   198621.923 |  37.73x |
| `intUMaxReduction`         |      3413.953 |   136597.353 |  40.01x |
| `intUMaxReductionMasked`   |      3027.659 |   133561.010 |  44.11x |
| `intUMinReduction`         |      3407.241 |   136546.549 |  40.08x |
| `intUMinReductionMasked`   |      3019.231 |   130177.581 |  43.12x |
| `longUMaxReduction`        |      1833.313 |    68673.987 |  37.46x |
| `longUMaxReductionMasked`  |      1585.733 |    66187.064 |  41.74x |
| `longUMinReduction`        |      1768.124 |    66887.971 |  37.83x |
| `longUMinReductionMasked`  |      1589.413 |    69487.003 |  43.72x |

## intUMin

### Before

```asm
vsetivli t0,8,e32,m1,tu,mu  # Load IntVector256 lanes
vle32.v  v1,(t2)

vsetivli t0,8,e32,m1,tu,mu  # Store lanes into a temporary vector payload
vse32.v  v1,(t2)

li       a4,4               # laneType = int
addiw    a1,zero,123        # oprId = VECTOR_OP_UMIN
li       a3,0               # maskClass = null
li       a5,8               # vector length = 8 lanes
li       a7,0               # mask = null

auipc    t1,0x0             # Static Java call relocation
ld       t1,324(t1)         # Load call target from relocation stub
jal      0x00007f08d104ad00 # Call VectorSupport.reductionCoerced fallback

sext.w   a0,a0              # Convert returned long bits to int result
```

### After

```asm
vsetivli    t0,8,e32,m1,tu,mu # Load IntVector256 lanes
vle32.v     v1,(t2)

li          t2,-1             # Initial unsigned min value = 0xffffffff
vsetivli    t0,8,e32,m1,tu,mu
vmv.s.x     v2,t2             # Move initial value into scalar lane
vredminu.vs v2,v1,v2          # Unsigned vector min reduction
vmv.x.s     a0,v2             # Move reduction result to return register
```

## intUMax

### Before

```asm
vsetivli t0,8,e32,m1,tu,mu  # Load IntVector256 lanes
vle32.v  v1,(t2)

vsetivli t0,8,e32,m1,tu,mu  # Store lanes into a temporary vector payload
vse32.v  v1,(t2)

li       a4,4               # laneType = int
addiw    a1,zero,124        # oprId = VECTOR_OP_UMAX
li       a3,0               # maskClass = null
li       a5,8               # vector length = 8 lanes
li       a7,0               # mask = null

auipc    t1,0x0             # Static Java call relocation
ld       t1,324(t1)         # Load call target from relocation stub
jal      0x00007f08d104ad00 # Call VectorSupport.reductionCoerced fallback

sext.w   a0,a0              # Convert returned long bits to int result
```

### After

```asm
vsetivli    t0,8,e32,m1,tu,mu # Load IntVector256 lanes
vle32.v     v1,(t2)

li          t2,0              # Initial unsigned max value = 0
vsetivli    t0,8,e32,m1,tu,mu
vmv.s.x     v2,t2             # Move initial value into scalar lane
vredmaxu.vs v2,v1,v2          # Unsigned vector max reduction
vmv.x.s     a0,v2             # Move reduction result to return register
```

## intUMinMasked

### Before

```asm
# Mask class, vector class, vector object, mask object, and defaultImpl are prepared as Java arguments.
addiw    a1,zero,123        # oprId = VECTOR_OP_UMIN
li       a5,8               # vector length = 8 lanes

auipc    t1,0x0             # Static Java call relocation
ld       t1,324(t1)         # Load call target from relocation stub
jal      0x00007f08d104ad00 # Call VectorSupport.reductionCoerced fallback

sext.w   a0,a0              # Convert returned long bits to int result
```

### After

```asm
vsetivli    t0,8,e8,m1,tu,mu  # Load mask bytes
vle8.v      v1,(t2)

vsetivli    t0,8,e32,m1,tu,mu # Load IntVector256 lanes
vle32.v     v2,(t2)

vsetivli    t0,8,e8,m1,tu,mu
vmsne.vx    v0,v1,zero        # Build mask register v0

li          t2,-1             # Initial unsigned min value = 0xffffffff
vsetivli    t0,8,e32,m1,tu,mu
vmv.s.x     v1,t2             # Move initial value into scalar lane
vredminu.vs v1,v2,v1,v0.t     # Unsigned vector min reduction under mask v0
vmv.x.s     a0,v1             # Move reduction result to return register
```

## intUMaxMasked

### Before

```asm
# Mask class, vector class, vector object, mask object, and defaultImpl are prepared as Java arguments.
addiw    a1,zero,124        # oprId = VECTOR_OP_UMAX
li       a5,8               # vector length = 8 lanes

auipc    t1,0x0             # Static Java call relocation
ld       t1,324(t1)         # Load call target from relocation stub
jal      0x00007f08d104ad00 # Call VectorSupport.reductionCoerced fallback

sext.w   a0,a0              # Convert returned long bits to int result
```

### After

```asm
vsetivli    t0,8,e8,m1,tu,mu  # Load mask bytes
vle8.v      v1,(t2)

vsetivli    t0,8,e32,m1,tu,mu # Load IntVector256 lanes
vle32.v     v2,(t2)

vsetivli    t0,8,e8,m1,tu,mu
vmsne.vx    v0,v1,zero        # Build mask register v0

li          t2,0              # Initial unsigned max value = 0
vsetivli    t0,8,e32,m1,tu,mu
vmv.s.x     v1,t2             # Move initial value into scalar lane
vredmaxu.vs v1,v2,v1,v0.t     # Unsigned vector max reduction under mask v0
vmv.x.s     a0,v1             # Move reduction result to return register
```

## longUMin

### Before

```asm
li       a4,5               # laneType = long
addiw    a1,zero,123        # oprId = VECTOR_OP_UMIN
li       a3,0               # maskClass = null
li       a5,4               # vector length = 4 lanes
li       a7,0               # mask = null

auipc    t1,0x0             # Static Java call relocation
ld       t1,324(t1)         # Load call target from relocation stub
jal      0x00007f08d104ad00 # Call VectorSupport.reductionCoerced fallback
```

### After

```asm
vsetivli    t0,4,e64,m1,tu,mu # Load LongVector256 lanes
vle64.v     v1,(t2)

li          t2,-1             # Initial unsigned min value = 0xffffffffffffffff
vsetivli    t0,4,e64,m1,tu,mu
vmv.s.x     v2,t2             # Move initial value into scalar lane
vredminu.vs v2,v1,v2          # Unsigned vector min reduction
vmv.x.s     a0,v2             # Move reduction result to return register
```

## longUMax

### Before

```asm
li       a4,5               # laneType = long
addiw    a1,zero,124        # oprId = VECTOR_OP_UMAX
li       a3,0               # maskClass = null
li       a5,4               # vector length = 4 lanes
li       a7,0               # mask = null

auipc    t1,0x0             # Static Java call relocation
ld       t1,324(t1)         # Load call target from relocation stub
jal      0x00007f08d104ad00 # Call VectorSupport.reductionCoerced fallback
```

### After

```asm
vsetivli    t0,4,e64,m1,tu,mu # Load LongVector256 lanes
vle64.v     v1,(t2)

li          t2,0              # Initial unsigned max value = 0
vsetivli    t0,4,e64,m1,tu,mu
vmv.s.x     v2,t2             # Move initial value into scalar lane
vredmaxu.vs v2,v1,v2          # Unsigned vector max reduction
vmv.x.s     a0,v2             # Move reduction result to return register
```

## longUMinMasked / longUMaxMasked

The long masked forms follow the same replacement pattern as the int masked forms, with `e64` lanes and 4 elements.

### Before

```asm
addiw    a1,zero,123        # oprId = VECTOR_OP_UMIN
# or
addiw    a1,zero,124        # oprId = VECTOR_OP_UMAX
li       a5,4               # vector length = 4 lanes

auipc    t1,0x0             # Static Java call relocation
ld       t1,324(t1)         # Load call target from relocation stub
jal      0x00007f08d104ad00 # Call VectorSupport.reductionCoerced fallback
```

### After

```asm
vredminu.vs v1,v2,v1,v0.t   # Unsigned vector min reduction under mask v0
vredmaxu.vs v1,v2,v1,v0.t   # Unsigned vector max reduction under mask v0
```

## Bottom Line

Before this patch, C2 could not match `UMinReductionV` / `UMaxReductionV` on RISC-V, so it kept the `VectorSupport.reductionCoerced` static call path.

After this patch, C2 matches these nodes and emits direct RVV instructions:

```asm
vredminu.vs  # Direct unsigned vector min reduction
vredmaxu.vs  # Direct unsigned vector max reduction
```
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391895](https://bugs.openjdk.org/browse/JDK-8391895): RISC-V: Add unsigned vector min/max reductions (**Enhancement** - P4)


### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32724/head:pull/32724` \
`$ git checkout pull/32724`

Update a local copy of the PR: \
`$ git checkout pull/32724` \
`$ git pull https://git.openjdk.org/jdk.git pull/32724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32724`

View PR using the GUI difftool: \
`$ git pr show -t 32724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32724.diff">https://git.openjdk.org/jdk/pull/32724.diff</a>

</details>
