### PR TITLE
8391919: G1: Change G1CardSetGroup* length identifiers to num_regions

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -411,7 +411,7 @@ void G1CollectionSet::add_optional_group(G1CardSetGroup* group,
                                          double predicted_time_ms) {
   _optional_groups.append(group);
   prepare_optional_group(group, num_optional_regions);
-  num_optional_regions += group->length();
+  num_optional_regions += group->num_regions();
   predicted_optional_time_ms += predicted_time_ms;
 }
 
@@ -428,7 +428,7 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
 
   double optional_threshold_ms = time_remaining_ms * _policy->optional_prediction_fraction();
 
-  uint min_num_old_cset_regions = _policy->calc_min_num_old_cset_regions(candidates()->last_marking_candidates_length());
+  uint min_num_old_cset_regions = _policy->calc_min_num_old_cset_regions(candidates()->num_last_marking_candidate_regions());
   uint max_num_old_cset_regions = MAX2(min_num_old_cset_regions, _policy->calc_max_num_old_cset_regions());
   bool check_time_remaining = _policy->use_adaptive_num_young_regions();
 
@@ -471,12 +471,12 @@ double G1CollectionSet::select_candidates_from_marking(double time_remaining_ms)
       add_group_to_collection_set(group);
       selected_groups.append(group);
 
