### PR TITLE
8391911: PPC64: Remove postalloc_expand for narrow constant loads

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -5664,7 +5664,7 @@ instruct loadConN0(iRegNdst dst, immN_0 src) %{
 %}
 
 // Load hi part of compressed oop constant.
-instruct loadConN_hi(iRegNdst dst, immN src) %{
+instruct loadConN_hi(iRegIdst dst, immN src) %{
   effect(DEF dst, USE src);
   ins_cost(DEFAULT_COST);
 
@@ -5677,7 +5677,7 @@ instruct loadConN_hi(iRegNdst dst, immN src) %{
 %}
 
 // Add lo part of compressed oop constant to already loaded hi part.
-instruct loadConN_lo(iRegNdst dst, iRegNsrc src1, immN src2) %{
+instruct loadConN_lo(iRegIdst dst, iRegIsrc src1, immN src2) %{
   effect(DEF dst, USE src1, USE src2);
   ins_cost(DEFAULT_COST);
 
@@ -5705,7 +5705,7 @@ instruct rldicl(iRegLdst dst, iRegLsrc src, immI16 shift, immI16 mask_begin) %{
 // 32 bits with sign-extension bits.
 // This clears these bits: dst = src & 0xFFFFFFFF.
 // TODO: Eventually call this maskN_regN_FFFFFFFF.
-instruct clearMs32b(iRegNdst dst, iRegNsrc src) %{
+instruct clearMs32b(iRegNdst dst, iRegIsrc src) %{
   effect(DEF dst, USE src);
   predicate(false);
 
@@ -5735,19 +5735,17 @@ instruct loadConN_Ex(iRegNdst dst, immN src) %{
   ins_cost(DEFAULT_COST*2);
 
   expand %{
-    iRegNdst tmp1;
-    iRegNdst tmp2;
+    iRegIdst tmp1;
+    iRegIdst tmp2;
     loadConN_hi(tmp1, src);
     loadConN_lo(tmp2, tmp1, src);
     clearMs32b(dst, tmp2);
   %}
 %}
 
-// We have seen a safepoint between the hi and lo parts, and this node was handled
-// as an oop. Therefore this needs a match rule so that build_oop_map knows this is
-// not a narrow oop.
-instruct loadConNKlass_hi(iRegNdst dst, immNKlass_NM src) %{
-  match(Set dst src);
+// Keep intermediate materialization in integer registers. Only the final
+// loadConNKlass_lo result carries the narrow klass type from the expanded node.
+instruct loadConNKlass_hi(iRegIdst dst, immNKlass_NM src) %{
   effect(DEF dst, USE src);
   ins_cost(DEFAULT_COST);
 
@@ -5760,34 +5758,29 @@ instruct loadConNKlass_hi(iRegNdst dst, immNKlass_NM src) %{
   ins_pipe(pipe_class_default);
 %}
 
-// As loadConNKlass_hi this must be recognized as narrow klass, not oop!
-instruct loadConNKlass_mask(iRegNdst dst, immNKlass_NM src) %{
-  match(Set dst src);
-  effect(USE_DEF dst, USE src);
+instruct loadConNKlass_mask(iRegIdst dst, iRegIsrc src) %{
+  effect(DEF dst, USE src);
   ins_cost(DEFAULT_COST);
 
-  format %{ "MASK    $dst, $dst, 0xFFFFFFFF" %} // mask
+  format %{ "MASK    $dst, $src, 0xFFFFFFFF" %} // mask
   size(4);
   ins_encode %{
-    __ clrldi($dst$$Register, $dst$$Register, 0x20);
+    __ clrldi($dst$$Register, $src$$Register, 0x20);
   %}
   ins_pipe(pipe_class_default);
 %}
 
-// This needs a match rule so that build_oop_map knows this is
-// not a narrow oop.
-instruct loadConNKlass_lo(iRegNdst dst, immNKlass_NM src) %{
-  match(Set dst src);
-  effect(USE_DEF dst, USE src);
+instruct loadConNKlass_lo(iRegNdst dst, immNKlass_NM src1, iRegIsrc src2) %{
+  effect(DEF dst, USE src1, USE src2);
   ins_cost(DEFAULT_COST);
 
-  format %{ "ORI     $dst, $dst, $src \t// narrow klass lo" %}
+  format %{ "ORI     $dst, $src2, $src1 \t// narrow klass lo" %}
   size(4);
   ins_encode %{
     // Notify OOP recorder (don't need the relocation)
-    AddressLiteral md = __ constant_metadata_address((Klass*)$src$$constant);
+    AddressLiteral md = __ constant_metadata_address((Klass*)$src1$$constant);
     intptr_t Csrc = CompressedKlassPointers::encode((Klass*)md.value());
-    __ ori($dst$$Register, $dst$$Register, Csrc & 0xffff);
+    __ ori($dst$$Register, $src2$$Register, Csrc & 0xffff);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -5797,8 +5790,9 @@ instruct loadConNKlass_Ex(iRegNdst dst, immNKlass_no_mask src) %{
   ins_cost(DEFAULT_COST*2);
 
   expand %{
-    loadConNKlass_hi(dst, src);
-    loadConNKlass_lo(dst, src);
+    iRegIdst tmp;
+    loadConNKlass_hi(tmp, src);
+    loadConNKlass_lo(dst, src, tmp);
   %}
 %}
 
@@ -5807,9 +5801,11 @@ instruct loadConNKlass_mask_Ex(iRegNdst dst, immNKlass_mask src) %{
   ins_cost(DEFAULT_COST*3);
 
   expand %{
-    loadConNKlass_hi(dst, src);
-    loadConNKlass_mask(dst, src);
-    loadConNKlass_lo(dst, src);
+    iRegIdst tmp1;
+    iRegIdst tmp2;
+    loadConNKlass_hi(tmp1, src);
+    loadConNKlass_mask(tmp2, tmp1);
+    loadConNKlass_lo(dst, src, tmp2);
   %}
 %}
 

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3776,14 +3776,6 @@ operand immN_0() %{
 %}
 
 // Compressed klass constants
-operand immNKlass() %{
-  match(ConNKlass);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 operand immNKlass_no_mask() %{
   predicate(Assembler::is_uimm((jlong)CompressedKlassPointers::encode((Klass*)n->bottom_type()->is_narrowklass()->get_con()), 31));
   match(ConNKlass);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -5677,16 +5677,16 @@ instruct loadConN_hi(iRegIdst dst, immN src) %{
 %}
 
 // Add lo part of compressed oop constant to already loaded hi part.
-instruct loadConN_lo(iRegIdst dst, iRegIsrc src1, immN src2) %{
-  effect(DEF dst, USE src1, USE src2);
+instruct loadConN_lo(iRegIdst dst, immN src) %{
+  effect(USE_DEF dst, USE src);
   ins_cost(DEFAULT_COST);
 
-  format %{ "ORI     $dst, $src1, $src2 \t// narrow oop lo" %}
+  format %{ "ORI     $dst, $dst, $src \t// narrow oop lo" %}
   size(4);
   ins_encode %{
-    AddressLiteral addrlit = __ constant_oop_address((jobject)$src2$$constant);
+    AddressLiteral addrlit = __ constant_oop_address((jobject)$src$$constant);
     __ relocate(addrlit.rspec(), /*compressed format*/ 1);
-    __ ori($dst$$Register, $src1$$Register, 0); // Will get patched.
+    __ ori($dst$$Register, $dst$$Register, 0); // Will get patched.
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -5735,11 +5735,10 @@ instruct loadConN_Ex(iRegNdst dst, immN src) %{
   ins_cost(DEFAULT_COST*2);
 
   expand %{
-    iRegIdst tmp1;
-    iRegIdst tmp2;
-    loadConN_hi(tmp1, src);
-    loadConN_lo(tmp2, tmp1, src);
-    clearMs32b(dst, tmp2);
+    iRegIdst tmp;
+    loadConN_hi(tmp, src);
+    loadConN_lo(tmp, src);
+    clearMs32b(dst, tmp);
   %}
 %}
 

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3802,6 +3802,16 @@ operand immNKlass_mask() %{
   interface(CONST_INTER);
 %}
 
+// This operand can be used to avoid matching of an instruct
+// with chain rule.
+operand immNKlass_NM() %{
+  match(ConNKlass);
+  predicate(false);
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 // Pointer Immediate: 64-bit
 operand immP() %{
   match(ConP);
@@ -5744,10 +5754,9 @@ instruct loadConN_Ex(iRegNdst dst, immN src) %{
 // We have seen a safepoint between the hi and lo parts, and this node was handled
 // as an oop. Therefore this needs a match rule so that build_oop_map knows this is
 // not a narrow oop.
-instruct loadConNKlass_hi(iRegNdst dst, immNKlass src) %{
+instruct loadConNKlass_hi(iRegNdst dst, immNKlass_NM src) %{
   match(Set dst src);
   effect(DEF dst, USE src);
-  predicate(false);
   ins_cost(DEFAULT_COST);
 
   format %{ "LIS     $dst, $src \t// narrow klass hi" %}
@@ -5760,35 +5769,33 @@ instruct loadConNKlass_hi(iRegNdst dst, immNKlass src) %{
 %}
 
 // As loadConNKlass_hi this must be recognized as narrow klass, not oop!
-instruct loadConNKlass_mask(iRegNdst dst, immNKlass src1, iRegNsrc src2) %{
-  match(Set dst src1);
-  effect(DEF dst, USE src1, USE src2);
-  predicate(false);
+instruct loadConNKlass_mask(iRegNdst dst, immNKlass_NM src) %{
+  match(Set dst src);
+  effect(USE_DEF dst, USE src);
   ins_cost(DEFAULT_COST);
 
-  format %{ "MASK    $dst, $src2, 0xFFFFFFFF" %} // mask
+  format %{ "MASK    $dst, $dst, 0xFFFFFFFF" %} // mask
   size(4);
   ins_encode %{
-    __ clrldi($dst$$Register, $src2$$Register, 0x20);
+    __ clrldi($dst$$Register, $dst$$Register, 0x20);
   %}
   ins_pipe(pipe_class_default);
 %}
 
 // This needs a match rule so that build_oop_map knows this is
 // not a narrow oop.
-instruct loadConNKlass_lo(iRegNdst dst, immNKlass src1, iRegNsrc src2) %{
-  match(Set dst src1);
-  effect(DEF dst, USE src1, USE src2);
-  predicate(false);
+instruct loadConNKlass_lo(iRegNdst dst, immNKlass_NM src) %{
+  match(Set dst src);
+  effect(USE_DEF dst, USE src);
   ins_cost(DEFAULT_COST);
 
-  format %{ "ORI     $dst, $src1, $src2 \t// narrow klass lo" %}
+  format %{ "ORI     $dst, $dst, $src \t// narrow klass lo" %}
   size(4);
   ins_encode %{
     // Notify OOP recorder (don't need the relocation)
-    AddressLiteral md = __ constant_metadata_address((Klass*)$src1$$constant);
+    AddressLiteral md = __ constant_metadata_address((Klass*)$src$$constant);
     intptr_t Csrc = CompressedKlassPointers::encode((Klass*)md.value());
-    __ ori($dst$$Register, $src2$$Register, Csrc & 0xffff);
+    __ ori($dst$$Register, $dst$$Register, Csrc & 0xffff);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -5798,9 +5805,8 @@ instruct loadConNKlass_Ex(iRegNdst dst, immNKlass_no_mask src) %{
   ins_cost(DEFAULT_COST*2);
 
   expand %{
-    iRegNdst tmp;
-    loadConNKlass_hi(tmp, src);
-    loadConNKlass_lo(dst, src, tmp);
+    loadConNKlass_hi(dst, src);
+    loadConNKlass_lo(dst, src);
   %}
 %}
 
@@ -5809,11 +5815,9 @@ instruct loadConNKlass_mask_Ex(iRegNdst dst, immNKlass_mask src) %{
   ins_cost(DEFAULT_COST*3);
 
   expand %{
-    iRegNdst tmp1;
-    iRegNdst tmp2;
-    loadConNKlass_hi(tmp1, src);
-    loadConNKlass_mask(tmp2, src, tmp1);
-    loadConNKlass_lo(dst, src, tmp2);
+    loadConNKlass_hi(dst, src);
+    loadConNKlass_mask(dst, src);
+    loadConNKlass_lo(dst, src);
   %}
 %}
 

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3784,11 +3784,19 @@ operand immNKlass() %{
   interface(CONST_INTER);
 %}
 
-// This operand can be used to avoid matching of an instruct
-// with chain rule.
-operand immNKlass_NM() %{
+operand immNKlass_no_mask() %{
+  predicate(Assembler::is_uimm((jlong)CompressedKlassPointers::encode((Klass*)n->bottom_type()->is_narrowklass()->get_con()), 31));
   match(ConNKlass);
-  predicate(false);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+operand immNKlass_mask() %{
+  predicate(!Assembler::is_uimm((jlong)CompressedKlassPointers::encode((Klass*)n->bottom_type()->is_narrowklass()->get_con()), 31));
+  match(ConNKlass);
+
   op_cost(0);
   format %{ %}
   interface(CONST_INTER);
@@ -5691,8 +5699,8 @@ instruct rldicl(iRegLdst dst, iRegLsrc src, immI16 shift, immI16 mask_begin) %{
   ins_pipe(pipe_class_default);
 %}
 
-// Needed to postalloc expand loadConN: ConN is loaded as ConI
-// leaving the upper 32 bits with sign-extension bits.
+// Needed to expand loadConN: ConN is loaded as ConI leaving the upper
+// 32 bits with sign-extension bits.
 // This clears these bits: dst = src & 0xFFFFFFFF.
 // TODO: Eventually call this maskN_regN_FFFFFFFF.
 instruct clearMs32b(iRegNdst dst, iRegNsrc src) %{
@@ -5719,46 +5727,27 @@ instruct loadBase(iRegLdst dst) %{
   ins_pipe(pipe_class_default);
 %}
 
-// Loading ConN must be postalloc expanded so that edges between
-// the nodes are safe. They may not interfere with a safepoint.
 // GL TODO: This needs three instructions: better put this into the constant pool.
 instruct loadConN_Ex(iRegNdst dst, immN src) %{
   match(Set dst src);
   ins_cost(DEFAULT_COST*2);
 
-  format %{ "LoadN   $dst, $src \t// postalloc expanded" %} // mask
-  postalloc_expand %{
-    MachNode *m1 = new loadConN_hiNode();
-    MachNode *m2 = new loadConN_loNode();
-    MachNode *m3 = new clearMs32bNode();
-    m1->_bottom_type = bottom_type();
-    m2->_bottom_type = bottom_type();
-    m3->_bottom_type = bottom_type();
-    m1->add_req(nullptr);
-    m2->add_req(nullptr, m1);
-    m3->add_req(nullptr, m2);
-    m1->_opnds[0] = op_dst;
-    m1->_opnds[1] = op_src;
-    m2->_opnds[0] = op_dst;
-    m2->_opnds[1] = op_dst;
-    m2->_opnds[2] = op_src;
-    m3->_opnds[0] = op_dst;
-    m3->_opnds[1] = op_dst;
-    ra_->set_pair(m1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
-    ra_->set_pair(m2->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
-    ra_->set_pair(m3->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
-    nodes->push(m1);
-    nodes->push(m2);
-    nodes->push(m3);
+  expand %{
+    iRegNdst tmp1;
+    iRegNdst tmp2;
+    loadConN_hi(tmp1, src);
+    loadConN_lo(tmp2, tmp1, src);
+    clearMs32b(dst, tmp2);
   %}
 %}
 
 // We have seen a safepoint between the hi and lo parts, and this node was handled
 // as an oop. Therefore this needs a match rule so that build_oop_map knows this is
 // not a narrow oop.
-instruct loadConNKlass_hi(iRegNdst dst, immNKlass_NM src) %{
+instruct loadConNKlass_hi(iRegNdst dst, immNKlass src) %{
   match(Set dst src);
   effect(DEF dst, USE src);
+  predicate(false);
   ins_cost(DEFAULT_COST);
 
   format %{ "LIS     $dst, $src \t// narrow klass hi" %}
@@ -5771,9 +5760,10 @@ instruct loadConNKlass_hi(iRegNdst dst, immNKlass_NM src) %{
 %}
 
 // As loadConNKlass_hi this must be recognized as narrow klass, not oop!
-instruct loadConNKlass_mask(iRegNdst dst, immNKlass_NM src1, iRegNsrc src2) %{
+instruct loadConNKlass_mask(iRegNdst dst, immNKlass src1, iRegNsrc src2) %{
   match(Set dst src1);
-  effect(TEMP src2);
+  effect(DEF dst, USE src1, USE src2);
+  predicate(false);
   ins_cost(DEFAULT_COST);
 
   format %{ "MASK    $dst, $src2, 0xFFFFFFFF" %} // mask
@@ -5786,9 +5776,10 @@ instruct loadConNKlass_mask(iRegNdst dst, immNKlass_NM src1, iRegNsrc src2) %{
 
 // This needs a match rule so that build_oop_map knows this is
 // not a narrow oop.
-instruct loadConNKlass_lo(iRegNdst dst, immNKlass_NM src1, iRegNsrc src2) %{
+instruct loadConNKlass_lo(iRegNdst dst, immNKlass src1, iRegNsrc src2) %{
   match(Set dst src1);
-  effect(TEMP src2);
+  effect(DEF dst, USE src1, USE src2);
+  predicate(false);
   ins_cost(DEFAULT_COST);
 
   format %{ "ORI     $dst, $src1, $src2 \t// narrow klass lo" %}
@@ -5802,44 +5793,27 @@ instruct loadConNKlass_lo(iRegNdst dst, immNKlass_NM src1, iRegNsrc src2) %{
   ins_pipe(pipe_class_default);
 %}
 
-// Loading ConNKlass must be postalloc expanded so that edges between
-// the nodes are safe. They may not interfere with a safepoint.
-instruct loadConNKlass_Ex(iRegNdst dst, immNKlass src) %{
+instruct loadConNKlass_Ex(iRegNdst dst, immNKlass_no_mask src) %{
   match(Set dst src);
   ins_cost(DEFAULT_COST*2);
 
-  format %{ "LoadN   $dst, $src \t// postalloc expanded" %} // mask
-  postalloc_expand %{
-    // Load high bits into register. Sign extended.
-    MachNode *m1 = new loadConNKlass_hiNode();
-    m1->_bottom_type = bottom_type();
-    m1->add_req(nullptr);
-    m1->_opnds[0] = op_dst;
-    m1->_opnds[1] = op_src;
-    ra_->set_pair(m1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
-    nodes->push(m1);
+  expand %{
+    iRegNdst tmp;
+    loadConNKlass_hi(tmp, src);
+    loadConNKlass_lo(dst, src, tmp);
+  %}
+%}
 
-    MachNode *m2 = m1;
-    if (!Assembler::is_uimm((jlong)CompressedKlassPointers::encode((Klass *)op_src->constant()), 31)) {
-      // Value might be 1-extended. Mask out these bits.
-      m2 = new loadConNKlass_maskNode();
-      m2->_bottom_type = bottom_type();
-      m2->add_req(nullptr, m1);
-      m2->_opnds[0] = op_dst;
-      m2->_opnds[1] = op_src;
-      m2->_opnds[2] = op_dst;
-      ra_->set_pair(m2->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
-      nodes->push(m2);
-    }
+instruct loadConNKlass_mask_Ex(iRegNdst dst, immNKlass_mask src) %{
+  match(Set dst src);
+  ins_cost(DEFAULT_COST*3);
 
-    MachNode *m3 = new loadConNKlass_loNode();
-    m3->_bottom_type = bottom_type();
-    m3->add_req(nullptr, m2);
-    m3->_opnds[0] = op_dst;
-    m3->_opnds[1] = op_src;
-    m3->_opnds[2] = op_dst;
-    ra_->set_pair(m3->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
-    nodes->push(m3);
+  expand %{
+    iRegNdst tmp1;
+    iRegNdst tmp2;
+    loadConNKlass_hi(tmp1, src);
+    loadConNKlass_mask(tmp2, src, tmp1);
+    loadConNKlass_lo(dst, src, tmp2);
   %}
 %}
 


### PR DESCRIPTION
Convert PPC loadConN_Ex and loadConNKlass_Ex from manual postalloc_expand blocks to normal ADLC expand rules. 

The ConNKlass case is split into masked and no-mask variants so the previous conditional mask behavior is preserved while making the expanded nodes visible before register allocation.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391911](https://bugs.openjdk.org/browse/JDK-8391911): PPC64: Remove postalloc_expand for narrow constant loads (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32735/head:pull/32735` \
`$ git checkout pull/32735`

Update a local copy of the PR: \
`$ git checkout pull/32735` \
`$ git pull https://git.openjdk.org/jdk.git pull/32735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32735`

View PR using the GUI difftool: \
`$ git pr show -t 32735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32735.diff">https://git.openjdk.org/jdk/pull/32735.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32735#issuecomment-5570829994)
</details>
