### PR TITLE
8391940: Test serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp failed: ERROR: DWARF: Unknown opcode: 0xf

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.cpp
@@ -131,14 +131,14 @@ bool DwarfParser::process_cie(unsigned char *start_of_entry, uint32_t id) {
   init_state(_state);
   _state.return_address_reg = initial_ra;
 
-  parse_dwarf_instructions(0L, static_cast<uintptr_t>(-1L), end);
+  bool result = parse_dwarf_instructions(0L, static_cast<uintptr_t>(-1L), end);
 
   _initial_state = _state;
   _buf = orig_pos;
-  return true;
+  return result;
 }
 
-void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const unsigned char *end) {
+bool DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const unsigned char *end) {
   uintptr_t operand1;
   _current_pc = begin;
   std::stack<struct DwarfState> remember_state;
@@ -152,7 +152,7 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
 
     switch (op) {
       case 0x0:  // DW_CFA_nop
-        return;
+        break;
       case 0x01: // DW_CFA_set_loc
         operand1 = get_decoded_value(_fde_ptr_encoding);
         if (_current_pc != 0L) {
@@ -226,12 +226,15 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
       case 0x0b: // DW_CFA_restore_state
         if (remember_state.empty()) {
           print_debug("DWARF Error: DW_CFA_restore_state with empty stack.\n");
-          return;
+          return false;
         }
         _state = remember_state.top();
         remember_state.pop();
         restore_arch_specific_state();
         break;
+      case 0x0f: // DW_CFA_def_cfa_expression
+        print_debug("DWARF: DW_CFA_def_cfa_expression is not yet supported.\n");
+        return false;
       case 0xc0: {// DW_CFA_restore
         enum DWARF_Register reg = static_cast<enum DWARF_Register>(opa);
         _state.offset_from_cfa[reg] = _initial_state.offset_from_cfa[reg];
@@ -240,10 +243,12 @@ void DwarfParser::parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const 
       default:
         if (!process_arch_specific_dwarf_instructions(op)) {
           print_error("DWARF: Unknown opcode: 0x%x\n", op);
-          return;
+          return false;
         }
     }
   }
+
+  return true;
 }
 
 /* from dwarf.c in binutils */
@@ -358,8 +363,7 @@ bool DwarfParser::process_dwarf(const uintptr_t pc) {
         }
 
         // Process FDE
-        parse_dwarf_instructions(pc_begin, pc, next_entry);
-        return true;
+        return parse_dwarf_instructions(pc_begin, pc, next_entry);
       }
     }
 

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.hpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/dwarf.hpp
@@ -75,7 +75,7 @@ class DwarfParser {
     void init_state(struct DwarfState& st);
     uint64_t get_entry_length();
     bool process_cie(unsigned char *start_of_entry, uint32_t id);
-    void parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const unsigned char *end);
+    bool parse_dwarf_instructions(uintptr_t begin, uintptr_t pc, const unsigned char *end);
     uint32_t get_decoded_value(unsigned char enc);
     unsigned int get_pc_range();
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/DwarfCFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/DwarfCFrame.java
@@ -26,6 +26,7 @@
 package sun.jvm.hotspot.debugger.linux;
 
 import sun.jvm.hotspot.debugger.Address;
+import sun.jvm.hotspot.debugger.DebuggerException;
 import sun.jvm.hotspot.debugger.ThreadProxy;
 import sun.jvm.hotspot.debugger.UnalignedAddressException;
 import sun.jvm.hotspot.debugger.UnmappedAddressException;
@@ -57,7 +58,19 @@ public class DwarfCFrame extends BasicCFrame {
         if (libptr != null) {
             DwarfParser dwarf = linuxDbg.getCPU().equals("aarch64") ? new AARCH64DwarfParser(libptr)
                                                                     : new DwarfParser(libptr);
-            dwarf.processDwarf(pc);
+            try {
+                dwarf.processDwarf(pc);
+            } catch (DebuggerException e) {
+                // DebuggerException might be thrown from unwinding signal trampoline
+                // (e.g. __restore_rt on AMD64) because it might have DW_CFA_def_cfa_expression
+                // DWARF instruction.
+                // However SA can ignore the case safely because it does not rely on DWARF,
+                // would restore register values from the stack directly.
+                // Thus DebuggerException would be rethrown if the pc is not in signal trampoline.
+                if (!linuxDbg.isSignalTrampoline(pc)) {
+                    throw e;
+                }
+            }
             return dwarf;
         }
         return null;


### PR DESCRIPTION
[JDK-8388696](https://bugs.openjdk.org/browse/JDK-8388696) (PR #31999) has changed SA code to show error message if DWARF parser encounts unsupported DWARF instructions. This caused a new error in TestJhsdbJstackMixedWithXComp.java#xcomp. See JBS for details.

This PR updates to return the result from `DwarfParser::parse_dwarf_instructions` - `false` if DWARF parser failed such as unknown instruction. `DW_CFA_def_cfa_expression` is one of cases of failure because SA does not support it.
However `DW_CFA_def_cfa_expression` might be set for signal trampoline such as `__restore_rt` on AMD64. Thus this PR ignores the failure in `DwarfParser::parse_dwarf_instructions` if PC points signal trampoline.

This PR passed serviceability/sa tests on both AMD64 and AArch64 Linux.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391940](https://bugs.openjdk.org/browse/JDK-8391940): Test serviceability/sa/TestJhsdbJstackMixedWithXComp.java#xcomp failed: ERROR: DWARF: Unknown opcode: 0xf (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32777/head:pull/32777` \
`$ git checkout pull/32777`

Update a local copy of the PR: \
`$ git checkout pull/32777` \
`$ git pull https://git.openjdk.org/jdk.git pull/32777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32777`

View PR using the GUI difftool: \
`$ git pr show -t 32777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32777.diff">https://git.openjdk.org/jdk/pull/32777.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32777#issuecomment-5597688015)
</details>
