### PR TITLE
8391923: G1: NUMA-node accounting should use num_regions identifiers

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1549,7 +1549,7 @@ jint G1CollectedHeap::initialize() {
 
   G1HeapRegionRemSet::initialize(_reserved);
 
-  G1FreeRegionList::set_unrealistically_long_length(max_num_regions() + 1);
+  G1FreeRegionList::set_unrealistically_large_num_regions(max_num_regions() + 1);
 
   _bot = new G1BlockOffsetTable(reserved(), bot_storage);
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1234,9 +1234,9 @@ public:
 
   inline uint target_num_eden_regions() const;
   uint num_eden_regions() const { return _eden.num_regions(); }
-  uint num_eden_regions(uint node_index) const { return _eden.regions_on_node(node_index); }
+  uint num_eden_regions(uint node_index) const { return _eden.num_regions_on_node(node_index); }
   uint num_survivor_regions() const { return _survivor.num_regions(); }
-  uint num_survivor_regions(uint node_index) const { return _survivor.regions_on_node(node_index); }
+  uint num_survivor_regions(uint node_index) const { return _survivor.num_regions_on_node(node_index); }
   size_t eden_regions_used_bytes() const { return _eden.used_bytes(); }
   size_t survivor_regions_used_bytes() const { return _survivor.used_bytes(); }
   uint num_young_regions() const { return _eden.num_regions() + _survivor.num_regions(); }

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
@@ -61,10 +61,10 @@ class G1HeapRegionTable : public G1BiasedMappedArray<G1HeapRegion*> {
 // region we retain the G1HeapRegion to be able to re-use it in the
 // future (in case we recommit it).
 //
-// We keep track of four lengths:
+// We keep track of three region counts:
 //
-// * _num_committed (returned by length()) is the number of currently
-//   committed regions. These may not be contiguous.
+// * num_committed_regions() is the number of currently committed regions using
+//   the committed map. These may not be contiguous.
 // * _next_highest_used_hrm_index (not exposed outside this class) is the
 //   highest heap region index +1 for which we have G1HeapRegions.
 // * max_num_regions() returns the maximum number of regions the heap has reserved.
@@ -226,7 +226,7 @@ public:
   uint num_used_regions() const { return num_committed_regions() - num_free_regions(); }
 
   uint num_free_regions(uint node_index) const {
-    return _free_list.length(node_index);
+    return _free_list.num_regions_on_node(node_index);
   }
 
   size_t total_free_bytes() const {

--- a/src/hotspot/share/gc/g1/g1HeapRegionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionSet.cpp
@@ -340,7 +340,7 @@ void G1FreeRegionList::verify_list() {
 
     actual_num_regions++;
     guarantee(actual_num_regions < _unrealistically_large_num_regions,
-              "[%s] the calculated number of regions: %u seems very long, cycle? curr: " PTR_FORMAT " prev0: " PTR_FORMAT " " "prev1: " PTR_FORMAT " num_regions: %u",
+              "[%s] the calculated number of regions: %u seems unrealistically large, cycle? curr: " PTR_FORMAT " prev0: " PTR_FORMAT " " "prev1: " PTR_FORMAT " num_regions: %u",
               name(), actual_num_regions, p2i(curr), p2i(prev0), p2i(prev1), num_regions());
 
     if (curr->next() != nullptr) {

--- a/src/hotspot/share/gc/g1/g1HeapRegionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionSet.cpp
@@ -27,7 +27,7 @@
 #include "gc/g1/g1HeapRegionSet.inline.hpp"
 #include "gc/g1/g1NUMA.hpp"
 
-uint G1FreeRegionList::_unrealistically_long_length = 0;
+uint G1FreeRegionList::_unrealistically_large_num_regions = 0;
 
 #ifndef PRODUCT
 void G1HeapRegionSetBase::verify_region(G1HeapRegion* hr) {
@@ -83,9 +83,9 @@ G1HeapRegionSetBase::G1HeapRegionSetBase(const char* name, G1HeapRegionSetChecke
 {
 }
 
-void G1FreeRegionList::set_unrealistically_long_length(uint len) {
-  guarantee(_unrealistically_long_length == 0, "should only be set once");
-  _unrealistically_long_length = len;
+void G1FreeRegionList::set_unrealistically_large_num_regions(uint num_regions) {
+  guarantee(_unrealistically_large_num_regions == 0, "should only be set once");
+  _unrealistically_large_num_regions = num_regions;
 }
 
 void G1FreeRegionList::abandon() {
@@ -107,7 +107,7 @@ void G1FreeRegionList::remove_all() {
     curr->set_prev(nullptr);
     curr->set_containing_set(nullptr);
 
-    decrease_length(curr->node_index());
+    decrease_num_regions(curr->node_index());
 
     curr = next;
   }
@@ -250,7 +250,7 @@ void G1FreeRegionList::remove_starting_at(G1HeapRegion* first, uint num_regions_
   assert_free_region_list(num_regions() >= num_regions_to_remove, "pre-condition");
 
   verify_optional();
-  DEBUG_ONLY(uint old_length = num_regions();)
+  DEBUG_ONLY(uint old_num_regions = num_regions();)
 
   // prev points to the node right before first or null when first == _head
   G1HeapRegion* const prev = first->prev();
@@ -276,7 +276,7 @@ void G1FreeRegionList::remove_starting_at(G1HeapRegion* first, uint num_regions_
 
     num_regions_removed++;
 
-    decrease_length(curr->node_index());
+    decrease_num_regions(curr->node_index());
 
     curr = next;
   }
@@ -293,12 +293,12 @@ void G1FreeRegionList::remove_starting_at(G1HeapRegion* first, uint num_regions_
   }
 
   assert(num_regions_removed == num_regions_to_remove,
-         "[%s] count: %u should be == num_regions: %u",
+         "[%s] removed: %u should be equal to num_regions_to_remove: %u",
          name(), num_regions_removed, num_regions_to_remove);
-  assert(num_regions() + num_regions_to_remove == old_length,
-         "[%s] new length should be consistent "
-         "new length: %u old length: %u num_regions: %u",
-         name(), num_regions(), old_length, num_regions_to_remove);
+  assert(num_regions() + num_regions_to_remove == old_num_regions,
+         "[%s] new num_regions should be equal "
+         "new num_regions: %u old num_regions: %u num_regions_to_remove: %u",
+         name(), num_regions(), old_num_regions, num_regions_to_remove);
 
   verify_optional();
 }
@@ -331,26 +331,23 @@ void G1FreeRegionList::verify_list() {
   G1HeapRegion* curr = _head;
   G1HeapRegion* prev1 = nullptr;
   G1HeapRegion* prev0 = nullptr;
-  uint count = 0;
-  size_t capacity = 0;
+  uint actual_num_regions = 0;
   uint last_index = 0;
 
   guarantee(_head == nullptr || _head->prev() == nullptr, "_head should not have a prev");
   while (curr != nullptr) {
     verify_region(curr);
 
-    count++;
-    guarantee(count < _unrealistically_long_length,
-              "[%s] the calculated length: %u seems very long, is there maybe a cycle? curr: " PTR_FORMAT " prev0: " PTR_FORMAT " " "prev1: " PTR_FORMAT " length: %u",
-              name(), count, p2i(curr), p2i(prev0), p2i(prev1), num_regions());
+    actual_num_regions++;
+    guarantee(actual_num_regions < _unrealistically_large_num_regions,
+              "[%s] the calculated number of regions: %u seems very long, cycle? curr: " PTR_FORMAT " prev0: " PTR_FORMAT " " "prev1: " PTR_FORMAT " num_regions: %u",
+              name(), actual_num_regions, p2i(curr), p2i(prev0), p2i(prev1), num_regions());
 
     if (curr->next() != nullptr) {
       guarantee(curr->next()->prev() == curr, "Next or prev pointers messed up");
     }
     guarantee(curr->hrm_index() == 0 || curr->hrm_index() > last_index, "List should be sorted");
     last_index = curr->hrm_index();
-
-    capacity += curr->capacity();
 
     prev1 = prev0;
     prev0 = curr;
@@ -359,7 +356,7 @@ void G1FreeRegionList::verify_list() {
 
   guarantee(_tail == prev0, "Expected %s to end with %u but it ended with %u.", name(), _tail->hrm_index(), prev0->hrm_index());
   guarantee(_tail == nullptr || _tail->next() == nullptr, "_tail should not have a next");
-  guarantee(num_regions() == count, "%s count mismatch. Expected %u, actual %u.", name(), num_regions(), count);
+  guarantee(num_regions() == actual_num_regions, "%s num_regions mismatch. Expected %u, actual %u.", name(), num_regions(), actual_num_regions);
 }
 
 
@@ -376,25 +373,25 @@ G1FreeRegionList::~G1FreeRegionList() {
   }
 }
 
-G1FreeRegionList::NodeInfo::NodeInfo() : _numa(G1NUMA::numa()), _length_of_node(nullptr),
+G1FreeRegionList::NodeInfo::NodeInfo() : _numa(G1NUMA::numa()), _num_regions_on_node(nullptr),
                                          _num_nodes(_numa->num_active_nodes()) {
   assert(UseNUMA, "Invariant");
 
-  _length_of_node = NEW_C_HEAP_ARRAY(uint, _num_nodes, mtGC);
+  _num_regions_on_node = NEW_C_HEAP_ARRAY(uint, _num_nodes, mtGC);
 }
 
 G1FreeRegionList::NodeInfo::~NodeInfo() {
-  FREE_C_HEAP_ARRAY(_length_of_node);
+  FREE_C_HEAP_ARRAY(_num_regions_on_node);
 }
 
 void G1FreeRegionList::NodeInfo::clear() {
   for (uint i = 0; i < _num_nodes; ++i) {
-    _length_of_node[i] = 0;
+    _num_regions_on_node[i] = 0;
   }
 }
 
 void G1FreeRegionList::NodeInfo::add(NodeInfo* info) {
   for (uint i = 0; i < _num_nodes; ++i) {
-    _length_of_node[i] += info->_length_of_node[i];
+    _num_regions_on_node[i] += info->_num_regions_on_node[i];
   }
 }

--- a/src/hotspot/share/gc/g1/g1HeapRegionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionSet.hpp
@@ -145,17 +145,17 @@ private:
   // This class is only initialized if there are multiple active nodes.
   class NodeInfo : public CHeapObj<mtGC> {
     G1NUMA* _numa;
-    uint*   _length_of_node;
+    uint*   _num_regions_on_node;
     uint    _num_nodes;
 
   public:
     NodeInfo();
     ~NodeInfo();
 
-    inline void increase_length(uint node_index);
-    inline void decrease_length(uint node_index);
+    inline void increase_num_regions(uint node_index);
+    inline void decrease_num_regions(uint node_index);
 
-    inline uint length(uint index) const;
+    inline uint num_regions_on_node(uint index) const;
 
     void clear();
 
@@ -169,15 +169,15 @@ private:
   // time. It helps to improve performance when adding several ordered items in a row.
   G1HeapRegion* _last;
 
-  NodeInfo*   _node_info;
+  NodeInfo* _node_info;
 
-  static uint _unrealistically_long_length;
+  static uint _unrealistically_large_num_regions;
 
   inline G1HeapRegion* remove_from_head_impl();
   inline G1HeapRegion* remove_from_tail_impl();
 
-  inline void increase_length(uint node_index);
-  inline void decrease_length(uint node_index);
+  inline void increase_num_regions(uint node_index);
+  inline void decrease_num_regions(uint node_index);
 
   // Common checks for adding a list.
   void add_list_common_start(G1FreeRegionList* from_list);
@@ -200,7 +200,7 @@ public:
   }
 #endif
 
-  static void set_unrealistically_long_length(uint len);
+  static void set_unrealistically_large_num_regions(uint num_regions);
 
   // Add hr to the list. The region should not be a member of another set.
   // Assumes that the list is ordered and will preserve that order. The order
@@ -235,7 +235,7 @@ public:
   virtual void verify();
 
   using G1HeapRegionSetBase::num_regions;
-  uint length(uint node_index) const;
+  uint num_regions_on_node(uint node_index) const;
 };
 
 // Iterator class that provides a convenient way to iterate over the

--- a/src/hotspot/share/gc/g1/g1HeapRegionSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionSet.inline.hpp
@@ -68,7 +68,7 @@ inline void G1FreeRegionList::add_to_tail(G1HeapRegion* region_to_add) {
     _head = region_to_add;
     _tail = region_to_add;
   }
-  increase_length(region_to_add->node_index());
+  increase_num_regions(region_to_add->node_index());
 }
 
 inline void G1FreeRegionList::add_ordered(G1HeapRegion* hr) {
@@ -117,7 +117,7 @@ inline void G1FreeRegionList::add_ordered(G1HeapRegion* hr) {
   }
   _last = hr;
 
-  increase_length(hr->node_index());
+  increase_num_regions(hr->node_index());
 }
 
 inline G1HeapRegion* G1FreeRegionList::remove_from_head_impl() {
@@ -169,7 +169,7 @@ inline G1HeapRegion* G1FreeRegionList::remove_region(bool from_head) {
   // remove() will verify the region and check mt safety.
   remove(hr);
 
-  decrease_length(hr->node_index());
+  decrease_num_regions(hr->node_index());
 
   return hr;
 }
@@ -227,45 +227,45 @@ inline G1HeapRegion* G1FreeRegionList::remove_region_with_node_index(bool from_h
   }
 
   remove(cur);
-  decrease_length(cur->node_index());
+  decrease_num_regions(cur->node_index());
 
   return cur;
 }
 
-inline void G1FreeRegionList::NodeInfo::increase_length(uint node_index) {
+inline void G1FreeRegionList::NodeInfo::increase_num_regions(uint node_index) {
   if (node_index < _num_nodes) {
-    _length_of_node[node_index] += 1;
+    _num_regions_on_node[node_index] += 1;
   }
 }
 
-inline void G1FreeRegionList::NodeInfo::decrease_length(uint node_index) {
+inline void G1FreeRegionList::NodeInfo::decrease_num_regions(uint node_index) {
   if (node_index < _num_nodes) {
-    assert(_length_of_node[node_index] > 0,
-           "Current length %u should be greater than zero for node %u",
-           _length_of_node[node_index], node_index);
-    _length_of_node[node_index] -= 1;
+    assert(_num_regions_on_node[node_index] > 0,
+           "Current num_regions %u should be greater than zero for node %u",
+           _num_regions_on_node[node_index], node_index);
+    _num_regions_on_node[node_index] -= 1;
   }
 }
 
-inline uint G1FreeRegionList::NodeInfo::length(uint node_index) const {
-  return _length_of_node[node_index];
+inline uint G1FreeRegionList::NodeInfo::num_regions_on_node(uint node_index) const {
+  return _num_regions_on_node[node_index];
 }
 
-inline void G1FreeRegionList::increase_length(uint node_index) {
+inline void G1FreeRegionList::increase_num_regions(uint node_index) {
   if (_node_info != nullptr) {
-    return _node_info->increase_length(node_index);
+    return _node_info->increase_num_regions(node_index);
   }
 }
 
-inline void G1FreeRegionList::decrease_length(uint node_index) {
+inline void G1FreeRegionList::decrease_num_regions(uint node_index) {
   if (_node_info != nullptr) {
-    return _node_info->decrease_length(node_index);
+    return _node_info->decrease_num_regions(node_index);
   }
 }
 
-inline uint G1FreeRegionList::length(uint node_index) const {
+inline uint G1FreeRegionList::num_regions_on_node(uint node_index) const {
   if (_node_info != nullptr) {
-    return _node_info->length(node_index);
+    return _node_info->num_regions_on_node(node_index);
   } else {
     return 0;
   }

--- a/src/hotspot/share/gc/g1/g1RegionsOnNodes.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionsOnNodes.cpp
@@ -26,13 +26,13 @@
 #include "gc/g1/g1NUMA.hpp"
 #include "gc/g1/g1RegionsOnNodes.hpp"
 
-G1RegionsOnNodes::G1RegionsOnNodes() : _num_regions_per_node(nullptr), _numa(G1NUMA::numa()) {
-  _num_regions_per_node = NEW_C_HEAP_ARRAY(Atomic<uint>, _numa->num_active_nodes(), mtGC);
+G1RegionsOnNodes::G1RegionsOnNodes() : _num_regions_on_node(nullptr), _numa(G1NUMA::numa()) {
+  _num_regions_on_node = NEW_C_HEAP_ARRAY(Atomic<uint>, _numa->num_active_nodes(), mtGC);
   clear();
 }
 
 G1RegionsOnNodes::~G1RegionsOnNodes() {
-  FREE_C_HEAP_ARRAY(_num_regions_per_node);
+  FREE_C_HEAP_ARRAY(_num_regions_on_node);
 }
 
 void G1RegionsOnNodes::add(G1HeapRegion* hr) {
@@ -40,14 +40,14 @@ void G1RegionsOnNodes::add(G1HeapRegion* hr) {
 
   // Update only if the node index is valid.
   if (node_index < _numa->num_active_nodes()) {
-    _num_regions_per_node[node_index].add_then_fetch(1u, memory_order_relaxed);
+    _num_regions_on_node[node_index].add_then_fetch(1u, memory_order_relaxed);
   }
 }
 
 void G1RegionsOnNodes::clear() {
-  ::new (_num_regions_per_node) Atomic<uint>[_numa->num_active_nodes()]{};
+  ::new (_num_regions_on_node) Atomic<uint>[_numa->num_active_nodes()]{};
 }
 
-uint G1RegionsOnNodes::num_regions_per_node(uint node_index) const {
-  return _num_regions_per_node[node_index].load_relaxed();
+uint G1RegionsOnNodes::num_regions_on_node(uint node_index) const {
+  return _num_regions_on_node[node_index].load_relaxed();
 }

--- a/src/hotspot/share/gc/g1/g1RegionsOnNodes.hpp
+++ b/src/hotspot/share/gc/g1/g1RegionsOnNodes.hpp
@@ -33,7 +33,7 @@ class G1HeapRegion;
 
 // Contains per node index region count
 class G1RegionsOnNodes : public StackObj {
-  Atomic<uint>*  _num_regions_per_node;
+  Atomic<uint>*  _num_regions_on_node;
   G1NUMA*        _numa;
 
 public:
@@ -46,7 +46,7 @@ public:
 
   void clear();
 
-  uint num_regions_per_node(uint node_index) const;
+  uint num_regions_on_node(uint node_index) const;
 };
 
 #endif // SHARE_VM_GC_G1_G1REGIONS_HPP

--- a/src/hotspot/share/gc/g1/g1YoungRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungRegions.hpp
@@ -46,8 +46,8 @@ protected:
   NONCOPYABLE(G1YoungRegions);
 
 public:
-  uint regions_on_node(uint node_index) const {
-    return _regions_on_node.num_regions_per_node(node_index);
+  uint num_regions_on_node(uint node_index) const {
+    return _regions_on_node.num_regions_on_node(node_index);
   }
 
   void add_used_bytes(size_t used_bytes) { _used_bytes.add_then_fetch(used_bytes, memory_order_relaxed); }


### PR DESCRIPTION
Hi all,

  please review this "length" to "num_regions" cleanup for NUMA node management.

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391923](https://bugs.openjdk.org/browse/JDK-8391923): G1: NUMA-node accounting should use num_regions identifiers (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32752/head:pull/32752` \
`$ git checkout pull/32752`

Update a local copy of the PR: \
`$ git checkout pull/32752` \
`$ git pull https://git.openjdk.org/jdk.git pull/32752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32752`

View PR using the GUI difftool: \
`$ git pr show -t 32752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32752.diff">https://git.openjdk.org/jdk/pull/32752.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32752#issuecomment-5584792937)
</details>
