### PR TITLE
8390031: vmTestbase/nsk/jdb/suspend/suspend001 hangs with virtual test threads after suspend/cont

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -37,6 +37,7 @@
 #include "oops/weakHandle.inline.hpp"
 #include "prims/jvmtiDeferredUpdates.hpp"
 #include "prims/jvmtiExport.hpp"
+#include "prims/jvmtiThreadState.hpp"
 #include "runtime/atomicAccess.hpp"
 #include "runtime/continuationWrapper.inline.hpp"
 #include "runtime/globals.hpp"
@@ -153,11 +154,22 @@ static const jlong MAX_RECHECK_INTERVAL = 1000;
 //   the wakee will recontend for ownership of the monitor. The successor
 //   (wakee) will either acquire the lock or re-park/unmount itself.
 //
+//   If the successor is a suspended vthread then more work is needed as
+//   the vthread will block for suspension when it tries to unpark and
+//   reschedule itself. That can leave the monitor unowned yet still have
+//   threads blocked waiting to enter it. We have to try to select a
+//   non-suspended vthread, or a platform thread, as the successor, but also
+//   ensure that if the only candidate is a suspended vthread then it must
+//   not be allowed to get stranded, blocked on an unowned monitor, after
+//   it has been resumed.
+//
 //   Succession is provided for by a policy of competitive handoff.
 //   The exiting thread does _not_ grant or pass ownership to the
 //   successor thread. (This is also referred to as "handoff succession").
 //   Instead the exiting thread releases ownership and possibly wakes
 //   a successor, so the successor can (re)compete for ownership of the lock.
+//   Selecting a single successor is an optimisation; we could unpark multiple
+//   threads if needed and let them all (re)compete.
 //
 // * The entry_list forms a queue of threads stalled trying to acquire
 //   the lock. Within the entry_list the next pointers always form a
@@ -1444,9 +1456,21 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
         // presumptive (successor) must be made ready. Since threads
         // are woken up in FIFO order, we need to find the tail of the
         // entry_list.
-        w = entry_list_tail(current);
-        // I'd like to write: guarantee (w->_thread != current).
-        // But in practice an exiting thread may find itself on the entry_list.
+
+        w = find_successor(current);
+
+        // We have found a suitable successor w or else w is null as all candidates
+        // were suspended virtual threads. We can't make one of those successor as that
+        // will cause a later monitor exit to skip finding a replacement successor.
+
+        // Note: If there is now a new head of the list and w is a suspended
+        // vthread then that new thread is stranded until either w's vthread is resumed
+        // and acquires then releases the monitor, or a different thread takes
+        // ownership of the monitor and then releases it. We are not trying to handle
+        // arbitrary races between monitor acquisition and "asynchronous" suspension.
+
+        // We'd like to write: guarantee (w->_thread != current), but in
+        // practice an exiting thread may find itself on the entry_list.
         // Let's say thread T1 calls O.wait(). Wait() enqueues T1 on O's waitset and
         // then calls exit(). Exit releases the lock by setting O._owner to null.
         // Let's say T1 then stalls. T2 acquires O and calls O.notify(). The
@@ -1456,14 +1480,14 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
         // reacquires the lock and then finds itself on the entry_list.
         // Given all that, we have to tolerate the circumstance where "w" is
         // associated with current.
-        assert(w->TState == ObjectWaiter::TS_ENTER, "invariant");
+        assert(w == nullptr || w->TState == ObjectWaiter::TS_ENTER, "invariant");
         exit_epilog(current, w);
         return;
       }
     }
 
     // Drop the lock.
-    // release semantics: prior loads and stores from within the critical section
+    // Release semantics: prior loads and stores from within the critical section
     // must not float (reorder) past the following store that drops the lock.
     // Uses a storeload to separate release_store(owner) from the
     // successor check. The try_set_owner_from() below uses cmpxchg() so
@@ -1515,34 +1539,102 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
   }
 }
 
