### PR TITLE
8391418: C2: "assert(_base >= VectorMask && _base <= VectorZ) failed: Not a Vector" with VectorMaskCast

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -2435,9 +2435,13 @@ Node* VectorMaskCastNode::Identity(PhaseGVN* phase) {
   // If the types of the input and output nodes in a VectorMaskCast chain are
   // exactly the same, the intermediate VectorMaskCast nodes can be eliminated.
   Node* n = VectorNode::uncast_mask(this);
-  // The chain can end at `Top` node if it's a dead path.
-  if (!n->is_top() && vect_type()->eq(n->bottom_type())) {
-      return n;
+  // A chain can also end up converting between different mask types, in which
+  // case it must be kept, so the types have to be compared below.
+  //
+  // Types are hash-consed, so a pointer comparison is enough. It also tolerates
+  // the chain ending at a `Top` node on a dead path.
+  if (vect_type() == n->bottom_type()) {
+    return n;
   }
   return this;
 }

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -2435,7 +2435,8 @@ Node* VectorMaskCastNode::Identity(PhaseGVN* phase) {
   // If the types of the input and output nodes in a VectorMaskCast chain are
   // exactly the same, the intermediate VectorMaskCast nodes can be eliminated.
   Node* n = VectorNode::uncast_mask(this);
-  if (vect_type()->eq(n->bottom_type())) {
+  // The chain can end at `Top` node if it's a dead path.
+  if (!n->is_top() && vect_type()->eq(n->bottom_type())) {
       return n;
   }
   return this;

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskCastTopInput.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskCastTopInput.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8391418
+ * @key randomness
+ * @summary VectorMaskCastNode::Identity must handle the TOP input during IGVN
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @modules jdk.incubator.vector
+ *
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+StressIGVN -XX:RepeatCompilation=100
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+
+package compiler.vectorapi;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+public class TestVectorMaskCastTopInput {
+    static final VectorSpecies<Double> SPECIES = DoubleVector.SPECIES_256;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 1000; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        MemorySegment segment = MemorySegment.ofArray(new byte[2000]);
+        VectorMask<Double> vectorMask = VectorMask.fromLong(SPECIES, 0x111);
+        DoubleVector vector = DoubleVector.zero(SPECIES);
+
+        for (int i = 0; i < 1000; i += 16) {
+            vector.intoMemorySegment(segment, i, ByteOrder.BIG_ENDIAN, vectorMask);
+        }
+
+        // This store is always out of bounds: C2 kills this path, leaving the
+        // VectorMaskCastNode that feeds the store's mask with a TOP input.
+        try {
+            vector.intoMemorySegment(segment, -1, ByteOrder.BIG_ENDIAN, vectorMask);
+        } catch (IndexOutOfBoundsException e) {
+            // Expected.
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskCastTopInput.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskCastTopInput.java
@@ -24,9 +24,8 @@
 /**
  * @test
  * @bug 8391418
- * @key randomness
  * @summary VectorMaskCastNode::Identity must handle the TOP input during IGVN
- * @requires vm.debug == true & vm.compiler2.enabled
+ * @requires vm.compiler2.enabled
  * @modules jdk.incubator.vector
  *
  * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskCastTopInput.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorMaskCastTopInput.java
@@ -29,9 +29,10 @@
  * @modules jdk.incubator.vector
  *
  * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
- *                   -XX:+StressIGVN -XX:RepeatCompilation=100
+ *                   -XX:CompileThreshold=100 -XX:+StressIGVN -XX:StressSeed=14
  *                   -XX:CompileCommand=compileonly,${test.main.class}::test
  *                   ${test.main.class}
+ * @run main ${test.main.class}
  */
 
 package compiler.vectorapi;
@@ -47,7 +48,7 @@ public class TestVectorMaskCastTopInput {
     static final VectorSpecies<Double> SPECIES = DoubleVector.SPECIES_256;
 
     public static void main(String[] args) {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 100; i++) {
             test();
         }
     }


### PR DESCRIPTION
`VectorMaskCastNode::Identity` uses `VectorNode::uncast_mask` to eliminate a `VectorMaskCast` chain. It then uses `TypeVect::eq` to compare the type of the node returned by `VectorNode::uncast_mask`. However, `VectorNode::uncast_mask` may return the `Top` node if the `VectorMaskCast` chain is a dead path, which causes this assertion to be triggered.
```
    992  VectorMaskCast  === _ 1  [[ 779 ]]  #vectormask<J,4>
         !jvms: ... DoubleVector::intoMemorySegment @ bci:96 Test::test @ bci:62
      1  Con  === 0  [[ ]]  #top
```

`Top` is the only non-vector input possible here: the constructor of `VectorMaskCastNode` requires a vector, and a node whose type collapses to `Type::TOP` is immediately subsumed by the `top` node because `Type::TOP` is a singleton. Therefore this PR skips the transformation when the chain ends at `Top`.

The test is the reproducer from the bug report; it fails without the fix.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391418](https://bugs.openjdk.org/browse/JDK-8391418): C2: "assert(_base &gt;= VectorMask &amp;&amp; _base &lt;= VectorZ) failed: Not a Vector" with VectorMaskCast (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32751/head:pull/32751` \
`$ git checkout pull/32751`

Update a local copy of the PR: \
`$ git checkout pull/32751` \
`$ git pull https://git.openjdk.org/jdk.git pull/32751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32751`

View PR using the GUI difftool: \
`$ git pr show -t 32751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32751.diff">https://git.openjdk.org/jdk/pull/32751.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32751#issuecomment-5579962762)
</details>
