### PR TITLE
8311029: G1: Check constraints before adjusting G1HeapRegionSize

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -267,7 +267,7 @@
   product(size_t, G1HeapRegionSize, 0,                                      \
           "Size of the G1 regions.")                                        \
           range(0, NOT_LP64(32*M) LP64_ONLY(512*M))                         \
-          constraint(G1HeapRegionSizeConstraintFunc,AfterErgo)              \
+          constraint(G1HeapRegionSizeConstraintFunc, AfterErgo)             \
                                                                             \
   product(uint, G1ConcRefinementThreads, 0,                                 \
           "The number of parallel remembered set update threads. "          \

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -267,7 +267,7 @@
   product(size_t, G1HeapRegionSize, 0,                                      \
           "Size of the G1 regions.")                                        \
           range(0, NOT_LP64(32*M) LP64_ONLY(512*M))                         \
-          constraint(G1HeapRegionSizeConstraintFunc,AfterMemoryInit)        \
+          constraint(G1HeapRegionSizeConstraintFunc,AfterErgo)              \
                                                                             \
   product(uint, G1ConcRefinementThreads, 0,                                 \
           "The number of parallel remembered set update threads. "          \

--- a/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
+++ b/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
@@ -84,8 +84,8 @@ JVMFlag::Error G1HeapRegionSizeConstraintFunc(size_t value, bool verbose) {
   if (value != 0 && value < G1HeapRegionBounds::min_size()) {
     JVMFlag::printError(verbose,
                         "G1HeapRegionSize (%zu) must be "
-                        "greater than or equal to ergonomic heap region minimum size (%zu)\n",
-                        value, G1HeapRegionBounds::min_size());
+                        "greater than or equal to ergonomic heap region minimum size (%zuM)\n",
+                        value, G1HeapRegionBounds::min_size() / M);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {
     return JVMFlag::SUCCESS;

--- a/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
+++ b/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
@@ -84,8 +84,8 @@ JVMFlag::Error G1HeapRegionSizeConstraintFunc(size_t value, bool verbose) {
   if (value != 0 && value < G1HeapRegionBounds::min_size()) {
     JVMFlag::printError(verbose,
                         "G1HeapRegionSize (%zu) must be "
-                        "greater than or equal to ergonomic heap region minimum size\n",
-                        value);
+                        "greater than or equal to ergonomic heap region minimum size (%zu)\n",
+                        value, G1HeapRegionBounds::min_size());
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {
     return JVMFlag::SUCCESS;

--- a/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
+++ b/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
@@ -81,7 +81,7 @@ JVMFlag::Error G1HeapRegionSizeConstraintFunc(size_t value, bool verbose) {
   if (!UseG1GC) return JVMFlag::SUCCESS;
 
   // Default value of G1HeapRegionSize=0 means will be set ergonomically.
-  if (FLAG_IS_CMDLINE(G1HeapRegionSize) && (value < G1HeapRegionBounds::min_size())) {
+  if (value != 0 && value < G1HeapRegionBounds::min_size()) {
     JVMFlag::printError(verbose,
                         "G1HeapRegionSize (%zu) must be "
                         "greater than or equal to ergonomic heap region minimum size\n",

--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ package gc.arguments;
 
 /*
  * @test TestG1HeapRegionSize
- * @bug 8021879
+ * @bug 8021879 8311029
  * @requires vm.gc.G1 & vm.opt.G1HeapRegionSize == null
  * @summary Verify that the flag G1HeapRegionSize is updated properly
  * @modules java.base/jdk.internal.misc
@@ -78,6 +78,8 @@ public class TestG1HeapRegionSize {
     final int M = 1024 * 1024;
 
     checkG1HeapRegionSize(new String[] { "-Xmx64m"   /* default is 1m */        },  1*M, 0);
+    checkG1HeapRegionSize(new String[] { "-Xmx64m",  "-XX:G1HeapRegionSize=0"   },  1*M, 0);
+    checkG1HeapRegionSize(new String[] { "-Xmx64m",  "-XX:G1HeapRegionSize=16"  },    0, 1);
     checkG1HeapRegionSize(new String[] { "-Xmx64m",  "-XX:G1HeapRegionSize=2m"  },  2*M, 0);
     checkG1HeapRegionSize(new String[] { "-Xmx64m",  "-XX:G1HeapRegionSize=3m"  },  4*M, 0);
     checkG1HeapRegionSize(new String[] { "-Xmx256m", "-XX:G1HeapRegionSize=32m" }, 32*M, 0);

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryManagement.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug     4530538 6980984
+ * @bug     4530538 6980984 8311029
  * @summary Basic unit test of memory management testing:
  *          1) setUsageThreshold() and getUsageThreshold()
  *          2) test low memory detection on the old generation.
@@ -35,7 +35,7 @@
  * @modules jdk.management
  *
  * @run main/othervm/timeout=600 -Xmn8m -XX:+IgnoreUnrecognizedVMOptions
- * -XX:G1HeapRegionSize=1 -XX:-UseLargePages MemoryManagement
+ * -XX:G1HeapRegionSize=1m -XX:-UseLargePages MemoryManagement
  */
 
 /*


### PR DESCRIPTION
Please review this small fix.

**Problem:**

G1 only supports region sizes from 1 MiB up to 32 MiB on 32-bit platforms or 512 MiB on 64-bit platforms. However, an invalid value such as `16` is silently adjusted to 1 MiB before the constraint is checked:

```text
$ java -XX:G1HeapRegionSize=16 -XX:+PrintFlagsFinal -version | grep G1HeapRegionSize
   size_t G1HeapRegionSize                         = 1048576                                   {product} {command line, ergonomic}
openjdk version "28-internal" 2027-03-23
OpenJDK Runtime Environment (build 28-internal-adhoc.zhangyunbo)
OpenJDK 64-Bit Server VM (build 28-internal-adhoc.zhangyunbo, mixed mode, sharing)
```

**Fix:**

- Move the `G1HeapRegionSize` constraint from `AfterMemoryInit` to `AfterErgo`, so it is checked after GC selection but before the value is adjusted during heap initialization.
- Keep `0` as the valid ergonomic value and reject non-zero values below 1 MiB.
- Update `MemoryManagement.java` to use the valid minimum value `1m` instead of relying on an invalid value being adjusted.

**Testing:**

- gc/arguments：47 passed, 0 failed, 2 skipped
- tier1:all pass
- MemoryManagement.java & TestG1HeapRegionSize.java: pass

```
$ java -XX:G1HeapRegionSize=16 -version
G1HeapRegionSize (16) must be greater than or equal to ergonomic heap region minimum size
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311029](https://bugs.openjdk.org/browse/JDK-8311029): G1: Check constraints before adjusting G1HeapRegionSize (**Enhancement** - P4)


### Reviewers
 * [April Ivy](https://openjdk.org/census#aivy) (@aprilivy - Author)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32749/head:pull/32749` \
`$ git checkout pull/32749`

Update a local copy of the PR: \
`$ git checkout pull/32749` \
`$ git pull https://git.openjdk.org/jdk.git pull/32749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32749`

View PR using the GUI difftool: \
`$ git pr show -t 32749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32749.diff">https://git.openjdk.org/jdk/pull/32749.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32749#issuecomment-5578743705)
</details>