+#if INCLUDE_JVMTI
+// The nominal successor is the tail, but if the tail is a suspended vthread then
+// we need to find a different successor.
+ObjectWaiter* ObjectMonitor::find_successor(JavaThread* current) {
+  assert(AtomicAccess::load(&_entry_list) != nullptr, "must be");
+  bool do_vthread_unpark = false;
+  bool found = false;
+  ObjectWaiter* tail = entry_list_tail(current);
+  ObjectWaiter* w;
+  // fast-path: expected normal case
+  // We scan the current entry queue, from the tail, looking for an eligible
+  // successor.
+  for (w = tail; w != nullptr; w = w->prev()) {
+    if (!w->is_vthread() || !JvmtiVTSuspender::is_vthread_suspended(w->vthread())) {
+      found = true;
+      break; // w is the successor
+    }
+  }
+  if (!found) {
+    // The queue consists only of suspended vthreads, so we have to iterate
+    // through and unpark them all so they are not stranded if resumed.
+    ObjectWaiter* last;
+    for (w = tail, last = nullptr; w != nullptr; last = w, w = w->prev()) {
+      assert(w->is_vthread(), "must be");
+      // Note we can't assert the thread is still suspended as it may have been
+      // resumed. That doesn't change what we do here.
+      do_vthread_unpark |= java_lang_VirtualThread::set_onWaitingList(w->vthread(), vthread_list_head());
+    }
+
+    // Do one more check before giving up on a valid successor.
+    if (last != AtomicAccess::load(&_entry_list)) {
+      // The entry queue has grown since we started processing it. There may
+      // be a valid successor now waiting, but we need to convert to full DLL
+      // to continue the scan. Note we only do this once - as soon as this is done
+      // there could be another new waiter.
+      entry_list_build_dll(current);
+      for (w = last; w != nullptr; w = w->prev()) {
+        if (!w->is_vthread()) {
+          break; // w is the successor
+        }
+        if (!JvmtiVTSuspender::is_vthread_suspended(w->vthread())) {
+          break; // w is the successor
+        }
+        else {
+          // We found `w` so ensure it is not left stranded if resumed after
+          // the unlock completes.
+          do_vthread_unpark |= java_lang_VirtualThread::set_onWaitingList(w->vthread(), vthread_list_head());
+        }
+      }
+    }
+
+    // Finally do the actual unpark if needed.
+    if (do_vthread_unpark) {
+      ObjectMonitor::vthread_unparker_ParkEvent()->unpark();
+    }
+  }
+  return w;
+}
+#else
+// Without JVMTI we trivially return the tail.
+ObjectWaiter* ObjectMonitor::find_successor(JavaThread* current) {
+  assert(AtomicAccess::load(&_entry_list) != nullptr, "must be");
+  return entry_list_tail(current);
+}
+#endif // INCLUDE_JVMTI
+
 void ObjectMonitor::exit_epilog(JavaThread* current, ObjectWaiter* Wakee) {
   assert(has_owner(current), "invariant");
-
-  // Exit protocol:
-  // 1. ST _succ = wakee
-  // 2. membar #loadstore|#storestore;
-  // 2. ST _owner = nullptr
-  // 3. unpark(wakee)
-
   oop vthread = nullptr;
-  ParkEvent * Trigger;
-  if (!Wakee->is_vthread()) {
-    JavaThread* t = Wakee->thread();
-    assert(t != nullptr, "");
-    Trigger = t->_ParkEvent;
-    set_successor(t);
-  } else {
-    assert_not_at_safepoint();
-    vthread = Wakee->vthread();
-    assert(vthread != nullptr, "");
-    Trigger = ObjectMonitor::vthread_unparker_ParkEvent();
-    set_successor(vthread);
-  }
+  ParkEvent * Trigger = nullptr;
 
-  // Hygiene -- once we've set _owner = nullptr we can't safely dereference Wakee again.
-  // The thread associated with Wakee may have grabbed the lock and "Wakee" may be
-  // out-of-scope (non-extant).
-  Wakee  = nullptr;
+  if (Wakee != nullptr) {
+    // Exit protocol:
+    // 1. ST _succ = wakee
+    // 2. membar #loadstore|#storestore;
+    // 2. ST _owner = nullptr
+    // 3. unpark(wakee)
+
+    if (!Wakee->is_vthread()) {
+      JavaThread* t = Wakee->thread();
+      assert(t != nullptr, "");
+      Trigger = t->_ParkEvent;
+      set_successor(t);
+    } else {
+      assert_not_at_safepoint();
+      vthread = Wakee->vthread();
+      assert(vthread != nullptr, "");
+      Trigger = ObjectMonitor::vthread_unparker_ParkEvent();
+      set_successor(vthread);
+    }
+
+    // Hygiene -- once we've set _owner = nullptr we can't safely dereference Wakee again.
+    // The thread associated with Wakee may have grabbed the lock and "Wakee" may be
+    // out-of-scope (non-extant).
+    Wakee  = nullptr;
+  }
 
   // Drop the lock.
   // Uses a fence to separate release_store(owner) from the LD in unpark().
@@ -1551,12 +1643,14 @@ void ObjectMonitor::exit_epilog(JavaThread* current, ObjectWaiter* Wakee) {
 
   DTRACE_MONITOR_PROBE(contended__exit, this, object(), current);
 
-  if (vthread == nullptr) {
-    // Platform thread case.
-    Trigger->unpark();
-  } else if (java_lang_VirtualThread::set_onWaitingList(vthread, vthread_list_head())) {
-    // Virtual thread case.
-    Trigger->unpark();
+  if (Trigger != nullptr) {
+    if (vthread == nullptr) {
+      // Platform thread case.
+      Trigger->unpark();
+    } else if (java_lang_VirtualThread::set_onWaitingList(vthread, vthread_list_head())) {
+      // Virtual thread case.
+      Trigger->unpark();
+    }
   }
 }
 

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1550,7 +1550,7 @@ ObjectWaiter* ObjectMonitor::find_successor(JavaThread* current) {
   ObjectWaiter* w;
   // fast-path: expected normal case
   // We scan the current entry queue, from the tail, looking for an eligible
-  // successor.
+  // successor. If the entry-queue is not in DLL form then this will be a short loop.
   for (w = tail; w != nullptr; w = w->prev()) {
     if (!w->is_vthread() || !JvmtiVTSuspender::is_vthread_suspended(w->vthread())) {
       found = true;
@@ -1568,12 +1568,10 @@ ObjectWaiter* ObjectMonitor::find_successor(JavaThread* current) {
       do_vthread_unpark |= java_lang_VirtualThread::set_onWaitingList(w->vthread(), vthread_list_head());
     }
 
-    // Do one more check before giving up on a valid successor.
+    // The entry queue may not have been in DLL form, or may have had new entries
+    // enqueued since we checked, so reform the DLL and check again. If subsequent
+    // new waiters enqueue themselves we will not process those.
     if (last != AtomicAccess::load(&_entry_list)) {
-      // The entry queue has grown since we started processing it. There may
-      // be a valid successor now waiting, but we need to convert to full DLL
-      // to continue the scan. Note we only do this once - as soon as this is done
-      // there could be another new waiter.
       entry_list_build_dll(current);
       for (w = last; w != nullptr; w = w->prev()) {
         if (!w->is_vthread()) {

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1448,27 +1448,20 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
     // If there is a successor we should release the lock as soon as
     // possible, so that the successor can acquire the lock. If there is
     // no successor, we might need to wake up a waiting thread.
-    if (!has_successor()) {
-      ObjectWaiter* w = AtomicAccess::load(&_entry_list);
+    ObjectWaiter* head = AtomicAccess::load(&_entry_list);
+    if (!has_successor() && head != nullptr) {
+      // Other threads are blocked trying to acquire the lock and
+      // there is no successor, so it appears that an heir-
+      // presumptive (successor) must be made ready. Since threads
+      // are woken up in FIFO order, we need to find the tail of the
+      // entry_list.
+      ObjectWaiter* w = find_successor(current);
+
+      // We have found a suitable successor w or else w is null as all candidates
+      // were suspended virtual threads. We can't make one of those successor as that
+      // will cause a later monitor exit to skip finding a replacement successor.
+      // We can only use exit_epilog if there is a successor.
       if (w != nullptr) {
-        // Other threads are blocked trying to acquire the lock and
-        // there is no successor, so it appears that an heir-
-        // presumptive (successor) must be made ready. Since threads
-        // are woken up in FIFO order, we need to find the tail of the
-        // entry_list.
-
-        w = find_successor(current);
-
-        // We have found a suitable successor w or else w is null as all candidates
-        // were suspended virtual threads. We can't make one of those successor as that
-        // will cause a later monitor exit to skip finding a replacement successor.
-
-        // Note: If there is now a new head of the list and w is a suspended
-        // vthread then that new thread is stranded until either w's vthread is resumed
-        // and acquires then releases the monitor, or a different thread takes
-        // ownership of the monitor and then releases it. We are not trying to handle
-        // arbitrary races between monitor acquisition and "asynchronous" suspension.
-
         // We'd like to write: guarantee (w->_thread != current), but in
         // practice an exiting thread may find itself on the entry_list.
         // Let's say thread T1 calls O.wait(). Wait() enqueues T1 on O's waitset and
@@ -1480,7 +1473,7 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
         // reacquires the lock and then finds itself on the entry_list.
         // Given all that, we have to tolerate the circumstance where "w" is
         // associated with current.
-        assert(w == nullptr || w->TState == ObjectWaiter::TS_ENTER, "invariant");
+        assert(w->TState == ObjectWaiter::TS_ENTER, "invariant");
         exit_epilog(current, w);
         return;
       }
@@ -1520,7 +1513,10 @@ void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
     // the lock. Note that the dropped lock needs to become visible to the
     // spinner.
 
-    if (_entry_list == nullptr || has_successor()) {
+    // As all potential waiters could be suspended vthreads we have to ensure we don't
+    // livelock checking the same threads over and over again. If the current head of
+    // the entry-list is unchanged then we are done.
+    if (_entry_list == nullptr || _entry_list == head || has_successor()) {
       return;
     }
 
@@ -1551,15 +1547,18 @@ ObjectWaiter* ObjectMonitor::find_successor(JavaThread* current) {
   // fast-path: expected normal case
   // We scan the current entry queue, from the tail, looking for an eligible
   // successor. If the entry-queue is not in DLL form then this will be a short loop.
-  for (w = tail; w != nullptr; w = w->prev()) {
-    if (!w->is_vthread() || !JvmtiVTSuspender::is_vthread_suspended(w->vthread())) {
-      found = true;
-      break; // w is the successor
+  {
+    MutexLocker ml(JvmtiVThreadSuspend_lock, Mutex::_no_safepoint_check_flag);
+    for (w = tail; w != nullptr; w = w->prev()) {
+      if (!w->is_vthread() || !JvmtiVTSuspender::is_vthread_suspended(w->vthread())) {
+        found = true;
+        break; // w is the successor
+      }
     }
   }
   if (!found) {
-    // The queue consists only of suspended vthreads, so we have to iterate
-    // through and unpark them all so they are not stranded if resumed.
+    // The DLL part of the queue consists only of suspended vthreads, so we have
+    // to iterate through and unpark them all so they are not stranded if resumed.
     ObjectWaiter* last;
     for (w = tail, last = nullptr; w != nullptr; last = w, w = w->prev()) {
       assert(w->is_vthread(), "must be");
@@ -1570,20 +1569,25 @@ ObjectWaiter* ObjectMonitor::find_successor(JavaThread* current) {
 
     // The entry queue may not have been in DLL form, or may have had new entries
     // enqueued since we checked, so reform the DLL and check again. If subsequent
-    // new waiters enqueue themselves we will not process those.
+    // new waiters enqueue themselves we will not process those but the enclosing exit
+    // protocol will if needed. Note the key thing here is to reform the DLL so that all
+    // current waiters are considered.
     if (last != AtomicAccess::load(&_entry_list)) {
       entry_list_build_dll(current);
       for (w = last; w != nullptr; w = w->prev()) {
         if (!w->is_vthread()) {
           break; // w is the successor
         }
-        if (!JvmtiVTSuspender::is_vthread_suspended(w->vthread())) {
-          break; // w is the successor
-        }
-        else {
-          // We found `w` so ensure it is not left stranded if resumed after
-          // the unlock completes.
-          do_vthread_unpark |= java_lang_VirtualThread::set_onWaitingList(w->vthread(), vthread_list_head());
+        {
+          MutexLocker ml(JvmtiVThreadSuspend_lock, Mutex::_no_safepoint_check_flag);
+          if (!JvmtiVTSuspender::is_vthread_suspended(w->vthread())) {
+            break; // w is the successor
+          }
+          else {
+            // We found `w` so ensure it is not left stranded if resumed after
+            // the unlock completes.
+            do_vthread_unpark |= java_lang_VirtualThread::set_onWaitingList(w->vthread(), vthread_list_head());
+          }
         }
       }
     }
@@ -1605,34 +1609,33 @@ ObjectWaiter* ObjectMonitor::find_successor(JavaThread* current) {
 
 void ObjectMonitor::exit_epilog(JavaThread* current, ObjectWaiter* Wakee) {
   assert(has_owner(current), "invariant");
+  assert(Wakee != nullptr, "must have a successor to use this path");
   oop vthread = nullptr;
   ParkEvent * Trigger = nullptr;
 
-  if (Wakee != nullptr) {
-    // Exit protocol:
-    // 1. ST _succ = wakee
-    // 2. membar #loadstore|#storestore;
-    // 2. ST _owner = nullptr
-    // 3. unpark(wakee)
+  // Exit protocol:
+  // 1. ST _succ = wakee
+  // 2. membar #loadstore|#storestore;
+  // 2. ST _owner = nullptr
+  // 3. unpark(wakee)
 
-    if (!Wakee->is_vthread()) {
-      JavaThread* t = Wakee->thread();
-      assert(t != nullptr, "");
-      Trigger = t->_ParkEvent;
-      set_successor(t);
-    } else {
-      assert_not_at_safepoint();
-      vthread = Wakee->vthread();
-      assert(vthread != nullptr, "");
-      Trigger = ObjectMonitor::vthread_unparker_ParkEvent();
-      set_successor(vthread);
-    }
-
-    // Hygiene -- once we've set _owner = nullptr we can't safely dereference Wakee again.
-    // The thread associated with Wakee may have grabbed the lock and "Wakee" may be
-    // out-of-scope (non-extant).
-    Wakee  = nullptr;
+  if (!Wakee->is_vthread()) {
+    JavaThread* t = Wakee->thread();
+    assert(t != nullptr, "");
+    Trigger = t->_ParkEvent;
+    set_successor(t);
+  } else {
+    assert_not_at_safepoint();
+    vthread = Wakee->vthread();
+    assert(vthread != nullptr, "");
+    Trigger = ObjectMonitor::vthread_unparker_ParkEvent();
+    set_successor(vthread);
   }
+
+  // Hygiene -- once we've set _owner = nullptr we can't safely dereference Wakee again.
+  // The thread associated with Wakee may have grabbed the lock and "Wakee" may be
+  // out-of-scope (non-extant).
+  Wakee  = nullptr;
 
   // Drop the lock.
   // Uses a fence to separate release_store(owner) from the LD in unpark().

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -252,6 +252,8 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   void      clear_successor();
   int64_t   successor() const;
 
+  ObjectWaiter* find_successor(JavaThread* current);
+
   // Returns true if _owner field == owner_id of thread, false otherwise.
   bool has_owner(JavaThread* thread) const { return owner() == owner_id_from(thread); }
   // Set _owner field to owner_id of thread; current value must be NO_OWNER.

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -60,9 +60,6 @@ vmTestbase/nsk/jdb/where/where005/where005.java 8278470 generic-all
 
 vmTestbase/nsk/jdb/list/list003/list003.java        8300707 generic-all
 vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java  8300707 generic-all
-###
-# suspend001 hangs with virtual threads until the suspended-successor issue is fixed.
-vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java 8390031 generic-all
 
 ####
 ## NSK JDI tests failing with wrapper

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume5/SuspendResume5.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume5/SuspendResume5.java
@@ -137,6 +137,7 @@ public class SuspendResume5 {
         // R1R2R3  -> 0
 
         for (int mask = (1 << nThreads) - 1; mask >= 0; mask--) {
+            System.out.println("Processing mask: " + mask);
             Thread[] threads = new Thread[nThreads];
             boolean[] suspended = new boolean[nThreads];
             try{
@@ -197,12 +198,20 @@ public class SuspendResume5 {
                 // Now resume the threads
                 for (int i = 0; i < nThreads; i++) {
                     if (suspended[i]) {
+                        System.out.println("Resuming thread: " + threads[i]);
                         JVMTIUtils.resumeThread(threads[i]);
                     }
                 }
                 for (Thread t : threads) {
                     if (t != null) {
-                        t.join();
+                        System.out.println("Joining thread: " + t);
+                        t.join(10000);
+                        if (t.isAlive()) {
+                            System.out.println("Failed to join thread: " + t);
+                            System.out.println("First successor was " + successor);
+                            System.out.println("Last owner was " + owner);
+                            t.join(); // let the test timeout
+                        }
                     }
                 }
             }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume5/SuspendResume5.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume5/SuspendResume5.java
@@ -73,6 +73,7 @@ public class SuspendResume5 {
             synchronized(lock) {
                 final CountDownLatch started = new CountDownLatch(1);
                 suspendee = Thread.ofVirtual().start(() -> worker(started));
+                suspendee.setName("Suspendee");
                 started.await();
                 await(suspendee, Thread.State.BLOCKED);
                 JVMTIUtils.suspendThread(suspendee);
@@ -92,6 +93,7 @@ public class SuspendResume5 {
                 // Now let a second thread block on the lock
                 final CountDownLatch started = new CountDownLatch(1);
                 thread2 = Thread.ofVirtual().start(() -> worker(started));
+                thread2.setName("Thread-2");
                 started.await();
                 await(thread2,Thread.State.BLOCKED);
             }
@@ -147,6 +149,7 @@ public class SuspendResume5 {
                     for (int i = 0; i < nThreads; i++) {
                         final CountDownLatch started = new CountDownLatch(1);
                         threads[i] = Thread.ofVirtual().start(() -> worker(started));
+                        threads[i].setName("Thread-" + i);
                         started.await();
                         await(threads[i], Thread.State.BLOCKED);
                         boolean suspend = (mask & (1 << (nThreads - 1 - i))) != 0;
@@ -225,6 +228,7 @@ public class SuspendResume5 {
                     for (int i = 0; i < nThreads; i++) {
                         final CountDownLatch started = new CountDownLatch(1);
                         threads[i] = Thread.ofVirtual().start(() -> worker(started));
+                        threads[i].setName("Thread-" + i);
                         started.await();
                         await(threads[i], Thread.State.BLOCKED);
                         JVMTIUtils.suspendThread(threads[i]);

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume5/SuspendResume5.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume5/SuspendResume5.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8390031
+ * @summary Suspend one or more vthreads while it's trying to acquire a monitor
+ *          and check successor selection works as expected
+ *
+ * @requires vm.continuations
+ * @requires vm.jvmti
+ * @library /test/lib /test/hotspot/jtreg/testlibrary
+ * @run main/othervm/native SuspendResume5
+ */
+
+import java.util.concurrent.CountDownLatch;
+
+import jvmti.JVMTIUtils;
+
+public class SuspendResume5 {
+    static volatile Thread successor;
+    static volatile Thread owner;
+    static final Object lock = new Object();
+
+
+    static void worker(CountDownLatch started) {
+        started.countDown();
+        synchronized (lock) {
+            // Mark this thread as owner - this is only used to check
+            // the owner is not the main thread.
+            owner = Thread.currentThread();
+            // Update successor only if it is null - that means we were
+            // the selected successor when the main thread first released
+            // the monitor.
+            if (successor == null) {
+                successor = owner;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        test1();
+        test2();
+        test3();
+    }
+
+    // Simple test that a suspended vthread doesn't get selected as
+    // successor when the monitor is released.
+    static void test1() throws Exception {
+        Thread suspendee = null;
+        boolean suspended = false;
+        try {
+            synchronized(lock) {
+                final CountDownLatch started = new CountDownLatch(1);
+                suspendee = Thread.ofVirtual().start(() -> worker(started));
+                started.await();
+                await(suspendee, Thread.State.BLOCKED);
+                JVMTIUtils.suspendThread(suspendee);
+                suspended = true;
+            }
+
+            // As thread is suspended whilst waiting on the lock it should not
+            // be made the successor or acquire the lock. Grab the lock again and
+            // check there has been no progress. Then insert a second thread.
+
+            Thread thread2;
+
+            synchronized(lock) {
+                assertTrue(successor == null,
+                           "Suspended vthread acquired the lock and executed");
+
+                // Now let a second thread block on the lock
+                final CountDownLatch started = new CountDownLatch(1);
+                thread2 = Thread.ofVirtual().start(() -> worker(started));
+                started.await();
+                await(thread2,Thread.State.BLOCKED);
+            }
+            thread2.join();
+            assertTrue(successor == thread2,
+                       "Successor not as expected: " + successor);
+            successor = null;
+        }
+        finally {
+            if (suspended) {
+                JVMTIUtils.resumeThread(suspendee);
+            }
+            if (suspendee != null) {
+                suspendee.join();
+                assertTrue(successor == suspendee,
+                           "Successor should be " + suspendee +
+                           " but was actually " + successor);
+            }
+        }
+    }
+
+    // More complicated test that a suspended vthread doesn't get selected as
+    // successor when the monitor is released. We use 3 queued threads and
+    // cycle through which are suspended and which not, and so which should
+    // get the lock next. Note that when all threads are suspended and then
+    // resumed they will race to acquire the lock.
+    static void test2() throws Exception {
+        Thread me = Thread.currentThread();
+
+        final int nThreads = 3;
+
+        // The test matrix is as follows where S is suspended and R runnable.
+        // Threads -> Expected successor index
+        // S1S2S3  -> nil
+        // S1S2R1  -> 2
+        // S1R1S2  -> 1
+        // S1R1R2  -> 1
+        // R1S1S2  -> 0
+        // R1S1R2  -> 0
+        // R1R2S1  -> 0
+        // R1R2R3  -> 0
+
+        for (int mask = (1 << nThreads) - 1; mask >= 0; mask--) {
+            Thread[] threads = new Thread[nThreads];
+            boolean[] suspended = new boolean[nThreads];
+            try{
+                successor = null;
+                // Start all threads whilst holding the lock
+                synchronized(lock) {
+                    owner = me;
+                    // Start the threads one at a time and allow them to block
+                    // so we know the entry queue order.
+                    for (int i = 0; i < nThreads; i++) {
+                        final CountDownLatch started = new CountDownLatch(1);
+                        threads[i] = Thread.ofVirtual().start(() -> worker(started));
+                        started.await();
+                        await(threads[i], Thread.State.BLOCKED);
+                        boolean suspend = (mask & (1 << (nThreads - 1 - i))) != 0;
+                        if (suspend) {
+                            JVMTIUtils.suspendThread(threads[i]);
+                            suspended[i] = true;
+                        }
+                    }
+                }
+
+                boolean allSuspended = (mask == (1 << nThreads) - 1);
+                // We don't want to grab the lock before the other eligible
+                // threads have had a chance to claim it.
+                if (!allSuspended) {
+                    while (owner == me) {
+                        Thread.yield();
+                    }
+                }
+
+                // Grab the lock again and see whether the successor is as expected.
+                synchronized(lock) {
+                    // If all threads are suspended then we need a different check.
+                    if (allSuspended) {
+                        assertTrue(owner == me, "Unexpected owner: " + owner);
+                        assertTrue(successor == null, "Unexpected successor: " + successor);
+                    } else {
+                        // Expected successor is the first non-suspended thread.
+                        int expected = -1;
+                        for (int i = 0; i < nThreads; i++) {
+                            if (suspended[i]) {
+                                assertTrue(successor != threads[i],
+                                           "Suspended thread was successor: " + threads[i]);
+                            } else {
+                                expected = i;
+                                break;
+                            }
+                        }
+                        assertTrue(successor == threads[expected],
+                                   "Successor should be " + threads[expected] +
+                                   " but was actually " + successor);
+                    }
+                }
+            }
+            finally {
+                // Now resume the threads
+                for (int i = 0; i < nThreads; i++) {
+                    if (suspended[i]) {
+                        JVMTIUtils.resumeThread(threads[i]);
+                    }
+                }
+                for (Thread t : threads) {
+                    if (t != null) {
+                        t.join();
+                    }
+                }
+            }
+        }
+    }
+
+    // Test that resumed threads get the monitor as expected.
+    static void test3() throws Exception {
+        Thread me = Thread.currentThread();
+
+        final int nThreads = 3;
+
+        for (int firstResumer = 0; firstResumer < nThreads; firstResumer++) {
+            Thread[] threads = new Thread[nThreads];
+            boolean[] suspended = new boolean[nThreads];
+            try{
+                successor = null;
+                // Start all threads whilst holding the lock
+                synchronized(lock) {
+                    owner = me;
+                    // Start the threads one at a time and allow them to block
+                    // so we know the entry queue order.
+                    for (int i = 0; i < nThreads; i++) {
+                        final CountDownLatch started = new CountDownLatch(1);
+                        threads[i] = Thread.ofVirtual().start(() -> worker(started));
+                        started.await();
+                        await(threads[i], Thread.State.BLOCKED);
+                        JVMTIUtils.suspendThread(threads[i]);
+                        suspended[i] = true;
+                    }
+                }
+
+                // Grab the lock again then resume a thread
+                synchronized(lock) {
+                    assertTrue(owner == me, "Unexpected owner: " + owner);
+                    assertTrue(successor == null, "Unexpected successor: " + successor);
+                    JVMTIUtils.resumeThread(threads[firstResumer]);
+                    suspended[firstResumer] = false;
+                }
+                // Ensure the resumed thread has completed
+                threads[firstResumer].join();
+                assertTrue(successor == threads[firstResumer],
+                           "Successor should be " + threads[firstResumer] +
+                           " but was actually " + successor);
+            }
+            finally {
+                // Now resume the remaining threads
+                for (int i = 0; i < nThreads; i++) {
+                    if (suspended[i]) {
+                        JVMTIUtils.resumeThread(threads[i]);
+                    }
+                }
+                // Now join the remaining threads
+                for (Thread t : threads) {
+                    if (t != null) {
+                        t.join();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Waits for the given thread to reach a given state.
+     */
+    static void await(Thread thread, Thread.State expectedState) throws InterruptedException {
+        Thread.State state = thread.getState();
+        while (state != expectedState) {
+            assertTrue(state != Thread.State.TERMINATED, "Thread has terminated");
+            Thread.sleep(10);
+            state = thread.getState();
+        }
+    }
+
+    static void assertTrue(boolean condition, String msg) {
+        if (!condition) {
+            throw new RuntimeException(msg);
+        }
+    }
+}


### PR DESCRIPTION
If a suspended virtual thread is selected as successor when the monitor is released it will suspend as it tries to transition to runnable and the monitor will be left unowned but potentially with threads (not suspended) still waiting for it. These threads will be stalled until either the successor thread is resumed, or else a new thread barges through and acquires then releases the monitor.

A suspended thread should not be able to acquire a monitor after it has been suspended - and we have taken great pains over the years to ensure that is the case.  For platform threads, a suspended thread will acquire the monitor, see it is suspended and then release the monitor again (and so select a new successor in the process). For virtual threads however, we must not select a suspended thread as successor in the first place. If the nominal successor (tail of the entry queue) is a suspended virtual thread then we look for an alternate successor. Things are complicated somewhat as we must not allow the suspended thread to get stranded when the monitor is later released again (after the thread is resumed).

Note that as soon as we have checked the entry list for a successor, another thread could have joined it, and we could potentially keep checking "forever". We limit the additional check to a single occurrence, noting that the initial full traversal of the entry list may take some time whereas the check for new arrivals should be relative short.

There is an inherent race between suspension and enqueuing trying to acquire a monitor. We do not try to deal with such "asynchronous" interactions, rather we are dealing with the synchronous form as outlined in test, where we suspend a thread when it is blocked on the monitor we are holding.

Testing:
 - new regressiontest
 - jdb tests (all tier5 svc tests)
 - tier 1-3 sanity

Thanks

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390031](https://bugs.openjdk.org/browse/JDK-8390031): vmTestbase/nsk/jdb/suspend/suspend001 hangs with virtual test threads after suspend/cont (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32753/head:pull/32753` \
`$ git checkout pull/32753`

Update a local copy of the PR: \
`$ git checkout pull/32753` \
`$ git pull https://git.openjdk.org/jdk.git pull/32753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32753`

View PR using the GUI difftool: \
`$ git pr show -t 32753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32753.diff">https://git.openjdk.org/jdk/pull/32753.diff</a>

</details>
