### PR TITLE
8391973: TimeZoneNamesTest fails for America/Vancouver for non-US default locales

### DIFF
--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
- /*
+/*
  * @test
  * @bug 8181157 8202537 8234347 8236548 8261279 8322647 8174269 8346948
  *      8354548 8381379 8382020 8384043 8371842
@@ -299,15 +299,17 @@ public class TimeZoneNamesTest {
     }
 
     private static Stream<Arguments> explicitDstOffsets() {
+        var irl = Locale.of("en", "IE");
+
         return Stream.of(
             // CLDR v48
-            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Irish Standard Time", "IST"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Greenwich Mean Time", "GMT"),
-            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Irish Standard Time", "IST"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Greenwich Mean Time", "GMT"),
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), irl, "Irish Standard Time", "IST"),
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), irl, "Greenwich Mean Time", "GMT"),
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), irl, "Irish Standard Time", "IST"),
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), irl, "Greenwich Mean Time", "GMT"),
             // CLDR v48.2 & tz2026b. America/Vancouver switched to permanent DST
-            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time", "PDT"),
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time", "PDT")
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), Locale.CANADA, "Pacific Daylight Time", "PDT"),
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), Locale.CANADA, "Pacific Daylight Time", "PDT")
         );
     }
 
@@ -348,18 +350,18 @@ public class TimeZoneNamesTest {
     // updated TZDB data are required (e.g., tz2026b for America/Vancouver).
     @ParameterizedTest
     @MethodSource("explicitDstOffsets")
-    public void test_ExplicitMetazoneOffsets(ZonedDateTime zdt, String expectedLong, String expectedShort) {
+    public void test_ExplicitMetazoneOffsets(ZonedDateTime zdt, Locale l, String expectedLong, String expectedShort) {
         // java.time
-        assertEquals(expectedLong, DateTimeFormatter.ofPattern("zzzz").format(zdt));
-        assertEquals(expectedShort, DateTimeFormatter.ofPattern("z").format(zdt));
+        assertEquals(expectedLong, DateTimeFormatter.ofPattern("zzzz").withLocale(l).format(zdt));
+        assertEquals(expectedShort, DateTimeFormatter.ofPattern("z").withLocale(l).format(zdt));
 
         // java.text/util
         var date = Date.from(zdt.toInstant());
         var tz = TimeZone.getTimeZone(zdt.getZone());
-        var sdf = new SimpleDateFormat("zzzz");
+        var sdf = new SimpleDateFormat("zzzz", l);
         sdf.setTimeZone(tz);
         assertEquals(expectedLong, sdf.format(date));
-        sdf = new SimpleDateFormat("z");
+        sdf = new SimpleDateFormat("z", l);
         sdf.setTimeZone(tz);
         assertEquals(expectedShort, sdf.format(date));
     }


### PR DESCRIPTION
Specifying explicit locales for the explicit DST offset tests to avoid failures caused by the default locale.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391973](https://bugs.openjdk.org/browse/JDK-8391973): TimeZoneNamesTest fails for America/Vancouver for non-US default locales (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32771/head:pull/32771` \
`$ git checkout pull/32771`

Update a local copy of the PR: \
`$ git checkout pull/32771` \
`$ git pull https://git.openjdk.org/jdk.git pull/32771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32771`

View PR using the GUI difftool: \
`$ git pr show -t 32771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32771.diff">https://git.openjdk.org/jdk/pull/32771.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32771#issuecomment-5590918198)
</details>
