### PR TITLE
8391977: Shenandoah: Internal memory should be mtGC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
@@ -29,7 +29,7 @@
 #include "runtime/atomicAccess.hpp"
 
 HdrSeq::HdrSeq() {
-  _hdr = NEW_C_HEAP_ARRAY(int*, MagBuckets, mtInternal);
+  _hdr = NEW_C_HEAP_ARRAY(int*, MagBuckets, mtGC);
   for (int c = 0; c < MagBuckets; c++) {
     _hdr[c] = nullptr;
   }
@@ -95,7 +95,7 @@ void HdrSeq::add(double val) {
 
   int* b = _hdr[bucket];
   if (b == nullptr) {
-    b = NEW_C_HEAP_ARRAY(int, ValBuckets, mtInternal);
+    b = NEW_C_HEAP_ARRAY(int, ValBuckets, mtGC);
     for (int c = 0; c < ValBuckets; c++) {
       b[c] = 0;
     }
@@ -141,7 +141,7 @@ void HdrSeq::add(const HdrSeq& other) {
       }
     } else {
       // Create our bucket and copy the contents over
-      bucket = NEW_C_HEAP_ARRAY(int, ValBuckets, mtInternal);
+      bucket = NEW_C_HEAP_ARRAY(int, ValBuckets, mtGC);
       for (int val = 0; val < ValBuckets; val++) {
         bucket[val] = other_bucket[val];
       }
@@ -186,7 +186,7 @@ void HdrSeq::clear() {
 }
 
 BinaryMagnitudeSeq::BinaryMagnitudeSeq() {
-  _mags = NEW_C_HEAP_ARRAY(size_t, BitsPerSize_t, mtInternal);
+  _mags = NEW_C_HEAP_ARRAY(size_t, BitsPerSize_t, mtGC);
   clear();
 }
 


### PR DESCRIPTION
I was surprised to see that some Shenandoah internal data structures were tagged mtInternal, not mtGC. So they are mis-attributed in NMT. I deliberately keep this patch very simple to backport to at least 25u.

Additional testing:
 - [x] Eyeballing NMT logs

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391977](https://bugs.openjdk.org/browse/JDK-8391977): Shenandoah: Internal memory should be mtGC (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@johan-sjolen - **Reviewer**)
 * [Rui Li](https://openjdk.org/census#ruili) (@rgithubli - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32763/head:pull/32763` \
`$ git checkout pull/32763`

Update a local copy of the PR: \
`$ git checkout pull/32763` \
`$ git pull https://git.openjdk.org/jdk.git pull/32763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32763`

View PR using the GUI difftool: \
`$ git pr show -t 32763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32763.diff">https://git.openjdk.org/jdk/pull/32763.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32763#issuecomment-5584917021)
</details>
