### PR TITLE
8391805: New test java/net/httpclient/IdleConnectionTimeoutReuseTest.java timed out with virtual threads

### DIFF
--- a/test/jdk/java/net/httpclient/IdleConnectionTimeoutReuseTest.java
+++ b/test/jdk/java/net/httpclient/IdleConnectionTimeoutReuseTest.java
@@ -87,7 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  *          carrier thread pool (i.e., FJP) requires `parallelism <= maxPoolSize`
  *          and having 1 thread in the pool is easier to make it starve.
  *
- * @requires os.family != "windows"
+ * @requires os.family != "windows" & test.thread.factory != "Virtual"
  *
  * @run junit/othervm
  *      -Djdk.httpclient.keepalive.timeout=1


### PR DESCRIPTION
Skip `IdleConnectionTimeoutReuseTest` when JTreg is configured to run tests using VTs.

The test limits the default VT scheduler to a single platform thread to observe a particular starvation behavior. If the test itself is also run using a VT, a deadlock occurs, and the test times out, as reported in the associated JBS ticket. Skip the test when JTreg uses VTs.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391805](https://bugs.openjdk.org/browse/JDK-8391805): New test java/net/httpclient/IdleConnectionTimeoutReuseTest.java timed out with virtual threads (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32725/head:pull/32725` \
`$ git checkout pull/32725`

Update a local copy of the PR: \
`$ git checkout pull/32725` \
`$ git pull https://git.openjdk.org/jdk.git pull/32725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32725`

View PR using the GUI difftool: \
`$ git pr show -t 32725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32725.diff">https://git.openjdk.org/jdk/pull/32725.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32725#issuecomment-5567307546)
</details>
