### PR TITLE
8391804: Test java/foreign/TestConfinedSegmentPoolDefensiveRelease.java fails on zero

### DIFF
--- a/test/jdk/java/foreign/TestConfinedSegmentPoolDefensiveRelease.java
+++ b/test/jdk/java/foreign/TestConfinedSegmentPoolDefensiveRelease.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires vm.flavor != "zero"
+ * @requires vm.continuations
  * @modules java.base/jdk.internal.foreign:+open java.base/java.lang:+open java.base/jdk.internal.access
  * @library /test/lib
  * @build TestConfinedSegmentPoolUtils


### PR DESCRIPTION
This PR proposes to fix a failing test on zero machines in tier4.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391804](https://bugs.openjdk.org/browse/JDK-8391804): Test java/foreign/TestConfinedSegmentPoolDefensiveRelease.java fails on zero (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32731/head:pull/32731` \
`$ git checkout pull/32731`

Update a local copy of the PR: \
`$ git checkout pull/32731` \
`$ git pull https://git.openjdk.org/jdk.git pull/32731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32731`

View PR using the GUI difftool: \
`$ git pr show -t 32731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32731.diff">https://git.openjdk.org/jdk/pull/32731.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32731#issuecomment-5570401034)
</details>
