### PR TITLE
8392000: JNI memory allocations should be mtJNI

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2225,7 +2225,7 @@ JNI_ENTRY_NO_PRESERVE(const jchar*, jni_GetStringChars(
   if (s_value != nullptr) {
     int s_len = java_lang_String::length(s, s_value);
     bool is_latin1 = java_lang_String::is_latin1(s);
-    buf = NEW_C_HEAP_ARRAY_RETURN_NULL(jchar, s_len + 1, mtInternal);  // add one for zero termination
+    buf = NEW_C_HEAP_ARRAY_RETURN_NULL(jchar, s_len + 1, mtJNI);  // add one for zero termination
     /* JNI Specification states return null on OOM */
     if (buf != nullptr) {
       if (s_len > 0) {
@@ -2304,7 +2304,7 @@ JNI_ENTRY(const char*, jni_GetStringUTFChars(JNIEnv *env, jstring string, jboole
     size_t length = java_lang_String::utf8_length(java_string, s_value);
     // JNI Specification states return null on OOM.
     // The resulting sequence doesn't have to be NUL-terminated but we do.
-    result = AllocateHeap(length + 1, mtInternal, AllocFailStrategy::RETURN_NULL);
+    result = AllocateHeap(length + 1, mtJNI, AllocFailStrategy::RETURN_NULL);
     if (result != nullptr) {
       java_lang_String::as_utf8_string(java_string, s_value, result, length + 1);
       if (isCopy != nullptr) {
@@ -2469,7 +2469,7 @@ static char* get_bad_address() {
   static char* bad_address = nullptr;
   if (bad_address == nullptr) {
     size_t size = os::vm_allocation_granularity();
-    bad_address = os::reserve_memory(size, mtInternal);
+    bad_address = os::reserve_memory(size, mtJNI);
     if (bad_address != nullptr) {
       os::protect_memory(bad_address, size, os::MEM_PROT_READ,
                          /*is_committed*/false);
@@ -2500,7 +2500,7 @@ JNI_ENTRY_NO_PRESERVE(ElementType*, \
     result = (ElementType*)get_bad_address(); \
   } else { \
     /* JNI Specification states return null on OOM */                    \
-    result = NEW_C_HEAP_ARRAY_RETURN_NULL(ElementType, len, mtInternal); \
+    result = NEW_C_HEAP_ARRAY_RETURN_NULL(ElementType, len, mtJNI);      \
     if (result != nullptr) {                                             \
       /* copy the array to the c chunk */                                \
       ArrayAccess<>::arraycopy_to_native(a, typeArrayOopDesc::element_offset<ElementType>(0), \
@@ -2924,7 +2924,7 @@ JNI_ENTRY(const jchar*, jni_GetStringCritical(JNIEnv *env, jstring string, jbool
     // Inflate latin1 encoded string to UTF16
     typeArrayOop s_value = java_lang_String::value(s);
     int s_len = java_lang_String::length(s, s_value);
-    ret = NEW_C_HEAP_ARRAY_RETURN_NULL(jchar, s_len + 1, mtInternal);  // add one for zero termination
+    ret = NEW_C_HEAP_ARRAY_RETURN_NULL(jchar, s_len + 1, mtJNI);  // add one for zero termination
     /* JNI Specification states return null on OOM */
     if (ret != nullptr) {
       for (int i = 0; i < s_len; i++) {

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -53,8 +53,8 @@ OopStorage* JNIHandles::_global_handles = nullptr;
 OopStorage* JNIHandles::_weak_global_handles = nullptr;
 
 void jni_handles_init() {
-  JNIHandles::_global_handles = OopStorageSet::create_strong("JNI Global", mtInternal);
-  JNIHandles::_weak_global_handles = OopStorageSet::create_weak("JNI Weak", mtInternal);
+  JNIHandles::_global_handles = OopStorageSet::create_strong("JNI Global", mtJNI);
+  JNIHandles::_weak_global_handles = OopStorageSet::create_weak("JNI Weak", mtJNI);
 }
 
 jobject JNIHandles::make_local(oop obj) {

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -134,7 +134,7 @@ public:
 
 // JNI handle blocks holding local/global JNI handles
 
-class JNIHandleBlock : public CHeapObj<mtInternal> {
+class JNIHandleBlock : public CHeapObj<mtJNI> {
   friend class VMStructs;
   friend class ZeroInterpreter;
 


### PR DESCRIPTION
Looking at some real-world NMT dumps, I am seeing that `mtInternal` is very crowded. This improvement should more clearly separate the allocations that are done at JNI side, or for the sake of JNI.

I am not 100% sure about the allocations done in `jni_GetString*`. They can arguably be `mtOther` to match what `ByteBuffer.allocateDirect` does. But it also stands to reason those allocations _are_ JNI-related, and they are hopefully short-lived. So if the real application shows lots of these allocations retained, that points more promptly to JNI use.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/NMT`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392000](https://bugs.openjdk.org/browse/JDK-8392000): JNI memory allocations should be mtJNI (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32769/head:pull/32769` \
`$ git checkout pull/32769`

Update a local copy of the PR: \
`$ git checkout pull/32769` \
`$ git pull https://git.openjdk.org/jdk.git pull/32769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32769`

View PR using the GUI difftool: \
`$ git pr show -t 32769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32769.diff">https://git.openjdk.org/jdk/pull/32769.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32769#issuecomment-5589228595)
</details>
