### PR TITLE
8391863: Missed usage cases for TLSHandshakeEvent

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -433,6 +433,7 @@ final class Finished {
                 if (!chc.sslContext.isDTLS()) {
                     chc.conContext.finishHandshake();
                 }
+                recordEvent(chc);
             }
 
             // The handshake message has been delivered.
@@ -499,6 +500,7 @@ final class Finished {
                 if (!shc.sslContext.isDTLS()) {
                     shc.conContext.finishHandshake();
                 }
+                recordEvent(shc);
             }
 
             // The handshake message has been delivered.
@@ -562,12 +564,12 @@ final class Finished {
 
                 // handshake context cleanup.
                 chc.handshakeFinished = true;
-                recordEvent(chc);
 
                 // May need to retransmit the last flight for DTLS.
                 if (!chc.sslContext.isDTLS()) {
                     chc.conContext.finishHandshake();
                 }
+                recordEvent(chc);
             } else {
                 chc.handshakeProducers.put(SSLHandshake.FINISHED.id,
                         SSLHandshake.FINISHED);
@@ -623,12 +625,12 @@ final class Finished {
 
                 // handshake context cleanup.
                 shc.handshakeFinished = true;
-                recordEvent(shc);
 
                 // May need to retransmit the last flight for DTLS.
                 if (!shc.sslContext.isDTLS()) {
                     shc.conContext.finishHandshake();
                 }
+                recordEvent(shc);
             } else {
                 shc.handshakeProducers.put(SSLHandshake.FINISHED.id,
                         SSLHandshake.FINISHED);

--- a/test/jdk/jdk/jfr/event/security/TestTLS12HandshakeEvent.java
+++ b/test/jdk/jdk/jfr/event/security/TestTLS12HandshakeEvent.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.security;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+import jdk.test.lib.net.SimpleSSLContext;
+
+/*
+ * @test
+ * @bug 8391863
+ * @summary Test that TLS 1.2 handshake events are recorded properly for both
+ *          full and abbreviated handshakes.
+ * @requires vm.flagless
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.event.security.TestTLS12HandshakeEvent
+ */
+
+public class TestTLS12HandshakeEvent {
+
+    private static final String PROTOCOL = "TLSv1.2";
+    private static final int CONNECTION_COUNT = 2;
+
+    public static void main(String[] args) throws Exception {
+        // Use stateful resumption for a simple resumption assertion
+        System.setProperty("jdk.tls.client.enableSessionTicketExtension", "false");
+        System.setProperty("jdk.tls.server.enableSessionTicketExtension", "false");
+
+        SSLContext serverContext = SimpleSSLContext.findSSLContext(PROTOCOL);
+        SSLContext clientContext = SimpleSSLContext.findSSLContext(PROTOCOL);
+
+        try (SSLServerSocket serverSocket = (SSLServerSocket) serverContext
+                .getServerSocketFactory().createServerSocket(0)) {
+
+            serverSocket.setEnabledProtocols(new String[] { PROTOCOL });
+            int serverPort = serverSocket.getLocalPort();
+            CompletableFuture<Void> server = CompletableFuture.runAsync(
+                    () -> serve(serverSocket));
+
+            try (Recording recording = new Recording()) {
+                recording.enable(EventNames.TLSHandshake);
+                recording.start();
+
+                SSLSession initialSession = connect(clientContext, serverPort, 0);
+                SSLSession resumedSession = connect(clientContext, serverPort, 1);
+                server.join();
+
+                recording.stop();
+
+                // Assert resumption
+                Asserts.assertTrue(Arrays.equals(initialSession.getId(),
+                        resumedSession.getId()),
+                        "The second connection did not resume the TLS session");
+
+                // Assert JFR events
+                assertEvents(Events.fromRecording(recording), serverPort);
+            }
+        }
+    }
+
+    private static SSLSession connect(SSLContext context, int port, int value)
+            throws IOException {
+        try (SSLSocket socket = (SSLSocket) context.getSocketFactory()
+                .createSocket("localhost", port)) {
+            socket.setEnabledProtocols(new String[] { PROTOCOL });
+            socket.getOutputStream().write(value);
+            socket.getOutputStream().flush();
+            Asserts.assertEquals(socket.getInputStream().read(), value,
+                    "Unexpected response from server");
+            return socket.getSession();
+        }
+    }
+
+    private static void serve(SSLServerSocket serverSocket) {
+        try {
+            for (int i = 0; i < CONNECTION_COUNT; i++) {
+                try (SSLSocket socket = (SSLSocket) serverSocket.accept()) {
+                    int value = socket.getInputStream().read();
+                    socket.getOutputStream().write(value);
+                    socket.getOutputStream().flush();
+                }
+            }
+        } catch (IOException e) {
+            throw new CompletionException(e);
+        }
+    }
+
+    private static void assertEvents(List<RecordedEvent> events, int serverPort) {
+        System.out.println(events);
+        Asserts.assertEquals(events.size(), CONNECTION_COUNT * 2,
+                "Expected one TLS handshake event from each peer");
+
+        long clientEvents = events.stream()
+                .filter(e -> e.getInt("peerPort") == serverPort)
+                .count();
+        Asserts.assertEquals(clientEvents, (long) CONNECTION_COUNT,
+                "Incorrect number of client TLS handshake events");
+
+        for (RecordedEvent event : events) {
+            Events.assertField(event, "protocolVersion").equal(PROTOCOL);
+        }
+    }
+}


### PR DESCRIPTION
There is a subtle bug in the implementation in JFR TLSHandshakeEvent: the event wasn't recorded on the client side for the TLSv1.2 resumed session (abbreviated handshake) and on the server side for TLSv1.2 full handshake. For a resumed handshake the client produces the last Finished in TLSv1.2, unlike the full handshake where the server produces the last Finished. In TLSv1.3 the client produces the last Finished for both resumed and full handshake.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391863](https://bugs.openjdk.org/browse/JDK-8391863): Missed usage cases for TLSHandshakeEvent (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32768/head:pull/32768` \
`$ git checkout pull/32768`

Update a local copy of the PR: \
`$ git checkout pull/32768` \
`$ git pull https://git.openjdk.org/jdk.git pull/32768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32768`

View PR using the GUI difftool: \
`$ git pr show -t 32768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32768.diff">https://git.openjdk.org/jdk/pull/32768.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32768#issuecomment-5587190553)
</details>
