### PR TITLE
8391708: Resolve same-size versus unbounded-size contract of MemorySegment.reinterpret(Arena, Consumer)

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -732,8 +732,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     MemorySegment asSlice(long offset);
 
     /**
-     * Returns a new memory segment that has the same address and scope as this segment,
-     * but with the provided size.
+     * {@return a new memory segment that has the same address and scope as this segment,
+     *          but with the provided size}
      * <p>
      * If this segment is {@linkplain MemorySegment#isReadOnly() read-only},
      * the returned segment is also {@linkplain MemorySegment#isReadOnly() read-only}.
@@ -742,8 +742,6 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * Hence, no memory will be allocated or freed by this method.
      *
      * @param newSize the size of the returned segment
-     * @return a new memory segment that has the same address and scope as
-     *         this segment, but the new provided size
      * @throws IllegalArgumentException if {@code newSize < 0}
      * @throws UnsupportedOperationException if this segment is not a
      *         {@linkplain #isNative() native} segment
@@ -755,11 +753,13 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     MemorySegment reinterpret(long newSize);
 
     /**
-     * Returns a new memory segment with the same address and size as this segment, but
-     * with the provided arena's scope. As such, the returned segment cannot be accessed
-     * after the provided arena has been closed. Moreover, the returned segment can be
-     * accessed compatibly with the confinement restrictions associated with the provided
-     * arena: that is, if the provided arena is a {@linkplain Arena#ofConfined() confined arena},
+     * {@return a new memory segment with the same address and size as this segment, but
+     *          with the provided arena's scope}
+     * <p>
+     * As such, the returned segment cannot be accessed after the provided arena has been
+     * closed. Moreover, the returned segment can be accessed compatibly with
+     * the confinement restrictions associated with the provided arena: that is, if
+     * the provided arena is a {@linkplain Arena#ofConfined() confined arena},
      * the returned segment can only be accessed by the arena's owner thread, regardless
      * of the confinement restrictions associated with this segment. In other words, this
      * method returns a segment that can be used as any other segment allocated using the
@@ -799,7 +799,6 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @param arena the arena to be associated with the returned segment
      * @param cleanup the cleanup action that should be executed when the provided arena
      *                is closed (can be {@code null})
-     * @return a new memory segment with unbounded size
      * @throws IllegalStateException if {@code arena.scope().isAlive() == false}
      * @throws UnsupportedOperationException if this segment is not a
      *         {@linkplain #isNative() native} segment
@@ -811,11 +810,13 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     MemorySegment reinterpret(Arena arena, Consumer<MemorySegment> cleanup);
 
     /**
-     * Returns a new segment with the same address as this segment, but with the provided
-     * size and the provided arena's scope. As such, the returned segment cannot be
-     * accessed after the provided arena has been closed. Moreover, if the returned
-     * segment can be accessed compatibly with the confinement restrictions associated
-     * with the provided arena: that is, if the provided arena is a {@linkplain Arena#ofConfined() confined arena},
+     * {@return a new segment with the same address as this segment, but with the provided
+     *          size and the provided arena's scope}
+     * <p>
+     * As such, the returned segment cannot be accessed after the provided arena has been
+     * closed. Moreover, if the returned segment can be accessed compatibly with
+     * the confinement restrictions associated with the provided arena: that is, if
+     * the provided arena is a {@linkplain Arena#ofConfined() confined arena},
      * the returned segment can only be accessed by the arena's owner thread, regardless
      * of the confinement restrictions associated with this segment. In other words, this
      * method returns a segment that can be used as any other segment allocated using the
@@ -856,8 +857,6 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @param arena the arena to be associated with the returned segment
      * @param cleanup the cleanup action that should be executed when the provided arena
      *                is closed (can be {@code null}).
-     * @return a new segment that has the same address as this segment, but with the new
-     *         size and its scope set to that of the provided arena.
      * @throws UnsupportedOperationException if this segment is not a
      *         {@linkplain #isNative() native} segment
      * @throws IllegalArgumentException if {@code newSize < 0}


### PR DESCRIPTION
This PR proposes to correct an error in the documentation of `MemorySegment`, which was likely a copy/paste error. In order to avoid such errors in the future, the PR also proposes to collect the return documentation under a single `@return` tag rather than having duplicate text.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8391899](https://bugs.openjdk.org/browse/JDK-8391899) to be approved

### Issues
 * [JDK-8391708](https://bugs.openjdk.org/browse/JDK-8391708): Resolve same-size versus unbounded-size contract of MemorySegment.reinterpret(Arena, Consumer) (**Bug** - P3)
 * [JDK-8391899](https://bugs.openjdk.org/browse/JDK-8391899): Resolve same-size versus unbounded-size contract of MemorySegment.reinterpret(Arena, Consumer) (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32726/head:pull/32726` \
`$ git checkout pull/32726`

Update a local copy of the PR: \
`$ git checkout pull/32726` \
`$ git pull https://git.openjdk.org/jdk.git pull/32726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32726`

View PR using the GUI difftool: \
`$ git pr show -t 32726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32726.diff">https://git.openjdk.org/jdk/pull/32726.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32726#issuecomment-5567702001)
</details>
