### PR TITLE
8391921: RISC-V: Add C2 vector support for CompressBitsV and ExpandBitsV

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2183,6 +2183,121 @@ void C2_MacroAssembler::enc_cmove_fp_cmp_fp(int cmpFlag,
   }
 }
 
+static void vshift_left(C2_MacroAssembler* masm, VectorRegister dst, VectorRegister src,
+                        int shift, Register tmp) {
+  if (shift < BitsPerInt) {
+    masm->vsll_vi(dst, src, shift);
+  } else {
+    assert(shift == BitsPerInt, "unexpected shift amount");
+    masm->mv(tmp, shift);
+    masm->vsll_vx(dst, src, tmp);
+  }
+}
+
+static void vshift_right(C2_MacroAssembler* masm, VectorRegister dst, VectorRegister src,
+                         int shift, Register tmp) {
+  if (shift < BitsPerInt) {
+    masm->vsrl_vi(dst, src, shift);
+  } else {
+    assert(shift == BitsPerInt, "unexpected shift amount");
+    masm->mv(tmp, shift);
+    masm->vsrl_vx(dst, src, tmp);
+  }
+}
+
+static void parallel_suffix_v(C2_MacroAssembler* masm, VectorRegister dst,
+                              VectorRegister src, VectorRegister tmp,
+                              Register shift_tmp, bool is_int) {
+  const int rounds = is_int ? 5 : 6;
+
+  masm->vmv_v_v(dst, src);
+  for (int j = 0; j < rounds; j++) {
+    vshift_left(masm, tmp, dst, 1 << j, shift_tmp);
+    masm->vxor_vv(dst, dst, tmp);
+  }
+}
+
+void C2_MacroAssembler::compress_bits_v(VectorRegister dst, VectorRegister src,
+                                        VectorRegister mask, VectorRegister src_tmp,
+                                        VectorRegister mask_tmp, VectorRegister tmp1,
+                                        VectorRegister tmp2, Register tmp,
+                                        BasicType bt, uint vector_length) {
+  assert(bt == T_INT || bt == T_LONG, "unsupported element type");
+  const bool is_int = bt == T_INT;
+  const int rounds = is_int ? 5 : 6;
+
+  vsetvli_helper(bt, vector_length);
+  vand_vv(dst, src, mask);
+  vmv_v_v(mask_tmp, mask);
+  vnot_v(tmp1, mask_tmp);
+  vshift_left(this, tmp1, tmp1, 1, tmp);
+
+  for (int j = 0; j < rounds; j++) {
+    const int shift = 1 << j;
+    parallel_suffix_v(this, tmp2, tmp1, src_tmp, tmp, is_int);
+    vand_vv(src_tmp, tmp2, mask_tmp);
+    vnot_v(tmp2, tmp2);
+    vand_vv(tmp1, tmp1, tmp2);
+
+    vxor_vv(mask_tmp, mask_tmp, src_tmp);
+    vshift_right(this, tmp2, src_tmp, shift, tmp);
+    vor_vv(mask_tmp, mask_tmp, tmp2);
+
+    vand_vv(tmp2, dst, src_tmp);
+    vxor_vv(dst, dst, tmp2);
+    vshift_right(this, tmp2, tmp2, shift, tmp);
+    vor_vv(dst, dst, tmp2);
+  }
+}
+
+void C2_MacroAssembler::expand_bits_v(VectorRegister dst, VectorRegister src,
+                                      VectorRegister mask, VectorRegister src_tmp,
+                                      VectorRegister mask_tmp,
+                                      VectorRegister mask_move1,
+                                      VectorRegister mask_move2,
+                                      VectorRegister mask_move3,
+                                      VectorRegister mask_move4,
+                                      VectorRegister mask_move5,
+                                      VectorRegister mask_move6,
+                                      VectorRegister tmp1, VectorRegister tmp2,
+                                      Register tmp, BasicType bt,
+                                      uint vector_length) {
+  assert(bt == T_INT || bt == T_LONG, "unsupported element type");
+  const bool is_int = bt == T_INT;
+  const int rounds = is_int ? 5 : 6;
+  VectorRegister mask_moves[6] = {
+    mask_move1, mask_move2, mask_move3, mask_move4, mask_move5, mask_move6
+  };
+
+  vsetvli_helper(bt, vector_length);
+  vmv_v_v(src_tmp, src);
+  vmv_v_v(mask_tmp, mask);
+  vmv_v_v(dst, mask_tmp);
+  vnot_v(tmp1, mask_tmp);
+  vshift_left(this, tmp1, tmp1, 1, tmp);
+
+  for (int j = 0; j < rounds; j++) {
+    const int shift = 1 << j;
+    parallel_suffix_v(this, tmp2, tmp1, mask_moves[j], tmp, is_int);
+    vand_vv(mask_moves[j], tmp2, mask_tmp);
+    vnot_v(tmp2, tmp2);
+    vand_vv(tmp1, tmp1, tmp2);
+
+    vxor_vv(mask_tmp, mask_tmp, mask_moves[j]);
+    vshift_right(this, tmp2, mask_moves[j], shift, tmp);
+    vor_vv(mask_tmp, mask_tmp, tmp2);
+  }
+
+  for (int j = rounds - 1; j >= 0; j--) {
+    const int shift = 1 << j;
+    vshift_left(this, tmp2, src_tmp, shift, tmp);
+    vxor_vv(tmp2, tmp2, src_tmp);
+    vand_vv(tmp2, tmp2, mask_moves[j]);
+    vxor_vv(src_tmp, src_tmp, tmp2);
+  }
+  vand_vv(dst, src_tmp, dst);
+}
+
 // Set dst to NaN if any NaN input.
 void C2_MacroAssembler::minmax_fp(FloatRegister dst, FloatRegister src1, FloatRegister src2,
                                   FLOAT_TYPE ft, bool is_min) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -142,6 +142,18 @@
                            FloatRegister dst, FloatRegister src,
                            bool cmp_single, bool cmov_single);
 
