### PR TITLE
8391946: RISC-V: optimize SHA-1 intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2813,7 +2813,7 @@ enum Nf {
     emit(insn);                                         \
   }
 
-  INSN(add_uw,    0b0111011, 0b000, 0b0000100);
+  INSN(_add_uw,    0b0111011, 0b000, 0b0000100);
   INSN(rolr,      0b0110011, 0b001, 0b0110000);
   INSN(rolrw,     0b0111011, 0b001, 0b0110000);
   INSN(rorr,      0b0110011, 0b101, 0b0110000);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -6752,6 +6752,17 @@ void MacroAssembler::zero_memory(Register addr, Register len, Register tmp) {
   bnez(len, loop);
 }
 
+void MacroAssembler::add_uw(Register Rd, Register Rs1, Register Rs2, Register tmp) {
+  if (UseZba) {
+    _add_uw(Rd, Rs1, Rs2);
+    return;
+  }
+
+  assert_different_registers(tmp, Rs2);
+  zext(tmp, Rs1, 32);
+  add(Rd, tmp, Rs2);
+}
+
 // shift left by shamt and add
 // Rd = (Rs1 << shamt) + Rs2
 void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -614,7 +614,7 @@ class MacroAssembler: public Assembler {
     if (do_compress_zcb(Rd, Rs) && (Rd == Rs)) {
       c_zext_w(Rd);
     } else {
-      add_uw(Rd, Rs, zr);
+      _add_uw(Rd, Rs, zr);
     }
   }
 
@@ -1467,6 +1467,8 @@ public:
   void zero_memory(Register addr, Register len, Register tmp);
   void zero_dcache_blocks(Register base, Register cnt, Register tmp1, Register tmp2);
 
