### PR TITLE
8391958: G1: Evacuation failure handling should use num_regions identifiers

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -152,7 +152,7 @@ void G1Allocator::release_gc_alloc_regions(G1EvacInfo* evacuation_info) {
     num_survivor_regions += survivor_gc_alloc_region(node_index)->num_regions_used();
     survivor_gc_alloc_region(node_index)->release();
   }
-  evacuation_info->set_allocation_regions(num_survivor_regions +
+  evacuation_info->set_num_allocation_regions(num_survivor_regions +
                                           old_gc_alloc_region()->num_regions_used());
 
   // If we have an old GC alloc region to release, we'll save it in

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2861,11 +2861,11 @@ void G1CollectedHeap::set_young_gen_card_set_stats(const G1MonotonicArenaMemoryS
 
 void G1CollectedHeap::record_obj_copy_mem_stats() {
   size_t total_old_allocated = _old_evac_stats.allocated() + _old_evac_stats.direct_allocated();
-  uint total_allocated = _survivor_evac_stats.num_filled_regions() + _old_evac_stats.num_filled_regions();
+  uint num_allocated_regions = _survivor_evac_stats.num_filled_regions() + _old_evac_stats.num_filled_regions();
 
   log_debug(gc)("Allocated %u survivor %u old percent total %1.2f%% (%u%%)",
                 _survivor_evac_stats.num_filled_regions(), _old_evac_stats.num_filled_regions(),
-                percent_of(total_allocated, num_committed_regions() - total_allocated),
+                percent_of(num_allocated_regions, num_committed_regions() - num_allocated_regions),
                 G1ReservePercent);
 
   policy()->old_gen_alloc_tracker()->

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2467,7 +2467,7 @@ G1HeapSummary G1CollectedHeap::create_g1_heap_summary() {
 G1EvacSummary G1CollectedHeap::create_g1_evac_summary(G1EvacStats* stats) {
   return G1EvacSummary(stats->allocated(), stats->wasted(), stats->undo_wasted(),
                        stats->unused(), stats->used(), stats->region_end_waste(),
-                       stats->regions_filled(), stats->num_plab_filled(),
+                       stats->num_filled_regions(), stats->num_plab_filled(),
                        stats->direct_allocated(), stats->num_direct_allocated(),
                        stats->failure_used(), stats->failure_waste());
 }
@@ -2861,10 +2861,10 @@ void G1CollectedHeap::set_young_gen_card_set_stats(const G1MonotonicArenaMemoryS
 
 void G1CollectedHeap::record_obj_copy_mem_stats() {
   size_t total_old_allocated = _old_evac_stats.allocated() + _old_evac_stats.direct_allocated();
-  uint total_allocated = _survivor_evac_stats.regions_filled() + _old_evac_stats.regions_filled();
+  uint total_allocated = _survivor_evac_stats.num_filled_regions() + _old_evac_stats.num_filled_regions();
 
   log_debug(gc)("Allocated %u survivor %u old percent total %1.2f%% (%u%%)",
-                _survivor_evac_stats.regions_filled(), _old_evac_stats.regions_filled(),
+                _survivor_evac_stats.num_filled_regions(), _old_evac_stats.num_filled_regions(),
                 percent_of(total_allocated, num_committed_regions() - total_allocated),
                 G1ReservePercent);
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2913,12 +2913,12 @@ void G1CollectedHeap::free_humongous_region(G1HeapRegion* hr,
   free_region(hr, free_list);
 }
 
-void G1CollectedHeap::remove_from_old_gen_sets(const uint old_regions_removed,
-                                               const uint humongous_regions_removed) {
-  if (old_regions_removed > 0 || humongous_regions_removed > 0) {
+void G1CollectedHeap::remove_from_old_gen_sets(const uint num_old_regions_removed,
+                                               const uint num_humongous_regions_removed) {
+  if (num_old_regions_removed > 0 || num_humongous_regions_removed > 0) {
     MutexLocker x(G1OldSets_lock, Mutex::_no_safepoint_check_flag);
-    _old_set.bulk_remove(old_regions_removed);
-    _humongous_set.bulk_remove(humongous_regions_removed);
+    _old_set.bulk_remove(num_old_regions_removed);
+    _humongous_set.bulk_remove(num_humongous_regions_removed);
   }
 
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1037,8 +1037,8 @@ public:
 
   bool last_gc_was_periodic() { return _gc_lastcause == GCCause::_g1_periodic_collection; }
 
-  void remove_from_old_gen_sets(const uint old_regions_removed,
-                                const uint humongous_regions_removed);
+  void remove_from_old_gen_sets(const uint num_old_regions_removed,
+                                const uint num_humongous_regions_removed);
   void prepend_to_freelist(G1FreeRegionList* list);
   void decrement_summary_bytes(size_t bytes);
 

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
@@ -42,12 +42,12 @@ G1EvacFailureRegions::~G1EvacFailureRegions() {
   assert(_evac_failed_regions == nullptr, "not cleaned up");
 }
 
-void G1EvacFailureRegions::pre_collection(uint max_regions) {
+void G1EvacFailureRegions::pre_collection(uint max_num_regions) {
   _num_evac_failed_regions.store_relaxed(0u);
-  _evac_failed_regions_map.resize(max_regions);
-  _regions_pinned.resize(max_regions);
-  _regions_alloc_failed.resize(max_regions);
-  _evac_failed_regions = NEW_C_HEAP_ARRAY(uint, max_regions, mtGC);
+  _evac_failed_regions_map.resize(max_num_regions);
+  _regions_pinned.resize(max_num_regions);
+  _regions_alloc_failed.resize(max_num_regions);
+  _evac_failed_regions = NEW_C_HEAP_ARRAY(uint, max_num_regions, mtGC);
 }
 
 void G1EvacFailureRegions::post_collection() {

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
@@ -32,26 +32,26 @@
 #include "utilities/bitMap.inline.hpp"
 
 G1EvacFailureRegions::G1EvacFailureRegions() :
-  _regions_evac_failed(mtGC),
+  _evac_failed_regions_map(mtGC),
   _regions_pinned(mtGC),
   _regions_alloc_failed(mtGC),
   _evac_failed_regions(nullptr),
-  _num_regions_evac_failed(0) { }
+  _num_evac_failed_regions(0) { }
 
 G1EvacFailureRegions::~G1EvacFailureRegions() {
   assert(_evac_failed_regions == nullptr, "not cleaned up");
 }
 
 void G1EvacFailureRegions::pre_collection(uint max_regions) {
-  _num_regions_evac_failed.store_relaxed(0u);
-  _regions_evac_failed.resize(max_regions);
+  _num_evac_failed_regions.store_relaxed(0u);
+  _evac_failed_regions_map.resize(max_regions);
   _regions_pinned.resize(max_regions);
   _regions_alloc_failed.resize(max_regions);
   _evac_failed_regions = NEW_C_HEAP_ARRAY(uint, max_regions, mtGC);
 }
 
 void G1EvacFailureRegions::post_collection() {
-  _regions_evac_failed.resize(0);
+  _evac_failed_regions_map.resize(0);
   _regions_pinned.resize(0);
   _regions_alloc_failed.resize(0);
 
@@ -60,7 +60,7 @@ void G1EvacFailureRegions::post_collection() {
 }
 
 bool G1EvacFailureRegions::contains(uint region_idx) const {
-  return _regions_evac_failed.par_at(region_idx, memory_order_relaxed);
+  return _evac_failed_regions_map.par_at(region_idx, memory_order_relaxed);
 }
 
 void G1EvacFailureRegions::par_iterate(G1HeapRegionClosure* closure,
@@ -69,6 +69,6 @@ void G1EvacFailureRegions::par_iterate(G1HeapRegionClosure* closure,
   G1CollectedHeap::heap()->par_iterate_regions_array(closure,
                                                      hrclaimer,
                                                      _evac_failed_regions,
-                                                     num_regions_evac_failed(),
+                                                     num_evac_failed_regions(),
                                                      worker_id);
 }

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.hpp
@@ -37,17 +37,18 @@ class G1HeapRegionClosure;
 // evacuation failure.
 // An evacuation failure may occur due to pinning or due to allocation failure
 // (not enough to-space). For every such occurrence the class records region
-// information to speed up iteration of these regions in various gc phases.
+// information to speed up iteration of these regions in various GC phases.
 //
 // Pinned regions may experience an allocation failure at the same time as G1
-// tries to evacuate anything but objects that are possible to be pinned. So
+// tries to evacuate anything but objects that are possible to be pinned.
 //
-//   _num_regions_pinned + _num_regions_alloc_failed >= _num_regions_evac_failed
+// So it is possible that the number of pinned regions plus the number of allocation
+// failed regions is larger than the number of evacuation failed regions.
 //
 class G1EvacFailureRegions {
   // Records for every region on the heap whether the region has experienced an
   // evacuation failure.
-  CHeapBitMap _regions_evac_failed;
+  CHeapBitMap _evac_failed_regions_map;
   // Records for every region on the heap whether the evacuation failure cause
   // has been allocation failure or region pinning.
   CHeapBitMap _regions_pinned;
@@ -55,14 +56,14 @@ class G1EvacFailureRegions {
   // Evacuation failed regions (indexes) in the current collection.
   uint* _evac_failed_regions;
   // Number of regions evacuation failed in the current collection.
-  Atomic<uint> _num_regions_evac_failed;
+  Atomic<uint> _num_evac_failed_regions;
 
 public:
   G1EvacFailureRegions();
   ~G1EvacFailureRegions();
 
   uint get_region_idx(uint idx) const {
-    assert(idx < _num_regions_evac_failed.load_relaxed(), "precondition");
+    assert(idx < _num_evac_failed_regions.load_relaxed(), "precondition");
     return _evac_failed_regions[idx];
   }
 
@@ -79,11 +80,11 @@ public:
   // Return a G1AbstractSubTask which does necessary preparation for evacuation failed regions
   G1AbstractSubTask* create_prepare_regions_task();
 
-  inline uint num_regions_evac_failed() const;
+  inline uint num_evac_failed_regions() const;
 
-  inline bool has_regions_evac_failed() const;
-  inline bool has_regions_evac_pinned() const;
-  inline bool has_regions_alloc_failed() const;
+  inline bool has_evac_failed_regions() const;
+  inline bool has_evac_pinned_regions() const;
+  inline bool has_alloc_failed_regions() const;
 
   // Record that the garbage collection encountered an evacuation failure in the
   // given region. Returns whether this has been the first occurrence of an evacuation

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.hpp
@@ -68,7 +68,7 @@ public:
   }
 
   // Sets up the bitmap and failed regions array for addition.
-  void pre_collection(uint max_regions);
+  void pre_collection(uint max_num_regions);
   // Drops memory for internal data structures, but keep counts.
   void post_collection();
 

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.inline.hpp
@@ -31,22 +31,22 @@
 #include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1GCPhaseTimes.hpp"
 
-uint G1EvacFailureRegions::num_regions_evac_failed() const {
-  return _num_regions_evac_failed.load_relaxed();
+uint G1EvacFailureRegions::num_evac_failed_regions() const {
+  return _num_evac_failed_regions.load_relaxed();
 }
 
-bool G1EvacFailureRegions::has_regions_evac_failed() const {
-  return num_regions_evac_failed() > 0;
+bool G1EvacFailureRegions::has_evac_failed_regions() const {
+  return num_evac_failed_regions() > 0;
 }
 
-bool G1EvacFailureRegions::has_regions_evac_pinned() const {
+bool G1EvacFailureRegions::has_evac_pinned_regions() const {
   G1GCPhaseTimes* p = G1CollectedHeap::heap()->phase_times();
   size_t count = p->sum_thread_work_items(G1GCPhaseTimes::RestoreEvacuationFailedRegions,
                                           G1GCPhaseTimes::RestoreEvacFailureRegionsPinnedNum);
   return count != 0;
 }
 
-bool G1EvacFailureRegions::has_regions_alloc_failed() const {
+bool G1EvacFailureRegions::has_alloc_failed_regions() const {
   G1GCPhaseTimes* p = G1CollectedHeap::heap()->phase_times();
   size_t count = p->sum_thread_work_items(G1GCPhaseTimes::RestoreEvacuationFailedRegions,
                                           G1GCPhaseTimes::RestoreEvacFailureRegionsAllocFailedNum);
@@ -54,10 +54,10 @@ bool G1EvacFailureRegions::has_regions_alloc_failed() const {
 }
 
 bool G1EvacFailureRegions::record(uint worker_id, uint region_idx, bool cause_pinned) {
-  bool success = _regions_evac_failed.par_set_bit(region_idx,
+  bool success = _evac_failed_regions_map.par_set_bit(region_idx,
                                                   memory_order_relaxed);
   if (success) {
-    size_t offset = _num_regions_evac_failed.fetch_then_add(1u);
+    size_t offset = _num_evac_failed_regions.fetch_then_add(1u);
     _evac_failed_regions[offset] = region_idx;
 
     G1CollectedHeap* g1h = G1CollectedHeap::heap();

--- a/src/hotspot/share/gc/g1/g1EvacInfo.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacInfo.hpp
@@ -66,7 +66,7 @@ public:
     _bytes_used = used;
   }
 
-  void add_to_freed_regions(uint num_freed_regions) {
+  void add_to_num_freed_regions(uint num_freed_regions) {
     _num_freed_regions += num_freed_regions;
   }
 

--- a/src/hotspot/share/gc/g1/g1EvacInfo.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacInfo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,26 +28,26 @@
 #include "memory/allocation.hpp"
 
 class G1EvacInfo : public StackObj {
-  uint _collection_set_regions;
-  uint _allocation_regions;
+  uint _num_collection_set_regions;
+  uint _num_allocation_regions;
   size_t _collection_set_used_before;
   size_t _collection_set_used_after;
   size_t _alloc_regions_used_before;
   size_t _bytes_used;
-  uint   _regions_freed;
+  uint   _num_freed_regions;
 
 public:
   G1EvacInfo() :
-    _collection_set_regions(0), _allocation_regions(0), _collection_set_used_before(0),
+    _num_collection_set_regions(0), _num_allocation_regions(0), _collection_set_used_before(0),
     _collection_set_used_after(0), _alloc_regions_used_before(0),
-    _bytes_used(0), _regions_freed(0) { }
+    _bytes_used(0), _num_freed_regions(0) { }
 
-  void set_collection_set_regions(uint collection_set_regions) {
-    _collection_set_regions = collection_set_regions;
+  void set_num_collection_set_regions(uint num_collection_set_regions) {
+    _num_collection_set_regions = num_collection_set_regions;
   }
 
-  void set_allocation_regions(uint allocation_regions) {
-    _allocation_regions = allocation_regions;
+  void set_num_allocation_regions(uint num_allocation_regions) {
+    _num_allocation_regions = num_allocation_regions;
   }
 
   void set_collection_set_used_before(size_t used) {
@@ -66,17 +66,17 @@ public:
     _bytes_used = used;
   }
 
-  void set_regions_freed(uint freed) {
-    _regions_freed += freed;
+  void add_to_freed_regions(uint num_freed_regions) {
+    _num_freed_regions += num_freed_regions;
   }
 
-  uint   collection_set_regions()     { return _collection_set_regions; }
-  uint   allocation_regions()         { return _allocation_regions; }
+  uint   num_collection_set_regions() { return _num_collection_set_regions; }
+  uint   num_allocation_regions()     { return _num_allocation_regions; }
   size_t collection_set_used_before() { return _collection_set_used_before; }
   size_t collection_set_used_after()  { return _collection_set_used_after; }
   size_t alloc_regions_used_before()  { return _alloc_regions_used_before; }
   size_t bytes_used()                 { return _bytes_used; }
-  uint   regions_freed()              { return _regions_freed; }
+  uint   num_freed_regions()          { return _num_freed_regions; }
 };
 
 #endif // SHARE_GC_G1_G1EVACINFO_HPP

--- a/src/hotspot/share/gc/g1/g1EvacStats.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacStats.cpp
@@ -32,7 +32,7 @@
 void G1EvacStats::reset() {
   PLABStats::reset();
   _region_end_waste.store_relaxed(0);
-  _regions_filled.store_relaxed(0);
+  _num_filled_regions.store_relaxed(0);
   _num_plab_filled.store_relaxed(0);
   _direct_allocated.store_relaxed(0);
   _num_direct_allocated.store_relaxed(0);
@@ -63,7 +63,7 @@ void G1EvacStats::log_plab_allocation() {
                       "failure wasted: %zuB",
                       _description,
                       region_end_waste() * HeapWordSize,
-                      regions_filled(),
+                      num_filled_regions(),
                       num_plab_filled(),
                       direct_allocated() * HeapWordSize,
                       num_direct_allocated(),
@@ -132,7 +132,7 @@ G1EvacStats::G1EvacStats(const char* description, size_t default_per_thread_plab
   _desired_net_plab_size(default_per_thread_plab_size * ParallelGCThreads),
   _net_plab_size_filter(wt),
   _region_end_waste(0),
-  _regions_filled(0),
+  _num_filled_regions(0),
   _num_plab_filled(0),
   _direct_allocated(0),
   _num_direct_allocated(0),

--- a/src/hotspot/share/gc/g1/g1EvacStats.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacStats.hpp
@@ -38,7 +38,7 @@ class G1EvacStats : public PLABStats {
          _net_plab_size_filter;  // Integrator with decay
 
   Atomic<size_t> _region_end_waste; // Number of words wasted due to skipping to the next region.
-  Atomic<uint>   _regions_filled;   // Number of regions filled completely.
+  Atomic<uint>   _num_filled_regions; // Number of regions filled completely.
   Atomic<size_t> _num_plab_filled; // Number of PLABs filled and retired.
   Atomic<size_t> _direct_allocated; // Number of words allocated directly into the regions.
   Atomic<size_t> _num_direct_allocated; // Number of direct allocation attempts.
@@ -69,7 +69,7 @@ public:
   // Should be called at the end of a GC pause.
   void adjust_desired_plab_size();
 
-  uint regions_filled() const;
+  uint num_filled_regions() const;
   size_t num_plab_filled() const;
   size_t region_end_waste() const;
   size_t direct_allocated() const;

--- a/src/hotspot/share/gc/g1/g1EvacStats.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacStats.inline.hpp
@@ -27,8 +27,8 @@
 
 #include "gc/g1/g1EvacStats.hpp"
 
-inline uint G1EvacStats::regions_filled() const {
-  return _regions_filled.load_relaxed();
+inline uint G1EvacStats::num_filled_regions() const {
+  return _num_filled_regions.load_relaxed();
 }
 
 inline size_t G1EvacStats::num_plab_filled() const {
@@ -69,7 +69,7 @@ inline void G1EvacStats::add_num_direct_allocated(size_t value) {
 
 inline void G1EvacStats::add_region_end_waste(size_t value) {
   _region_end_waste.add_then_fetch(value, memory_order_relaxed);
-  _regions_filled.add_then_fetch(1u, memory_order_relaxed);
+  _num_filled_regions.add_then_fetch(1u, memory_order_relaxed);
 }
 
 inline void G1EvacStats::add_failure_used_and_waste(size_t used, size_t waste) {

--- a/src/hotspot/share/gc/g1/g1Trace.cpp
+++ b/src/hotspot/share/gc/g1/g1Trace.cpp
@@ -144,14 +144,14 @@ void G1NewTracer::send_evacuation_info_event(G1EvacInfo* info) {
   EventEvacuationInformation e;
   if (e.should_commit()) {
     e.set_gcId(GCId::current());
-    e.set_cSetRegions(info->collection_set_regions());
+    e.set_cSetRegions(info->num_collection_set_regions());
     e.set_cSetUsedBefore(info->collection_set_used_before());
     e.set_cSetUsedAfter(info->collection_set_used_after());
-    e.set_allocationRegions(info->allocation_regions());
+    e.set_allocationRegions(info->num_allocation_regions());
     e.set_allocationRegionsUsedBefore(info->alloc_regions_used_before());
     e.set_allocationRegionsUsedAfter(info->alloc_regions_used_before() + info->bytes_used());
     e.set_bytesCopied(info->bytes_used());
-    e.set_regionsFreed(info->regions_freed());
+    e.set_regionsFreed(info->num_freed_regions());
     e.commit();
   }
 }

--- a/src/hotspot/share/gc/g1/g1Trace.cpp
+++ b/src/hotspot/share/gc/g1/g1Trace.cpp
@@ -181,7 +181,7 @@ create_g1_evacstats(unsigned gcid, const G1EvacSummary& summary) {
   s.set_used(summary.used() * HeapWordSize);
   s.set_undoWaste(summary.undo_wasted() * HeapWordSize);
   s.set_regionEndWaste(summary.region_end_waste() * HeapWordSize);
-  s.set_regionsRefilled(summary.regions_filled());
+  s.set_regionsRefilled(summary.num_regions_filled());
   s.set_directAllocated(summary.direct_allocated() * HeapWordSize);
   s.set_failureUsed(summary.failure_used() * HeapWordSize);
   s.set_failureWaste(summary.failure_waste() * HeapWordSize);

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -260,7 +260,7 @@ void G1YoungCollector::calculate_collection_set(G1EvacInfo* evacuation_info, dou
   allocator()->release_mutator_alloc_regions();
 
   collection_set()->finalize_initial_collection_set(target_pause_time_ms, survivor_regions());
-  evacuation_info->set_collection_set_regions(collection_set()->num_initial_regions() +
+  evacuation_info->set_num_collection_set_regions(collection_set()->num_initial_regions() +
                                               collection_set()->num_optional_regions());
 
   concurrent_mark()->verify_no_collection_set_oops();
@@ -1084,15 +1084,15 @@ void G1YoungCollector::post_evacuate_collection_set(G1EvacInfo* evacuation_info,
 }
 
 bool G1YoungCollector::evacuation_failed() const {
-  return _evac_failure_regions.has_regions_evac_failed();
+  return _evac_failure_regions.has_evac_failed_regions();
 }
 
 bool G1YoungCollector::evacuation_pinned() const {
-  return _evac_failure_regions.has_regions_evac_pinned();
+  return _evac_failure_regions.has_evac_pinned_regions();
 }
 
 bool G1YoungCollector::evacuation_alloc_failed() const {
-  return _evac_failure_regions.has_regions_alloc_failed();
+  return _evac_failure_regions.has_alloc_failed_regions();
 }
 
 G1YoungCollector::G1YoungCollector(GCCause::Cause gc_cause,

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -390,8 +390,8 @@ G1PostEvacuateCollectionSetCleanupTask1::G1PostEvacuateCollectionSetCleanupTask1
 }
 
 class G1FreeHumongousRegionClosure : public G1HeapRegionIndexClosure {
-  uint _humongous_objects_reclaimed;
-  uint _humongous_regions_reclaimed;
+  uint _num_humongous_objects_reclaimed;
+  uint _num_humongous_regions_reclaimed;
   size_t _freed_bytes;
   G1CollectedHeap* _g1h;
 
@@ -429,8 +429,8 @@ class G1FreeHumongousRegionClosure : public G1HeapRegionIndexClosure {
 
 public:
   G1FreeHumongousRegionClosure() :
-    _humongous_objects_reclaimed(0),
-    _humongous_regions_reclaimed(0),
+    _num_humongous_objects_reclaimed(0),
+    _num_humongous_regions_reclaimed(0),
     _freed_bytes(0),
     _g1h(G1CollectedHeap::heap())
   {}
@@ -469,12 +469,12 @@ public:
            "Eagerly reclaimed humongous region %u should not be marked at all but is in bitmap %s",
            region_index,
            BOOL_TO_STR(cm->is_marked_in_bitmap(obj)));
-    _humongous_objects_reclaimed++;
+    _num_humongous_objects_reclaimed++;
 
     auto free_humongous_region = [&] (G1HeapRegion* r) {
       _freed_bytes += r->used();
       r->set_containing_set(nullptr);
-      _humongous_regions_reclaimed++;
+      _num_humongous_regions_reclaimed++;
       G1HeapRegionPrinter::eager_reclaim(r);
       // Humongous non-typeArrays may have dirty card tables. Need to be cleared. Do it
       // for all types just in case.
@@ -487,12 +487,12 @@ public:
     return false;
   }
 
-  uint humongous_objects_reclaimed() {
-    return _humongous_objects_reclaimed;
+  uint num_humongous_objects_reclaimed() {
+    return _num_humongous_objects_reclaimed;
   }
 
-  uint humongous_regions_reclaimed() {
-    return _humongous_regions_reclaimed;
+  uint num_humongous_regions_reclaimed() {
+    return _num_humongous_regions_reclaimed;
   }
 
   size_t bytes_freed() const {
@@ -536,9 +536,9 @@ public:
 
     record_work_item(worker_id, G1GCPhaseTimes::EagerlyReclaimNumTotal, g1h->num_humongous_objects());
     record_work_item(worker_id, G1GCPhaseTimes::EagerlyReclaimNumCandidates, g1h->num_humongous_reclaim_candidates());
-    record_work_item(worker_id, G1GCPhaseTimes::EagerlyReclaimNumReclaimed, cl.humongous_objects_reclaimed());
+    record_work_item(worker_id, G1GCPhaseTimes::EagerlyReclaimNumReclaimed, cl.num_humongous_objects_reclaimed());
 
-    _humongous_regions_reclaimed = cl.humongous_regions_reclaimed();
+    _humongous_regions_reclaimed = cl.num_humongous_regions_reclaimed();
     _bytes_freed = cl.bytes_freed();
   }
 };

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -176,7 +176,7 @@ class G1PostEvacuateCollectionSetCleanupTask1::RestoreEvacFailureRegionsTask : p
   CHeapBitMap _chunk_bitmap;
 
   uint _num_chunks_per_region;
-  uint _num_evac_fail_regions;
+  uint _num_evac_failed_regions;
   size_t _chunk_size;
 
   class PhaseTimesStat {
@@ -337,7 +337,7 @@ public:
     _evac_failure_regions(evac_failure_regions),
     _chunk_bitmap(mtGC) {
 
-    _num_evac_fail_regions = _evac_failure_regions->num_evac_failed_regions();
+    _num_evac_failed_regions = _evac_failure_regions->num_evac_failed_regions();
     _num_chunks_per_region = G1CollectedHeap::get_chunks_per_region_for_scan();
 
     _chunk_size = static_cast<uint>(G1HeapRegion::GrainWords / _num_chunks_per_region);
@@ -345,7 +345,7 @@ public:
     log_debug(gc, ergo)("Initializing removing self forwards with %u chunks per region",
                         _num_chunks_per_region);
 
-    _chunk_bitmap.resize(_num_chunks_per_region * _num_evac_fail_regions);
+    _chunk_bitmap.resize(_num_chunks_per_region * _num_evac_failed_regions);
   }
 
   double worker_cost() const override {
@@ -357,7 +357,7 @@ public:
 
   void do_work(uint worker_id) override {
     const uint total_workers = G1CollectedHeap::heap()->workers()->active_workers();
-    const uint total_chunks = _num_chunks_per_region * _num_evac_fail_regions;
+    const uint total_chunks = _num_chunks_per_region * _num_evac_failed_regions;
     const uint start_chunk_idx = worker_id * total_chunks / total_workers;
 
     for (uint i = 0; i < total_chunks; i++) {
@@ -603,7 +603,7 @@ class FreeCSetStats {
   size_t _bytes_allocated_in_old_since_last_pause; // Size of young regions turned into old
   size_t _failure_used_words;  // Live size in failed regions
   size_t _failure_waste_words; // Wasted size in failed regions
-  uint _regions_freed;         // Number of regions freed
+  uint _num_regions_freed;         // Number of regions freed
 
 public:
   FreeCSetStats() :
@@ -612,7 +612,7 @@ public:
       _bytes_allocated_in_old_since_last_pause(0),
       _failure_used_words(0),
       _failure_waste_words(0),
-      _regions_freed(0) { }
+      _num_regions_freed(0) { }
 
   void merge_stats(FreeCSetStats* other) {
     assert(other != nullptr, "invariant");
@@ -621,11 +621,11 @@ public:
     _bytes_allocated_in_old_since_last_pause += other->_bytes_allocated_in_old_since_last_pause;
     _failure_used_words += other->_failure_used_words;
     _failure_waste_words += other->_failure_waste_words;
-    _regions_freed += other->_regions_freed;
+    _num_regions_freed += other->_num_regions_freed;
   }
 
   void report(G1CollectedHeap* g1h, G1EvacInfo* evacuation_info) {
-    evacuation_info->add_to_freed_regions(_regions_freed);
+    evacuation_info->add_to_num_freed_regions(_num_regions_freed);
     evacuation_info->set_collection_set_used_before(_before_used_bytes + _after_used_bytes);
     evacuation_info->increment_collection_set_used_after(_after_used_bytes);
 
@@ -658,7 +658,7 @@ public:
     size_t used = r->used();
     assert(used > 0, "region %u %s zero used", r->hrm_index(), r->get_short_type_str());
     _before_used_bytes += used;
-    _regions_freed += 1;
+    _num_regions_freed += 1;
   }
 };
 

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -337,7 +337,7 @@ public:
     _evac_failure_regions(evac_failure_regions),
     _chunk_bitmap(mtGC) {
 
-    _num_evac_fail_regions = _evac_failure_regions->num_regions_evac_failed();
+    _num_evac_fail_regions = _evac_failure_regions->num_evac_failed_regions();
     _num_chunks_per_region = G1CollectedHeap::get_chunks_per_region_for_scan();
 
     _chunk_size = static_cast<uint>(G1HeapRegion::GrainWords / _num_chunks_per_region);
@@ -349,10 +349,10 @@ public:
   }
 
   double worker_cost() const override {
-    assert(_evac_failure_regions->has_regions_evac_failed(), "Should not call this if there were no evacuation failures");
+    assert(_evac_failure_regions->has_evac_failed_regions(), "Should not call this if there were no evacuation failures");
 
     double workers_per_region = (double)G1CollectedHeap::get_chunks_per_region_for_scan() / G1RestoreRetainedRegionChunksPerWorker;
-    return workers_per_region * _evac_failure_regions->num_regions_evac_failed();
+    return workers_per_region * _evac_failure_regions->num_evac_failed_regions();
   }
 
   void do_work(uint worker_id) override {
@@ -373,8 +373,8 @@ G1PostEvacuateCollectionSetCleanupTask1::G1PostEvacuateCollectionSetCleanupTask1
                                                                                  G1EvacFailureRegions* evac_failure_regions) :
   G1BatchedTask("Post Evacuate Cleanup 1", G1CollectedHeap::heap()->phase_times())
 {
-  bool evac_failed = evac_failure_regions->has_regions_evac_failed();
-  bool alloc_failed = evac_failure_regions->has_regions_alloc_failed();
+  bool evac_failed = evac_failure_regions->has_evac_failed_regions();
+  bool alloc_failed = evac_failure_regions->has_alloc_failed_regions();
 
   add_serial_task(new FlushPssTask(per_thread_states));
   add_serial_task(new RecalculateUsedTask(evac_failed, alloc_failed));
@@ -587,7 +587,7 @@ public:
   }
 
   double worker_cost() const override {
-    return _evac_failure_regions->num_regions_evac_failed();
+    return _evac_failure_regions->num_evac_failed_regions();
   }
 
   void do_work(uint worker_id) override {
@@ -625,7 +625,7 @@ public:
   }
 
   void report(G1CollectedHeap* g1h, G1EvacInfo* evacuation_info) {
-    evacuation_info->set_regions_freed(_regions_freed);
+    evacuation_info->add_to_freed_regions(_regions_freed);
     evacuation_info->set_collection_set_used_before(_before_used_bytes + _after_used_bytes);
     evacuation_info->increment_collection_set_used_after(_after_used_bytes);
 
@@ -804,7 +804,7 @@ public:
     }
   }
 
-  bool num_retained_regions() const { return _num_retained_regions; }
+  uint num_retained_regions() const { return _num_retained_regions; }
 };
 
 class G1PostEvacuateCollectionSetCleanupTask2::FreeCollectionSetTask : public G1AbstractSubTask {
@@ -952,7 +952,7 @@ G1PostEvacuateCollectionSetCleanupTask2::G1PostEvacuateCollectionSetCleanupTask2
   }
   add_serial_task(new DestroyPssTask(per_thread_states));
 
-  if (evac_failure_regions->has_regions_evac_failed()) {
+  if (evac_failure_regions->has_evac_failed_regions()) {
     add_parallel_task(new ProcessEvacuationFailedRegionsTask(evac_failure_regions));
   }
 

--- a/src/hotspot/share/gc/shared/gcHeapSummary.hpp
+++ b/src/hotspot/share/gc/shared/gcHeapSummary.hpp
@@ -178,7 +178,7 @@ private:
   size_t _used;
 
   size_t _region_end_waste; // Number of words wasted due to skipping to the next region.
-  uint   _regions_filled;   // Number of regions filled completely.
+  uint   _num_regions_filled; // Number of regions filled completely.
   size_t _num_plab_filled;  // Number of PLABs refilled/retired.
   size_t _direct_allocated; // Number of words allocated directly into the regions.
   size_t _num_direct_allocated; // Number of direct allocations.
@@ -205,7 +205,7 @@ public:
                 size_t failure_waste) :
     _allocated(allocated), _wasted(wasted), _undo_wasted(undo_wasted), _unused(unused),
     _used(used),  _region_end_waste(region_end_waste),
-    _regions_filled(regions_filled), _num_plab_filled(num_plab_filled),
+    _num_regions_filled(regions_filled), _num_plab_filled(num_plab_filled),
     _direct_allocated(direct_allocated),_num_direct_allocated(num_direct_allocated),
     _failure_used(failure_used), _failure_waste(failure_waste)
   { }
@@ -216,7 +216,7 @@ public:
   size_t unused() const { return _unused; }
   size_t used() const { return _used; }
   size_t region_end_waste() const { return _region_end_waste; }
-  uint regions_filled() const { return _regions_filled; }
+  uint num_regions_filled() const { return _num_regions_filled; }
   size_t num_plab_filled() const { return _num_plab_filled; }
   size_t direct_allocated() const { return _direct_allocated; }
   size_t num_direct_allocated() const { return _num_direct_allocated; }


### PR DESCRIPTION
Hi all,

  please review these num_regions region count renaming for the g1 evacuation handling/statistics.

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391958](https://bugs.openjdk.org/browse/JDK-8391958): G1: Evacuation failure handling should use num_regions identifiers (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32757/head:pull/32757` \
`$ git checkout pull/32757`

Update a local copy of the PR: \
`$ git checkout pull/32757` \
`$ git pull https://git.openjdk.org/jdk.git pull/32757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32757`

View PR using the GUI difftool: \
`$ git pr show -t 32757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32757.diff">https://git.openjdk.org/jdk/pull/32757.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32757#issuecomment-5584797983)
</details>
