### PR TITLE
8391908: X86: string indexof stubs use a wrong jump table

### DIFF
--- a/src/hotspot/cpu/x86/c2_stubGenerator_x86_64_string.cpp
+++ b/src/hotspot/cpu/x86/c2_stubGenerator_x86_64_string.cpp
@@ -211,7 +211,7 @@ static void generate_string_indexof_stubs(StubGenerator *stubgen, address *fnptr
 
   // Addresses of the two jump tables used for small needle processing
   address *big_jump_table = StubRoutines::x86::big_jump_table_base(ae);
-  address *small_jump_table = StubRoutines::x86::big_jump_table_base(ae);
+  address *small_jump_table = StubRoutines::x86::small_jump_table_base(ae);
 
   // If the stub has been cached we can retrieve the stub entry.  The
   // target addresses we need to install into the jump tables will


### PR DESCRIPTION
In generate_string_indexof_stubs, it has 2 jump tables , big and small jump table. But small_jump_table points to big_jump_table

```c++
  // Addresses of the two jump tables used for small needle processing
  address *big_jump_table = StubRoutines::x86::big_jump_table_base(ae);
  address *small_jump_table = StubRoutines::x86::big_jump_table_base(ae);
```
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391908](https://bugs.openjdk.org/browse/JDK-8391908): X86: string indexof stubs use a wrong jump table (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32730/head:pull/32730` \
`$ git checkout pull/32730`

Update a local copy of the PR: \
`$ git checkout pull/32730` \
`$ git pull https://git.openjdk.org/jdk.git pull/32730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32730`

View PR using the GUI difftool: \
`$ git pr show -t 32730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32730.diff">https://git.openjdk.org/jdk/pull/32730.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32730#issuecomment-5570137706)
</details>
