### PR TITLE
8391146: assert(_base == AryPtr) failed: Not an array pointer

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1927,8 +1927,7 @@ void GraphKit::access_clone(Node* src, Node* dst, Node* size, bool is_array) {
 //-------------------------array_element_address-------------------------
 Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
                                       const TypeInt* sizetype, Node* ctrl) {
-  const TypeAryPtr* arytype = _gvn.type(ary)->isa_aryptr();
-  precond(arytype != nullptr);
+  const TypeAryPtr* arytype = _gvn.type(ary)->is_aryptr();
   uint shift;
   uint header;
   if (arytype->is_flat() && arytype->klass_is_exact()) {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1928,9 +1928,10 @@ void GraphKit::access_clone(Node* src, Node* dst, Node* size, bool is_array) {
 Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
                                       const TypeInt* sizetype, Node* ctrl) {
   const TypeAryPtr* arytype = _gvn.type(ary)->isa_aryptr();
+  precond(arytype != nullptr);
   uint shift;
   uint header;
-  if (arytype != nullptr && arytype->is_flat() && arytype->klass_is_exact()) {
+  if (arytype->is_flat() && arytype->klass_is_exact()) {
     // We can only determine the flat array layout statically if the klass is exact. Otherwise, we could have different
     // value classes at runtime with a potentially different layout. The caller needs to fall back to call
     // load/store_unknown_value_Type() at runtime. We could return a sentinel node for the non-exact case but that

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1927,10 +1927,10 @@ void GraphKit::access_clone(Node* src, Node* dst, Node* size, bool is_array) {
 //-------------------------array_element_address-------------------------
 Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
                                       const TypeInt* sizetype, Node* ctrl) {
-  const TypeAryPtr* arytype = _gvn.type(ary)->is_aryptr();
+  const TypeAryPtr* arytype = _gvn.type(ary)->isa_aryptr();
   uint shift;
   uint header;
-  if (arytype->is_flat() && arytype->klass_is_exact()) {
+  if (arytype != nullptr && arytype->is_flat() && arytype->klass_is_exact()) {
     // We can only determine the flat array layout statically if the klass is exact. Otherwise, we could have different
     // value classes at runtime with a potentially different layout. The caller needs to fall back to call
     // load/store_unknown_value_Type() at runtime. We could return a sentinel node for the non-exact case but that

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -7737,6 +7737,11 @@ bool LibraryCallKit::inline_vectorizedHashCode() {
     return false; // Only intrinsify if mode argument is constant
   }
 
+  const TypeAryPtr* array_t = _gvn.type(array)->isa_aryptr();
+  if (array_t == nullptr || array_t->elem() == Type::BOTTOM) {
+    return false; // failed input validation
+  }
+
   array = must_be_not_null(array, true);
 
   BasicType bt = (BasicType)basic_type_t->get_con();

--- a/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,21 @@
  */
 
 /*
- * @test
+ * @test id=normal
  * @bug 8301093
  * @summary Verify failure to intrinsify does not pollute control flow
  * @modules java.base/jdk.internal.util:+open
  *
  * @run main/othervm -Xbatch -XX:-TieredCompilation compiler.intrinsics.TestArraysHashCode
+ */
+
+/*
+ * @test id=osr
+ * @bug 8391146
+ * @summary Verify failure to check for array type in OSR compilation
+ * @modules java.base/jdk.internal.util:+open
+ *
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileThreshold=50 compiler.intrinsics.TestArraysHashCode
  */
 
 package compiler.intrinsics;

--- a/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
@@ -33,7 +33,7 @@
 /*
  * @test id=osr
  * @bug 8391146
- * @summary Verify failure to check for array type in OSR compilation
+ * @summary Verify array type check in OSR compilation
  * @modules java.base/jdk.internal.util:+open
  *
  * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileThreshold=50 compiler.intrinsics.TestArraysHashCode


### PR DESCRIPTION
Added missing Array type check in `GraphKit::array_element_address`.
Added OSR case (with `-XX:CompileThreshold=50` flag) to `TestArraysHashCode.java` test which hits the issue.

Tested: tier1,tier2,tier3,hs-comp-stress,hs-aot-stress

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391146](https://bugs.openjdk.org/browse/JDK-8391146): assert(_base == AryPtr) failed: Not an array pointer (**Bug** - P3)


### Reviewers
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author) Review applies to [60b7e51a](https://git.openjdk.org/jdk/pull/32744/files/60b7e51a793ef3fb864d823379ba0bbf2373b99f)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32744/head:pull/32744` \
`$ git checkout pull/32744`

Update a local copy of the PR: \
`$ git checkout pull/32744` \
`$ git pull https://git.openjdk.org/jdk.git pull/32744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32744`

View PR using the GUI difftool: \
`$ git pr show -t 32744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32744.diff">https://git.openjdk.org/jdk/pull/32744.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32744#issuecomment-5576301270)
</details>
