### PR TITLE
8391986: JFR: TestLookForUntestedEvents should only read a file once

### DIFF
--- a/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
+++ b/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
@@ -120,7 +120,7 @@ public class TestLookForUntestedEvents {
         for (Path p : paths) {
             List<String> lines = Files.readAllLines(p);
             for (String event : checkedEvents) {
-                if (findStringInFile(lines, event)) {
+                if (findStringInLines(lines, event)) {
                     eventsNotCoveredByTest.remove(event);
                 }
             }
@@ -196,7 +196,7 @@ public class TestLookForUntestedEvents {
         return "java".equals(fileName.substring(i+1));
     }
 
-    private static boolean findStringInFile(List<String> lines, String searchTerm) {
+    private static boolean findStringInLines(List<String> lines, String searchTerm) {
         return lines.stream().filter(line -> line.contains(searchTerm)).count() != 0;
     }
 

--- a/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
+++ b/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 package jdk.jfr.event.metadata;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import jdk.jfr.EventType;
 import jdk.jfr.Experimental;
@@ -119,11 +117,11 @@ public class TestLookForUntestedEvents {
         Set<String> eventsNotCoveredByTest = new HashSet<>(jfrEventTypes);
         Set<String> checkedEvents = new HashSet<>(jfrEventTypes);
         checkedEvents.addAll(experimentalButTestedEvents);
-        for (String event : checkedEvents) {
-            for (Path p : paths) {
-                if (findStringInFile(p, event)) {
+        for (Path p : paths) {
+            List<String> lines = Files.readAllLines(p);
+            for (String event : checkedEvents) {
+                if (findStringInFile(lines, event)) {
                     eventsNotCoveredByTest.remove(event);
-                    break;
                 }
             }
         }
@@ -198,14 +196,8 @@ public class TestLookForUntestedEvents {
         return "java".equals(fileName.substring(i+1));
     }
 
-    private static boolean findStringInFile(Path p, String searchTerm) throws IOException {
-        long c = 0;
-        try (Stream<String> stream = Files.lines(p)) {
-            c = stream
-                .filter(line -> line.contains(searchTerm))
-                .count();
-        }
-        return (c != 0);
+    private static boolean findStringInFile(List<String> lines, String searchTerm) {
+        return lines.stream().filter(line -> line.contains(searchTerm)).count() != 0;
     }
 
     private static void printSetDiff(Set<String> a, Set<String> b,


### PR DESCRIPTION
Could I have a review of PR that speeds up a test.

Testing: test/jdk/jdk/jfr

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391986](https://bugs.openjdk.org/browse/JDK-8391986): JFR: TestLookForUntestedEvents should only read a file once (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32767/head:pull/32767` \
`$ git checkout pull/32767`

Update a local copy of the PR: \
`$ git checkout pull/32767` \
`$ git pull https://git.openjdk.org/jdk.git pull/32767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32767`

View PR using the GUI difftool: \
`$ git pr show -t 32767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32767.diff">https://git.openjdk.org/jdk/pull/32767.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32767#issuecomment-5587326147)
</details>
