### PR TITLE
8391902: RISC-V: Add MulAddS2I and MulAddVS2VI rules

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6610,6 +6610,34 @@ instruct umulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2)
   ins_pipe(lmul_reg_reg);
 %}
 
+// Combined Multiply-Add Shorts into Integer (dst = src1 * src2 + src3 * src4)
+
+instruct mulAddS2I(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2,
+                   iRegIorL2I src3, iRegIorL2I src4) %{
+  match(Set dst (MulAddS2I (Binary src1 src2) (Binary src3 src4)));
+
+  ins_cost(IMUL_COST * 2 + ALU_COST * 5);
+  format %{ "sext  t0, $src1, 16\n\t"
+            "sext  t1, $src2, 16\n\t"
+            "mulw  t0, t0, t1\n\t"
+            "sext  t1, $src4, 16\n\t"
+            "sext  $dst, $src3, 16\n\t"
+            "mulw  t1, $dst, t1\n\t"
+            "addw  $dst, t0, t1\t#@mulAddS2I" %}
+
+  ins_encode %{
+    __ sext(t0, as_Register($src1$$reg), 16);
+    __ sext(t1, as_Register($src2$$reg), 16);
+    __ mulw(t0, t0, t1);
+    __ sext(t1, as_Register($src4$$reg), 16);
+    __ sext(as_Register($dst$$reg), as_Register($src3$$reg), 16);
+    __ mulw(t1, as_Register($dst$$reg), t1);
+    __ addw(as_Register($dst$$reg), t0, t1);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
 // Integer Divide
 
 instruct divI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -2149,6 +2149,46 @@ instruct vmul(vReg dst, vReg src1, vReg src2) %{
   ins_pipe(pipe_slow);
 %}
 
+// Vector Multiply-Add Shorts into Integer.
+instruct vmulAddVS2VI(vReg dst, vReg src1, vReg src2, vReg tmp1, vReg tmp2, vReg tmp3, vReg tmp4, vReg tmp5) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_INT &&
+            Matcher::vector_element_basic_type(n->in(1)) == T_SHORT);
+  match(Set dst (MulAddVS2VI src1 src2));
+  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, TEMP tmp5);
+
+  format %{ "vmulAddVS2VI $dst, $src1, $src2\t# KILL $tmp1, $tmp2, $tmp3, $tmp4, $tmp5" %}
+  ins_encode %{
+    uint vlen = Matcher::vector_length(this);
+    VectorRegister vdst = as_VectorRegister($dst$$reg);
+    VectorRegister vsrc1 = as_VectorRegister($src1$$reg);
+    VectorRegister vsrc2 = as_VectorRegister($src2$$reg);
+    VectorRegister even1 = as_VectorRegister($tmp1$$reg);
+    VectorRegister even2 = as_VectorRegister($tmp2$$reg);
+    VectorRegister odd1 = as_VectorRegister($tmp3$$reg);
+    VectorRegister odd2 = as_VectorRegister($tmp4$$reg);
+    VectorRegister idx = as_VectorRegister($tmp5$$reg);
+
+    __ vsetvli_helper(T_SHORT, vlen);
+    __ vid_v(idx);
+    __ vsll_vi(idx, idx, 1);
+    __ vrgather_vv(even1, vsrc1, idx);
+    __ vrgather_vv(even2, vsrc2, idx);
+    __ vadd_vi(idx, idx, 1);
+    __ vrgather_vv(odd1, vsrc1, idx);
+    __ vrgather_vv(odd2, vsrc2, idx);
+
+    // Gather strided short inputs into the low half, then use mf2 so the
+    // widening multiply consumes those lanes and produces an int vector.
+    __ vsetvli_helper(T_SHORT, vlen, Assembler::mf2);
+    __ vwmul_vv(vdst, even1, even2);
+    __ vwmul_vv(even1, odd1, odd2);
+
+    __ vsetvli_helper(T_INT, vlen);
+    __ vadd_vv(vdst, vdst, even1);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 instruct vmul_hfp(vReg dst, vReg src1, vReg src2) %{
   match(Set dst (MulVHF src1 src2));
   format %{ "vmul_hfp $dst, $src1, $src2" %}


### PR DESCRIPTION
Hi, please consider.
This patch adds RISC-V backend support for the C2 MulAddS2I and MulAddVS2VI nodes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391902](https://bugs.openjdk.org/browse/JDK-8391902): RISC-V: Add MulAddS2I and MulAddVS2VI rules (**Enhancement** - P4)


### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32732/head:pull/32732` \
`$ git checkout pull/32732`

Update a local copy of the PR: \
`$ git checkout pull/32732` \
`$ git pull https://git.openjdk.org/jdk.git pull/32732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32732`

View PR using the GUI difftool: \
`$ git pr show -t 32732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32732.diff">https://git.openjdk.org/jdk/pull/32732.diff</a>

</details>
