### PR TITLE
8391912: Avoid switching off the unused-variable warning in BUILD_LIBJLI

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -176,7 +176,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
     EXTRA_HEADER_DIRS := libjvm, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(LIBJLI_CFLAGS) $(LIBZ_CFLAGS), \
-    DISABLED_WARNINGS_gcc := unused-function unused-variable, \
+    DISABLED_WARNINGS_gcc := unused-function, \
     DISABLED_WARNINGS_clang := deprecated-non-prototype format-nonliteral \
         unused-function, \
     DISABLED_WARNINGS_clang_java_md_macosx.m := unused-variable, \

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -88,6 +88,7 @@ static jboolean _have_classpath = JNI_FALSE;
 static const char *_fVersion;
 static jboolean _wc_enabled = JNI_FALSE;
 static jboolean dumpSharedSpaces = JNI_FALSE; /* -Xshare:dump */
+static const char *launchModeNames[] = { "Unknown", "Main class", "JAR file", "Module", "Source" };
 
 /*
  * Values that will be stored into splash screen environment variables.

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,9 +214,6 @@ enum LaunchMode {               // cf. sun.launcher.LauncherHelper
     LM_MODULE,
     LM_SOURCE
 };
-
-static const char *launchModeNames[]
-    = { "Unknown", "Main class", "JAR file", "Module", "Source" };
 
 typedef struct {
     int    argc;


### PR DESCRIPTION
Currently we switch off the unused-variable warning in BUILD_LIBJLI; this should be changed.

We might also consider getting rid of the unused-function warning which is switched off in BUILD_LIBJLI :

```
/jdk/src/java.base/unix/native/libjli/java_md.h:58:17: error: 'GetJVMPath' declared 'static' but never defined [-Werror=unused-function]
   58 | static jboolean GetJVMPath(const char *jdkroot, const char *jvmtype,
      | ^~~~~~~~~~
/jdk/src/java.base/unix/native/libjli/java_md.h:60:17: error: 'GetJDKInstallRoot' declared 'static' but never defined [-Werror=unused-function]
   60 | static jboolean GetJDKInstallRoot(char *path, jint pathsize, jboolean speculative);
      | ^~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

(e.g. by moving the static function declarations to the c files)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391912](https://bugs.openjdk.org/browse/JDK-8391912): Avoid switching off the unused-variable warning in BUILD_LIBJLI (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32737/head:pull/32737` \
`$ git checkout pull/32737`

Update a local copy of the PR: \
`$ git checkout pull/32737` \
`$ git pull https://git.openjdk.org/jdk.git pull/32737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32737`

View PR using the GUI difftool: \
`$ git pr show -t 32737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32737.diff">https://git.openjdk.org/jdk/pull/32737.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32737#issuecomment-5571434079)
</details>
