### PR TITLE
8391909: Improve ConfinedSegmentPool Performance

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
@@ -72,14 +72,15 @@ public sealed class ArenaImpl implements Arena {
         // This field is set at most once but its content can change arbitarly so it
         // cannot be @Stable
         private long[] poolCache;
-        // This field is set at most once so it can be @Stable
+        // This field is set at most once so it can be @Stable. Use a plus-one strategy
+        // to unlock stability for the common zero case.
         @Stable
-        private int poolCacheIndex;
+        private byte poolCacheIndexPlusOne;
 
         // Set at most once: an arena never switches backing pools.
         @Stable
         private long pool;
-        private long poolSp;
+        private int poolSp;
 
         OfConfined(ConfinedSession session) {
             super(session);
@@ -96,7 +97,7 @@ public sealed class ArenaImpl implements Arena {
                 // cleanup segments, so clear and release the pool only after they have run.
                 if (pool != 0) {
                     if (poolCache != null) {
-                        ConfinedSegmentPool.releaseToRememeberedPoolSlot(poolCache, poolCacheIndex, pool, poolSp);
+                        ConfinedSegmentPool.releaseToRememeberedPoolSlot(poolCache, poolCacheIndexPlusOne - 1, pool, poolSp);
                     } else {
                         ConfinedSegmentPool.release(pool, poolSp);
                     }
@@ -148,7 +149,9 @@ public sealed class ArenaImpl implements Arena {
             final long start = Utils.alignUp(pool + poolSp, byteAlignment) - pool;
             if (start + byteSize <= POOL_SIZE) {
                 // The backing memory is zeroed on initial allocation and on each pool release.
-                poolSp = start + byteSize;
+                // The (int) cast is safe because the preceding bounds check limits it to
+                // "small" configured pool sizes.
+                poolSp = (int) (start + byteSize);
                 return pool + start;
             }
             return 0;
@@ -157,7 +160,7 @@ public sealed class ArenaImpl implements Arena {
         @ForceInline
         void rememberPoolCacheAndIndex(long[] poolCache, int poolCacheIndex) {
             this.poolCache = poolCache;
-            this.poolCacheIndex = poolCacheIndex;
+            this.poolCacheIndexPlusOne = (byte) (poolCacheIndex + 1);
         }
 
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
@@ -64,6 +64,18 @@ public sealed class ArenaImpl implements Arena {
 
         private static final long POOL_SIZE = ConfinedSegmentPool.pooledMemorySize();
 
+        // The two fields below are set together only when a platform-thread arena
+        // acquires a cached pool.
+        // The pool is detached from the cache while owned by the arena. Its original
+        // slot is normally empty at close, but another arena may have occupied it.
+        // Virtual-thread and locally allocated pools leave `poolCache` null.
+        // This field is set at most once but its content can change arbitarly so it
+        // cannot be @Stable
+        private long[] poolCache;
+        // This field is set at most once so it can be @Stable
+        @Stable
+        private int poolCacheIndex;
+
         // Set at most once: an arena never switches backing pools.
         @Stable
         private long pool;
@@ -83,7 +95,11 @@ public sealed class ArenaImpl implements Arena {
                 // Cleanup actions can access the backing region through globally scoped
                 // cleanup segments, so clear and release the pool only after they have run.
                 if (pool != 0) {
-                    ConfinedSegmentPool.release(pool, poolSp);
+                    if (poolCache != null) {
+                        ConfinedSegmentPool.releaseToRememeberedPoolSlot(poolCache, poolCacheIndex, pool, poolSp);
+                    } else {
+                        ConfinedSegmentPool.release(pool, poolSp);
+                    }
                 }
             }
         }
@@ -107,7 +123,7 @@ public sealed class ArenaImpl implements Arena {
                 session.checkValidState();
                 long pool = this.pool;
                 if (pool == 0) {
-                    pool = ConfinedSegmentPool.acquire();
+                    pool = ConfinedSegmentPool.acquire(this);
                     if (pool == 0) {
                         pool = ConfinedSegmentPool.allocateLocal();
                     }
@@ -136,6 +152,12 @@ public sealed class ArenaImpl implements Arena {
                 return pool + start;
             }
             return 0;
+        }
+
+        @ForceInline
+        void rememberPoolCacheAndIndex(long[] poolCache, int poolCacheIndex) {
+            this.poolCache = poolCache;
+            this.poolCacheIndex = poolCacheIndex;
         }
 
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/ConfinedSegmentPool.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ConfinedSegmentPool.java
@@ -97,7 +97,7 @@ public final class ConfinedSegmentPool {
     // 2^3, 2^4, ..., 2^20 bytes, defaulting to 2^6 = 64 bytes.
     private static final String POOLED_MEMORY_SIZE_PROPERTY = PROPERTY_PATH + "size";
 
-    private static final long POOLED_MEMORY_SIZE =
+    private static final int POOLED_MEMORY_SIZE =
             clampedPowerOfPropertyOr(POOLED_MEMORY_SIZE_PROPERTY, 3, 20, 6);
 
     // Unsupported implementation-specific tuning knob; no behavioral or compatibility
@@ -115,7 +115,7 @@ public final class ConfinedSegmentPool {
     /**
      * Returns the size of the native memory pool, or {@code -1} if pooling is disabled.
      */
-    public static long pooledMemorySize() {
+    public static int pooledMemorySize() {
         return POOLING_DISABLED ? -1 : POOLED_MEMORY_SIZE;
     }
 
@@ -159,7 +159,7 @@ public final class ConfinedSegmentPool {
      * return pools to the current carrier.
      */
     @ForceInline
-    static void release(long pool, long usedSize) {
+    static void release(long pool, int usedSize) {
         final Thread thread = Thread.currentThread();
         if (ContinuationSupport.isSupported() && thread.isVirtual()) {
             Continuation.pin();
@@ -181,7 +181,7 @@ public final class ConfinedSegmentPool {
      * preserves the usual release semantics.
      */
     @ForceInline
-    static void releaseToRememeberedPoolSlot(long[] pools, int poolIndex, long pool, long usedSize) {
+    static void releaseToRememeberedPoolSlot(long[] pools, int poolIndex, long pool, int usedSize) {
         checkRelease(pool, usedSize);
         if (poolIndex < 0 || poolIndex >= pools.length) {
             throw cannotReleasePooledMemory(pool, usedSize);
@@ -243,7 +243,7 @@ public final class ConfinedSegmentPool {
     }
 
     @ForceInline
-    private static void releaseToCache(Thread cacheOwner, long pool, long usedSize) {
+    private static void releaseToCache(Thread cacheOwner, long pool, int usedSize) {
         // Reject invalid prefixes before zeroOutMemory performs unchecked writes.
         checkRelease(pool, usedSize);
 
@@ -259,7 +259,7 @@ public final class ConfinedSegmentPool {
     }
 
     @ForceInline
-    private static void releaseToCacheOrFree(long[] pools, long pool, long usedSize) {
+    private static void releaseToCacheOrFree(long[] pools, long pool, int usedSize) {
         for (int i = 0; i < pools.length; i++) {
             final long entry = pools[i];
             if (entry == pool) {
@@ -288,13 +288,13 @@ public final class ConfinedSegmentPool {
     }
 
     @DontInline
-    private static IllegalStateException cannotReleasePooledMemory(long pool, long size) {
+    private static IllegalStateException cannotReleasePooledMemory(long pool, int size) {
         return new IllegalStateException("Cannot release pooled memory owned by " + JLA.currentCarrierThread() + ", pool = " + pool + ", size = " + size);
     }
 
     @SuppressWarnings("fallthrough")
     @ForceInline
-    private static void zeroOutMemory(long address, long size) {
+    private static void zeroOutMemory(long address, int size) {
         // Pools are always at least `long` aligned so we can use aligned Unsafe access
         // below.
         // We are first checking `POOLED_MEMORY_SIZE` here rather than
@@ -302,7 +302,7 @@ public final class ConfinedSegmentPool {
         if (POOLED_MEMORY_SIZE <= 64 || size <= 64) {
             // Deliberate fall-through clears the required number of 8-byte buckets
             // without a loop branch. The validated size guarantees writes remain in-pool.
-            switch ((int) ((size + Long.BYTES - 1) >>> 3)) {
+            switch (((size + Long.BYTES - 1) >>> 3)) {
                 case 8: U.putLong(address + 0x38, 0L);
                 case 7: U.putLong(address + 0x30, 0L);
                 case 6: U.putLong(address + 0x28, 0L);
@@ -317,14 +317,15 @@ public final class ConfinedSegmentPool {
         } else {
             // This is safe because the underlying pool is guaranteed to be of a size
             // that is a multiple of a `long`.
-            for (long i = 0; i < size; i += Long.BYTES) {
+            final long sizeL = size; // Use all-long loop template
+            for (long i = 0; i < sizeL; i += Long.BYTES) {
                 U.putLong(address + i, 0L);
             }
         }
     }
 
     @ForceInline
-    private static void checkRelease(long pool, long usedSize) {
+    private static void checkRelease(long pool, int usedSize) {
         // Reject invalid prefixes before zeroOutMemory performs unchecked writes.
         if (pool == 0 || usedSize < 0 || usedSize > POOLED_MEMORY_SIZE) {
             throw cannotReleasePooledMemory(pool, usedSize);

--- a/src/java.base/share/classes/jdk/internal/foreign/ConfinedSegmentPool.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ConfinedSegmentPool.java
@@ -123,11 +123,12 @@ public final class ConfinedSegmentPool {
      * Acquires and removes a pool from the appropriate cache for an arena owned
      * by the current thread. A platform-thread arena uses its owner's cache, while
      * a virtual-thread arena uses the current carrier's cache.
-     *
+     * @param confinedArena the confined arena to which we shall "remember" pool cache
+     *                      and pool slot upon successful platform-thread acquisition
      * @return a non-zero native address, or zero if no pool is available
      */
     @ForceInline
-    static long acquire() {
+    static long acquire(ArenaImpl.OfConfined confinedArena) {
         if (POOLING_DISABLED) {
             return 0;
         }
@@ -135,12 +136,12 @@ public final class ConfinedSegmentPool {
         if (ContinuationSupport.isSupported() && thread.isVirtual()) {
             Continuation.pin();
             try {
-                return acquireFromCache(JLA.currentCarrierThread());
+                return acquireFromCache(JLA.currentCarrierThread(), null);
             } finally {
                 Continuation.unpin();
             }
         } else {
-            return acquireFromCache(thread);
+            return acquireFromCache(thread, confinedArena);
         }
     }
 
@@ -172,6 +173,30 @@ public final class ConfinedSegmentPool {
         }
     }
 
+
+    /**
+     * Clears the used prefix and returns a platform-thread arena's pool directly
+     * to the cache slot from which it was acquired. If another arena, including one
+     * created during reentrant cleanup, has occupied that slot, the generic cache search
+     * preserves the usual release semantics.
+     */
+    @ForceInline
+    static void releaseToRememeberedPoolSlot(long[] pools, int poolIndex, long pool, long usedSize) {
+        checkRelease(pool, usedSize);
+        if (poolIndex < 0 || poolIndex >= pools.length) {
+            throw cannotReleasePooledMemory(pool, usedSize);
+        }
+        final long entry = pools[poolIndex];
+        if (entry == 0) {
+            zeroOutMemory(pool, usedSize);
+            pools[poolIndex] = pool;
+        } else {
+            // Cleanup can reenter allocation and release another arena into our
+            // remembered slot before this arena closes.
+            releaseToCacheOrFree(pools, pool, usedSize);
+        }
+    }
+
     /**
      * Frees all available pools recorded in the terminating platform thread's
      * cache. Pools owned by open arenas are detached from the cache and are not
@@ -188,7 +213,7 @@ public final class ConfinedSegmentPool {
     }
 
     @ForceInline
-    private static long acquireFromCache(Thread cacheOwner) {
+    private static long acquireFromCache(Thread cacheOwner, ArenaImpl.OfConfined confinedArena) {
         final long[] pools = JLA.getConfinedMemoryPools(cacheOwner);
         if (pools == null) {
             return 0;
@@ -197,6 +222,9 @@ public final class ConfinedSegmentPool {
             final long pool = pools[i];
             if (pool != 0) {
                 pools[i] = 0; // available -> arena-owned and detached
+                if (confinedArena != null) {
+                    confinedArena.rememberPoolCacheAndIndex(pools, i);
+                }
                 return pool;
             }
         }
@@ -217,9 +245,7 @@ public final class ConfinedSegmentPool {
     @ForceInline
     private static void releaseToCache(Thread cacheOwner, long pool, long usedSize) {
         // Reject invalid prefixes before zeroOutMemory performs unchecked writes.
-        if (pool == 0 || usedSize < 0 || usedSize > POOLED_MEMORY_SIZE) {
-            throw cannotReleasePooledMemory(pool, usedSize);
-        }
+        checkRelease(pool, usedSize);
 
         long[] pools = JLA.getConfinedMemoryPools(cacheOwner);
         if (pools == null) {
@@ -229,6 +255,11 @@ public final class ConfinedSegmentPool {
             }
         }
 
+        releaseToCacheOrFree(pools, pool, usedSize);
+    }
+
+    @ForceInline
+    private static void releaseToCacheOrFree(long[] pools, long pool, long usedSize) {
         for (int i = 0; i < pools.length; i++) {
             final long entry = pools[i];
             if (entry == pool) {
@@ -289,6 +320,14 @@ public final class ConfinedSegmentPool {
             for (long i = 0; i < size; i += Long.BYTES) {
                 U.putLong(address + i, 0L);
             }
+        }
+    }
+
+    @ForceInline
+    private static void checkRelease(long pool, long usedSize) {
+        // Reject invalid prefixes before zeroOutMemory performs unchecked writes.
+        if (pool == 0 || usedSize < 0 || usedSize > POOLED_MEMORY_SIZE) {
+            throw cannotReleasePooledMemory(pool, usedSize);
         }
     }
 

--- a/test/jdk/java/foreign/TestConfinedSegmentPool.java
+++ b/test/jdk/java/foreign/TestConfinedSegmentPool.java
@@ -250,7 +250,10 @@ final class TestConfinedSegmentPool {
                 seedArena.allocate(1);
             }
             Arena displacedArena = Arena.ofConfined();
-            long displacedAddress = displacedArena.allocate(1).address();
+            MemorySegment displacedSegment = displacedArena.allocate(ValueLayout.JAVA_BYTE);
+            long displacedAddress = displacedSegment.address();
+            // Make sure this is cleared later on
+            displacedSegment.set(ValueLayout.JAVA_BYTE, 0, (byte) 42);
 
             // No cached pool remains, so occupyingArena allocates a detached pool.
             // Its generic release occupies displacedArena's remembered slot.
@@ -267,7 +270,10 @@ final class TestConfinedSegmentPool {
                 // Only do this test if we have more than a single pool slot
                 if (THREAD_POOL_COUNT > 1) {
                     try (Arena displacedPoolVerificationArena = Arena.ofConfined()) {
-                        assertEquals(displacedAddress, displacedPoolVerificationArena.allocate(1).address());
+                        MemorySegment displacedPoolVerificationSegment = displacedPoolVerificationArena.allocate(ValueLayout.JAVA_BYTE);
+                        assertEquals(displacedAddress, displacedPoolVerificationSegment.address());
+                        // Assert the 42 is cleared
+                        assertEquals((byte) 0, displacedPoolVerificationSegment.get(ValueLayout.JAVA_BYTE, 0));
                     }
                 }
             }

--- a/test/jdk/java/foreign/TestConfinedSegmentPool.java
+++ b/test/jdk/java/foreign/TestConfinedSegmentPool.java
@@ -235,6 +235,46 @@ final class TestConfinedSegmentPool {
     }
 
     @Test
+    void rememberedCacheSlotOccupiedDuringClose() throws Throwable {
+        assumeTrue(TestConfinedSegmentPoolUtils.isPoolEnabled());
+        TestConfinedSegmentPoolUtils.runOn(Thread.ofPlatform(), () -> {
+            // State                          Cache             Arena-owned
+            // ------------------------------------------------------------
+            // Seed arena closed              [P1, ...]         -
+            // displacedArena acquires P1     [ 0, ...]         P1
+            // occupyingArena closes          [P2, ...]         P1
+            // displacedArena closes          [P2, P1, ...]     -
+            //
+            // With a single-slot cache, P1 is freed in the final step instead.
+            try (Arena seedArena = Arena.ofConfined()) {
+                seedArena.allocate(1);
+            }
+            Arena displacedArena = Arena.ofConfined();
+            long displacedAddress = displacedArena.allocate(1).address();
+
+            // No cached pool remains, so occupyingArena allocates a detached pool.
+            // Its generic release occupies displacedArena's remembered slot.
+            final long occupyingAddress;
+            try (Arena occupyingArena = Arena.ofConfined()) {
+                occupyingAddress = occupyingArena.allocate(1).address();
+            }
+
+            // displacedArena must fall back to searching another slot (or freeing its
+            // pool), without overwriting occupyingArena's cached pool.
+            displacedArena.close();
+            try (Arena verificationArena = Arena.ofConfined()) {
+                assertEquals(occupyingAddress, verificationArena.allocate(1).address());
+                // Only do this test if we have more than a single pool slot
+                if (THREAD_POOL_COUNT > 1) {
+                    try (Arena displacedPoolVerificationArena = Arena.ofConfined()) {
+                        assertEquals(displacedAddress, displacedPoolVerificationArena.allocate(1).address());
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
     void scopesAreUnique() {
         Arena firstArena = Arena.ofConfined();
         Arena secondArena = Arena.ofConfined();

--- a/test/jdk/java/foreign/TestConfinedSegmentPool.java
+++ b/test/jdk/java/foreign/TestConfinedSegmentPool.java
@@ -605,7 +605,7 @@ final class TestConfinedSegmentPool {
         }
     }
 
-    static long confinedSessionSp(Arena arena) {
+    static int confinedSessionSp(Arena arena) {
 
         final class Holder {
 
@@ -626,7 +626,7 @@ final class TestConfinedSegmentPool {
         }
 
         try {
-            return Holder.getOrSet(arena).getLong(arena);
+            return Holder.getOrSet(arena).getInt(arena);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }

--- a/test/jdk/java/foreign/TestConfinedSegmentPoolDefensiveRelease.java
+++ b/test/jdk/java/foreign/TestConfinedSegmentPoolDefensiveRelease.java
@@ -180,7 +180,7 @@ final class TestConfinedSegmentPoolDefensiveRelease {
         TestConfinedSegmentPoolUtils.rethrowIfFailed(failure.get());
     }
 
-    static void release(long pool, long size) throws Throwable {
+    static void release(long pool, int size) throws Throwable {
         try {
             RELEASE.invoke(null, pool, size);
         } catch (InvocationTargetException ex) {
@@ -190,7 +190,7 @@ final class TestConfinedSegmentPoolDefensiveRelease {
 
     static Method releaseMethod() {
         try {
-            Method method = ConfinedSegmentPool.class.getDeclaredMethod("release", long.class, long.class);
+            Method method = ConfinedSegmentPool.class.getDeclaredMethod("release", long.class, int.class);
             method.setAccessible(true);
             return method;
         } catch (ReflectiveOperationException ex) {


### PR DESCRIPTION
This PR proposes to improve the performance of the newly integrated confined arena cache. Confined arenas now remember the platform pool array and the pool array index used for pool acquisition. Upon closing the arena, the pool can be returned (in most cases) directly to the correct index in the confined arena cache.

If the opportunistic pool index is occupied, the logic falls back to the regular path, which scans the array for an empty slot.

The PR additionally proposes to add a test to make sure the unusual release path works correctly. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391909](https://bugs.openjdk.org/browse/JDK-8391909): Improve ConfinedSegmentPool Performance (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32766/head:pull/32766` \
`$ git checkout pull/32766`

Update a local copy of the PR: \
`$ git checkout pull/32766` \
`$ git pull https://git.openjdk.org/jdk.git pull/32766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32766`

View PR using the GUI difftool: \
`$ git pr show -t 32766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32766.diff">https://git.openjdk.org/jdk/pull/32766.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32766#issuecomment-5586748482)
</details>
