### PR TITLE
8391945: RISC-V: Add floating-point vector multiplication reduction rules

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -3050,13 +3050,13 @@ void C2_MacroAssembler::reduce_mul_fp_v(FloatRegister dst, FloatRegister src1, V
   vsetvli_helper(bt, vector_length);
 
   vector_length /= 2;
-  vslidedown_vi(vtmp1, src2, vector_length);
+  slidedown_v(vtmp1, src2, vector_length);
   vsetvli_helper(bt, vector_length);
   vfmul_vv(vtmp1, vtmp1, src2);
 
   while (vector_length > 1) {
     vector_length /= 2;
-    vslidedown_vi(vtmp2, vtmp1, vector_length);
+    slidedown_v(vtmp2, vtmp1, vector_length);
     vsetvli_helper(bt, vector_length);
     vfmul_vv(vtmp1, vtmp1, vtmp2);
   }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -3038,6 +3038,34 @@ void C2_MacroAssembler::reduce_minmax_fp_v(FloatRegister dst,
   bind(L_done);
 }
 
+void C2_MacroAssembler::reduce_mul_fp_v(FloatRegister dst, FloatRegister src1, VectorRegister src2,
+                                        VectorRegister vtmp1, VectorRegister vtmp2,
+                                        bool is_double, uint vector_length) {
+  assert(vector_length >= 2, "unsupported vector length");
+  assert(is_power_of_2(vector_length), "vector length must be a power of two");
+  assert_different_registers(dst, src1);
+  assert_different_registers(src2, vtmp1, vtmp2);
+
+  BasicType bt = is_double ? T_DOUBLE : T_FLOAT;
+  vsetvli_helper(bt, vector_length);
+
+  vector_length /= 2;
+  vslidedown_vi(vtmp1, src2, vector_length);
+  vsetvli_helper(bt, vector_length);
+  vfmul_vv(vtmp1, vtmp1, src2);
+
+  while (vector_length > 1) {
+    vector_length /= 2;
+    vslidedown_vi(vtmp2, vtmp1, vector_length);
+    vsetvli_helper(bt, vector_length);
+    vfmul_vv(vtmp1, vtmp1, vtmp2);
+  }
+
+  vfmv_f_s(dst, vtmp1);
+  is_double ? fmul_d(dst, dst, src1)
+            : fmul_s(dst, dst, src1);
+}
+
 bool C2_MacroAssembler::in_scratch_emit_size() {
   if (ciEnv::current()->task() != nullptr) {
     PhaseOutput* phase_output = Compile::current()->output();

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -262,6 +262,10 @@
                           bool is_double, bool is_min, uint vector_length,
                           VectorMask vm = Assembler::unmasked);
 
+  void reduce_mul_fp_v(FloatRegister dst, FloatRegister src1, VectorRegister src2,
+                       VectorRegister vtmp1, VectorRegister vtmp2,
+                       bool is_double, uint vector_length);
+
   void reduce_integral_v(Register dst, Register src1,
                         VectorRegister src2, VectorRegister tmp,
                         int opc, BasicType bt, uint vector_length,

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -48,6 +48,9 @@ source %{
   }
 
   bool Matcher::match_rule_supported_auto_vectorization(int opcode, int vlen, BasicType bt) {
+    if (opcode == Op_MulReductionVF || opcode == Op_MulReductionVD) {
+      return false;
+    }
     return match_rule_supported_vector(opcode, vlen, bt);
   }
 
@@ -111,6 +114,12 @@ source %{
           return false;
         }
         break;
+      case Op_MulReductionVF:
+      case Op_MulReductionVD:
+        if (vlen < 2 || !is_power_of_2(vlen)) {
+          return false;
+        }
+        break;
       case Op_VectorCastHF2F:
       case Op_VectorCastF2HF:
         return UseZvfh || UseZvfhmin;
@@ -150,6 +159,9 @@ source %{
     }
 
     switch (opcode) {
+      case Op_MulReductionVF:
+      case Op_MulReductionVD:
+        return false;
       case Op_SelectFromTwoVector:
         // There is no masked version of selectFrom two vector, i.e. selectFrom(av, bv, mask) in vector API.
         return false;
@@ -2994,6 +3006,36 @@ instruct reduce_mulL_masked(iRegLNoSp dst, iRegL isrc, vReg vsrc,
                              as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
                              Matcher::vector_element_basic_type(this, $vsrc), Matcher::vector_length(this, $vsrc),
                              Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct reduce_mulF(fRegF dst, fRegF fsrc, vReg vsrc,
+                     vReg tmp1, vReg tmp2) %{
+  predicate(!n->as_Reduction()->requires_strict_order());
+  match(Set dst (MulReductionVF fsrc vsrc));
+  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  format %{ "reduce_mulF $dst, $fsrc, $vsrc\t# KILL $tmp1, $tmp2" %}
+
+  ins_encode %{
+    __ reduce_mul_fp_v($dst$$FloatRegister, $fsrc$$FloatRegister, as_VectorRegister($vsrc$$reg),
+                       as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
+                       false /* is_double */, Matcher::vector_length(this, $vsrc));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct reduce_mulD(fRegD dst, fRegD dsrc, vReg vsrc,
+                     vReg tmp1, vReg tmp2) %{
+  predicate(!n->as_Reduction()->requires_strict_order());
+  match(Set dst (MulReductionVD dsrc vsrc));
+  effect(TEMP_DEF dst, TEMP tmp1, TEMP tmp2);
+  format %{ "reduce_mulD $dst, $dsrc, $vsrc\t# KILL $tmp1, $tmp2" %}
+
+  ins_encode %{
+    __ reduce_mul_fp_v($dst$$FloatRegister, $dsrc$$FloatRegister, as_VectorRegister($vsrc$$reg),
+                       as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
+                       true /* is_double */, Matcher::vector_length(this, $vsrc));
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
This patch adds C2 matching rules for floating-point vector multiplication reductions on RISC-V: 
```
MulReductionVF
MulReductionVD
```
RVV does not provide a dedicated floating-point multiplication reduction instruction. The reduction is therefore implemented as a tree reduction using `vslidedown` and `vfmul`, followed by multiplying the reduced value with the scalar accumulator.



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391945](https://bugs.openjdk.org/browse/JDK-8391945): RISC-V: Add floating-point vector multiplication reduction rules (**Enhancement** - P4)


### Contributors
 * Dingli Zhang `<dzhang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32747/head:pull/32747` \
`$ git checkout pull/32747`

Update a local copy of the PR: \
`$ git checkout pull/32747` \
`$ git pull https://git.openjdk.org/jdk.git pull/32747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32747`

View PR using the GUI difftool: \
`$ git pr show -t 32747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32747.diff">https://git.openjdk.org/jdk/pull/32747.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32747#issuecomment-5599013801)
</details>
