### PR TITLE
8391817: VarHandle CAS throws NPE for null-expected value on null-restricted field

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -211,7 +211,7 @@ final class VarHandle$InputType$s {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.compareAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -220,7 +220,7 @@ final class VarHandle$InputType$s {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -229,7 +229,7 @@ final class VarHandle$InputType$s {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -238,7 +238,7 @@ final class VarHandle$InputType$s {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -247,7 +247,7 @@ final class VarHandle$InputType$s {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Plain(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -256,7 +256,7 @@ final class VarHandle$InputType$s {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -265,7 +265,7 @@ final class VarHandle$InputType$s {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -274,7 +274,7 @@ final class VarHandle$InputType$s {
             FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -579,7 +579,7 @@ final class VarHandle$InputType$s {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.compareAndSet$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -589,7 +589,7 @@ final class VarHandle$InputType$s {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.compareAndExchange$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -598,7 +598,7 @@ final class VarHandle$InputType$s {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.compareAndExchange$Type$Acquire(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -607,7 +607,7 @@ final class VarHandle$InputType$s {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.compareAndExchange$Type$Release(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -616,7 +616,7 @@ final class VarHandle$InputType$s {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.weakCompareAndSet$Type$Plain(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -625,7 +625,7 @@ final class VarHandle$InputType$s {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.weakCompareAndSet$Type$(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -634,7 +634,7 @@ final class VarHandle$InputType$s {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.weakCompareAndSet$Type$Acquire(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 
@@ -643,7 +643,7 @@ final class VarHandle$InputType$s {
             FieldStaticReadWrite handle = (FieldStaticReadWrite) ob.onStaticFieldAccess(true);
             return UNSAFE.weakCompareAndSet$Type$Release(handle.base,
                                                handle.fieldOffset{#if[FlatValue]?, handle.layout}{#if[Object]?, handle.fieldType},
-                                               {#if[Object]?checkCast(handle, expected):expected},
+                                               {#if[Object]?handle.fieldType.cast(expected):expected},
                                                {#if[Object]?checkCast(handle, value):value});
         }
 

--- a/test/jdk/java/lang/invoke/VarHandles/NullRestrictedCompareNull.java
+++ b/test/jdk/java/lang/invoke/VarHandles/NullRestrictedCompareNull.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8391817
+ * @summary Make sure CAS with null for null-restricted fields does not fail
+ * @modules java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @run main ${test.main.class}
+ * @run main/othervm -Xcomp ${test.main.class}
+ * @run main/othervm -Xint ${test.main.class}
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import jdk.internal.vm.annotation.NullRestricted;
+
+public class NullRestrictedCompareNull {
+    @NullRestricted Integer i;
+
+    NullRestrictedCompareNull() {
+        i = 42;
+        super();
+    }
+
+    public static void main(String[] args) throws ReflectiveOperationException {
+        VarHandle handle = MethodHandles.lookup().findVarHandle(NullRestrictedCompareNull.class, "i", Integer.class);
+        NullRestrictedCompareNull holder = new NullRestrictedCompareNull();
+        if (handle.compareAndSet(holder, null, 2)) {
+            throw new RuntimeException("Should not find null");
+        }
+    }
+}


### PR DESCRIPTION
Currently, the CAS operations of field instance/static var handles for null-restricted fields are failing with NPE because the type check includes a null check. Only perform the class check for these handles for the expected argument. ArrayVarHandle is already performing the right checks.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391817](https://bugs.openjdk.org/browse/JDK-8391817): VarHandle CAS throws NPE for null-expected value on null-restricted field (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32772/head:pull/32772` \
`$ git checkout pull/32772`

Update a local copy of the PR: \
`$ git checkout pull/32772` \
`$ git pull https://git.openjdk.org/jdk.git pull/32772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32772`

View PR using the GUI difftool: \
`$ git pr show -t 32772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32772.diff">https://git.openjdk.org/jdk/pull/32772.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32772#issuecomment-5591434569)
</details>
