### PR TITLE
8391287: C2: Potential null dereference in inline_vector_gather_scatter

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1392,8 +1392,7 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
     addr = array_element_address(base, index, elem_bt);
   }
 
-  const TypePtr* addr_type = gvn().type(addr)->isa_ptr();
-  const TypeAryPtr* arr_type = addr_type != nullptr ? addr_type->isa_aryptr() : nullptr;
+  const TypeAryPtr* arr_type = gvn().type(addr)->isa_aryptr();
 
   // Gather and scatter address an array, and the array must be consistent with
   // the vector type.
@@ -1454,17 +1453,17 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
 
     Node* vstore = nullptr;
     if (mask != nullptr) {
-      vstore = gvn().transform(trace_vector(new StoreVectorScatterMaskedNode(control(), memory(addr), addr, addr_type, val, indexes, mask)));
+      vstore = gvn().transform(trace_vector(new StoreVectorScatterMaskedNode(control(), memory(addr), addr, arr_type, val, indexes, mask)));
     } else {
-      vstore = gvn().transform(trace_vector(new StoreVectorScatterNode(control(), memory(addr), addr, addr_type, val, indexes)));
+      vstore = gvn().transform(trace_vector(new StoreVectorScatterNode(control(), memory(addr), addr, arr_type, val, indexes)));
     }
-    set_memory(vstore, addr_type);
+    set_memory(vstore, arr_type);
   } else {
     Node* vload = nullptr;
     if (mask != nullptr) {
-      vload = gvn().transform(trace_vector(new LoadVectorGatherMaskedNode(control(), memory(addr), addr, addr_type, vector_type, indexes, mask)));
+      vload = gvn().transform(trace_vector(new LoadVectorGatherMaskedNode(control(), memory(addr), addr, arr_type, vector_type, indexes, mask)));
     } else {
-      vload = gvn().transform(trace_vector(new LoadVectorGatherNode(control(), memory(addr), addr, addr_type, vector_type, indexes)));
+      vload = gvn().transform(trace_vector(new LoadVectorGatherNode(control(), memory(addr), addr, arr_type, vector_type, indexes)));
     }
     Node* box = box_vector(vload, vbox_type, elem_bt, num_elem);
     set_result(box);

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1393,10 +1393,17 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
   }
 
   const TypePtr* addr_type = gvn().type(addr)->isa_ptr();
-  const TypeAryPtr* arr_type = addr_type->isa_aryptr();
+  const TypeAryPtr* arr_type = addr_type != nullptr ? addr_type->isa_aryptr() : nullptr;
 
-  // The array must be consistent with vector type
-  if (arr_type == nullptr || (arr_type != nullptr && !elem_consistent_with_arr(elem_bt, arr_type, false))) {
+  // Gather and scatter address an array, and the array must be consistent with
+  // the vector type.
+  if (arr_type == nullptr) {
+    log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=not an array",
+                    is_scatter, is_scatter ? "scatter" : "gather",
+                    num_elem, type2name(elem_bt));
+    return false;
+  }
+  if (!elem_consistent_with_arr(elem_bt, arr_type, false)) {
     log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s ismask=no",
                     is_scatter, is_scatter ? "scatter" : "gather",
                     num_elem, type2name(elem_bt), type2name(arr_type->elem()->array_element_basic_type()));


### PR DESCRIPTION
`inline_vector_gather_scatter` rejects a base that is not an array, and the log message in that same branch calls `arr_type->elem()`, so a non-array base dereferences null under `PrintIntrinsics`. `addr_type` one line above comes from `isa_ptr()` and was dereferenced without a check too.

The null case is now its own branch with its own message, and `arr_type` is only computed when `addr_type` is a pointer.

The path is unreachable on aarch64 at any element type: `aarch64_vector.ad` rejects `Op_LoadVectorGather` when `UseSVE == 0` or the element is subword, so C2 gives up on the intrinsic first. I confirmed that with a local build that forced a non-array base into the gather. Reproducing at runtime needs x86 with AVX2.

Testing:
- `make CONF=macosx-aarch64-server-fastdebug-nometal test TEST="jtreg:test/hotspot/jtreg/compiler/vectorapi"`
- `hotspot:tier1_compiler` on macos-aarch64 fastdebug

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391287](https://bugs.openjdk.org/browse/JDK-8391287): C2: Potential null dereference in inline_vector_gather_scatter (**Bug** - P5)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32750/head:pull/32750` \
`$ git checkout pull/32750`

Update a local copy of the PR: \
`$ git checkout pull/32750` \
`$ git pull https://git.openjdk.org/jdk.git pull/32750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32750`

View PR using the GUI difftool: \
`$ git pr show -t 32750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32750.diff">https://git.openjdk.org/jdk/pull/32750.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32750#issuecomment-5578870082)
</details>
