### PR TITLE
8391974: G1: Clean up policy related number-of-regions identifiers

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3160,7 +3160,7 @@ bool G1CollectedHeap::has_more_regions(G1HeapRegionAttr dest) {
   if (dest.is_old()) {
     return true;
   } else {
-    return num_survivor_regions() < policy()->max_survivor_regions();
+    return num_survivor_regions() < policy()->max_num_survivor_regions();
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -133,7 +133,7 @@ void G1HeapTransition::print() {
   Data after(_g1_heap);
 
   size_t num_eden_after_gc = _g1_heap->policy()->target_num_young_regions() - after._num_survivor_regions;
-  size_t num_survivor_before_gc = _g1_heap->policy()->max_survivor_regions();
+  size_t num_survivor_before_gc = _g1_heap->policy()->max_num_survivor_regions();
 
   DetailedUsage usage;
   if (log_is_enabled(Trace, gc, heap)) {

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -65,7 +65,7 @@ G1Policy::G1Policy(STWGCTimer* gc_timer) :
   _eden_surv_rate_group(new G1SurvRateGroup()),
   _survivor_surv_rate_group(new G1SurvRateGroup()),
   _reserve_factor((double) G1ReservePercent / 100.0),
-  _reserve_regions(0),
+  _num_reserve_regions(0),
   _young_gen_sizer(),
   _free_regions_at_end_of_collection(0),
   _pending_cards_from_gc(0),
@@ -75,7 +75,7 @@ G1Policy::G1Policy(STWGCTimer* gc_timer) :
   _phase_times_timer(gc_timer),
   _phase_times(nullptr),
   _tenuring_threshold(MaxTenuringThreshold),
-  _max_survivor_regions(0),
+  _max_num_survivor_regions(0),
   _survivors_age_table(true)
 {
 }
@@ -156,16 +156,15 @@ class G1NumYoungRegionsPredictor {
   }
 };
 
-void G1Policy::record_new_heap_size(uint new_number_of_regions) {
-  // re-calculate the necessary reserve
-  double reserve_regions_d = (double) new_number_of_regions * _reserve_factor;
-  // We use ceiling so that if reserve_regions_d is > 0.0 (but
-  // smaller than 1.0) we'll get 1.
-  _reserve_regions.store_relaxed((uint) ceil(reserve_regions_d));
+void G1Policy::record_new_heap_size(uint new_num_regions) {
+  // Re-calculate the necessary reserve.
+  double num_reserve_regions_d = (double)new_num_regions * _reserve_factor;
+  // Round up above result to always get a non-zero result.
+  _num_reserve_regions.store_relaxed((uint)ceil(num_reserve_regions_d));
 
-  _young_gen_sizer.heap_size_changed(new_number_of_regions);
+  _young_gen_sizer.heap_size_changed(new_num_regions);
 
-  _ihop_control->update_target_occupancy(new_number_of_regions * G1HeapRegion::GrainBytes);
+  _ihop_control->update_target_occupancy(new_num_regions * G1HeapRegion::GrainBytes);
 }
 
 uint G1Policy::calculate_desired_num_eden_regions_by_mmu() const {
@@ -340,10 +339,10 @@ uint G1Policy::calculate_target_num_young_regions(uint desired_num_young_regions
     // It can be concurrently modified by the mutator as it expands the heap. It can
     // only increase at that time, so this is a conservative snapshot. So at worst this
     // method will return a too small number of young regions in that case.
-    uint reserve_regions = _reserve_regions.load_relaxed();
+    uint num_reserve_regions = _num_reserve_regions.load_relaxed();
 
     uint max_to_eat_into_reserve = MIN2(min_num_young_regions_by_sizer,
-                                        (reserve_regions + 1) / 2);
+                                        (num_reserve_regions + 1) / 2);
 
     log_trace(gc, ergo, heap)("Target young regions: Common "
                               "free regions at end of collection %u "
@@ -352,14 +351,14 @@ uint G1Policy::calculate_target_num_young_regions(uint desired_num_young_regions
                               "max to eat into reserve %u",
                               _free_regions_at_end_of_collection,
                               desired_num_young_regions,
-                              reserve_regions,
+                              num_reserve_regions,
                               max_to_eat_into_reserve);
 
     uint num_survivor_regions = _g1h->num_survivor_regions();
     uint desired_num_eden_regions = desired_num_young_regions - num_survivor_regions;
     uint num_eden_regions = num_young_regions - num_survivor_regions;
 
-    if (_free_regions_at_end_of_collection <= reserve_regions) {
+    if (_free_regions_at_end_of_collection <= num_reserve_regions) {
       // Fully eat (or already eating) into the reserve.
       uint receiving_eden = MIN3(_free_regions_at_end_of_collection,
                                  desired_num_eden_regions,
@@ -374,9 +373,9 @@ uint G1Policy::calculate_target_num_young_regions(uint desired_num_young_regions
       log_trace(gc, ergo, heap)("Target young regions: Fully eat into reserve "
                                 "receiving eden %u receiving additional eden %u",
                                 receiving_eden, receiving_additional_eden);
-    } else if (_free_regions_at_end_of_collection < (desired_num_eden_regions + reserve_regions)) {
+    } else if (_free_regions_at_end_of_collection < (desired_num_eden_regions + num_reserve_regions)) {
       // Partially eat into the reserve, at most max_to_eat_into_reserve regions.
-      uint free_outside_reserve = _free_regions_at_end_of_collection - reserve_regions;
+      uint free_outside_reserve = _free_regions_at_end_of_collection - num_reserve_regions;
       assert(free_outside_reserve < desired_num_eden_regions,
              "must be %u %u",
              free_outside_reserve, desired_num_eden_regions);
@@ -699,9 +698,9 @@ void G1Policy::record_young_collection_start() {
   // every time we calculate / recalculate the target number of young regions.
   update_survivors_policy();
 
-  assert(max_survivor_regions() + _g1h->num_used_regions() <= _g1h->max_num_regions(),
+  assert(max_num_survivor_regions() + _g1h->num_used_regions() <= _g1h->max_num_regions(),
          "Maximum survivor regions %u plus used regions %u exceeds max regions %u",
-         max_survivor_regions(), _g1h->num_used_regions(), _g1h->max_num_regions());
+         max_num_survivor_regions(), _g1h->num_used_regions(), _g1h->max_num_regions());
   assert_used_and_recalculate_used_equal(_g1h);
 
   // do that for any other surv rate groups
@@ -858,8 +857,8 @@ G1CollectorState G1Policy::record_young_collection_end(bool concurrent_operation
     // given that humongous object allocations do not really affect
     // either the pause's duration nor when the next pause will take
     // place we can safely ignore them here.
-    uint regions_allocated = _collection_set->num_eden_regions();
-    double alloc_rate_ms = (double) regions_allocated / app_time_ms;
+    uint num_eden_regions = _collection_set->num_eden_regions();
+    double alloc_rate_ms = (double) num_eden_regions / app_time_ms;
     _analytics->report_alloc_rate_ms(alloc_rate_ms);
 
     double merge_refinement_table_time = p->cur_merge_refinement_table_time();
@@ -1222,8 +1221,8 @@ size_t G1Policy::estimate_used_young_bytes_locked() const {
   return bytes_used + allocator->used_in_alloc_regions();
 }
 
-size_t G1Policy::desired_survivor_size(uint max_regions) const {
-  size_t const survivor_capacity = G1HeapRegion::GrainWords * max_regions;
+size_t G1Policy::desired_survivor_size(uint max_num_regions) const {
+  size_t const survivor_capacity = G1HeapRegion::GrainWords * max_num_regions;
   return (size_t)((((double)survivor_capacity) * TargetSurvivorRatio) / 100);
 }
 
@@ -1233,14 +1232,14 @@ void G1Policy::print_age_table() {
 
 // Calculates survivor space parameters.
 void G1Policy::update_survivors_policy() {
-  double max_survivor_regions_d =
+  double max_num_survivor_regions_d =
                  (double)target_num_young_regions() / (double) SurvivorRatio;
 
   // Calculate desired survivor size based on desired max survivor regions (unconstrained
   // by remaining heap). Otherwise we may cause undesired promotions as we are
   // already getting close to end of the heap, impacting performance even more.
-  uint const desired_max_survivor_regions = ceil(max_survivor_regions_d);
-  size_t const survivor_size = desired_survivor_size(desired_max_survivor_regions);
+  uint const desired_max_num_survivor_regions = ceil(max_num_survivor_regions_d);
+  size_t const survivor_size = desired_survivor_size(desired_max_num_survivor_regions);
 
   _tenuring_threshold = _survivors_age_table.compute_tenuring_threshold(survivor_size);
   if (UsePerfData) {
@@ -1249,8 +1248,8 @@ void G1Policy::update_survivors_policy() {
   }
   // The real maximum survivor size is bounded by the number of regions that can
   // be allocated into.
-  _max_survivor_regions = MIN2(desired_max_survivor_regions,
-                               _g1h->num_available_regions());
+  _max_num_survivor_regions = MIN2(desired_max_num_survivor_regions,
+                                   _g1h->num_available_regions());
 }
 
 bool G1Policy::force_concurrent_start_if_outside_cycle(GCCause::Cause gc_cause) {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -95,7 +95,7 @@ class G1Policy: public CHeapObj<mtGC> {
   // G1 allocation of new regions for eden is restrained when allocating into that reserve.
   // This intentionally slows down the allocation when the heap is close to full to allow
   // concurrent marking to finish and hopefully avoid a Full GC.
-  Atomic<uint> _reserve_regions;
+  Atomic<uint> _num_reserve_regions;
 
   G1YoungGenSizer _young_gen_sizer;
 
@@ -290,7 +290,7 @@ public:
   void revise_target_num_young_regions(size_t pending_cards, size_t card_rs_length, size_t code_root_rs_length);
 
   // This should be called after the heap is resized.
-  void record_new_heap_size(uint new_number_of_regions);
+  void record_new_heap_size(uint new_num_regions);
 
   void init(G1CollectedHeap* g1h, G1CollectionSet* collection_set);
 
@@ -401,11 +401,11 @@ private:
   uint _tenuring_threshold;
 
   // The limit on the number of regions allocated for survivors.
-  uint _max_survivor_regions;
+  uint _max_num_survivor_regions;
 
   AgeTable _survivors_age_table;
 
-  size_t desired_survivor_size(uint max_regions) const;
+  size_t desired_survivor_size(uint max_num_regions) const;
 
 public:
   // Fraction used when predicting how many optional regions to include in
@@ -422,8 +422,8 @@ public:
 
   uint tenuring_threshold() const { return _tenuring_threshold; }
 
-  uint max_survivor_regions() {
-    return _max_survivor_regions;
+  uint max_num_survivor_regions() {
+    return _max_num_survivor_regions;
   }
 
   void start_adding_survivor_regions() {

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
@@ -118,37 +118,37 @@ G1YoungGenSizer::G1YoungGenSizer() : _sizer_kind(SizerDefaults),
   }
 }
 
-uint G1YoungGenSizer::calculate_default_min_num_regions(uint new_number_of_heap_regions) {
-  uint default_value = (new_number_of_heap_regions * G1NewSizePercent) / 100;
+uint G1YoungGenSizer::calculate_default_min_num_regions(uint new_num_regions) {
+  uint default_value = (new_num_regions * G1NewSizePercent) / 100;
   return MAX2(1U, default_value);
 }
 
-uint G1YoungGenSizer::calculate_default_max_num_regions(uint new_number_of_heap_regions) {
-  uint default_value = (new_number_of_heap_regions * G1MaxNewSizePercent) / 100;
+uint G1YoungGenSizer::calculate_default_max_num_regions(uint new_num_regions) {
+  uint default_value = (new_num_regions * G1MaxNewSizePercent) / 100;
   return MAX2(1U, default_value);
 }
 
-void G1YoungGenSizer::recalculate_min_max_num_regions(uint number_of_heap_regions, uint* min_num_young_regions, uint* max_num_young_regions) {
-  assert(number_of_heap_regions > 0, "Heap must be initialized");
+void G1YoungGenSizer::recalculate_min_max_num_regions(uint num_regions, uint* min_num_young_regions, uint* max_num_young_regions) {
+  assert(num_regions > 0, "Heap must be initialized");
 
   switch (_sizer_kind) {
     case SizerDefaults:
-      *min_num_young_regions = calculate_default_min_num_regions(number_of_heap_regions);
-      *max_num_young_regions = calculate_default_max_num_regions(number_of_heap_regions);
+      *min_num_young_regions = calculate_default_min_num_regions(num_regions);
+      *max_num_young_regions = calculate_default_max_num_regions(num_regions);
       break;
     case SizerNewSizeOnly:
-      *max_num_young_regions = calculate_default_max_num_regions(number_of_heap_regions);
+      *max_num_young_regions = calculate_default_max_num_regions(num_regions);
       *max_num_young_regions = MAX2(*min_num_young_regions, *max_num_young_regions);
       break;
     case SizerMaxNewSizeOnly:
-      *min_num_young_regions = calculate_default_min_num_regions(number_of_heap_regions);
+      *min_num_young_regions = calculate_default_min_num_regions(num_regions);
       *min_num_young_regions = MIN2(*min_num_young_regions, *max_num_young_regions);
       break;
     case SizerMaxAndNewSize:
       // Do nothing. Values set on the command line, don't update them at runtime.
       break;
     case SizerNewRatio:
-      *min_num_young_regions = MAX2((uint)(number_of_heap_regions / (NewRatio + 1)), 1u);
+      *min_num_young_regions = MAX2((uint)(num_regions / (NewRatio + 1)), 1u);
       *max_num_young_regions = *min_num_young_regions;
       break;
     default:
@@ -158,12 +158,12 @@ void G1YoungGenSizer::recalculate_min_max_num_regions(uint number_of_heap_region
   assert(*min_num_young_regions <= *max_num_young_regions, "Invalid min/max young gen size values");
 }
 
-void G1YoungGenSizer::adjust_max_new_size(uint number_of_heap_regions) {
+void G1YoungGenSizer::adjust_max_new_size(uint num_regions) {
   // We need to pass the desired values because recalculation may not update these
   // values in some cases.
   uint unused_new_min = min_desired_num_regions();
   uint new_max = max_desired_num_regions();
-  recalculate_min_max_num_regions(number_of_heap_regions, &unused_new_min, &new_max);
+  recalculate_min_max_num_regions(num_regions, &unused_new_min, &new_max);
 
   size_t max_young_size = new_max * G1HeapRegion::GrainBytes;
   if (max_young_size != MaxNewSize) {
@@ -171,10 +171,10 @@ void G1YoungGenSizer::adjust_max_new_size(uint number_of_heap_regions) {
   }
 }
 
-void G1YoungGenSizer::heap_size_changed(uint new_number_of_heap_regions) {
+void G1YoungGenSizer::heap_size_changed(uint new_num_regions) {
   uint min = min_desired_num_regions();
   uint max = max_desired_num_regions();
-  recalculate_min_max_num_regions(new_number_of_heap_regions, &min, &max);
+  recalculate_min_max_num_regions(new_num_regions, &min, &max);
   _min_desired_num_regions.store_relaxed(min);
   _max_desired_num_regions.store_relaxed(max);
 }

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.hpp
@@ -82,20 +82,20 @@ private:
   Atomic<uint> _min_desired_num_regions;
   Atomic<uint> _max_desired_num_regions;
 
-  uint calculate_default_min_num_regions(uint new_number_of_heap_regions);
-  uint calculate_default_max_num_regions(uint new_number_of_heap_regions);
+  uint calculate_default_min_num_regions(uint new_num_regions);
+  uint calculate_default_max_num_regions(uint new_num_regions);
 
   // Recalculate the minimum and maximum number of young regions for the
   // given number of heap regions according to the current sizing algorithm.
-  void recalculate_min_max_num_regions(uint number_of_heap_regions, uint* min_num_young_regions, uint* max_num_young_regions);
+  void recalculate_min_max_num_regions(uint num_regions, uint* min_num_young_regions, uint* max_num_young_regions);
 
 public:
   G1YoungGenSizer();
   // Calculate the maximum size of the young gen given the number of regions
   // depending on the sizing algorithm.
-  virtual void adjust_max_new_size(uint number_of_heap_regions);
+  virtual void adjust_max_new_size(uint num_regions);
 
-  virtual void heap_size_changed(uint new_number_of_heap_regions);
+  virtual void heap_size_changed(uint new_num_regions);
   uint min_desired_num_regions() const {
     return _min_desired_num_regions.load_relaxed();
   }


### PR DESCRIPTION
Hi all,

  please review region count naming changes to num_*_region for policy related classes.

Testing: gha, local compilation

Thanks,
  Thomas




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391974](https://bugs.openjdk.org/browse/JDK-8391974): G1: Clean up policy related number-of-regions identifiers (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32762/head:pull/32762` \
`$ git checkout pull/32762`

Update a local copy of the PR: \
`$ git checkout pull/32762` \
`$ git pull https://git.openjdk.org/jdk.git pull/32762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32762`

View PR using the GUI difftool: \
`$ git pr show -t 32762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32762.diff">https://git.openjdk.org/jdk/pull/32762.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32762#issuecomment-5597625143)
</details>
