### PR TITLE
8390945: Make gtest random sampling reproducible

### DIFF
--- a/test/hotspot/gtest/gc/g1/test_g1RegionMap.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1RegionMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
  */
 
 #include "gc/g1/g1CommittedRegionMap.inline.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "unittest.hpp"
 
 class G1CommittedRegionMapSerial : public G1CommittedRegionMap {
@@ -41,7 +41,7 @@ protected:
 };
 
 static bool mutate() {
-  return os::random() % 2 == 0;
+  return GtestRandom::random() % 2 == 0;
 }
 
 static void generate_random_map(G1CommittedRegionMap* map) {

--- a/test/hotspot/gtest/gc/g1/test_g1ServiceThread.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1ServiceThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 #include "gc/g1/g1ServiceThread.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/autoRestore.hpp"
 #include "unittest.hpp"
 
@@ -139,7 +140,7 @@ TEST_VM(G1ServiceTaskQueue, add_ordered) {
   // random multiplier.
   for (jlong now = 0; now < 1000000; now++) {
     // Random multiplier is at least 1 to ensure progress.
-    int multiplier = 1 + os::random() % 10;
+    int multiplier = 1 + GtestRandom::random() % 10;
     while (queue.front()->time() < now) {
       TestTask* task = (TestTask*) queue.front();
       queue.remove_front();

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -139,6 +139,30 @@ class JVMInitializerListener : public ::testing::EmptyTestEventListener {
   }
 };
 
+class RandomSeedListener : public ::testing::EmptyTestEventListener {
+ private:
+  int _seed = 0;
+
+ public:
+  virtual void OnTestIterationStart(const ::testing::UnitTest& unit_test, int) {
+    _seed = unit_test.random_seed();
+    printf("Random seed: %d (reproduce with --gtest_random_seed=%d)\n", _seed, _seed);
+    fflush(stdout);
+  }
+
+  virtual void OnTestStart(const ::testing::TestInfo&) {
+    os::init_random(static_cast<unsigned int>(_seed));
+  }
+
+  virtual void OnTestEnd(const ::testing::TestInfo& test_info) {
+    if (test_info.result()->Failed()) {
+      printf("Random seed for failed test: %d "
+             "(reproduce with --gtest_random_seed=%d)\n", _seed, _seed);
+      fflush(stdout);
+    }
+  }
+};
+
 static char* get_java_home_arg(int argc, char** argv) {
   for (int i = 0; i < argc; i++) {
     if (strncmp(argv[i], "-jdk", strlen(argv[i])) == 0) {
@@ -270,6 +294,7 @@ static void runUnitTestsInner(int argc, char** argv) {
   argv = remove_test_runner_arguments(&argc, argv);
 
 
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
   JVMInitializerListener* jvm_listener = nullptr;
 
   if (is_vmassert_test || is_othervm_test) {
@@ -282,10 +307,11 @@ static void runUnitTestsInner(int argc, char** argv) {
       abort();
     }
   } else {
-    ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
     jvm_listener = new JVMInitializerListener(argc, argv);
     listeners.Append(jvm_listener);
   }
+  // Seed after JVM initialization so it cannot consume the test's random sequence.
+  listeners.Append(new RandomSeedListener());
 
   int result = RUN_ALL_TESTS();
 

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -26,6 +26,7 @@
 #include "jni.h"
 #include "runtime/os.hpp"
 #include "runtime/thread.inline.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/permitForbiddenFunctions.hpp"
 #include "unittest.hpp"
@@ -151,7 +152,7 @@ class RandomSeedListener : public ::testing::EmptyTestEventListener {
   }
 
   virtual void OnTestStart(const ::testing::TestInfo&) {
-    os::init_random(static_cast<unsigned int>(_seed));
+    GtestRandom::init(static_cast<unsigned int>(_seed));
   }
 
   virtual void OnTestEnd(const ::testing::TestInfo& test_info) {
@@ -310,7 +311,6 @@ static void runUnitTestsInner(int argc, char** argv) {
     jvm_listener = new JVMInitializerListener(argc, argv);
     listeners.Append(jvm_listener);
   }
-  // Seed after JVM initialization so it cannot consume the test's random sequence.
   listeners.Append(new RandomSeedListener());
 
   int result = RUN_ALL_TESTS();

--- a/test/hotspot/gtest/gtestRandom.cpp
+++ b/test/hotspot/gtest/gtestRandom.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "gtestRandom.hpp"
+#include "runtime/atomicAccess.hpp"
+#include "runtime/os.hpp"
+
+// Valid non-zero fallback before the listener supplies the GoogleTest seed.
+volatile unsigned int GtestRandom::_seed = 1;
+
+void GtestRandom::init(unsigned int seed) {
+  AtomicAccess::store(&_seed, seed);
+}
+
+int GtestRandom::random() {
+  while (true) {
+    unsigned int seed = _seed;
+    unsigned int next_seed = os::next_random(seed);
+    if (AtomicAccess::cmpxchg(&_seed, seed, next_seed, memory_order_relaxed) == seed) {
+      return static_cast<int>(next_seed);
+    }
+  }
+}

--- a/test/hotspot/gtest/gtestRandom.hpp
+++ b/test/hotspot/gtest/gtestRandom.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef GTEST_RANDOM_HPP
+#define GTEST_RANDOM_HPP
+
+#include "memory/allStatic.hpp"
+
+// Pseudo-random generator for gtest data sampling. The gtest harness resets
+// the state from the GoogleTest seed before each test.
+class GtestRandom : public AllStatic {
+private:
+  static volatile unsigned int _seed;
+
+public:
+  static void init(unsigned int seed);
+  static int random();
+};
+
+#endif // GTEST_RANDOM_HPP

--- a/test/hotspot/gtest/jfr/test_adaptiveSampler.cpp
+++ b/test/hotspot/gtest/jfr/test_adaptiveSampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Datadog, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,6 +38,7 @@
 #include "jfr/utilities/jfrTimeConverter.hpp"
 #include "jfr/utilities/jfrTryLock.hpp"
 #include "logging/log.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/spinCriticalSection.hpp"
 #include "unittest.hpp"
@@ -150,16 +151,16 @@ class JfrGTestAdaptiveSampling : public ::testing::Test {
 
  public:
   size_t incoming_uniform() const {
-    return os::random() % max_population_per_window + min_population_per_window;
+    return GtestRandom::random() % max_population_per_window + min_population_per_window;
   }
 
   size_t incoming_bursty_10_percent() const {
-    bool is_burst = (os::random() % 100) < 10; // 10% burst chance
+    bool is_burst = (GtestRandom::random() % 100) < 10; // 10% burst chance
     return is_burst ? max_population_per_window : min_population_per_window;
   }
 
   size_t incoming_bursty_90_percent() const {
-    bool is_burst = (os::random() % 100) < 90; // 90% burst chance
+    bool is_burst = (GtestRandom::random() % 100) < 90; // 90% burst chance
     return is_burst ? max_population_per_window : min_population_per_window;
   }
 
@@ -207,7 +208,7 @@ void JfrGTestAdaptiveSampling::test(JfrGTestAdaptiveSampling::incoming inc, size
     const size_t incoming_events = (this->*inc)();
     for (size_t i = 0; i < incoming_events; i++) {
       ++population_size;
-      size_t index = os::random() % 100;
+      size_t index = GtestRandom::random() % 100;
       population[index] += 1;
       if (sampler.sample()) {
         ++sample_size;

--- a/test/hotspot/gtest/logging/test_logOutputList.cpp
+++ b/test/hotspot/gtest/logging/test_logOutputList.cpp
@@ -26,7 +26,7 @@
 #include "logging/logLevel.hpp"
 #include "logging/logOutput.hpp"
 #include "logging/logOutputList.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "unittest.hpp"
 
 // Count the outputs in the given list, starting from the specified level
@@ -76,7 +76,6 @@ TEST(LogOutputList, set_output_level_update) {
   size_t outputs_on_level[LogLevel::Count];
   LogLevelType expected_level_for_output[TestOutputCount];
 
-  os::init_random(0x4711);
   for (size_t i = 0; i < LogLevel::Count; i++) {
     outputs_on_level[i] = 0;
   }
@@ -86,8 +85,8 @@ TEST(LogOutputList, set_output_level_update) {
   }
 
   for (size_t iteration = 0; iteration < TestIterations; iteration++) {
-    size_t output_idx = os::random() % TestOutputCount;
-    size_t levelnum = os::random() % LogLevel::Count;
+    size_t output_idx = GtestRandom::random() % TestOutputCount;
+    size_t levelnum = GtestRandom::random() % LogLevel::Count;
     LogLevelType level = static_cast<LogLevelType>(levelnum);
 
     // Update the expectations

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 SAP SE. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -24,10 +24,10 @@
  */
 
 #include "memory/arena.hpp"
-#include "runtime/os.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "unittest.hpp"
+#include "gtestRandom.hpp"
 #include "testutils.hpp"
 
 #define ASSERT_CONTAINS(ar, p) ASSERT_TRUE(ar.contains(p))
@@ -235,10 +235,10 @@ TEST_VM(Arena, random_allocs) {
 
   // Allocate
   for (int i = 0; i < num_allocs; i ++) {
-    size_t size = os::random() % (avg_alloc_size * 2); // Note: size==0 is okay; we want to test that too
+    size_t size = GtestRandom::random() % (avg_alloc_size * 2); // Note: size==0 is okay; we want to test that too
     size_t alignment = 0;
     void* p = nullptr;
-    if (os::random() % 2) { // randomly switch between Amalloc and AmallocWords
+    if (GtestRandom::random() % 2) { // randomly switch between Amalloc and AmallocWords
       p = ar.Amalloc(size);
       alignment = BytesPerLong;
     } else {
@@ -266,7 +266,7 @@ TEST_VM(Arena, random_allocs) {
 
   // realloc all of them
   for (int i = 0; i < num_allocs; i ++) {
-    size_t new_size = os::random() % (avg_alloc_size * 2);  // Note: 0 is possible and should work
+    size_t new_size = GtestRandom::random() % (avg_alloc_size * 2);  // Note: 0 is possible and should work
     void* p2 = ar.Arealloc(ptrs[i], sizes[i], new_size);
     if (new_size > 0) {
       ASSERT_NOT_NULL(p2);
@@ -292,7 +292,7 @@ TEST_VM(Arena, random_allocs) {
 
   // Randomly free a bunch of allocations.
   for (int i = 0; i < num_allocs; i ++) {
-    if (os::random() % 10 == 0) {
+    if (GtestRandom::random() % 10 == 0) {
       ar.Afree(ptrs[i], sizes[i]);
       // In debug builds the freed space should be filled the space with badResourceValue
       DEBUG_ONLY(ASSERT_RANGE_IS_MARKED_WITH(ptrs[i], sizes[i], badResourceValue));
@@ -353,13 +353,13 @@ TEST_VM(Arena, Arena_grows_large_unaligned) {
 
 static size_t random_arena_chunk_size() {
   // Return with a 50% rate a standard size, otherwise some random size
-  if (os::random() % 10 < 5) {
+  if (GtestRandom::random() % 10 < 5) {
     static const size_t standard_sizes[4] = {
         Chunk::tiny_size, Chunk::init_size, Chunk::size, Chunk::medium_size
     };
-    return standard_sizes[os::random() % 4];
+    return standard_sizes[GtestRandom::random() % 4];
   }
-  return ARENA_ALIGN(os::random() % 1024);
+  return ARENA_ALIGN(GtestRandom::random() % 1024);
 }
 
 TEST_VM(Arena, different_chunk_sizes) {

--- a/test/hotspot/gtest/metaspace/metaspaceGtestCommon.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestCommon.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,7 +27,7 @@
 #define GTEST_METASPACE_METASPACEGTESTCOMMON_HPP
 
 #include "memory/allocation.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "unittest.hpp"
 
@@ -101,13 +101,13 @@ public:
   size_t get() const {
     size_t l1 = _min;
     size_t l2 = _max;
-    int r = os::random() % 1000;
+    int r = GtestRandom::random() % 1000;
     if ((float)r < _outlier_chance * 1000.0) {
       l1 = _outlier_min;
       l2 = _outlier_max;
     }
     const size_t d = l2 - l1;
-    return l1 + (os::random() % d);
+    return l1 + (GtestRandom::random() % d);
   }
 
 }; // end RandSizeGenerator

--- a/test/hotspot/gtest/metaspace/metaspaceGtestRangeHelpers.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestRangeHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,7 +31,7 @@
 
 #include "memory/allocation.hpp"
 #include "memory/metaspace/chunklevel.hpp"
-#include "runtime/os.hpp" // For os::random
+#include "gtestRandom.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -49,9 +49,9 @@ class Range : public StackObj {
 
   static Td random_uncapped_offset() {
     if (sizeof(Td) > 4) {
-      return (Td)((uint64_t)os::random() * os::random());
+      return (Td)((uint64_t)GtestRandom::random() * GtestRandom::random());
     } else {
-      return (Td)os::random();
+      return (Td)GtestRandom::random();
     }
   }
 

--- a/test/hotspot/gtest/metaspace/test_blocktree.cpp
+++ b/test/hotspot/gtest/metaspace/test_blocktree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,6 +29,7 @@
 #include "memory/resourceArea.hpp"
 // #define LOG_PLEASE
 #include "metaspaceGtestCommon.hpp"
+#include "gtestRandom.hpp"
 
 using metaspace::BlockTree;
 using metaspace::MemRangeCounter;
@@ -341,7 +342,7 @@ class BlockTreeTest {
     for (int i = 0; i < iterations; i++) {
       int taker = 0;
       int giver = 1;
-      if ((os::random() % 10) > 5) {
+      if ((GtestRandom::random() % 10) > 5) {
         giver = 0; taker = 1;
       }
       size_t s =_rgen.get();

--- a/test/hotspot/gtest/metaspace/test_chunkheaderpool.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkheaderpool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,6 +28,7 @@
 #include "memory/metaspace/metachunk.hpp"
 //#define LOG_PLEASE
 #include "metaspaceGtestCommon.hpp"
+#include "gtestRandom.hpp"
 
 using metaspace::ChunkHeaderPool;
 using metaspace::Metachunk;
@@ -92,7 +93,7 @@ class ChunkHeaderPoolTest {
   void test_random_alloc_free(int num_iterations) {
 
     for (int iter = 0; iter < num_iterations; iter++) {
-      size_t index = (size_t)os::random() % max_cap;
+      size_t index = (size_t)GtestRandom::random() % max_cap;
       attempt_allocate_or_free_at(index);
     }
 

--- a/test/hotspot/gtest/metaspace/test_commitmask.cpp
+++ b/test/hotspot/gtest/metaspace/test_commitmask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,14 +27,14 @@
 #include "memory/metaspace/metaspaceSettings.hpp"
 #include "metaspaceGtestCommon.hpp"
 #include "metaspaceGtestRangeHelpers.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 
 using metaspace::CommitMask;
 using metaspace::Settings;
 
-static int get_random(int limit) { return os::random() % limit; }
+static int get_random(int limit) { return GtestRandom::random() % limit; }
 
 class CommitMaskTest {
   const MetaWord* const _base;
@@ -224,7 +224,7 @@ class CommitMaskTest {
       // A random range
       SizeRange r = SizeRange(_word_size).random_aligned_subrange(Settings::commit_granule_words());
 
-      if (os::random() % 100 < 50) {
+      if (GtestRandom::random() % 100 < 50) {
         _mask.mark_range_as_committed(_base + r.lowest(), r.size());
         map.set_range(r.lowest(), r.end());
       } else {
@@ -336,9 +336,9 @@ TEST_VM(metaspace, commit_mask_random) {
 
     // make up a range out of thin air
     const MetaWord* const base =
-        align_down( (const MetaWord*) ((uintptr_t) os::random() * os::random()),
+        align_down( (const MetaWord*) ((uintptr_t) GtestRandom::random() * GtestRandom::random()),
                     Settings::commit_granule_bytes());
-    const size_t len = align_up( 1 + (os::random() % M),
+    const size_t len = align_up( 1 + (GtestRandom::random() % M),
                     Settings::commit_granule_words());
 
     CommitMaskTest test(base, len);

--- a/test/hotspot/gtest/metaspace/test_metachunk.cpp
+++ b/test/hotspot/gtest/metaspace/test_metachunk.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
 #include "metaspaceGtestCommon.hpp"
 #include "metaspaceGtestContexts.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "gtestRandom.hpp"
 
 using metaspace::ChunkManager;
 using metaspace::FreeChunkListVector;
@@ -315,7 +316,7 @@ TEST_VM(metaspace, chunk_split_and_merge) {
     // We allocate from this chunk to be able to completely paint the payload.
     context.allocate_from_chunk(c, c->word_size());
 
-    const uintx canary = os::random();
+    const uintx canary = GtestRandom::random();
     fill_range_with_pattern(c->base(), c->word_size(), canary);
 
     FreeChunkListVector splinters;

--- a/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,6 +38,7 @@
 #include "metaspaceGtestCommon.hpp"
 #include "metaspaceGtestContexts.hpp"
 #include "metaspaceGtestSparseArray.hpp"
+#include "gtestRandom.hpp"
 
 using metaspace::AllocationAlignmentByteSize;
 using metaspace::ArenaGrowthPolicy;
@@ -196,7 +197,7 @@ public:
   // Deallocate a random allocation
   void checked_random_deallocate() {
     allocation_t* a = _allocations;
-    while (a && a->p != nullptr && os::random() % 10 != 0) {
+    while (a && a->p != nullptr && GtestRandom::random() % 10 != 0) {
       a = a->next;
     }
     if (a != nullptr && a->p != nullptr) {

--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -28,6 +28,7 @@
 #include "nmt/memTracker.hpp"
 #include "runtime/os.hpp"
 #include "sanitizers/address.hpp"
+#include "gtestRandom.hpp"
 #include "testutils.hpp"
 #include "unittest.hpp"
 
@@ -135,7 +136,7 @@ TEST_VM(NMT, random_reallocs) {
   GtestUtils::mark_range_with(p, size, content);
 
   for (int n = 0; n < 100; n ++) {
-    size_t new_size = (size_t)(os::random() % 512) + 1;
+    size_t new_size = (size_t)(GtestRandom::random() % 512) + 1;
     // LOG_HERE("reallocating %zu->%zu", size, new_size);
     p = do_realloc(p, size, new_size, content, nmt_enabled);
     size = new_size;

--- a/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #include "jvm_io.h"
 #include "memory/allocation.hpp"
 #include "nmt/nmtPreInit.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
@@ -36,7 +36,7 @@ static size_t small_random_nonzero_size() {
   // We keep the sizes random but not too random; the more regular the sizes, the
   // more regular the malloc return pointers and the better we see how our hash
   // function copes in the NMT preinit lu table.
-  switch (os::random() % 4) {
+  switch (GtestRandom::random() % 4) {
   case 0: return 0x10;
   case 1: return 0x42;
   case 2: return 0x20;
@@ -83,7 +83,7 @@ TEST_VM(NMTPreInit, stress_test_map) {
 
   // Randomly realloc
   for (int j = 0; j < num_allocs/2; j++) {
-    int pos = os::random() % num_allocs;
+    int pos = GtestRandom::random() % num_allocs;
     NMTPreInitAllocation* a1 = allocations[pos];
     NMTPreInitAllocation* a2 = table.find_and_remove(a1->payload);
     ASSERT_EQ(a1, a2);

--- a/test/hotspot/gtest/nmt/test_vmatree.cpp
+++ b/test/hotspot/gtest/nmt/test_vmatree.cpp
@@ -27,7 +27,7 @@
 #include "nmt/memTracker.hpp"
 #include "nmt/nmtNativeCallStackStorage.hpp"
 #include "nmt/vmatree.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "unittest.hpp"
 
 using Tree = VMATree;
@@ -950,8 +950,8 @@ TEST_VM_F(NMTVMATreeTest, TestConsistencyWithSimpleTracker) {
 
   const int operation_count = 100000; // One hundred thousand
   for (int i = 0; i < operation_count; i++) {
-    size_t page_start = (size_t)(os::random() % SimpleVMATracker::num_pages);
-    size_t page_end = (size_t)(os::random() % (SimpleVMATracker::num_pages));
+    size_t page_start = (size_t)(GtestRandom::random() % SimpleVMATracker::num_pages);
+    size_t page_end = (size_t)(GtestRandom::random() % (SimpleVMATracker::num_pages));
 
     if (page_end < page_start) {
       const size_t temp = page_start;
@@ -967,13 +967,13 @@ TEST_VM_F(NMTVMATreeTest, TestConsistencyWithSimpleTracker) {
     const size_t start = page_start * page_size;
     const size_t size = num_pages * page_size;
 
-    const MemTag mem_tag = candidate_tags[os::random() % candidates_len_tags];
-    const NativeCallStack stack = candidate_stacks[os::random() % candidates_len_stacks];
+    const MemTag mem_tag = candidate_tags[GtestRandom::random() % candidates_len_tags];
+    const NativeCallStack stack = candidate_stacks[GtestRandom::random() % candidates_len_stacks];
 
     const NCS::StackIndex si = ncss.push(stack);
     VMATree::RegionData data(si, mem_tag);
 
-    const SimpleVMATracker::Kind kind = (SimpleVMATracker::Kind)(os::random() % 3);
+    const SimpleVMATracker::Kind kind = (SimpleVMATracker::Kind)(GtestRandom::random() % 3);
 
     VMATree::SummaryDiff tree_diff;
     VMATree::SummaryDiff simple_diff;

--- a/test/hotspot/gtest/opto/test_rangeinference.cpp
+++ b/test/hotspot/gtest/opto/test_rangeinference.cpp
@@ -25,7 +25,7 @@
 #include "opto/intrinsicnode.hpp"
 #include "opto/rangeinference.hpp"
 #include "opto/type.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "unittest.hpp"
 #include "utilities/intn_t.hpp"
 #include "utilities/rbTree.hpp"
@@ -35,12 +35,12 @@
 
 template <class U>
 static U uniform_random() {
-  return U(juint(os::random()));
+  return U(juint(GtestRandom::random()));
 }
 
 template <>
 julong uniform_random<julong>() {
-  return (julong(os::random()) << 32) | julong(juint(os::random()));
+  return (julong(GtestRandom::random()) << 32) | julong(juint(GtestRandom::random()));
 }
 
 static void test_canonicalize_constraints_trivial() {

--- a/test/hotspot/gtest/opto/test_typejavaptr.cpp
+++ b/test/hotspot/gtest/opto/test_typejavaptr.cpp
@@ -25,6 +25,7 @@
 #include "nmt/memTag.hpp"
 #include "opto/type.hpp"
 #include "opto/typejavaptr.hpp"
+#include "gtestRandom.hpp"
 #include "unittest.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -1942,7 +1943,7 @@ static void test_meet_join() {
   // Running all instances takes a lot of time, so we only run a fraction of them regularly
   auto sample_hit = [] {
     constexpr double sampling_prob = 0.02;
-    return uint(os::random()) < max_juint * sampling_prob;
+    return uint(GtestRandom::random()) < max_juint * sampling_prob;
   };
 
   GrowableArray<const PtrType*> type_samples(samples_size, MemTag::mtOther);

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -123,6 +123,20 @@ TEST_VM(os, page_size_for_region_unaligned) {
   }
 }
 
+static void assert_random_seeded_from_gtest() {
+  const unsigned int seed =
+      static_cast<unsigned int>(::testing::UnitTest::GetInstance()->random_seed());
+  ASSERT_EQ(os::next_random(seed), os::random());
+}
+
+TEST(os, random_seeded_from_gtest) {
+  assert_random_seeded_from_gtest();
+}
+
+TEST_VM(os, random_reseeded_after_jvm_initialization) {
+  assert_random_seeded_from_gtest();
+}
+
 TEST(os, test_random) {
   const double m = 2147483647;
   double mean = 0.0, variance = 0.0, t;

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -123,20 +123,6 @@ TEST_VM(os, page_size_for_region_unaligned) {
   }
 }
 
-static void assert_random_seeded_from_gtest() {
-  const unsigned int seed =
-      static_cast<unsigned int>(::testing::UnitTest::GetInstance()->random_seed());
-  ASSERT_EQ(os::next_random(seed), os::random());
-}
-
-TEST(os, random_seeded_from_gtest) {
-  assert_random_seeded_from_gtest();
-}
-
-TEST_VM(os, random_reseeded_after_jvm_initialization) {
-  assert_random_seeded_from_gtest();
-}
-
 TEST(os, test_random) {
   const double m = 2147483647;
   double mean = 0.0, variance = 0.0, t;

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -29,6 +29,7 @@
 #include "runtime/globals_extension.hpp"
 #include "runtime/os.inline.hpp"
 #include "runtime/safefetch.hpp"
+#include "gtestRandom.hpp"
 #include "concurrentTestRunner.inline.hpp"
 #include "unittest.hpp"
 
@@ -229,9 +230,9 @@ static bool unnormalize_path(wchar_t* result, size_t size, bool is_dir, const wc
     path_start = wcschr(src + 1, L'\\');
   }
 
-  bool allow_sep_change = (mods_filter & Allow_Sep_Mods) && (os::random() & 1) == 0;
-  bool allow_dot_change = (mods_filter & Allow_Dot_Path) && (os::random() & 1) == 0;
-  bool allow_dotdot_change = (mods_filter & Allow_Dot_Dot_Path) && (os::random() & 1) == 0;
+  bool allow_sep_change = (mods_filter & Allow_Sep_Mods) && (GtestRandom::random() & 1) == 0;
+  bool allow_dot_change = (mods_filter & Allow_Dot_Path) && (GtestRandom::random() & 1) == 0;
+  bool allow_dotdot_change = (mods_filter & Allow_Dot_Dot_Path) && (GtestRandom::random() & 1) == 0;
 
   while ((*src != L'\0') && (result + size > dest)) {
     wchar_t c = *src;
@@ -240,15 +241,15 @@ static bool unnormalize_path(wchar_t* result, size_t size, bool is_dir, const wc
     ++dest;
 
     if (c == L'\\') {
-      if (allow_sep_change && (os::random() & 3) == 3) {
-        int i = os::random() % (sizeof(sep_replacements) / sizeof(sep_replacements[0]));
+      if (allow_sep_change && (GtestRandom::random() & 3) == 3) {
+        int i = GtestRandom::random() % (sizeof(sep_replacements) / sizeof(sep_replacements[0]));
 
         if (i >= 0) {
           const wchar_t* replacement = sep_replacements[i];
           dest = my_wcscpy_s(dest - 1, size,  result, replacement);
         }
       } else if (path_start != nullptr) {
-        if (allow_dotdot_change && (src > path_start + 1) && ((os::random() & 7) == 7)) {
+        if (allow_dotdot_change && (src > path_start + 1) && ((GtestRandom::random() & 7) == 7)) {
           wchar_t const* last_sep = src - 2;
 
           while (last_sep[0] != L'\\') {
@@ -259,14 +260,14 @@ static bool unnormalize_path(wchar_t* result, size_t size, bool is_dir, const wc
             dest = my_wcscpy_s(dest, size, result, L"../");
             src = last_sep + 1;
           }
-        } else if (allow_dot_change && (src > path_start + 1) && ((os::random() & 7) == 7)) {
+        } else if (allow_dot_change && (src > path_start + 1) && ((GtestRandom::random() & 7) == 7)) {
           dest = my_wcscpy_s(dest, size, result, L"./");
         }
       }
     }
   }
 
-  while (is_dir && ((os::random() & 15) == 1)) {
+  while (is_dir && ((GtestRandom::random() & 15) == 1)) {
     dest = my_wcscpy_s(dest, size, result, L"/");
   }
 

--- a/test/hotspot/gtest/utilities/test_bitMap.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 #include "logging/logStream.hpp"
 #include "memory/arena.hpp"
 #include "memory/resourceArea.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "unittest.hpp"
 
@@ -245,21 +246,21 @@ class BitMapTruncateTest {
       ResourceMark rm;
 
       const size_t max_size = 1024;
-      const size_t size = os::random() % max_size + 1;
-      const size_t truncate_size = os::random() % size + 1;
-      const size_t truncate_start = size == truncate_size ? 0 : os::random() % (size - truncate_size);
+      const size_t size = GtestRandom::random() % max_size + 1;
+      const size_t truncate_size = GtestRandom::random() % size + 1;
+      const size_t truncate_start = size == truncate_size ? 0 : GtestRandom::random() % (size - truncate_size);
 
       ResizableBitMapClass map(size);
       ResizableBitMapClass result(truncate_size);
 
       for (BitMap::idx_t idx = 0; idx < truncate_start; idx++) {
-        if (os::random() % 2 == 0) {
+        if (GtestRandom::random() % 2 == 0) {
           map.set_bit(idx);
         }
       }
 
       for (BitMap::idx_t idx = 0; idx < truncate_size; idx++) {
-        if (os::random() % 2 == 0) {
+        if (GtestRandom::random() % 2 == 0) {
           map.set_bit(truncate_start + idx);
           result.set_bit(idx);
         }

--- a/test/hotspot/gtest/utilities/test_bitMap_popcnt.cpp
+++ b/test/hotspot/gtest/utilities/test_bitMap_popcnt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, SAP and/or its affiliates.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -24,7 +24,7 @@
  */
 
 #include "memory/allocation.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
@@ -81,8 +81,8 @@ public:
 static void set_or_clear_random_range(BitMap& bm, SimpleFakeBitmap& fbm, int beg, int end) {
   int range = end - beg;
   if (range > 0) {
-    int from = os::random() % range;
-    int to = os::random() % range;
+    int from = GtestRandom::random() % range;
+    int to = GtestRandom::random() % range;
     if (from > to) {
       int s = from;
       from = to;
@@ -90,7 +90,7 @@ static void set_or_clear_random_range(BitMap& bm, SimpleFakeBitmap& fbm, int beg
     }
     from += beg;
     to += beg;
-    if ((os::random() % 10) > 5) {
+    if ((GtestRandom::random() % 10) > 5) {
       bm.set_range(from, to);
       fbm.set_range(from, to);
     } else {

--- a/test/hotspot/gtest/utilities/test_gtestRandom.cpp
+++ b/test/hotspot/gtest/utilities/test_gtestRandom.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "gtestRandom.hpp"
+#include "runtime/os.hpp"
+#include "unittest.hpp"
+
+static void assert_random_seeded_from_gtest() {
+  unsigned int seed =
+      static_cast<unsigned int>(::testing::UnitTest::GetInstance()->random_seed());
+
+  // Advancing the VM's random state must not affect the gtest random sequence.
+  for (int i = 0; i < 10; i++) {
+    os::random();
+    const int expected = os::next_random(seed);
+    seed = static_cast<unsigned int>(expected);
+    ASSERT_EQ(expected, GtestRandom::random());
+  }
+}
+
+TEST(GtestRandom, seeded_from_gtest) {
+  assert_random_seeded_from_gtest();
+}
+
+TEST_VM(GtestRandom, seeded_from_gtest_after_jvm_initialization) {
+  assert_random_seeded_from_gtest();
+}

--- a/test/hotspot/gtest/utilities/test_ostream.cpp
+++ b/test/hotspot/gtest/utilities/test_ostream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,7 +24,7 @@
  */
 
 #include "memory/resourceArea.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/ostream.hpp"
@@ -40,8 +40,8 @@ static size_t print_lorem(outputStream* st) {
       "orci sagittis eu volutpat odio facilisis mauris sit. Erat velit scelerisque in dictum non.";
   static const size_t len_lorem = strlen(lorem);
   // Randomly alternate between short and long writes at a ratio of 9:1.
-  const bool short_write = (os::random() % 10) > 0;
-  const size_t len = os::random() % (short_write ? 10 : len_lorem);
+  const bool short_write = (GtestRandom::random() % 10) > 0;
+  const size_t len = GtestRandom::random() % (short_write ? 10 : len_lorem);
   st->write(lorem, len);
   return len;
 }

--- a/test/hotspot/gtest/utilities/test_population_count.cpp
+++ b/test/hotspot/gtest/utilities/test_population_count.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
  */
 
 #include "cppstdlib/limits.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/population_count.hpp"
 #include "utilities/powerOfTwo.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -59,7 +59,7 @@ static void sparse() {
   // approach used historically
   T step = T(1) << ((sizeof(T) * 8) - 7);
 
-  for (T value = os::random() % step; value < max_val - step; value += step) {
+  for (T value = GtestRandom::random() % step; value < max_val - step; value += step) {
     uint64_t v = (uint64_t)value;
     unsigned lookup = 0u;
     for (unsigned i = 0u; i < sizeof(T); i++) {

--- a/test/hotspot/gtest/utilities/test_quicksort.cpp
+++ b/test/hotspot/gtest/utilities/test_quicksort.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
  */
 
 #include "memory/allocation.inline.hpp"
-#include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "utilities/quickSort.hpp"
 #include "unittest.hpp"
 
@@ -117,12 +117,12 @@ TEST(QuickSort, quicksort) {
 
 TEST(QuickSort, random) {
   for (int i = 0; i < 1000; i++) {
-    size_t length = os::random() % 100;
+    size_t length = GtestRandom::random() % 100;
     int* test_array = NEW_C_HEAP_ARRAY(int, length, mtInternal);
     int* expected_array = NEW_C_HEAP_ARRAY(int, length, mtInternal);
     for (size_t j = 0; j < length; j++) {
         // Choose random values, but get a chance of getting duplicates
-        test_array[j] = os::random() % (length * 2);
+        test_array[j] = GtestRandom::random() % (length * 2);
         expected_array[j] = test_array[j];
     }
 

--- a/test/hotspot/gtest/utilities/test_rbtree.cpp
+++ b/test/hotspot/gtest/utilities/test_rbtree.cpp
@@ -24,6 +24,7 @@
 
 #include "memory/resourceArea.hpp"
 #include "runtime/os.hpp"
+#include "gtestRandom.hpp"
 #include "testutils.hpp"
 #include "unittest.hpp"
 #include "utilities/growableArray.hpp"
@@ -547,7 +548,7 @@ public:
     }
 
     for (int i = 0; i < 2000; i++) {
-      int r = os::random() % 10000;
+      int r = GtestRandom::random() % 10000;
       Node* to_delete = rbtree.find_node(r);
       if (to_delete != nullptr && to_delete->_left != nullptr &&
           to_delete->_right != nullptr) {
@@ -575,7 +576,7 @@ public:
     }
 
     for (int i = 0; i < 2000; i++) {
-      int r = os::random() % 10000;
+      int r = GtestRandom::random() % 10000;
       Node* to_delete = rbtree.find_node(r);
       if (to_delete != nullptr && to_delete->_left != nullptr &&
           to_delete->_right != nullptr) {
@@ -766,7 +767,7 @@ public:
           ASSERT_EQ(rbtree_const.rightmost(), rbtree.rightmost());
           ASSERT_EQ(rbtree_const.leftmost(), rbtree.leftmost());
         }
-        const int r = os::random();
+        const int r = GtestRandom::random();
         rbtree.upsert(r, r);
         min = MIN2(min, r);
         max = MAX2(max, r);
@@ -790,13 +791,13 @@ public:
     int size = 10000;
     // Create random values
     for (int i = 0; i < size; i++) {
-      int r = os::random() % size;
+      int r = GtestRandom::random() % size;
       allocations.append(r);
     }
 
     // Insert ~half of the values
     for (int i = 0; i < size; i++) {
-      int r = os::random();
+      int r = GtestRandom::random();
       if (r % 2 == 0) {
         rbtree.upsert(allocations.at(i), allocations.at(i));
       }
@@ -807,7 +808,7 @@ public:
 
     // Insert and remove randomly
     for (int i = 0; i < size; i++) {
-      int r = os::random();
+      int r = GtestRandom::random();
       if (r % 2 == 0) {
         rbtree.upsert(allocations.at(i), allocations.at(i));
       } else {
@@ -1288,7 +1289,7 @@ TEST_VM_F(RBTreeTest, VerifyItThroughStressTest) {
     RBTreeInt rbtree;
     constexpr int ten_thousand = 10000;
     for (int i = 0; i < ten_thousand; i++) {
-      int r = os::random();
+      int r = GtestRandom::random();
       if (r % 2 == 0) {
         rbtree.upsert(i, i);
       } else {
@@ -1301,7 +1302,7 @@ TEST_VM_F(RBTreeTest, VerifyItThroughStressTest) {
     RBTreeInt::Cursor cursor = rbtree.cursor(10);
     RBTreeInt::Cursor cursor2 = rbtree.next(cursor);
     for (int i = 0; i < ten_thousand; i++) {
-      int r = os::random();
+      int r = GtestRandom::random();
       if (r % 2 == 0) {
         rbtree.upsert(i, i);
       } else {


### PR DESCRIPTION
Please review this enhancement.

**Problem:**

Gtests using `os::random()` share the VM's process-wide random state. This state can be advanced by previously executed tests and, after VM initialization, by VM background threads. Therefore, a test's random sequence cannot be reliably reproduced with `--gtest_random_seed=N`.

**Fix:**

Added a separate `GtestRandom` state for gtest sampling. It is initialized from the current GoogleTest seed before each test and does not modify or depend on the VM's `os::_rand_seed`.

The existing gtest sampling calls have been migrated from `os::random()` to `GtestRandom::random()`.

Added a `RandomSeedListener`:

- `OnTestIterationStart` gets the GoogleTest seed, prints it, and flushes the output so that the seed is preserved if the process crashes.
- `OnTestStart` initializes `GtestRandom` with that seed before each test.
- `OnTestEnd` prints the seed again if the test fails.

**Testing:**

- Added `test_gtestRandom.cpp`. Verified that calls to `os::random()` do not affect the `GtestRandom` sequence.
- `gtest:GtestRandom/server`: 2 passed.
- `gtest:all/server`: 1347 passed, 15 disabled, 0 failed.
- `test/hotspot/jtreg/gtest`: 22 passed, 6 did not meet platform requirements.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390945](https://bugs.openjdk.org/browse/JDK-8390945): Make gtest random sampling reproducible (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32743/head:pull/32743` \
`$ git checkout pull/32743`

Update a local copy of the PR: \
`$ git checkout pull/32743` \
`$ git pull https://git.openjdk.org/jdk.git pull/32743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32743`

View PR using the GUI difftool: \
`$ git pr show -t 32743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32743.diff">https://git.openjdk.org/jdk/pull/32743.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32743#issuecomment-5574606026)
</details>
