### PR TITLE
8392016: RISC-V: Add Zawrs-assisted retry for contended monitor acquisition

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1113,6 +1113,8 @@ protected:
 
   INSN(ecall,   0b1110011, 0b000, 0b000000000000);
   INSN(_ebreak, 0b1110011, 0b000, 0b000000000001);
+  INSN(wrs_nto, 0b1110011, 0b000, 0b000000001101);
+  INSN(wrs_sto, 0b1110011, 0b000, 0b000000011101);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -210,8 +210,30 @@ void C2_MacroAssembler::fast_lock(Register obj, Register box,
             /*acquire*/ Assembler::aq, /*release*/ Assembler::relaxed, /*result*/ tmp3_owner);
     beqz(tmp3_owner, monitor_locked);
 
-    // Check if recursive.
-    bne(tmp3_owner, tid, slow_path);
+    if (UseZawrs) {
+      Label recursive;
+      beq(tmp3_owner, tid, recursive);
+      // Values below the first valid thread id are ObjectMonitor protocol
+      // markers and must be handled by the runtime. In particular, do not
+      // wait on a monitor that may be reclaimed by async deflation.
+      mv(t0, (uint64_t)ThreadIdentifier::initial());
+      bltu(tmp3_owner, t0, slow_path);
+      // Wait once for a short-lived owner to release the monitor before
+      // paying the cost of entering the runtime slow path.
+      Label retry;
+      lr_d(tmp3_owner, tmp2_owner_addr, Assembler::relaxed);
+      beqz(tmp3_owner, retry);
+      bltu(tmp3_owner, t0, slow_path);
+      wrs_sto();
+      bind(retry);
+      cmpxchg(/*addr*/ tmp2_owner_addr, /*expected*/ zr, /*new*/ tid, Assembler::int64,
+              /*acquire*/ Assembler::aq, /*release*/ Assembler::relaxed, /*result*/ tmp3_owner);
+      beqz(tmp3_owner, monitor_locked);
+      bne(tmp3_owner, tid, slow_path);
+      bind(recursive);
+    } else {
+      bne(tmp3_owner, tid, slow_path);
+    }
 
     // Recursive.
     increment(recursions_address, 1, tmp2, tmp3);

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -119,6 +119,7 @@ define_pd_global(bool, ValueTypeReturnedAsFields, false);
   product(bool, UseZicond, false, DIAGNOSTIC, "Use Zicond instructions")         \
   product(bool, UseZihintpause, false, EXPERIMENTAL,                             \
           "Use Zihintpause instructions")                                        \
+  product(bool, UseZawrs, false, EXPERIMENTAL, "Use Zawrs instructions")         \
   product(bool, UseZtso, false, EXPERIMENTAL, "Assume Ztso memory model")        \
   product(bool, UseZvbb, false, DIAGNOSTIC, "Use Zvbb instructions")             \
   product(bool, UseZvbc, false, DIAGNOSTIC, "Use Zvbc instructions")             \

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -287,6 +287,8 @@ class VM_Version : public Abstract_VM_Version {
   decl(Zifencei    ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                         \
   /* Zihintpause Pause instruction HINT */                                                                \
   decl(Zihintpause ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZihintpause))                            \
+  /* Wait-on-Reservation-Set instructions */                                                              \
+  decl(Zawrs       ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT_DEP(UseZawrs, &ext_a, nullptr))             \
   /* Total Store Ordering */                                                                              \
   decl(Ztso        ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZtso))                                   \
   /* Vector Basic Bit-manipulation */                                                                     \
@@ -461,6 +463,7 @@ private:
     RV_ENABLE_EXTENSION(UseZicboz)                  \
     RV_ENABLE_EXTENSION(UseZicond)                  \
     RV_ENABLE_EXTENSION(UseZihintpause)             \
+    RV_ENABLE_EXTENSION(UseZawrs)                   \
     RV_ENABLE_EXTENSION(UseZvfhmin)                 \
     RV_ENABLE_EXTENSION(UseZvbb)                    \
 

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -81,6 +81,7 @@
 #define   RISCV_HWPROBE_EXT_ZACAS               (1ULL << 34)
 #define   RISCV_HWPROBE_EXT_ZICOND              (1ULL << 35)
 #define   RISCV_HWPROBE_EXT_ZCB                 (1ULL << 44)
+#define   RISCV_HWPROBE_EXT_ZAWRS               (1ULL << 48)
 
 #define RISCV_HWPROBE_KEY_CPUPERF_0     5
 #define   RISCV_HWPROBE_MISALIGNED_UNKNOWN      (0 << 0)
@@ -263,6 +264,11 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKG)) {
     VM_Version::ext_Zvkg.enable_feature();
   }
+#ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZAWRS)) {
+    VM_Version::ext_Zawrs.enable_feature();
+  }
+#endif
 
   // ====== non-extensions ======
   //

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -367,6 +367,7 @@ void VM_Version::xuantie_features() {
   ext_Zicboz.enable_feature();
   ext_Zicond.enable_feature();
   ext_Ztso.enable_feature();
+  ext_Zawrs.enable_feature();
 #endif
 
   unaligned_scalar.enable_feature(MISALIGNED_SCALAR_FAST);


### PR DESCRIPTION
Hi all,

We add `Zawrs` in C2 inflated monitor locking path on RISC-V. Before entering the runtime slow path, which uses adaptive spinning before blocking, the generated code performs a short `WRS.STO` wait followed by a second CAS. If the retry succeeds, the lock is acquired directly in C2-generated code, avoiding the runtime slow path entirely and improving the throughput. Even if the second CAS fails, the lock may be released sooner (since we've waited a short time in `WRS_STO`) after entering the slow path, reducing the time spent spinning.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392016](https://bugs.openjdk.org/browse/JDK-8392016): RISC-V: Add Zawrs-assisted retry for contended monitor acquisition (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**) 🔄 Re-review required (review applies to [861b53ee](https://git.openjdk.org/jdk/pull/32775/files/861b53ee086d031126d93f77e70376f89d5932c8))
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32775/head:pull/32775` \
`$ git checkout pull/32775`

Update a local copy of the PR: \
`$ git checkout pull/32775` \
`$ git pull https://git.openjdk.org/jdk.git pull/32775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32775`

View PR using the GUI difftool: \
`$ git pr show -t 32775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32775.diff">https://git.openjdk.org/jdk/pull/32775.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32775#issuecomment-5718168969)
</details>
