### PR TITLE
8391898: RISC-V: Use vwsll.vi for vector gather/scatter index scaling

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2145,6 +2145,9 @@ enum VectorMask {
   INSN(vnsra_wi, 0b1010111, 0b011, 0b101101);
   INSN(vnsrl_wi, 0b1010111, 0b011, 0b101100);
 
+  // Vector Widening Shift Left Logical (Zvbb) Extension
+  INSN(vwsll_vi, 0b1010111, 0b011, 0b110101);
+
 #undef INSN
 
 #define INSN(NAME, op, funct3, funct6)                                                             \
@@ -2705,6 +2708,9 @@ enum Nf {
   INSN(vror_vv,    0b1010111, 0b000, 0b010100);
   INSN(vrol_vv,    0b1010111, 0b000, 0b010101);
 
+  // Vector Widening Shift Left Logical (Zvbb) Extension
+  INSN(vwsll_vv,   0b1010111, 0b000, 0b110101);
+
   // Vector Bit-manipulation used in Cryptography (Zvbc) Extension
   INSN(vclmul_vv,  0b1010111, 0b010, 0b001100);
   INSN(vclmulh_vv, 0b1010111, 0b010, 0b001101);
@@ -2720,6 +2726,9 @@ enum Nf {
   INSN(vandn_vx,   0b1010111, 0b100, 0b000001);
   INSN(vrol_vx,    0b1010111, 0b100, 0b010101);
   INSN(vror_vx,    0b1010111, 0b100, 0b010100);
+
+  // Vector Widening Shift Left Logical (Zvbb) Extension
+  INSN(vwsll_vx,   0b1010111, 0b100, 0b110101);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -5553,9 +5553,18 @@ instruct gather_loadD(vReg dst, indirect mem, vReg idx) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vzext_vf2(as_VectorRegister($dst$$reg), as_VectorRegister($idx$$reg));
-    __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), (int)sew);
+    uint vlen = Matcher::vector_length(this);
+    if (UseZvbb) {
+      // Widen 32-bit indices to 64-bit byte offsets. e32,mf2 and e64,m1
+      // have the same VLMAX, so the following load observes the same vl.
+      __ vsetvli_helper(T_INT, vlen, Assembler::mf2);
+      __ vwsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($idx$$reg), (int)sew);
+      __ vsetvli_helper(bt, vlen);
+    } else {
+      __ vsetvli_helper(bt, vlen);
+      __ vzext_vf2(as_VectorRegister($dst$$reg), as_VectorRegister($idx$$reg));
+      __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), (int)sew);
+    }
     __ vluxei64_v(as_VectorRegister($dst$$reg), as_Register($mem$$base),
                   as_VectorRegister($dst$$reg));
  %}
@@ -5587,9 +5596,16 @@ instruct gather_loadD_masked(vReg dst, indirect mem, vReg idx, vRegMask_V0 v0, v
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
-    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    uint vlen = Matcher::vector_length(this);
+    if (UseZvbb) {
+      __ vsetvli_helper(T_INT, vlen, Assembler::mf2);
+      __ vwsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
+      __ vsetvli_helper(bt, vlen);
+    } else {
+      __ vsetvli_helper(bt, vlen);
+      __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
+      __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    }
     __ vmv_v_i(as_VectorRegister($dst$$reg), 0);
     __ vluxei64_v(as_VectorRegister($dst$$reg), as_Register($mem$$base),
                   as_VectorRegister($tmp$$reg), Assembler::v0_t);
@@ -5623,9 +5639,16 @@ instruct scatter_storeD(indirect mem, vReg src, vReg idx, vReg tmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
-    __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
-    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    uint vlen = Matcher::vector_length(this, $src);
+    if (UseZvbb) {
+      __ vsetvli_helper(T_INT, vlen, Assembler::mf2);
+      __ vwsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
+      __ vsetvli_helper(bt, vlen);
+    } else {
+      __ vsetvli_helper(bt, vlen);
+      __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
+      __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    }
     __ vsuxei64_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
                   as_VectorRegister($tmp$$reg));
   %}
@@ -5656,9 +5679,16 @@ instruct scatter_storeD_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
-    __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
-    __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
-    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    uint vlen = Matcher::vector_length(this, $src);
+    if (UseZvbb) {
+      __ vsetvli_helper(T_INT, vlen, Assembler::mf2);
+      __ vwsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
+      __ vsetvli_helper(bt, vlen);
+    } else {
+      __ vsetvli_helper(bt, vlen);
+      __ vzext_vf2(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
+      __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    }
     __ vsuxei64_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
                   as_VectorRegister($tmp$$reg), Assembler::v0_t);
   %}


### PR DESCRIPTION
This change uses the Zvbb `vwsll.vi` instruction when scaling 32-bit indices for RISC-V vector gather and scatter operations with 64-bit elements.

Currently, C2 generates 64-bit byte offsets using `vzext.vf2` followed by `vsll.vi`. When Zvbb is available, `vwsll.vi` combines the unsigned widening and left shift into a single vector ALU instruction.

The optimization is applied to both masked and unmasked gather/scatteroperations. The existing sequence remains unchanged when Zvbb is not available.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391898](https://bugs.openjdk.org/browse/JDK-8391898): RISC-V: Use vwsll.vi for vector gather/scatter index scaling (**Enhancement** - P4)


### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32729/head:pull/32729` \
`$ git checkout pull/32729`

Update a local copy of the PR: \
`$ git checkout pull/32729` \
`$ git pull https://git.openjdk.org/jdk.git pull/32729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32729`

View PR using the GUI difftool: \
`$ git pr show -t 32729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32729.diff">https://git.openjdk.org/jdk/pull/32729.diff</a>

</details>
