### PR TITLE
8390949: Remove displaced-mark related code from SA agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
@@ -118,10 +118,6 @@ public class Mark extends VMObject {
     return markField.getValue(addr);
   }
 
-  public Address valueAsAddress() {
-    return addr.getAddressAt(markField.getOffset());
-  }
-
   // lock accessors (note that these assume lock_shift == 0)
   public boolean isNonNeutral() {
     return (Bits.maskBitsLong(value(), lockMaskInPlace) != neutralValue);
@@ -152,7 +148,8 @@ public class Mark extends VMObject {
     return ((value() & lockMaskInPlace) == fastLockedValue);
   }
   public boolean hasMonitor() {
-    return ((value() & monitorValue) != 0);
+    // Align SA’s decoding with markWord::has_monitor().
+    return (value() & lockMaskInPlace) == monitorValue;
   }
   public ObjectMonitor monitor() {
     if (Assert.ASSERTS_ENABLED) {
@@ -166,16 +163,6 @@ public class Mark extends VMObject {
       }
     }
     return null;
-  }
-  public boolean hasDisplacedMarkHelper() {
-    return ((value() & neutralValue) == 0);
-  }
-  public Mark displacedMarkHelper() {
-    if (Assert.ASSERTS_ENABLED) {
-      Assert.that(hasDisplacedMarkHelper(), "check");
-    }
-    Address addr = valueAsAddress().andWithMask(~monitorValue);
-    return new Mark(addr.getAddressAt(0));
   }
   public int age() { return (int) Bits.maskBitsLong(value() >> ageShift, ageMask); }
 
@@ -195,18 +182,27 @@ public class Mark extends VMObject {
 
   // Debugging
   public void printOn(PrintStream tty) {
-    if (isNonNeutral()) {
-      tty.print("locked(0x" +
-                Long.toHexString(value()) + ")->");
-      displacedMarkHelper().printOn(tty);
+    if (isMarked()) {
+      tty.print("marked(" + Long.toHexString(value()) + ")");
+      return;
+    }
+    tty.print("mark(");
+    if (hasMonitor()) {
+      tty.print("has_monitor");
+    } else if (isNeutral()) {
+      tty.print("is_lock_neutral");
     } else {
       if (Assert.ASSERTS_ENABLED) {
-        Assert.that(isNeutral(), "just checking");
+        Assert.that(isFastLocked(), "should be");
       }
-      tty.print("mark(");
-      tty.print("hash " + Long.toHexString(hash()) + ",");
-      tty.print("age " + age() + ")");
+      tty.print("is_fast_locked");
     }
+    if (hasNoHash()) {
+      tty.print(" no_hash");
+    } else {
+      tty.print(" hash=" + Long.toHexString(hash()));
+    }
+    tty.print(" age=" + age() + ")");
   }
 
   public long getSize() { return (long)value(); }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
@@ -129,12 +129,6 @@ public class Mark extends VMObject {
     return (Bits.maskBitsLong(value(), lockMaskInPlace) == markedValue);
   }
 
-  // Special temporary state of the markWord while being inflated.
-  // Code that looks at mark outside a lock need to take this into account.
-  public boolean isBeingInflated() {
-    return (value() == 0);
-  }
-
   // Should this header be preserved during GC?
   public boolean mustBePreserved() {
     return (isNonNeutral() || !hasNoHash());
@@ -148,7 +142,6 @@ public class Mark extends VMObject {
     return ((value() & lockMaskInPlace) == fastLockedValue);
   }
   public boolean hasMonitor() {
-    // Align SA’s decoding with markWord::has_monitor().
     return (value() & lockMaskInPlace) == monitorValue;
   }
   public ObjectMonitor monitor() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectSynchronizer.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectSynchronizer.java
@@ -50,23 +50,7 @@ public class ObjectSynchronizer {
   }
 
   public long identityHashValueFor(Oop obj) {
-    Mark mark = obj.getMark();
-    if (mark.isNeutral()) {
-      // FIXME: can not generate marks in debugging system
-      return mark.hash();
-    } else if (mark.hasMonitor()) {
-      return mark.hash();
-    } else {
-      if (Assert.ASSERTS_ENABLED) {
-        Assert.that(VM.getVM().isDebugging(), "Can not access displaced header otherwise");
-      }
-      if (mark.hasDisplacedMarkHelper()) {
-        Mark temp = mark.displacedMarkHelper();
-        return temp.hash();
-      }
-      // FIXME: can not do anything else here in debugging system
-      return 0;
-    }
+    return obj.getMark().hash();
   }
 
   public static Iterator objectMonitorIterator() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectSynchronizer.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectSynchronizer.java
@@ -27,7 +27,6 @@ package sun.jvm.hotspot.runtime;
 import java.util.*;
 
 import sun.jvm.hotspot.oops.*;
-import sun.jvm.hotspot.utilities.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.types.*;
 import sun.jvm.hotspot.utilities.Observable;


### PR DESCRIPTION
This PR removes displaced-mark related code from the Serviceability Agent, which has become obsolete since [JDK-8389325](https://bugs.openjdk.org/browse/JDK-8389325) removed the `UseObjectMonitorTable` flag.

It also aligns the SA's mark-word related `printOn()` and `hasMonitor()` functions to their respective C++ functions, `markWord::print_on()` and `markWord::has_monitor()`.

Because the displaced-mark related code was removed, the `identityHashValueFor()` has been reduced to one line, just returning the hash code directly from the object's mark-word.

Passes tier1-3 on supported platforms. I also successfully ran `TEST="hotspot/jtreg/serviceability/sa"` on my local machine.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390949](https://bugs.openjdk.org/browse/JDK-8390949): Remove displaced-mark related code from SA agent (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32758/head:pull/32758` \
`$ git checkout pull/32758`

Update a local copy of the PR: \
`$ git checkout pull/32758` \
`$ git pull https://git.openjdk.org/jdk.git pull/32758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32758`

View PR using the GUI difftool: \
`$ git pr show -t 32758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32758.diff">https://git.openjdk.org/jdk/pull/32758.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32758#issuecomment-5585445269)
</details>