+  void compress_bits_v(VectorRegister dst, VectorRegister src, VectorRegister mask,
+                       VectorRegister src_tmp, VectorRegister mask_tmp,
+                       VectorRegister tmp1, VectorRegister tmp2,
+                       Register tmp, BasicType bt, uint vector_length);
+  void expand_bits_v(VectorRegister dst, VectorRegister src, VectorRegister mask,
+                     VectorRegister src_tmp, VectorRegister mask_tmp,
+                     VectorRegister mask_move1, VectorRegister mask_move2,
+                     VectorRegister mask_move3, VectorRegister mask_move4,
+                     VectorRegister mask_move5, VectorRegister mask_move6,
+                     VectorRegister tmp1, VectorRegister tmp2,
+                     Register tmp, BasicType bt, uint vector_length);
+
   void spill(Register r, bool is64, int offset) {
     is64 ? sd(r, Address(sp, offset))
          : sw(r, Address(sp, offset));

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7059,7 +7059,6 @@ instruct regL_not_reg(iRegLNoSp dst, iRegL src1, immL_M1 m1) %{
   ins_pipe(ialu_reg_imm);
 %}
 
-
 // ============================================================================
 // Floating Point Arithmetic Instructions
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -87,6 +87,9 @@ source %{
           return false;
         }
         return UseZvbb;
+      case Op_CompressBitsV:
+      case Op_ExpandBitsV:
+        return bt == T_INT || bt == T_LONG;
       case Op_LoadVectorGather:
       case Op_LoadVectorGatherMasked:
       case Op_StoreVectorScatter:
@@ -150,6 +153,9 @@ source %{
     }
 
     switch (opcode) {
+      case Op_CompressBitsV:
+      case Op_ExpandBitsV:
+        return false;
       case Op_SelectFromTwoVector:
         // There is no masked version of selectFrom two vector, i.e. selectFrom(av, bv, mask) in vector API.
         return false;
@@ -1612,6 +1618,63 @@ instruct vdiv_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
     __ vdiv_vv(as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($dst_src1$$reg),
                as_VectorRegister($src2$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector bit compress
+
+instruct vcompressBits(vReg dst, vReg src, vReg mask,
+                       vReg tmp1, vReg tmp2,
+                       vReg tmp3, vReg tmp4, iRegINoSp tmp) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_INT ||
+            Matcher::vector_element_basic_type(n) == T_LONG);
+  match(Set dst (CompressBitsV src mask));
+  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, TEMP tmp);
+  format %{ "vcompressBits $dst, $src, $mask\t# KILL $tmp1, $tmp2, $tmp3, $tmp4, $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ compress_bits_v(as_VectorRegister($dst$$reg),
+                       as_VectorRegister($src$$reg),
+                       as_VectorRegister($mask$$reg),
+                       as_VectorRegister($tmp1$$reg),
+                       as_VectorRegister($tmp2$$reg),
+                       as_VectorRegister($tmp3$$reg),
+                       as_VectorRegister($tmp4$$reg),
+                       $tmp$$Register, bt, Matcher::vector_length(this));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector bit expand
+
+instruct vexpandBits(vReg dst, vReg src, vReg mask,
+                     vReg tmp1, vReg tmp2, vReg tmp3, vReg tmp4,
+                     vReg tmp5, vReg tmp6, vReg tmp7, vReg tmp8,
+                     vReg tmp9, vReg tmp10, iRegINoSp tmp) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_INT ||
+            Matcher::vector_element_basic_type(n) == T_LONG);
+  match(Set dst (ExpandBitsV src mask));
+  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4,
+         TEMP tmp5, TEMP tmp6, TEMP tmp7, TEMP tmp8,
+         TEMP tmp9, TEMP tmp10, TEMP tmp);
+  format %{ "vexpandBits $dst, $src, $mask\t# KILL $tmp1, $tmp2, $tmp3, $tmp4, $tmp5, $tmp6, $tmp7, $tmp8, $tmp9, $tmp10, $tmp" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ expand_bits_v(as_VectorRegister($dst$$reg),
+                     as_VectorRegister($src$$reg),
+                     as_VectorRegister($mask$$reg),
+                     as_VectorRegister($tmp1$$reg),
+                     as_VectorRegister($tmp2$$reg),
+                     as_VectorRegister($tmp3$$reg),
+                     as_VectorRegister($tmp4$$reg),
+                     as_VectorRegister($tmp5$$reg),
+                     as_VectorRegister($tmp6$$reg),
+                     as_VectorRegister($tmp7$$reg),
+                     as_VectorRegister($tmp8$$reg),
+                     as_VectorRegister($tmp9$$reg),
+                     as_VectorRegister($tmp10$$reg),
+                     $tmp$$Register, bt, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
Hi, This PR adds RISC-V RVV support for the C2 CompressBitsV and ExpandBitsV nodes for int and long element types.

These nodes are generated by Vector API operations such as VectorOperators.COMPRESS_BITS and VectorOperators.EXPAND_BITS, and may also be generated by SuperWord for suitable scalar loops.

This is different from the scalar CompressBits/ExpandBits implementation removed by JDK-8334474. The old implementation used RVV instructions to process one scalar value at a time. This change operates on multiple vector lanes in parallel.

### Performance test
JMH test case: https://bugs.openjdk.org/secure/attachment/121609/VectorCompressExpandBits.java
before this patch:
```
Benchmark                                    Mode  Cnt    Score    Error  Units
VectorCompressExpandBits.intCompressScalar   avgt    5  112.867 ±  0.114  us/op
VectorCompressExpandBits.intCompressVector   avgt    5  195.669 ±  1.495  us/op
VectorCompressExpandBits.intExpandScalar     avgt    5   46.004 ±  0.167  us/op
VectorCompressExpandBits.intExpandVector     avgt    5  217.269 ±  8.046  us/op
VectorCompressExpandBits.longCompressScalar  avgt    5  172.373 ±  0.384  us/op
VectorCompressExpandBits.longCompressVector  avgt    5  316.451 ± 36.286  us/op
VectorCompressExpandBits.longExpandScalar    avgt    5  199.589 ±  0.068  us/op
VectorCompressExpandBits.longExpandVector    avgt    5  287.693 ±  8.183  us/op
Finished running test 'micro:jdk.incubator.vector.VectorCompressExpandBits'
```
after this patch:
```
Benchmark                                    Mode  Cnt    Score   Error  Units
VectorCompressExpandBits.intCompressScalar   avgt    5  112.859 ± 0.040  us/op
VectorCompressExpandBits.intCompressVector   avgt    5   53.248 ± 0.197  us/op
VectorCompressExpandBits.intExpandScalar     avgt    5   45.998 ± 0.221  us/op
VectorCompressExpandBits.intExpandVector     avgt    5   55.824 ± 0.193  us/op
VectorCompressExpandBits.longCompressScalar  avgt    5  171.392 ± 0.792  us/op
VectorCompressExpandBits.longCompressVector  avgt    5  140.685 ± 0.118  us/op
VectorCompressExpandBits.longExpandScalar    avgt    5  199.782 ± 0.210  us/op
VectorCompressExpandBits.longExpandVector    avgt    5  146.945 ± 0.374  us/op
Finished running test 'micro:jdk.incubator.vector.VectorCompressExpandBits'
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391921](https://bugs.openjdk.org/browse/JDK-8391921): RISC-V: Add C2 vector support for CompressBitsV and ExpandBitsV (**Enhancement** - P4)


### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32739/head:pull/32739` \
`$ git checkout pull/32739`

Update a local copy of the PR: \
`$ git checkout pull/32739` \
`$ git pull https://git.openjdk.org/jdk.git pull/32739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32739`

View PR using the GUI difftool: \
`$ git pr show -t 32739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32739.diff">https://git.openjdk.org/jdk/pull/32739.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32739#issuecomment-5587064233)
</details>
