### PR TITLE
8391962: G1: Change counts in uncommit task to num_regions

### DIFF
--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
@@ -34,7 +34,7 @@ G1UncommitRegionTask::G1UncommitRegionTask() :
     G1ServiceTask("G1 Uncommit Region Task"),
     _active(false),
     _summary_duration(),
-    _summary_region_count(0) { }
+    _summary_num_regions(0) { }
 
 void G1UncommitRegionTask::initialize() {
   assert(_instance == nullptr, "Already initialized");
@@ -77,28 +77,28 @@ void G1UncommitRegionTask::set_active(bool state) {
   _active = state;
 }
 
-void G1UncommitRegionTask::report_execution(Tickspan time, uint regions) {
-  _summary_region_count += regions;
-  _summary_duration += time;
+void G1UncommitRegionTask::report_execution(Tickspan uncommit_time, uint num_uncommitted_regions) {
+  _summary_num_regions += num_uncommitted_regions;
+  _summary_duration += uncommit_time;
 
   log_trace(gc, heap)("Concurrent Uncommit: %zu%s, %u regions, %1.3fms",
-                      byte_size_in_proper_unit(regions * G1HeapRegion::GrainBytes),
-                      proper_unit_for_byte_size(regions * G1HeapRegion::GrainBytes),
-                      regions,
-                      time.seconds() * 1000);
+                      byte_size_in_proper_unit(num_uncommitted_regions * G1HeapRegion::GrainBytes),
+                      proper_unit_for_byte_size(num_uncommitted_regions * G1HeapRegion::GrainBytes),
+                      num_uncommitted_regions,
+                      uncommit_time.seconds() * 1000);
 }
 
 void G1UncommitRegionTask::report_summary() {
   log_debug(gc, heap)("Concurrent Uncommit Summary: %zu%s, %u regions, %1.3fms",
-                      byte_size_in_proper_unit(_summary_region_count * G1HeapRegion::GrainBytes),
-                      proper_unit_for_byte_size(_summary_region_count * G1HeapRegion::GrainBytes),
-                      _summary_region_count,
+                      byte_size_in_proper_unit(_summary_num_regions * G1HeapRegion::GrainBytes),
+                      proper_unit_for_byte_size(_summary_num_regions * G1HeapRegion::GrainBytes),
+                      _summary_num_regions,
                       _summary_duration.seconds() * 1000);
 }
 
 void G1UncommitRegionTask::clear_summary() {
   _summary_duration = Tickspan();
-  _summary_region_count = 0;
+  _summary_num_regions = 0;
 }
 
 void G1UncommitRegionTask::execute() {
@@ -106,18 +106,18 @@ void G1UncommitRegionTask::execute() {
 
   // Translate the size limit into a number of regions. This cannot be a
   // compile time constant because G1HeapRegionSize is set ergonomically.
-  static const uint region_limit = (uint) (UncommitSizeLimit / G1HeapRegionSize);
+  static const uint max_num_regions_to_uncommit = (uint)(UncommitSizeLimit / G1HeapRegionSize);
 
   // Prevent from running during a GC pause.
   SuspendibleThreadSetJoiner sts;
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
   Ticks start = Ticks::now();
-  uint uncommit_count = g1h->uncommit_regions(region_limit);
+  uint num_uncommitted_regions = g1h->uncommit_regions(max_num_regions_to_uncommit);
   Tickspan uncommit_time = (Ticks::now() - start);
 
-  if (uncommit_count > 0) {
-    report_execution(uncommit_time, uncommit_count);
+  if (num_uncommitted_regions > 0) {
+    report_execution(uncommit_time, num_uncommitted_regions);
   }
 
   // Reschedule if there are more regions to uncommit, otherwise

--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.hpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.hpp
@@ -49,13 +49,13 @@ class G1UncommitRegionTask : public G1ServiceTask {
   // Members to keep a summary of the current concurrent uncommit
   // work. Used for printing when no more work is available.
   Tickspan _summary_duration;
-  uint _summary_region_count;
+  uint _summary_num_regions;
 
   G1UncommitRegionTask();
   bool is_active();
   void set_active(bool state);
 
-  void report_execution(Tickspan time, uint regions);
+  void report_execution(Tickspan uncommit_time, uint num_uncommitted_regions);
   void report_summary();
   void clear_summary();
 


### PR DESCRIPTION
Hi all,

  please review this change that fixes naming for identifiers in G1UncommitRegionTask wrt to number of regions naming.

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391962](https://bugs.openjdk.org/browse/JDK-8391962): G1: Change counts in uncommit task to num_regions (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32759/head:pull/32759` \
`$ git checkout pull/32759`

Update a local copy of the PR: \
`$ git checkout pull/32759` \
`$ git pull https://git.openjdk.org/jdk.git pull/32759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32759`

View PR using the GUI difftool: \
`$ git pr show -t 32759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32759.diff">https://git.openjdk.org/jdk/pull/32759.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32759#issuecomment-5587697730)
</details>
