### PR TITLE
8391886: Test serviceability/sa/sadebugd/DebugdConnectTest.java fails due to unexpected largepage warnings

### DIFF
--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -41,7 +41,7 @@ public final class OutputAnalyzer {
     private static final String jvmwarningmsg = ".* VM warning:.*";
 
     private static final String VM_DEPRECATED_MSG = ".* VM warning:.* deprecated.*";
-    private static final String OTHER_DEPRECATED_MSG = "^WARNING: .* is deprecated.*";
+    private static final String OTHER_DEPRECATED_MSG = "(?m)^WARNING: .* is deprecated.*";
 
     private static final String FATAL_ERROR_PAT = "# A fatal error has been detected.*";
 


### PR DESCRIPTION
Fix to ignore multi-line warning messages so that stderr is empty




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391886](https://bugs.openjdk.org/browse/JDK-8391886): Test serviceability/sa/sadebugd/DebugdConnectTest.java fails due to unexpected largepage warnings (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32770/head:pull/32770` \
`$ git checkout pull/32770`

Update a local copy of the PR: \
`$ git checkout pull/32770` \
`$ git pull https://git.openjdk.org/jdk.git pull/32770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32770`

View PR using the GUI difftool: \
`$ git pr show -t 32770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32770.diff">https://git.openjdk.org/jdk/pull/32770.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32770#issuecomment-5589909960)
</details>
