### PR TITLE
8390450: RISC-V: Add Xuantie vendor feature detection

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -44,7 +44,14 @@ class VM_Version : public Abstract_VM_Version {
 
   // JEDEC encoded as ((bank - 1) << 7) | (0x7f & JEDEC)
   enum VendorId {
-    RIVOS = 0x6cf, // JEDEC: 0x4f, Bank: 14
+    RIVOS   = 0x6cf, // JEDEC: 0x4f, Bank: 14
+    XUANTIE = 0x5b7, // JEDEC: 0x37, Bank: 12
+  };
+
+  enum XuantieArchitectureId : uint64_t {
+    C925_MARCHID = 0x80000000091c1600ULL,
+    C930_MARCHID = 0x8000000009201600ULL,
+    C950_MARCHID = 0x8000000009241600ULL,
   };
 
   class RVExtFeatures;
@@ -499,6 +506,7 @@ private:
   static void vendor_features();
   // Vendors specific features
   static void rivos_features();
+  static void xuantie_features();
 
   // Determine vector length iff ext_V/UseRVV
   static uint32_t cpu_vector_length();

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -285,10 +285,13 @@ void VM_Version::vendor_features() {
   }
   switch (mvendorid.value()) {
     case RIVOS:
-    rivos_features();
-    break;
+      rivos_features();
+      break;
+    case XUANTIE:
+      xuantie_features();
+      break;
     default:
-    break;
+      break;
   }
 }
 
@@ -323,4 +326,49 @@ void VM_Version::rivos_features() {
     ext_Zacas.enable_feature();
     ext_Zihintpause.enable_feature();
   }
+}
+
+void VM_Version::xuantie_features() {
+  if (!marchid.enabled()) {
+    return;
+  }
+
+  const uint64_t architecture_id = static_cast<uint64_t>(marchid.value());
+  if (architecture_id != C925_MARCHID &&
+      architecture_id != C930_MARCHID &&
+      architecture_id != C950_MARCHID) {
+    return;
+  }
+
+  ext_v.enable_feature();
+  ext_Zba.enable_feature();
+  ext_Zbb.enable_feature();
+  ext_Zbc.enable_feature();
+  ext_Zbs.enable_feature();
+  ext_Zcb.enable_feature();
+  ext_Zfa.enable_feature();
+  ext_Zfh.enable_feature();
+  ext_Zfhmin.enable_feature();
+  ext_Zicbom.enable_feature();
+  ext_Zicbop.enable_feature();
+  ext_Zicntr.enable_feature();
+  ext_Zicsr.enable_feature();
+  ext_Zic64b.enable_feature();
+  ext_Zifencei.enable_feature();
+  ext_Zihintpause.enable_feature();
+  ext_Zvbb.enable_feature();
+  ext_Zvbc.enable_feature();
+  ext_Zvfh.enable_feature();
+  ext_Zvkn.enable_feature();
+  ext_Zvkg.enable_feature();
+
+#ifndef PRODUCT
+  ext_Zacas.enable_feature();
+  ext_Zicboz.enable_feature();
+  ext_Zicond.enable_feature();
+  ext_Ztso.enable_feature();
+#endif
+
+  unaligned_scalar.enable_feature(MISALIGNED_SCALAR_FAST);
+  unaligned_vector.enable_feature(MISALIGNED_VECTOR_FAST);
 }


### PR DESCRIPTION
Hi all,

This patch adds XuanTie vendor feature detection based on `vendorid` and `marchid`. It enables some hardware supported RISC-V extensions (some of them may not be supported by Linux `hwprobe` now).

Best Regards,
-- Guoxiong

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390450](https://bugs.openjdk.org/browse/JDK-8390450): RISC-V: Add Xuantie vendor feature detection (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32727/head:pull/32727` \
`$ git checkout pull/32727`

Update a local copy of the PR: \
`$ git checkout pull/32727` \
`$ git pull https://git.openjdk.org/jdk.git pull/32727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32727`

View PR using the GUI difftool: \
`$ git pr show -t 32727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32727.diff">https://git.openjdk.org/jdk/pull/32727.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32727#issuecomment-5567861883)
</details>
