### PR TITLE
8391942: RISC-V: Remove redundant null checks in needs_acquiring_load_reserved()

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1181,13 +1181,13 @@ constexpr uint64_t MAJIK_DWORD = 0xabbaabbaabbaabbaull;
 // returns true if CAS needs to use an acquiring load otherwise false
 bool needs_acquiring_load_reserved(const Node *n)
 {
-  assert(n != nullptr && is_CAS(n->Opcode(), true), "expecting a compare and swap");
+  assert(is_CAS(n->Opcode(), true), "expecting a compare and swap");
 
   LoadStoreNode* ldst = n->as_LoadStore();
-  if (n != nullptr && is_CAS(n->Opcode(), false)) {
-    assert(ldst != nullptr && ldst->trailing_membar() != nullptr, "expected trailing membar");
+  if (is_CAS(n->Opcode(), false)) {
+    assert(ldst->trailing_membar() != nullptr, "expected trailing membar");
   } else {
-    return ldst != nullptr && ldst->trailing_membar() != nullptr;
+    return ldst->trailing_membar() != nullptr;
   }
   // so we can just return true here
   return true;


### PR DESCRIPTION
Hi, please consider.
`needs_acquiring_load_reserved()` in `riscv.ad` contains several null checks that cannot ever fail, and one of them is actively misleading. This patch removes them, bringing the function in line with its AArch64 counterpart
`needs_acquiring_load_exclusive()` in `aarch64.ad`.

- [ ]  Run tier1-tier3 test with release on SG2044

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391942](https://bugs.openjdk.org/browse/JDK-8391942): RISC-V: Remove redundant null checks in needs_acquiring_load_reserved() (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32745/head:pull/32745` \
`$ git checkout pull/32745`

Update a local copy of the PR: \
`$ git checkout pull/32745` \
`$ git pull https://git.openjdk.org/jdk.git pull/32745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32745`

View PR using the GUI difftool: \
`$ git pr show -t 32745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32745.diff">https://git.openjdk.org/jdk/pull/32745.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32745#issuecomment-5578040828)
</details>
