### PR TITLE
8391920: (fs) Improve Files.readSymbolicLink handling of corrupt sym links (win)

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsChannelFactory.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -319,7 +319,7 @@ class WindowsChannelFactory {
         // make the file sparse if needed
         if (dwCreationDisposition == CREATE_NEW && flags.sparse) {
             try {
-                DeviceIoControlSetSparse(handle);
+                DeviceIoControl(handle, FSCTL_SET_SPARSE, 0L, 0);
             } catch (WindowsException x) {
                 // ignore as sparse option is hint
             }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -78,6 +78,11 @@ class WindowsConstants {
     public static final int IO_REPARSE_TAG_DEDUP                = 0x80000013;
     public static final int IO_REPARSE_TAG_CLOUD                = 0x9000001A;
     public static final int IO_REPARSE_TAG_CLOUD_MASK           = 0x0000F000;
+
+    // DeviceIoControl control codes
+    public static final int FSCTL_GET_REPARSE_POINT         = 0x000900A8;
+    public static final int FSCTL_SET_SPARSE                = 0x000900C4;
+
     public static final int MAXIMUM_REPARSE_DATA_BUFFER_SIZE    = 16 * 1024;
     public static final int SYMBOLIC_LINK_FLAG_DIRECTORY        = 0x1;
     public static final int SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE = 0x2;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -328,7 +328,7 @@ class WindowsFileAttributes
             if (isReparsePoint(fileAttrs)) {
                 int size = MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
                 try (NativeBuffer reparseBuffer = NativeBuffers.getNativeBuffer(size)) {
-                    DeviceIoControlGetReparsePoint(handle, reparseBuffer.address(), size);
+                    DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, reparseBuffer.address(), size);
                     reparseTag = (int)unsafe.getLong(reparseBuffer.address());
                 }
             }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -329,7 +329,7 @@ class WindowsFileAttributes
                 int size = MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
                 try (NativeBuffer reparseBuffer = NativeBuffers.getNativeBuffer(size)) {
                     DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, reparseBuffer.address(), size);
-                    reparseTag = (int)unsafe.getLong(reparseBuffer.address());
+                    reparseTag = unsafe.getInt(reparseBuffer.address());
                 }
             }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,14 +291,17 @@ class WindowsLinkSupport {
      */
     static String readLink(WindowsPath path, long handle) throws IOException {
         int size = MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
+        String pathname = path.getPathForExceptionMessage();
         try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(size)) {
+            int bytesReturned;
             try {
-                DeviceIoControlGetReparsePoint(handle, buffer.address(), size);
+                bytesReturned = DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT,
+                                                buffer.address(), size);
             } catch (WindowsException x) {
-                String pathname = path.getPathForExceptionMessage();
-                if (x.lastError() == ERROR_NOT_A_REPARSE_POINT)
+                if (x.lastError() == ERROR_NOT_A_REPARSE_POINT) {
                     throw new NotLinkException(pathname, null, x.errorString());
-                x.rethrowAsIOException(pathname + ": " + x.errorString());
+                }
+                throw x.asIOException(path);
             }
 
             /*
@@ -328,21 +331,39 @@ class WindowsLinkSupport {
              * } REPARSE_DATA_BUFFER
              */
             final short OFFSETOF_REPARSETAG = 0;
+            final short OFFSETOF_REPARSEDATALENGTH = 4;
             final short OFFSETOF_PATHOFFSET = 8;
             final short OFFSETOF_PATHLENGTH = 10;
-            final short OFFSETOF_PATHBUFFER = 16 + 4;   // check this
+            final short OFFSETOF_PATHBUFFER = 20;
+            final short SIZEOF_SYMLINK_REPARSE_BUFFER = 12;
 
             int tag = (int)unsafe.getLong(buffer.address() + OFFSETOF_REPARSETAG);
             if (tag != IO_REPARSE_TAG_SYMLINK) {
-                String pathname = path.getPathForExceptionMessage();
                 throw new NotLinkException(pathname, null, "Reparse point is not a symbolic link");
             }
 
-            // get offset and length of target
-            short nameOffset = unsafe.getShort(buffer.address() + OFFSETOF_PATHOFFSET);
-            short nameLengthInBytes = unsafe.getShort(buffer.address() + OFFSETOF_PATHLENGTH);
-            if ((nameLengthInBytes % 2) != 0)
-                throw new FileSystemException(null, null, "Symbolic link corrupted");
+            // minimum size of valid symbolic-link REPARSE_DATA_BUFFER is 20 bytes
+            if (bytesReturned < OFFSETOF_PATHBUFFER) {
+                throw new NotLinkException(pathname, null, "Symbolic link corrupted");
+            }
+
+            int reparseDataLength = Short.toUnsignedInt(
+                unsafe.getShort(buffer.address() + OFFSETOF_REPARSEDATALENGTH));
+            int nameOffset = Short.toUnsignedInt(
+                unsafe.getShort(buffer.address() + OFFSETOF_PATHOFFSET));
+            int nameLengthInBytes = Short.toUnsignedInt(
+                unsafe.getShort(buffer.address() + OFFSETOF_PATHLENGTH));
+            int pathBufferSize = reparseDataLength - SIZEOF_SYMLINK_REPARSE_BUFFER;
+
+            // returned data must contain the fixed fields and an even-length
+            // UTF-16 name whose offset and length are within the path buffer
+            if ((reparseDataLength < SIZEOF_SYMLINK_REPARSE_BUFFER)
+                    || (reparseDataLength > bytesReturned - 8)
+                    || ((nameLengthInBytes & 1) != 0)
+                    || (nameOffset > pathBufferSize)
+                    || (nameLengthInBytes > pathBufferSize - nameOffset)) {
+                throw new NotLinkException(pathname, null, "Symbolic link corrupted");
+            }
 
             // copy into char array
             char[] name = new char[nameLengthInBytes/2];
@@ -352,7 +373,7 @@ class WindowsLinkSupport {
             // remove special prefix
             String target = stripPrefix(new String(name));
             if (target.isEmpty()) {
-                throw new IOException("Symbolic link target is invalid");
+                throw new NotLinkException(pathname, null, "Symbolic link target is empty");
             }
 
             // return normalized path string

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
@@ -44,7 +44,7 @@ class WindowsLinkSupport {
     }
 
     /**
-     * Creates a symbolic link, retyring if not privileged
+     * Creates a symbolic link, retrying if not privileged
      */
     static void createSymbolicLink(String link, String target, int flags)
         throws WindowsException
@@ -148,7 +148,7 @@ class WindowsLinkSupport {
             try {
                 WindowsFileAttributes attrs =
                     WindowsFileAttributes.get(target, false);
-                // non a link so we are done
+                // not a link so we are done
                 if (!attrs.isSymbolicLink()) {
                     return target.getPathForWin32Calls();
                 }
@@ -207,7 +207,7 @@ class WindowsLinkSupport {
         char c1 = path.charAt(1);
         if ((c0 <= 'z' && c0 >= 'a' || c0 <= 'Z' && c0 >= 'A') &&
             c1 == ':' && path.charAt(2) == '\\') {
-            // Driver specifier
+            // Drive specifier
             sb.append(Character.toUpperCase(c0));
             sb.append(":\\");
             start = 3;
@@ -315,6 +315,7 @@ class WindowsLinkSupport {
              *             USHORT  SubstituteNameLength;
              *             USHORT  PrintNameOffset;
              *             USHORT  PrintNameLength;
+             *             ULONG   Flags;
              *             WCHAR  PathBuffer[1];
              *         } SymbolicLinkReparseBuffer;
              *         struct {
@@ -335,9 +336,10 @@ class WindowsLinkSupport {
             final short OFFSETOF_PATHOFFSET = 8;
             final short OFFSETOF_PATHLENGTH = 10;
             final short OFFSETOF_PATHBUFFER = 20;
+            final short SIZEOF_REPARSE_DATA_BUFFER_HEADER = 8;
             final short SIZEOF_SYMLINK_REPARSE_BUFFER = 12;
 
-            int tag = (int)unsafe.getLong(buffer.address() + OFFSETOF_REPARSETAG);
+            int tag = unsafe.getInt(buffer.address() + OFFSETOF_REPARSETAG);
             if (tag != IO_REPARSE_TAG_SYMLINK) {
                 throw new NotLinkException(pathname, null, "Reparse point is not a symbolic link");
             }
@@ -358,7 +360,8 @@ class WindowsLinkSupport {
             // returned data must contain the fixed fields and an even-length
             // UTF-16 name whose offset and length are within the path buffer
             if ((reparseDataLength < SIZEOF_SYMLINK_REPARSE_BUFFER)
-                    || (reparseDataLength > bytesReturned - 8)
+                    || (reparseDataLength > bytesReturned - SIZEOF_REPARSE_DATA_BUFFER_HEADER)
+                    || ((nameOffset & 1) != 0)
                     || ((nameLengthInBytes & 1) != 0)
                     || (nameOffset > pathBufferSize)
                     || (nameLengthInBytes > pathBufferSize - nameOffset)) {
@@ -382,7 +385,7 @@ class WindowsLinkSupport {
     }
 
     /**
-     * Resolve all symbolic-links in a given absolute and normalized path
+     * Resolve all symbolic links in a given absolute and normalized path
      */
     private static WindowsPath resolveAllLinks(WindowsPath path)
         throws IOException

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -141,23 +141,18 @@ class WindowsNativeDispatcher {
         throws WindowsException;
 
     /**
-     * Marks a file as a sparse file.
-     *
      * DeviceIoControl(
-     *   FSCTL_SET_SPARSE
+     *   HANDLE hDevice,
+     *   DWORD dwIoControlCode,
+     *   NULL,
+     *   0,
+     *   LPVOID lpOutBuffer,
+     *   DWORD nOutBufferSize,
+     *   LPDWORD lpBytesReturned,
+     *   NULL
      * )
      */
-    static native void DeviceIoControlSetSparse(long handle)
-        throws WindowsException;
-
-    /**
-     * Retrieves the reparse point data associated with the file or directory.
-     *
-     * DeviceIoControl(
-     *   FSCTL_GET_REPARSE_POINT
-     * )
-     */
-    static native void DeviceIoControlGetReparsePoint(long handle,
+    static native int DeviceIoControl(long handle, int dwIoControlCode,
         long bufferAddress, int bufferSize) throws WindowsException;
 
     /**

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -278,30 +278,21 @@ Java_sun_nio_fs_WindowsNativeDispatcher_CreateFile0(JNIEnv* env, jclass this,
     return ptr_to_jlong(handle);
 }
 
-JNIEXPORT void JNICALL
-Java_sun_nio_fs_WindowsNativeDispatcher_DeviceIoControlSetSparse(JNIEnv* env, jclass this,
-    jlong handle)
-{
-    DWORD bytesReturned;
-    HANDLE h = (HANDLE)jlong_to_ptr(handle);
-    if (DeviceIoControl(h, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &bytesReturned, NULL) == 0) {
-        throwWindowsException(env, GetLastError());
-    }
-}
-
-JNIEXPORT void JNICALL
-Java_sun_nio_fs_WindowsNativeDispatcher_DeviceIoControlGetReparsePoint(JNIEnv* env, jclass this,
-    jlong handle, jlong bufferAddress, jint bufferSize)
+JNIEXPORT jint JNICALL
+Java_sun_nio_fs_WindowsNativeDispatcher_DeviceIoControl(JNIEnv* env, jclass this,
+    jlong handle, jint dwIoControlCode, jlong bufferAddress, jint bufferSize)
 {
     DWORD bytesReturned;
     HANDLE h = (HANDLE)jlong_to_ptr(handle);
     LPVOID outBuffer = (LPVOID)jlong_to_ptr(bufferAddress);
 
-    if (DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, NULL, 0, outBuffer, (DWORD)bufferSize,
+    if (DeviceIoControl(h, (DWORD)dwIoControlCode, NULL, 0, outBuffer, (DWORD)bufferSize,
                         &bytesReturned, NULL) == 0)
     {
         throwWindowsException(env, GetLastError());
+        return 0;
     }
+    return (jint)bytesReturned;
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
This is Windows specific cleanup/improvements to the readSymbolicLink implementation. The existing code does some basic checking when the reparse tag is IO_REPARSE_TAG_SYMLINK. The checks are improved so there is a useful exception.

The highly specific DeviceIoControlSetSparse and DeviceIoControlGetReparsePoint are replaced with a more general DeviceIoControl and the use-sites updated.

Testing: tier1-2, no new tests needed as it's not possible to create a special reparse point for testing without special setup.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391920](https://bugs.openjdk.org/browse/JDK-8391920): (fs) Improve Files.readSymbolicLink handling of corrupt sym links (win) (**Enhancement** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32741/head:pull/32741` \
`$ git checkout pull/32741`

Update a local copy of the PR: \
`$ git checkout pull/32741` \
`$ git pull https://git.openjdk.org/jdk.git pull/32741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32741`

View PR using the GUI difftool: \
`$ git pr show -t 32741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32741.diff">https://git.openjdk.org/jdk/pull/32741.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32741#issuecomment-5581505400)
</details>
