### PR TITLE
8391914: x86: Optimize StringUTF16.compress intrinsic with AVX2

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -24,6 +24,7 @@
 
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
+#include "assembler_x86.hpp"
 #include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "compiler/compiler_globals.hpp"
@@ -9320,7 +9321,78 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     bind(below_threshold);
   }
 
-  if (UseSSE42Intrinsics) {
+  if (UseAVX > 1) {
+    Label copy_64_loop, copy_32, copy_16, copy_tail_avx, reset_for_copy_tail;
+
+    cmpl(len, 8);
+    jcc(Assembler::less, copy_tail);
+
+    movl(tmp5, 0xff00ff00);   // create mask to test for Unicode chars in vectors
+    movdl(tmp1Reg, tmp5);
+    vpbroadcastd(tmp1Reg, tmp1Reg, Assembler::AVX_256bit);   // store Unicode mask in tmp1Reg
+
+    andl(len, 0xffffffe0);
+    jccb(Assembler::zero, copy_32);
+
+    // compress 32 chars per iter
+    lea(src, Address(src, len, Address::times_2));
+    lea(dst, Address(dst, len, Address::times_1));
+    negptr(len);
+
+    bind(copy_64_loop);
+    vmovdqu(tmp2Reg, Address(src, len, Address::times_2));     // load 1st 16 characters
+    vmovdqu(tmp3Reg, Address(src, len, Address::times_2, 32)); // load next 16 characters
+    vpor(tmp4Reg, tmp2Reg, tmp3Reg, Assembler::AVX_256bit);
+    vptest(tmp4Reg, tmp1Reg, Assembler::AVX_256bit);       // check for Unicode chars in next vector
+    jccb(Assembler::notZero, reset_for_copy_tail);
+    vpackuswb(tmp4Reg, tmp2Reg, tmp3Reg, Assembler::AVX_256bit);    // only ASCII chars; compress each to 1 byte
+    vpermq(tmp4Reg, tmp4Reg, 0xD8, Assembler::AVX_256bit); // permute to get the right order
+    vmovdqu(Address(dst, len, Address::times_1), tmp4Reg);
+    addptr(len, 32);
+    jccb(Assembler::notZero, copy_64_loop);
+
+    // compress next vector of 16 chars (if any)
+    bind(copy_32);
+    // len = 0
+    testl(result, 0x00000010);     // check if there's a block of 16 chars to compress
+    jccb(Assembler::zero, copy_16);
+
+    vmovdqu(tmp2Reg, Address(src, 0));
+    vptest(tmp2Reg, tmp1Reg, Assembler::AVX_256bit);       // check for Unicode chars in vector
+    jccb(Assembler::notZero, reset_for_copy_tail);
+    vextracti128_high(tmp3Reg, tmp2Reg);
+    vpackuswb(tmp2Reg, tmp2Reg, tmp3Reg, Assembler::AVX_128bit);    // only LATIN1 chars; compress each to 1 byte
+    movdqu(Address(dst, 0), tmp2Reg);
+    addptr(src, 32);
+    addptr(dst, 16);
+
+    // compress next vector of 8 chars (if any)
+    bind(copy_16);
+    // len = 0
+    testl(result, 0x00000008);     // check if there's a block of 8 chars to compress
+    jccb(Assembler::zero, copy_tail_avx);
+
+    movdqu(tmp2Reg, Address(src, 0));
+    vptest(tmp2Reg, tmp1Reg, Assembler::AVX_128bit);       // check for Unicode chars in vector
+    jccb(Assembler::notZero, reset_for_copy_tail);
+    vpackuswb(tmp2Reg, tmp2Reg, tmp2Reg, Assembler::AVX_128bit);    // only LATIN1 chars; compress each to 1 byte
+    movq(Address(dst, 0), tmp2Reg);
+    addptr(src, 16);
+    addptr(dst, 8);
+    jmpb(copy_tail_avx);
+
+    bind(reset_for_copy_tail);
+    movl(tmp5, result);
+    andl(tmp5, 0x0000001f);
+    lea(src, Address(src, tmp5, Address::times_2));
+    lea(dst, Address(dst, tmp5, Address::times_1));
+    subptr(len, tmp5);
+    jmpb(copy_chars_loop);
+
+    bind(copy_tail_avx);
+    movl(len, result);
+    andl(len, 0x00000007);    // tail count (in chars)
+  } else if (UseSSE42Intrinsics) {
     Label copy_32_loop, copy_16, copy_tail_sse, reset_for_copy_tail;
 
     // vectored compression
@@ -9359,12 +9431,10 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     testl(result, 0x00000008);     // check if there's a block of 8 chars to compress
     jccb(Assembler::zero, copy_tail_sse);
 
-    pxor(tmp3Reg, tmp3Reg);
-
     movdqu(tmp2Reg, Address(src, 0));
     ptest(tmp2Reg, tmp1Reg);       // check for Unicode chars in vector
     jccb(Assembler::notZero, reset_for_copy_tail);
-    packuswb(tmp2Reg, tmp3Reg);    // only LATIN1 chars; compress each to 1 byte
+    packuswb(tmp2Reg, tmp2Reg);    // only LATIN1 chars; compress each to 1 byte
     movq(Address(dst, 0), tmp2Reg);
     addptr(src, 16);
     addptr(dst, 8);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -24,7 +24,6 @@
 
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
-#include "assembler_x86.hpp"
 #include "code/aotCodeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "compiler/compiler_globals.hpp"
@@ -9353,32 +9352,34 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
 
     // compress next vector of 16 chars (if any)
     bind(copy_32);
-    // len = 0
+    movl(len, result);
+    andl(len, 0x1f);
     testl(result, 0x00000010);     // check if there's a block of 16 chars to compress
     jccb(Assembler::zero, copy_16);
 
     vmovdqu(tmp2Reg, Address(src, 0));
     vptest(tmp2Reg, tmp1Reg, Assembler::AVX_256bit);       // check for Unicode chars in vector
-    jccb(Assembler::notZero, reset_for_copy_tail);
+    jccb(Assembler::notZero, copy_tail_avx);
     vextracti128_high(tmp3Reg, tmp2Reg);
     vpackuswb(tmp2Reg, tmp2Reg, tmp3Reg, Assembler::AVX_128bit);    // only LATIN1 chars; compress each to 1 byte
     movdqu(Address(dst, 0), tmp2Reg);
     addptr(src, 32);
     addptr(dst, 16);
+    subl(len, 16);
 
     // compress next vector of 8 chars (if any)
     bind(copy_16);
-    // len = 0
     testl(result, 0x00000008);     // check if there's a block of 8 chars to compress
     jccb(Assembler::zero, copy_tail_avx);
 
     movdqu(tmp2Reg, Address(src, 0));
     vptest(tmp2Reg, tmp1Reg, Assembler::AVX_128bit);       // check for Unicode chars in vector
-    jccb(Assembler::notZero, reset_for_copy_tail);
+    jccb(Assembler::notZero, copy_tail_avx);
     vpackuswb(tmp2Reg, tmp2Reg, tmp2Reg, Assembler::AVX_128bit);    // only LATIN1 chars; compress each to 1 byte
     movq(Address(dst, 0), tmp2Reg);
     addptr(src, 16);
     addptr(dst, 8);
+    subl(len, 8);
     jmpb(copy_tail_avx);
 
     bind(reset_for_copy_tail);
@@ -9390,8 +9391,6 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     jmpb(copy_chars_loop);
 
     bind(copy_tail_avx);
-    movl(len, result);
-    andl(len, 0x00000007);    // tail count (in chars)
   } else if (UseSSE42Intrinsics) {
     Label copy_32_loop, copy_16, copy_tail_sse, reset_for_copy_tail;
 
@@ -9431,10 +9430,12 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     testl(result, 0x00000008);     // check if there's a block of 8 chars to compress
     jccb(Assembler::zero, copy_tail_sse);
 
+    pxor(tmp3Reg, tmp3Reg);
+
     movdqu(tmp2Reg, Address(src, 0));
     ptest(tmp2Reg, tmp1Reg);       // check for Unicode chars in vector
     jccb(Assembler::notZero, reset_for_copy_tail);
-    packuswb(tmp2Reg, tmp2Reg);    // only LATIN1 chars; compress each to 1 byte
+    packuswb(tmp2Reg, tmp3Reg);    // only LATIN1 chars; compress each to 1 byte
     movq(Address(dst, 0), tmp2Reg);
     addptr(src, 16);
     addptr(dst, 8);


### PR DESCRIPTION
Currently the StringUTF16.compress intrinsic (MacroAssembler::char_array_compress) intrinsic only has an AVX-512 path (gated by UseAVX > 2 && supports_avx512vlbw() && supports_bmi2()) and an SSE4.2 16-char path. Machines with AVX2 but no AVX-512 (or with AVX3Threshold > 0) fall back to the slower SSE4.2 path. This change adds a 32-char AVX2 loop for such CPUs.

Benchmarked with the following jmh test (AMD EPYC 9754, 3.1GHz)

```java
import org.openjdk.jmh.annotations.*;
import org.openjdk.jmh.infra.Blackhole;

import java.util.Random;
import java.util.concurrent.TimeUnit;

@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MICROSECONDS)
@State(Scope.Thread)
public class StringCompressTest {

    @Param({"80", "160", "320"})
    private int length;

    static final int SIZE = 1000;
    char[][] chars;
    private static final Random r = new Random();

    @Setup
    public void setup() {
        chars = new char[SIZE][length];
        for (int i = 0; i < SIZE; ++i) {
            randChars(chars[i]);
        }
    }

    static void randChars(char[] a) {
        for (int i = 0; i < a.length; ++i) {
            a[i] = (char) r.nextInt(256);
        }
    }

    static String test(char[] a) {
        return new String(a); // will call StringUTF16.compress
    }

    @Benchmark
    @OperationsPerInvocation(SIZE)
    public void test(Blackhole bh) {
        for (int i = 0; i < SIZE; ++i) {
            bh.consume(test(chars[i]));
        }
    }
}
```

| length | SSE4.2 (ops/us) | AVX2 (ops/us) | speedup |
|---------|----------------|----------------|---------|
| 1 | 214.757 ± 0.451 | 214.067 ± 0.475 | -0.3% |
| 2 | 202.259 ± 0.408 | 201.802 ± 0.052 | -0.2% |
| 7 | 138.091 ± 0.073 | 135.938 ± 0.780 | -1.6% |
| 8 | 197.174 ± 0.237 | 192.640 ± 0.251 | -2.3% |
| 9 | 179.555 ± 0.141 | 169.798 ± 0.041 | -5.4% |
| 15 | 113.118 ± 0.155 | 111.687 ± 0.083 | -1.3% |
| 16 | 175.742 ± 0.049 | 183.583 ± 0.156 | +4.5% |
| 17 | 153.135 ± 0.038 | 164.107 ± 0.093 | +7.2% |
| 23 | 98.537 ± 0.181 | 106.598 ± 0.120 | +8.2% |
| 24 | 151.005 ± 3.288 | 160.241 ± 4.064 | +6.1% |
| 25 | 141.541 ± 3.905 | 150.731 ± 3.203 | +6.5% |
| 31 | 88.531 ± 0.098 | 98.463 ± 0.054 | +11.2% |
| 32 | 143.776 ± 0.182 | 141.570 ± 0.049 | -1.5% |
| 33 | 131.862 ± 0.245 | 141.560 ± 0.215 | +7.4% |
| 63 | 75.332 ± 0.062 | 78.436 ± 0.003 | +4.1% |
| 64 | 103.849 ± 0.054 | 118.287 ± 0.037 | +13.9% |
| 65 | 88.291 ± 0.145 | 110.478 ± 0.173 | +25.1% |
| 100 | 71.164 ± 0.069 | 92.988 ± 0.011 | +30.7% |
| 300 | 34.041 ± 0.028 | 42.097 ± 0.036 | +23.7% |
| 1000 | 9.437 ± 0.010 | 16.126 ± 0.006 | +70.9% |
| 3000 | 3.012 ± 0.002 | 4.038 ± 0.002 | +34.1% |
| 10000 | 0.652 ± 0.001 | 0.840 ± 0.001 | +28.8% |

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391914](https://bugs.openjdk.org/browse/JDK-8391914): x86: Optimize StringUTF16.compress intrinsic with AVX2 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32736/head:pull/32736` \
`$ git checkout pull/32736`

Update a local copy of the PR: \
`$ git checkout pull/32736` \
`$ git pull https://git.openjdk.org/jdk.git pull/32736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32736`

View PR using the GUI difftool: \
`$ git pr show -t 32736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32736.diff">https://git.openjdk.org/jdk/pull/32736.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32736#issuecomment-5571441046)
</details>
