### PR TITLE
8266283: java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java fails with "Failed: wrong text location"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -358,7 +358,6 @@ java/awt/Robot/Delay/InterruptOfDelay.java 8265986 macosx-all
 java/awt/Robot/InfiniteLoopException.java 8342638 windows-all,linux-all
 java/awt/MenuBar/TestNoScreenMenuBar.java 8265987 macosx-all
 
-java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 generic-all
 java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all
 java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java 8257529 windows-x64
 java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeForModalDialogTest/ConsumeForModalDialogTest.java 8302787 windows-all

--- a/test/jdk/java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java
+++ b/test/jdk/java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java
@@ -48,7 +48,7 @@ public final class DrawRotatedStringUsingRotatedFont {
     private static final int SIZE = 500;
     private static final String STR = "MMMMMMMMMMMMMMMM";
 
-    private static AffineTransform[] txs = {
+    private static final AffineTransform[] txs = {
                             AffineTransform.getRotateInstance(toRadians(00)),
                             AffineTransform.getRotateInstance(toRadians(45)),
                             AffineTransform.getRotateInstance(toRadians(-45)),
@@ -68,19 +68,23 @@ public final class DrawRotatedStringUsingRotatedFont {
                             AffineTransform.getRotateInstance(toRadians(-360))
     };
 
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) throws Exception {
+
+        final Font font = new Font(Font.DIALOG, Font.PLAIN, 20);
+
         for (final AffineTransform tx2 : txs) {
             for (final AffineTransform tx1 : txs) {
                 for (final boolean aa : new boolean[]{true, false}) {
-                    final BufferedImage bi1 = createImage(aa, tx1, tx2);
-                    final BufferedImage bi2 = createImage(aa, tx2, tx1);
+                    final BufferedImage bi1 = createImage(font, aa, tx1, tx2);
+                    final BufferedImage bi2 = createImage(font, aa, tx2, tx1);
                     compareImage(bi1, bi2);
-                    fillTextArea(bi1, tx1, tx2);
-                    fillTextArea(bi2, tx2, tx1);
+                    fillTextArea(bi1, font, tx1, tx2);
+                    fillTextArea(bi2, font, tx2, tx1);
                     checkColors(bi1, bi2);
                 }
             }
         }
+
         System.out.println("Passed");
     }
 
@@ -88,8 +92,7 @@ public final class DrawRotatedStringUsingRotatedFont {
      * Compares two images.
      */
     private static void compareImage(final BufferedImage bi1,
-                                     final BufferedImage bi2)
-            throws IOException {
+                                        final BufferedImage bi2) throws IOException {
         for (int i = 0; i < SIZE; ++i) {
             for (int j = 0; j < SIZE; ++j) {
                 if (bi1.getRGB(i, j) != bi2.getRGB(i, j)) {
@@ -105,8 +108,7 @@ public final class DrawRotatedStringUsingRotatedFont {
      * Checks an image color. RED and GREEN are allowed only.
      */
     private static void checkColors(final BufferedImage bi1,
-                                    final BufferedImage bi2)
-            throws IOException {
+                                       final BufferedImage bi2) throws IOException {
         for (int i = 0; i < SIZE; ++i) {
             for (int j = 0; j < SIZE; ++j) {
                 final int rgb1 = bi1.getRGB(i, j);
@@ -114,7 +116,7 @@ public final class DrawRotatedStringUsingRotatedFont {
                 if (rgb1 != rgb2 || rgb1 != 0xFFFF0000 && rgb1 != 0xFF00FF00) {
                     ImageIO.write(bi1, "png", new File("image1.png"));
                     ImageIO.write(bi2, "png", new File("image2.png"));
-                    throw new RuntimeException("Failed: wrong text location");
+                    throw new RuntimeException("Failed: wrong color");
                 }
             }
         }
@@ -124,7 +126,8 @@ public final class DrawRotatedStringUsingRotatedFont {
      * Creates an BufferedImage and draws a text, using two transformations,
      * one for graphics and one for font.
      */
-    private static BufferedImage createImage(final boolean aa,
+    private static BufferedImage createImage(final Font font,
+                                             final boolean aa,
                                              final AffineTransform gtx,
                                              final AffineTransform ftx) {
         final BufferedImage bi = new BufferedImage(SIZE, SIZE, TYPE_INT_RGB);
@@ -137,7 +140,7 @@ public final class DrawRotatedStringUsingRotatedFont {
         bg.translate(100, 100);
         bg.transform(gtx);
         bg.setColor(Color.BLACK);
-        bg.setFont(bg.getFont().deriveFont(20.0f).deriveFont(ftx));
+        bg.setFont(font.deriveFont(20.0f).deriveFont(ftx));
         bg.drawString(STR, 0, 0);
         bg.dispose();
         return bi;
@@ -147,6 +150,7 @@ public final class DrawRotatedStringUsingRotatedFont {
      * Fills the area of text using green solid color.
      */
     private static void fillTextArea(final BufferedImage bi,
+                                     final Font font,
                                      final AffineTransform tx1,
                                      final AffineTransform tx2) {
         final Graphics2D bg = bi.createGraphics();
@@ -154,10 +158,10 @@ public final class DrawRotatedStringUsingRotatedFont {
         bg.transform(tx1);
         bg.transform(tx2);
         bg.setColor(Color.GREEN);
-        final Font font = bg.getFont().deriveFont(20.0f);
-        bg.setFont(font);
-        bg.fill(font.getStringBounds(STR, bg.getFontRenderContext()));
+        final Font derivedFont = font.deriveFont(20.0f);
+        bg.setFont(derivedFont);
+        bg.fill(derivedFont.getStringBounds(STR, bg.getFontRenderContext()));
         bg.dispose();
     }
-}
 
+}


### PR DESCRIPTION
Test used to fail on linux in CI in older releases but with upgrade in harfbuzz and linux, with current jdk, it is not failing now in several iterations in linux and other platforms (CI test job in JBS) so deproblemlisting 




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8266283](https://bugs.openjdk.org/browse/JDK-8266283): java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java fails with "Failed: wrong text location" (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) 🔄 Re-review required (review applies to [0bc3fc6f](https://git.openjdk.org/jdk/pull/32742/files/0bc3fc6fd1b3ae8a2a4643e80cc8eb3c5339b8d7))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32742/head:pull/32742` \
`$ git checkout pull/32742`

Update a local copy of the PR: \
`$ git checkout pull/32742` \
`$ git pull https://git.openjdk.org/jdk.git pull/32742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32742`

View PR using the GUI difftool: \
`$ git pr show -t 32742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32742.diff">https://git.openjdk.org/jdk/pull/32742.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32742#issuecomment-5573567937)
</details>