-      num_initial_regions += group->length();
+      num_initial_regions += group->num_regions();
 
       predicted_initial_time_ms += predicted_time_ms;
       // Record the number of regions added with no time remaining
       if (time_remaining_ms == 0.0) {
-        num_expensive_regions += group->length();
+        num_expensive_regions += group->num_regions();
       }
     } else if (!check_time_remaining) {
       // In the non-auto-tuning case, we'll finish adding regions
@@ -550,7 +550,7 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
   G1CardSetGroupList groups_to_abandon;
 
   for (G1CardSetGroup* group : *retained_groups) {
-    assert(group->length() == 1, "Retained groups should have only 1 region");
+    assert(group->num_regions() == 1, "Retained groups should have only 1 region");
 
     double predicted_time_ms = group->predict_group_total_time_ms();
 
@@ -579,13 +579,13 @@ void G1CollectionSet::select_candidates_from_retained(double time_remaining_ms) 
     if (num_initial_regions < min_num_regions || fits_in_remaining_time) {
       predicted_initial_time_ms += predicted_time_ms;
       if (!fits_in_remaining_time) {
-        num_expensive_regions += group->length();
+        num_expensive_regions += group->num_regions();
       }
 
       add_group_to_collection_set(group);
       remove_from_retained.append(group);
 
-      num_initial_regions += group->length();
+      num_initial_regions += group->num_regions();
     } else if (predicted_time_ms <= optional_time_remaining_ms) {
       // Prepare optional collection region.
       add_optional_group(group,
@@ -637,14 +637,14 @@ double G1CollectionSet::select_candidates_from_optional_groups(double time_remai
 
     if (predicted_time_ms > time_remaining_ms) {
       log_debug(gc, ergo, cset)("Prediction %.3fms for group with %u regions does not fit remaining time: %.3fms.",
-                                predicted_time_ms, group->length(), time_remaining_ms);
+                                predicted_time_ms, group->num_regions(), time_remaining_ms);
       break;
     }
 
     total_prediction_ms += predicted_time_ms;
     time_remaining_ms -= predicted_time_ms;
 
-    num_regions_selected += group->length();
+    num_regions_selected += group->num_regions();
 
     add_group_to_collection_set(group);
     selected.append(group);

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -63,8 +63,8 @@ void G1CardSetGroup::calculate_efficiency() {
 }
 
 double G1CardSetGroup::liveness_percent() const {
-  assert(length() > 0, "must be");
-  size_t capacity = length() * G1HeapRegion::GrainBytes;
+  assert(num_regions() > 0, "must be");
+  size_t capacity = num_regions() * G1HeapRegion::GrainBytes;
   return ((capacity - _reclaimable_bytes) * 100.0) / capacity;
 }
 
@@ -106,7 +106,7 @@ double G1CardSetGroup::predict_group_total_time_ms() const {
   size_t card_rs_length = _card_set.occupied();
 
   double merge_scan_time_ms = p->predict_merge_scan_time(card_rs_length);
-  double non_young_other_time_ms = p->predict_non_young_other_time_ms(length());
+  double non_young_other_time_ms = p->predict_non_young_other_time_ms(num_regions());
 
   double total_time_ms = merge_scan_time_ms +
                          predict_code_root_scan_time_ms +
@@ -115,7 +115,7 @@ double G1CardSetGroup::predict_group_total_time_ms() const {
 
   log_trace(gc, ergo, cset) ("Prediction for card set group %u (%u regions): total_time %.2fms card_rs_length %zu merge_scan_time %.2fms code_root_scan_time_ms %.2fms evac_time_ms %.2fms other_time %.2fms bytes_to_copy %zu",
                              group_id(),
-                             length(),
+                             num_regions(),
                              total_time_ms,
                              card_rs_length,
                              merge_scan_time_ms,
@@ -151,10 +151,10 @@ int G1CardSetGroup::compare_gc_efficiency(G1CardSetGroup** gr1, G1CardSetGroup**
 G1CardSetGroupList::G1CardSetGroupList() : _groups(8, mtGC), _num_regions(0) { }
 
 void G1CardSetGroupList::append(G1CardSetGroup* group) {
-  assert(group->length() > 0, "Do not add empty groups");
+  assert(group->num_regions() > 0, "Do not add empty groups");
   assert(!_groups.contains(group), "Already added to list");
   _groups.append(group);
-  _num_regions.store_relaxed(num_regions() + group->length());
+  _num_regions.store_relaxed(num_regions() + group->num_regions());
 }
 
 G1CardSetGroup* G1CardSetGroupList::at(uint index) {
@@ -230,7 +230,7 @@ G1CollectionSetCandidates::G1CollectionSetCandidates() :
   _from_marking_groups(),
   _retained_groups(),
   _max_regions(0),
-  _last_marking_candidates_length(0)
+  _num_last_marking_candidate_regions(0)
 { }
 
 G1CollectionSetCandidates::~G1CollectionSetCandidates() {
@@ -257,7 +257,7 @@ void G1CollectionSetCandidates::clear() {
   for (uint i = 0; i < _max_regions; i++) {
     _contains_map[i] = CandidateOrigin::Invalid;
   }
-  _last_marking_candidates_length = 0;
+  _num_last_marking_candidate_regions = 0;
 }
 
 void G1CollectionSetCandidates::sort_marking_by_efficiency() {
@@ -296,7 +296,7 @@ void G1CollectionSetCandidates::set_candidates_from_marking(GrowableArrayCHeap<G
     assert(!contains(r), "must not contain region %u", r->hrm_index());
     _contains_map[r->hrm_index()] = CandidateOrigin::Marking;
 
-    if (current->length() == group_limit) {
+    if (current->num_regions() == group_limit) {
       if (group_limit != G1OldCardSetGroupSize) {
         group_limit = G1OldCardSetGroupSize;
       }
@@ -313,7 +313,7 @@ void G1CollectionSetCandidates::set_candidates_from_marking(GrowableArrayCHeap<G
   assert(_from_marking_groups.num_regions() == num_candidates, "Must be!");
 
   log_debug(gc, ergo, cset) ("Finished creating %u card set groups from %u regions", _from_marking_groups.length(), num_candidates);
-  _last_marking_candidates_length = num_candidates;
+  _num_last_marking_candidate_regions = num_candidates;
 
   verify();
 }
@@ -337,7 +337,7 @@ void G1CollectionSetCandidates::remove(G1CardSetGroupList* other) {
   G1CardSetGroupList other_retained_groups;
 
   for (G1CardSetGroup* group : *other) {
-    assert(group->length() > 0, "Should not have empty groups");
+    assert(group->num_regions() > 0, "Should not have empty groups");
     // Regions in the same group have the same source (i.e from_marking or retained).
     G1HeapRegion* r = group->region_at(0);
     if (is_from_marking(r)) {
@@ -370,18 +370,18 @@ void G1CollectionSetCandidates::add_retained_region_unsorted(G1HeapRegion* r) {
 }
 
 bool G1CollectionSetCandidates::is_empty() const {
-  return length() == 0;
+  return num_regions() == 0;
 }
 
 bool G1CollectionSetCandidates::has_more_marking_candidates() const {
-  return marking_regions_length() != 0;
+  return num_marking_regions() != 0;
 }
 
-uint G1CollectionSetCandidates::marking_regions_length() const {
+uint G1CollectionSetCandidates::num_marking_regions() const {
   return _from_marking_groups.num_regions();
 }
 
-uint G1CollectionSetCandidates::retained_regions_length() const {
+uint G1CollectionSetCandidates::num_retained_regions() const {
   return _retained_groups.num_regions();
 }
 
@@ -415,13 +415,13 @@ void G1CollectionSetCandidates::verify() {
   }
 
   verify_helper(&_from_marking_groups, from_marking, verify_map);
-  assert(from_marking == marking_regions_length(), "must be");
+  assert(from_marking == num_marking_regions(), "must be");
 
   uint from_marking_retained = 0;
   verify_helper(&_retained_groups, from_marking_retained, verify_map);
   assert(from_marking_retained == 0, "must be");
 
-  assert(length() >= marking_regions_length(), "must be");
+  assert(num_regions() >= num_marking_regions(), "must be");
 
   // Check whether the _contains_map is consistent with the list.
   for (uint i = 0; i < _max_regions; i++) {

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -229,7 +229,7 @@ G1CollectionSetCandidates::G1CollectionSetCandidates() :
   _contains_map(nullptr),
   _from_marking_groups(),
   _retained_groups(),
-  _max_regions(0),
+  _max_num_regions(0),
   _num_last_marking_candidate_regions(0)
 { }
 
@@ -244,17 +244,17 @@ bool G1CollectionSetCandidates::is_from_marking(G1HeapRegion* r) const {
   return _contains_map[r->hrm_index()] == CandidateOrigin::Marking;
 }
 
-void G1CollectionSetCandidates::initialize(uint max_regions) {
+void G1CollectionSetCandidates::initialize(uint max_num_regions) {
   assert(_contains_map == nullptr, "already initialized");
-  _max_regions = max_regions;
-  _contains_map = NEW_C_HEAP_ARRAY(CandidateOrigin, max_regions, mtGC);
+  _max_num_regions = max_num_regions;
+  _contains_map = NEW_C_HEAP_ARRAY(CandidateOrigin, max_num_regions, mtGC);
   clear();
 }
 
 void G1CollectionSetCandidates::clear() {
   _retained_groups.clear(true /* uninstall_card_set_group */);
   _from_marking_groups.clear(true /* uninstall_card_set_group */);
-  for (uint i = 0; i < _max_regions; i++) {
+  for (uint i = 0; i < _max_num_regions; i++) {
     _contains_map[i] = CandidateOrigin::Invalid;
   }
   _num_last_marking_candidate_regions = 0;
@@ -409,8 +409,8 @@ void G1CollectionSetCandidates::verify_helper(G1CardSetGroupList* list, uint& fr
 void G1CollectionSetCandidates::verify() {
   uint from_marking = 0;
 
-  CandidateOrigin* verify_map = NEW_C_HEAP_ARRAY(CandidateOrigin, _max_regions, mtGC);
-  for (uint i = 0; i < _max_regions; i++) {
+  CandidateOrigin* verify_map = NEW_C_HEAP_ARRAY(CandidateOrigin, _max_num_regions, mtGC);
+  for (uint i = 0; i < _max_num_regions; i++) {
     verify_map[i] = CandidateOrigin::Invalid;
   }
 
@@ -424,7 +424,7 @@ void G1CollectionSetCandidates::verify() {
   assert(num_regions() >= num_marking_regions(), "must be");
 
   // Check whether the _contains_map is consistent with the list.
-  for (uint i = 0; i < _max_regions; i++) {
+  for (uint i = 0; i < _max_num_regions; i++) {
     assert(_contains_map[i] == verify_map[i] ||
            (_contains_map[i] != CandidateOrigin::Invalid && verify_map[i] == CandidateOrigin::Verify),
            "Candidate origin does not match for region %u, is %u but should be %u",
@@ -439,7 +439,7 @@ void G1CollectionSetCandidates::verify() {
 
 bool G1CollectionSetCandidates::contains(const G1HeapRegion* r) const {
   const uint index = r->hrm_index();
-  assert(index < _max_regions, "must be");
+  assert(index < _max_num_regions, "must be");
   return _contains_map[index] != CandidateOrigin::Invalid;
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -87,12 +87,12 @@ public:
   G1CardSetGroup();
   G1CardSetGroup(G1CardSetConfiguration* config, G1MonotonicArenaFreePool* card_set_freelist_pool, uint group_id);
   ~G1CardSetGroup() {
-    assert(length() == 0, "post condition!");
+    assert(num_regions() == 0, "post condition!");
   }
 
   void add(G1HeapRegion* hr);
 
-  uint length() const { return (uint)_items.length(); }
+  uint num_regions() const { return (uint)_items.length(); }
 
   G1CardSet* card_set() { return &_card_set; }
   const G1CardSet* card_set() const { return &_card_set; }
@@ -224,7 +224,7 @@ class G1CollectionSetCandidates : public CHeapObj<mtGC> {
   uint _max_regions;
 
   // The number of regions from the last merge of candidates from the marking.
-  uint _last_marking_candidates_length;
+  uint _num_last_marking_candidate_regions;
 
   bool is_from_marking(G1HeapRegion* r) const;
 
@@ -242,10 +242,9 @@ public:
   // Merge collection set candidate regions from marking into the current from_marking candidate
   // group list (which needs to be empty).
   void set_candidates_from_marking(GrowableArrayCHeap<G1HeapRegion*, mtGC>* selected);
-  // The most recent length of the list that had been merged last via
-  // set_candidates_from_marking(). Used for calculating minimum collection set
-  // regions.
-  uint last_marking_candidates_length() const { return _last_marking_candidates_length; }
+  // The number of regions most recently merged using set_candidates_from_marking(). Used for calculating
+  // minimum collection set regions.
+  uint num_last_marking_candidate_regions() const { return _num_last_marking_candidate_regions; }
 
   void sort_by_efficiency();
 
@@ -265,8 +264,8 @@ public:
   bool is_empty() const;
 
   bool has_more_marking_candidates() const;
-  uint marking_regions_length() const;
-  uint retained_regions_length() const;
+  uint num_marking_regions() const;
+  uint num_retained_regions() const;
 
 private:
   void verify_helper(G1CardSetGroupList* list, uint& from_marking, CandidateOrigin* verify_map) PRODUCT_RETURN;
@@ -274,7 +273,7 @@ private:
 public:
   void verify() PRODUCT_RETURN;
 
-  uint length() const { return marking_regions_length() + retained_regions_length(); }
+  uint num_regions() const { return num_marking_regions() + num_retained_regions(); }
 
   template<typename Func>
   void iterate_regions(Func&& f) const;

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -221,7 +221,7 @@ class G1CollectionSetCandidates : public CHeapObj<mtGC> {
   // should contain only one region each, making it easier to evacuate retained regions
   // in any young collection.
   G1CardSetGroupList _retained_groups;
-  uint _max_regions;
+  uint _max_num_regions;
 
   // The number of regions from the last merge of candidates from the marking.
   uint _num_last_marking_candidate_regions;
@@ -235,7 +235,7 @@ public:
   G1CardSetGroupList& from_marking_groups() { return _from_marking_groups; }
   G1CardSetGroupList& retained_groups() { return _retained_groups; }
 
-  void initialize(uint max_regions);
+  void initialize(uint max_num_regions);
 
   void clear();
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -3223,9 +3223,9 @@ void G1PrintRegionLivenessInfoClosure::log_card_set_group_add_total(G1CardSetGro
                           G1PPRL_BYTE_FORMAT
                           G1PPRL_TYPE_H_FORMAT,
                           group->group_id(),
-                          group->length(),
-                          group->length() > 0 ? group->gc_efficiency() : 0.0,
-                          group->length() > 0 ? group->liveness_percent() : 0.0,
+                          group->num_regions(),
+                          group->num_regions() > 0 ? group->gc_efficiency() : 0.0,
+                          group->num_regions() > 0 ? group->liveness_percent() : 0.0,
                           group->card_set()->mem_size(),
                           type);
   _total_remset_bytes += group->card_set()->mem_size();

--- a/src/hotspot/share/gc/g1/g1FullGCResetMetadataTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCResetMetadataTask.cpp
@@ -33,7 +33,7 @@ G1FullGCResetMetadataTask::G1ResetMetadataClosure::G1ResetMetadataClosure(G1Full
 void G1FullGCResetMetadataTask::G1ResetMetadataClosure::reset_region_metadata(G1HeapRegion* hr) {
   if (hr->rem_set()->has_card_set_group()) {
     assert(hr->is_starts_humongous(), "Only humongous start regions can retain a card set group");
-    assert(hr->rem_set()->card_set_group()->length() == 1,
+    assert(hr->rem_set()->card_set_group()->num_regions() == 1,
            "Humongous region card set group must contain exactly one region");
 
     hr->rem_set()->card_set_group()->clear_card_set();

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -508,7 +508,7 @@ uint G1Policy::calculate_desired_num_eden_regions_before_young_only(double base_
 uint G1Policy::calculate_desired_num_eden_regions_before_mixed(double base_time_ms,
                                                                uint min_num_eden_regions,
                                                                uint max_num_eden_regions) const {
-  uint min_num_marking_candidate_regions = MIN2(calc_min_num_old_cset_regions(candidates()->last_marking_candidates_length()),
+  uint min_num_marking_candidate_regions = MIN2(calc_min_num_old_cset_regions(candidates()->num_last_marking_candidate_regions()),
                                                 candidates()->from_marking_groups().num_regions());
   double predicted_region_evac_time_ms = base_time_ms;
   uint num_selected_candidate_regions = 0;
@@ -517,7 +517,7 @@ uint G1Policy::calculate_desired_num_eden_regions_before_mixed(double base_time_
       break;
     }
     predicted_region_evac_time_ms += gr->predict_group_total_time_ms();
-    num_selected_candidate_regions += gr->length();
+    num_selected_candidate_regions += gr->num_regions();
   }
 
   return calculate_desired_num_eden_regions_before_young_only(predicted_region_evac_time_ms,
@@ -545,7 +545,7 @@ double G1Policy::predict_retained_regions_evac_time() const {
                                retained_groups->num_regions());
 
   for (G1CardSetGroup* group : *retained_groups) {
-    assert(group->length() == 1, "We should only have one region in a retained group");
+    assert(group->num_regions() == 1, "We should only have one region in a retained group");
     G1HeapRegion* r = group->region_at(0); // We only have one region per group.
     // We optimistically assume that any regions of these card set groups that contain pinned
     // regions can be evacuated the next gc, so just consider them like normal.

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1079,7 +1079,7 @@ class G1MergeHeapRootsTask : public WorkerTask {
         // that were not reclaimed.
         G1CardSetGroup* group = r->rem_set()->card_set_group();
         assert(group != nullptr, "must have a card set group");
-        assert(group->length() == 1, "Card set groups containing humongous regions must have a single entry");
+        assert(group->num_regions() == 1, "Card set groups containing humongous regions must have a single region");
         group->clear_card_set();
       }
 

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -251,7 +251,7 @@ public:
 
     // Accumulate card set details for regions that are assigned to single-region
     // card set groups. G1HeapRegionRemSet::mem_size() includes the size of the code roots
-    if (hrrs->has_card_set_group() && hrrs->card_set_group()->length() == 1) {
+    if (hrrs->has_card_set_group() && hrrs->card_set_group()->num_regions() == 1) {
       G1CardSet* card_set = hrrs->card_set_group()->card_set();
 
       rs_mem_sz = hrrs->mem_size() + card_set->mem_size();
@@ -294,7 +294,7 @@ public:
   void accumulate_stats_for_group(G1CardSetGroup* group, G1PerRegionTypeRemSetCounters* gen_counter) {
     // If the group has only a single region, then stats were accumulated
     // during region iteration. Skip these.
-    if (group->length() > 1) {
+    if (group->num_regions() > 1) {
       G1CardSet* card_set = group->card_set();
 
       size_t rs_mem_sz = card_set->mem_size();
@@ -321,9 +321,9 @@ public:
       accumulate_stats_for_group(group, &_old);
     }
     // Skip gathering statistics for retained regions. Just verify that they have
-    // the expected amount of regions.
+    // the expected number of regions.
     for (G1CardSetGroup* group : candidates->retained_groups()) {
-      assert(group->length() == 1, "must be");
+      assert(group->num_regions() == 1, "must be");
     }
   }
 
@@ -360,7 +360,7 @@ public:
       G1CardSetGroup* card_set_group = max_card_set_mem_sz_group();
       out->print_cr("    Card Set Group with largest card set = %u:(%u regions), "
                     "size = %zu occupied = %zu",
-                    card_set_group->group_id(), card_set_group->length(),
+                    card_set_group->group_id(), card_set_group->num_regions(),
                     card_set_group->card_set()->mem_size(),
                     card_set_group->card_set()->occupied());
     }

--- a/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
@@ -105,7 +105,7 @@ void G1RemSetTrackingPolicy::update_after_rebuild(G1HeapRegion* r) {
       G1CardSetGroup* group = r->rem_set()->card_set_group();
 
       assert(group != nullptr, "humongous start must have a card set group");
-      assert(group->length() == 1, "humongous group must have only one region");
+      assert(group->num_regions() == 1, "humongous group must have only one region");
 
       group->clear_card_set();
       g1h->humongous_obj_regions_iterate(r,
@@ -120,7 +120,7 @@ void G1RemSetTrackingPolicy::update_after_rebuild(G1HeapRegion* r) {
     size_t occupied = 0;
     // Per-region card set group statistics are only valid if group contains a single region.
     if (r->rem_set()->has_card_set_group() &&
-        r->rem_set()->card_set_group()->length() == 1 ) {
+        r->rem_set()->card_set_group()->num_regions() == 1 ) {
         G1CardSet *card_set = r->rem_set()->card_set_group()->card_set();
         remset_bytes += card_set->mem_size();
         occupied = card_set->occupied();


### PR DESCRIPTION
Hi all,

  please review this change that changes identifiers containing `length` within the `G1CardSetGroup` classes to use `num_region` in some form to continue to have uniform naming in the g1 code.

Testing: gha

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391919](https://bugs.openjdk.org/browse/JDK-8391919): G1: Change G1CardSetGroup* length identifiers to num_regions (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32740/head:pull/32740` \
`$ git checkout pull/32740`

Update a local copy of the PR: \
`$ git checkout pull/32740` \
`$ git pull https://git.openjdk.org/jdk.git pull/32740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32740`

View PR using the GUI difftool: \
`$ git pr show -t 32740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32740.diff">https://git.openjdk.org/jdk/pull/32740.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32740#issuecomment-5573367690)
</details>