+  // zext add
+  void add_uw(Register Rd, Register Rs1, Register Rs2, Register tmp = t0);
   // shift left by shamt and add
   void shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -6356,7 +6356,8 @@ class StubGenerator: public StubCodeGenerator {
   // W't =
   //    M't,                                      0 <=  t <= 15
   //    ROTL'1(W't-3 ^ W't-8 ^ W't-14 ^ W't-16),  16 <= t <= 79
-  void sha1_prepare_w(Register cur_w, Register ws[], Register buf, int round) {
+  void sha1_prepare_w(Register cur_w, Register ws[], Register buf, Register cur_k,
+                      Register rmask, int round) {
     assert(round >= 0 && round < 80, "must be");
 
     if (round < 16) {
@@ -6371,8 +6372,9 @@ class StubGenerator: public StubCodeGenerator {
         // reverse bytes, as SHA-1 is defined in big-endian.
         __ revb(ws[round/2], ws[round/2]);
         __ srli(cur_w, ws[round/2], 32);
+        __ addw(cur_w, cur_w, cur_k);
       } else {
-        __ mv(cur_w, ws[round/2]);
+        __ addw(cur_w, ws[round/2], cur_k);
       }
 
       return;
@@ -6380,40 +6382,45 @@ class StubGenerator: public StubCodeGenerator {
 
     if ((round % 2) == 0) {
       int idx = 16;
-      // W't = ROTL'1(W't-3 ^ W't-8 ^ W't-14 ^ W't-16),  16 <= t <= 79
-      __ srli(t1, ws[(idx-8)/2], 32);
-      __ xorr(t0, ws[(idx-3)/2], t1);
+      // SWAR: compute both W[idx] and W[idx+1] together
+      // W't = ROTL'1(W't-3 ^ W't-8 ^ W't-14 ^ W't-16)
+      //
+      // Aligned operands (directly usable as packed pairs):
+      //   t-16: ws[(idx-16)/2] = (W[idx-16] : W[idx-15])
+      //   t-14: ws[(idx-14)/2] = (W[idx-14] : W[idx-13])
+      //   t-8:  ws[(idx-8)/2]  = (W[idx-8]  : W[idx-7])
+      //
+      // Misaligned t-3 operand: need (W[idx-3] : W[idx-2])
+      //   W[idx-3] is odd,  resides in low  32 bits of ws[(idx-4)/2]
+      //   W[idx-2] is even, resides in high 32 bits of ws[(idx-2)/2]
 
-      __ srli(t1, ws[(idx-14)/2], 32);
-      __ srli(cur_w, ws[(idx-16)/2], 32);
-      __ xorr(cur_w, cur_w, t1);
+      __ slli(t0, ws[(idx-4)/2], 32);   // t0.hi = W[idx-3]
+      __ xorr(t2, ws[(idx-16)/2], ws[(idx-14)/2]);  // t2 = (W[idx-16] : W[idx-15]) ^ (W[idx-14] : W[idx-13])
+      __ srli(t1, ws[(idx-2)/2], 32);   // t1.lo = W[idx-2]
+      __ xorr(t2, t2, ws[(idx-8)/2]);   // t2 ^= (W[idx-8] : W[idx-7])
+      __ orr(t0, t0, t1);               // t0 = (W[idx-3] : W[idx-2])
+      __ xorr(t0, t0, t2);              // t0 = pre-rotate for (W[idx] : W[idx+1])
 
-      __ xorr(cur_w, cur_w, t0);
-      __ rolw(cur_w, cur_w, 1, t0);
+      // SWAR ROTL1: ((t0 << 1) & ~rmask) | ((t0 >> 31) & rmask)
+      // This rotates both 32-bit halves independently without cross-contamination.
+      // rmask = 0x0000000100000001 marks bit 32 and bit 0 (cross-leak positions)
+      __ srli(t1, t0, 31);              // t1 = wrap bit candidates at bit 32 and bit 0
+      __ slli(cur_w, t0, 1);            // cur_w = t0 << 1 (ILP with above)
+      __ andr(t1, t1, rmask);           // t1 = wrap bits isolated
+      __ andn(t0, cur_w, rmask);        // t0 = (t0<<1) & ~rmask (clear cross-leak bits)
+                                        // Note: rd(t0) != rs1(cur_w), satisfies andn constraint
+      __ orr(ws[idx/2], t0, t1);        // ws[8] = (W[idx] : W[idx+1])
 
-      // copy the cur_w value to ws[8].
-      // now, valid w't values are at:
-      //  w0:       ws[0]'s lower 32 bits
-      //  w1 ~ w14: ws[1] ~ ws[7]
-      //  w15:      ws[8]'s higher 32 bits
-      __ slli(ws[idx/2], cur_w, 32);
+      // Extract W[idx] (high 32 bits) for current round
+      __ srli(cur_w, ws[idx/2], 32);
+      __ addw(cur_w, cur_w, cur_k);
 
       return;
     }
 
+    // Odd round: W[idx] was already computed in the previous even round
     int idx = 17;
-    // W't = ROTL'1(W't-3 ^ W't-8 ^ W't-14 ^ W't-16),  16 <= t <= 79
-    __ srli(t1, ws[(idx-3)/2], 32);
-    __ xorr(t0, t1, ws[(idx-8)/2]);
-
-    __ xorr(cur_w, ws[(idx-16)/2], ws[(idx-14)/2]);
-
-    __ xorr(cur_w, cur_w, t0);
-    __ rolw(cur_w, cur_w, 1, t0);
-
-    // copy the cur_w value to ws[8]
-    __ zext(cur_w, cur_w, 32);
-    __ orr(ws[idx/2], ws[idx/2], cur_w);
+    __ addw(cur_w, ws[(idx-1)/2], cur_k);        // cur_w = ws[8].lo = W[idx]
 
     // shift the w't registers, so they start from ws[0] again.
     // now, valid w't values are at:
@@ -6435,63 +6442,49 @@ class StubGenerator: public StubCodeGenerator {
     assert_different_registers(dst, x, y, z, t0, t1);
 
     if (round < 20) {
-      // (x & y) ^ (~x & z)
-      __ andr(t0, x, y);
-      __ andn(dst, z, x);
-      __ xorr(dst, dst, t0);
+      // (x & y) ^ (~x & z) = z ^ (x & (y ^ z))
+      __ xorr(dst, y, z);
+      __ andr(dst, x, dst);
+      __ xorr(dst, z, dst);
     } else if (round >= 40 && round < 60) {
-      // (x & y) ^ (x & z) ^ (y & z)
-      __ andr(t0, x, y);
-      __ andr(t1, x, z);
-      __ andr(dst, y, z);
-      __ xorr(dst, dst, t0);
+      // (x & y) ^ (x & z) ^ (y & z) = (x & y) ^ (z & (x ^ y))
+      __ xorr(t0, x, y);
+      __ andr(t1, x, y);
+      __ andr(dst, z, t0);
       __ xorr(dst, dst, t1);
     } else {
       // x ^ y ^ z
-      __ xorr(dst, x, y);
-      __ xorr(dst, dst, z);
+      __ xorr(dst, y, z);
+      __ xorr(dst, dst, x);
     }
   }
 
   // T = ROTL'5(a) + f't(b, c, d) + e + K't + W't
-  // e = d
-  // d = c
-  // c = ROTL'30(b)
-  // b = a
-  // a = T
+  // Updates values in place as follows to avoid register-move overhead:
+  //   a <- e = T
+  //   b <- a
+  //   c <- b = ROTL'30(b)
+  //   d <- c
+  //   e <- d
   void sha1_process_round(Register a, Register b, Register c, Register d, Register e,
-                          Register cur_k, Register cur_w, Register tmp, int round) {
+                          Register cur_w, Register tmp, int round) {
     assert(round >= 0 && round < 80, "must be");
-    assert_different_registers(a, b, c, d, e, cur_w, cur_k, tmp, t0);
+    assert_different_registers(a, b, c, d, e, cur_w, tmp, t0);
 
     // T = ROTL'5(a) + f't(b, c, d) + e + K't + W't
 
-    // cur_w will be recalculated at the beginning of each round,
-    // so, we can reuse it as a temp register here.
-    Register tmp2 = cur_w;
+    // Accumulate T directly into 'e' (prev e), physical register becomes next-round 'a'.
+    __ add(e, e, cur_w);
 
-    // reuse e as a temporary register, as we will mv new value into it later
-    Register tmp3 = e;
-    __ add(tmp2, cur_k, tmp2);
-    __ add(tmp3, tmp3, tmp2);
-    __ rolw(tmp2, a, 5, t0);
+    // cur_w is dead after W contribution above; reuse it for f(b,c,d).
+    sha1_f(cur_w, b, c, d, round);
 
-    sha1_f(tmp, b, c, d, round);
+    // b becomes next-round 'c'.
+    __ rolw(b, b, 30);
 
-    __ add(tmp2, tmp2, tmp);
-    __ add(tmp2, tmp2, tmp3);
-
-    // e = d
-    // d = c
-    // c = ROTL'30(b)
-    // b = a
-    // a = T
-    __ mv(e, d);
-    __ mv(d, c);
-
-    __ rolw(c, b, 30);
-    __ mv(b, a);
-    __ mv(a, tmp2);
+    __ add(e, e, cur_w);
+    __ rolw(tmp, a, 5, t0);
+    __ add(e, e, tmp);
   }
 
   // H(i)0 = a + H(i-1)0
@@ -6516,15 +6509,13 @@ class StubGenerator: public StubCodeGenerator {
 
   void sha1_preserve_prev_abcde(Register a, Register b, Register c, Register d, Register e,
                                 Register prev_ab, Register prev_cd, Register prev_e) {
-    assert_different_registers(a, b, c, d, e, prev_ab, prev_cd, prev_e, t0);
+    assert_different_registers(a, b, c, d, e, prev_ab, prev_cd, prev_e, t0, t1);
 
     __ slli(t0, b, 32);
-    __ zext(prev_ab, a, 32);
-    __ orr(prev_ab, prev_ab, t0);
+    __ add_uw(prev_ab, a, t0, prev_ab);
 
-    __ slli(t0, d, 32);
-    __ zext(prev_cd, c, 32);
-    __ orr(prev_cd, prev_cd, t0);
+    __ slli(t1, d, 32);
+    __ add_uw(prev_cd, c, t1, prev_cd);
 
     __ mv(prev_e, e);
   }
@@ -6575,6 +6566,7 @@ class StubGenerator: public StubCodeGenerator {
       // use x9 as src below.
       saved_regs += RegSet::of(x9);
     }
+    saved_regs += RegSet::of(x8);
     __ push_reg(saved_regs, sp);
 
     // c_rarg0 - c_rarg3: x10 - x13
@@ -6593,10 +6585,10 @@ class StubGenerator: public StubCodeGenerator {
 
     // [args-reg]:  x14 - x17
     // [temp-reg]:  x28 - x31
-    // [saved-reg]: x18 - x27
+    // [saved-reg]: x8, x18 - x27
 
     // h0/1/2/3/4
-    const Register a = x14, b = x15, c = x16, d = x17, e = x28;
+    const Register a0 = x14, b0 = x15, c0 = x16, d0 = x17, e0 = x28;
     // w0, w1, ... w15
     // put two adjecent w's in one register:
     //    one at high word part, another at low word part
@@ -6615,6 +6607,8 @@ class StubGenerator: public StubCodeGenerator {
     Register ws[9] = {x29, x30, x31, x18,
                       x19, x20, x21, x22,
                       x23}; // auxiliary register for calculating w's value
+    // mask register used for SWAR rotation
+    const Register rmask = x8;
     // current k't's value
     const Register cur_k = x24;
     // current w't's value
@@ -6635,28 +6629,37 @@ class StubGenerator: public StubCodeGenerator {
     // we can apply further optimization, which is to just ignore the
     // higher 32-bits in a/c/e, rather than set the higher
     // 32-bits of a/c/e to zero explicitly with extra instructions.
-    __ ld(a, Address(state, 0));
-    __ srli(b, a, 32);
-    __ ld(c, Address(state, 8));
-    __ srli(d, c, 32);
-    __ lw(e, Address(state, 16));
+    __ ld(a0, Address(state, 0));
+    __ srli(b0, a0, 32);
+    __ ld(c0, Address(state, 8));
+    __ srli(d0, c0, 32);
+    __ lw(e0, Address(state, 16));
+
+    __ li(rmask, 0x0000000100000001ul);
 
     Label L_sha1_loop;
     if (multi_block) {
       __ BIND(L_sha1_loop);
     }
 
-    sha1_preserve_prev_abcde(a, b, c, d, e, prev_ab, prev_cd, prev_e);
+    sha1_preserve_prev_abcde(a0, b0, c0, d0, e0, prev_ab, prev_cd, prev_e);
+
+    Register a = a0, b = b0, c = c0, d = d0, e = e0;
 
     for (int round = 0; round < 80; round++) {
       // prepare K't value
       sha1_prepare_k(cur_k, round);
 
       // prepare W't value
-      sha1_prepare_w(cur_w, ws, buf, round);
+      sha1_prepare_w(cur_w, ws, buf, cur_k, rmask, round);
 
       // one round process
-      sha1_process_round(a, b, c, d, e, cur_k, cur_w, t2, round);
+      sha1_process_round(a, b, c, d, e, cur_w, t2, round);
+
+      // Software register renaming for next round:
+      //   a' = e, b' = a, c' = b, d' = c, e' = d
+      Register pa = a, pb = b, pc = c, pd = d, pe = e;
+      a = pe, b = pa, c = pb, d = pc, e = pd;
     }
 
     // compute the intermediate hash value
@@ -6670,13 +6673,11 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     // store back the state.
-    __ zext(a, a, 32);
     __ slli(b, b, 32);
-    __ orr(a, a, b);
+    __ add_uw(a, a, b, a);
     __ sd(a, Address(state, 0));
-    __ zext(c, c, 32);
     __ slli(d, d, 32);
-    __ orr(c, c, d);
+    __ add_uw(c, c, d, c);
     __ sd(c, Address(state, 8));
     __ sw(e, Address(state, 16));
 


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391946](https://bugs.openjdk.org/browse/JDK-8391946): RISC-V: optimize SHA-1 intrinsic (**Enhancement** - P4)


### Contributors
 * gns `<wangbingzhen.riscv@isrc.iscas.ac.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32748/head:pull/32748` \
`$ git checkout pull/32748`

Update a local copy of the PR: \
`$ git checkout pull/32748` \
`$ git pull https://git.openjdk.org/jdk.git pull/32748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32748`

View PR using the GUI difftool: \
`$ git pr show -t 32748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32748.diff">https://git.openjdk.org/jdk/pull/32748.diff</a>

</details>
