### PR TITLE
8391943: RISC-V: Use Zba add.uw for additions with zero-extended 32-bit values

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -6779,26 +6779,15 @@ void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp
 
 // shift left by shamt and add (unsigned word variant)
 // Rd = (zext32(Rs1) << shamt) + Rs2
-void MacroAssembler::shadd_uw(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt) {
+void MacroAssembler::shadd_uw(Register Rd, Register Rs1, Register Rs2, int shamt) {
   assert(UseZba, "shadd_uw requires Zba");
-  if (shamt == 0) {
-    add_uw(Rd, Rs1, Rs2);
-  } else if (shamt == 1) {
+  assert(1 <= shamt && shamt <= 3, "shamt is invalid");
+  if (shamt == 1) {
     sh1add_uw(Rd, Rs1, Rs2);
   } else if (shamt == 2) {
     sh2add_uw(Rd, Rs1, Rs2);
-  } else if (shamt == 3) {
-    sh3add_uw(Rd, Rs1, Rs2);
   } else {
-    assert_different_registers(Rs2, tmp);
-    assert(0 <= shamt && shamt < 64, "shamt is invalid");
-    if (shamt <= 32) {
-      slli(tmp, Rs1, 32);
-      srli(tmp, tmp, 32 - shamt);
-    } else {
-      slli(tmp, Rs1, shamt);
-    }
-    add(Rd, Rs2, tmp);
+    sh3add_uw(Rd, Rs1, Rs2);
   }
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -6777,6 +6777,31 @@ void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp
   }
 }
 
+// shift left by shamt and add (unsigned word variant)
+// Rd = (zext32(Rs1) << shamt) + Rs2
+void MacroAssembler::shadd_uw(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt) {
+  assert(UseZba, "shadd_uw requires Zba");
+  if (shamt == 0) {
+    add_uw(Rd, Rs1, Rs2);
+  } else if (shamt == 1) {
+    sh1add_uw(Rd, Rs1, Rs2);
+  } else if (shamt == 2) {
+    sh2add_uw(Rd, Rs1, Rs2);
+  } else if (shamt == 3) {
+    sh3add_uw(Rd, Rs1, Rs2);
+  } else {
+    assert_different_registers(Rs2, tmp);
+    assert(0 <= shamt && shamt < 64, "shamt is invalid");
+    if (shamt <= 32) {
+      slli(tmp, Rs1, 32);
+      srli(tmp, tmp, 32 - shamt);
+    } else {
+      slli(tmp, Rs1, shamt);
+    }
+    add(Rd, Rs2, tmp);
+  }
+}
+
 void MacroAssembler::zext(Register dst, Register src, int bits) {
   switch (bits) {
     case 32:

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1470,6 +1470,9 @@ public:
   // shift left by shamt and add
   void shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
 
+  // shift left by shamt and add (unsigned word variant: zext(src1) << shamt + src2)
+  void shadd_uw(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
+
   // test single bit in Rs, result is set to Rd
   void test_bit(Register Rd, Register Rs, uint32_t bit_pos);
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1471,7 +1471,7 @@ public:
   void shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
 
   // shift left by shamt and add (unsigned word variant: zext(src1) << shamt + src2)
-  void shadd_uw(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
+  void shadd_uw(Register Rd, Register Rs1, Register Rs2, int shamt);
 
   // test single bit in Rs, result is set to Rd
   void test_bit(Register Rd, Register Rs, uint32_t bit_pos);

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -349,6 +349,40 @@ instruct shaddP_reg_reg_ext_b(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale i
   ins_pipe(ialu_reg_reg);
 %}
 
+instruct addP_reg_reg_uxtw_b(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immL_32bits mask) %{
+  predicate(UseZba);
+  match(Set dst (AddP src1 (AndL (ConvI2L src2) mask)));
+
+  ins_cost(ALU_COST);
+  format %{ "add.uw $dst, $src2, $src1\t# ptr, #@addP_reg_reg_uxtw_b" %}
+
+  ins_encode %{
+    __ add_uw(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct shaddP_reg_reg_uxtw_b(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immL_32bits mask, immIScale imm) %{
+  predicate(UseZba);
+  match(Set dst (AddP src1 (LShiftL (AndL (ConvI2L src2) mask) imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "shadd.uw $dst, $src2, $src1, $imm\t# ptr, #@shaddP_reg_reg_uxtw_b" %}
+
+  ins_encode %{
+    __ shadd_uw(as_Register($dst$$reg),
+                as_Register($src2$$reg),
+                as_Register($src1$$reg),
+                t0,
+                $imm$$constant);
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
 // Shift Add Long
 instruct shaddL_reg_reg_b(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale imm) %{
   predicate(UseZba);
@@ -363,6 +397,42 @@ instruct shaddL_reg_reg_b(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale imm) 
              as_Register($src1$$reg),
              t0,
              $imm$$constant);
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct addL_reg_reg_uxtw_b(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immL_32bits mask) %{
+  predicate(UseZba);
+  match(Set dst (AddL src1 (AndL (ConvI2L src2) mask)));
+  match(Set dst (AddL (AndL (ConvI2L src2) mask) src1));
+
+  ins_cost(ALU_COST);
+  format %{ "add.uw $dst, $src2, $src1\t#@addL_reg_reg_uxtw_b" %}
+
+  ins_encode %{
+    __ add_uw(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct shaddL_reg_reg_uxtw_b(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immL_32bits mask, immIScale imm) %{
+  predicate(UseZba);
+  match(Set dst (AddL src1 (LShiftL (AndL (ConvI2L src2) mask) imm)));
+  match(Set dst (AddL (LShiftL (AndL (ConvI2L src2) mask) imm) src1));
+
+  ins_cost(ALU_COST);
+  format %{ "shadd.uw $dst, $src2, $src1, $imm\t#@shaddL_reg_reg_uxtw_b" %}
+
+  ins_encode %{
+    __ shadd_uw(as_Register($dst$$reg),
+                as_Register($src2$$reg),
+                as_Register($src1$$reg),
+                t0,
+                $imm$$constant);
   %}
 
   ins_pipe(ialu_reg_reg);

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -404,7 +404,6 @@ instruct shaddL_reg_reg_b(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale imm) 
 instruct addL_reg_reg_uxtw_b(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immL_32bits mask) %{
   predicate(UseZba);
   match(Set dst (AddL src1 (AndL (ConvI2L src2) mask)));
-  match(Set dst (AddL (AndL (ConvI2L src2) mask) src1));
 
   ins_cost(ALU_COST);
   format %{ "add.uw $dst, $src2, $src1\t#@addL_reg_reg_uxtw_b" %}
@@ -421,7 +420,6 @@ instruct addL_reg_reg_uxtw_b(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immL_32
 instruct shaddL_reg_reg_uxtw_b(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immL_32bits mask, immIScale imm) %{
   predicate(UseZba);
   match(Set dst (AddL src1 (LShiftL (AndL (ConvI2L src2) mask) imm)));
-  match(Set dst (AddL (LShiftL (AndL (ConvI2L src2) mask) imm) src1));
 
   ins_cost(ALU_COST);
   format %{ "shadd.uw $dst, $src2, $src1, $imm\t#@shaddL_reg_reg_uxtw_b" %}

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -376,7 +376,6 @@ instruct shaddP_reg_reg_uxtw_b(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immL_
     __ shadd_uw(as_Register($dst$$reg),
                 as_Register($src2$$reg),
                 as_Register($src1$$reg),
-                t0,
                 $imm$$constant);
   %}
 
@@ -431,7 +430,6 @@ instruct shaddL_reg_reg_uxtw_b(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immL_
     __ shadd_uw(as_Register($dst$$reg),
                 as_Register($src2$$reg),
                 as_Register($src1$$reg),
-                t0,
                 $imm$$constant);
   %}
 


### PR DESCRIPTION
Hi, please consider.
This patch adds RISC-V C2 matching rules for additions involving a zero-extended 32-bit value.

### Testing
- [x] Run tier1-tier3 test with release on SG2044

### Opto log & Assembly log
We can use this test compiler.c2.riscv64.TestAddWithZeroExtendedInt.java case to verify opto log & assembly log:
#### addL_reg_reg_and_uxtw_b instruct verify
TestAddWithZeroExtendedInt.testAddLFromLong opto log without this patch:
```
022     zext.w  R7, R12	#@andL_32bits_b
026 +   add  R10, R11, R7	#@addL_reg_reg
```

TestAddWithZeroExtendedInt.testAddLFromLong opto log with this patch:
```
022     add.uw R10, R12, R11	#@addL_reg_reg_and_uxtw_b
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391943](https://bugs.openjdk.org/browse/JDK-8391943): RISC-V: Use Zba add.uw for additions with zero-extended 32-bit values (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) Review applies to [6263ce0e](https://git.openjdk.org/jdk/pull/32746/files/6263ce0ebe05be619e1ba984f19c950fc2fd444a)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32746/head:pull/32746` \
`$ git checkout pull/32746`

Update a local copy of the PR: \
`$ git checkout pull/32746` \
`$ git pull https://git.openjdk.org/jdk.git pull/32746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32746`

View PR using the GUI difftool: \
`$ git pr show -t 32746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32746.diff">https://git.openjdk.org/jdk/pull/32746.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32746#issuecomment-5614281627)
</details>
