### PR TITLE
8391064: JMX: RMIConnector findRMIServer error message should not mention /ior/

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1779,8 +1779,7 @@ public class RMIConnector implements JMXConnector, Serializable, JMXAddressable 
         else if (path.startsWith("/stub/"))
             return findRMIServerJRMP(path.substring(6,end), environment);
         else {
-            final String msg = "URL path must begin with /jndi/ or /stub/ " +
-                    "or /ior/: " + path;
+            final String msg = "URL path must begin with /jndi/ or /stub/: " + path;
             throw new MalformedURLException(msg);
         }
     }


### PR DESCRIPTION
Please review this change. Thanks!

The JMX RMIConnector error message still mentions the `/ior/` path, even though IIOP transport support was removed by JDK-8043937.

This change removes the obsolete `/ior/` reference from the error message.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391064](https://bugs.openjdk.org/browse/JDK-8391064): JMX: RMIConnector findRMIServer error message should not mention /ior/ (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32774/head:pull/32774` \
`$ git checkout pull/32774`

Update a local copy of the PR: \
`$ git checkout pull/32774` \
`$ git pull https://git.openjdk.org/jdk.git pull/32774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32774`

View PR using the GUI difftool: \
`$ git pr show -t 32774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32774.diff">https://git.openjdk.org/jdk/pull/32774.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32774#issuecomment-5594493463)
</details>
