### PR TITLE
8375645: C2: NPE in compiled method does not occur with interpreter

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1469,7 +1469,7 @@ Node* CallStaticJavaNode::replace_identity_hash_code(PhaseIterGVN* igvn) {
   }
   Node* new_mem = kit.reset_memory();
   assert(in(TypeFunc::Memory) == new_mem, "must not modify memory");
-  return TupleNode::make(tf()->range_cc(), igvn->C->top(), kit.i_o(), new_mem, kit.frameptr(), kit.returnadr(), replace);
+  return TupleNode::make(tf()->range_cc(), adr_type(), igvn->C->top(), kit.i_o(), new_mem, kit.frameptr(), kit.returnadr(), replace);
 }
 
 // Try to replace a runtime call to the substitutability test by either a simple pointer comparison
@@ -1516,7 +1516,7 @@ Node* CallStaticJavaNode::replace_is_substitutable(PhaseIterGVN* igvn) {
   }
   Node* new_mem = kit.reset_memory();
   assert(in(TypeFunc::Memory) == new_mem, "must not modify memory");
-  return TupleNode::make(tf()->range_cc(), igvn->C->top(), kit.i_o(), new_mem, kit.frameptr(), kit.returnadr(), replace);
+  return TupleNode::make(tf()->range_cc(), adr_type(), igvn->C->top(), kit.i_o(), new_mem, kit.frameptr(), kit.returnadr(), replace);
 }
 
 #ifndef PRODUCT
@@ -1685,7 +1685,7 @@ bool CallLeafPureNode::is_dead() const {
 TupleNode* CallLeafPureNode::make_tuple_of_input_state_and_top_return_values(const Compile* C) const {
   // Transparently propagate input state but parameters
   TupleNode* tuple = TupleNode::make(
-      tf()->range_cc(),
+      tf()->range_cc(), nullptr,
       in(TypeFunc::Control),
       in(TypeFunc::I_O),
       in(TypeFunc::Memory),
@@ -2980,7 +2980,7 @@ TupleNode* PowDNode::make_tuple_of_input_state_and_result(PhaseIterGVN* phase, N
   Compile* C = phase->C;
   C->remove_macro_node(this);
   TupleNode* tuple = TupleNode::make(
-      tf()->range_cc(),
+      tf()->range_cc(), nullptr,
       control,
       in(TypeFunc::I_O),
       in(TypeFunc::Memory),

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -34,6 +34,7 @@
 #include "opto/convertnode.hpp"
 #include "opto/loopnode.hpp"
 #include "opto/machnode.hpp"
+#include "opto/memnode.hpp"
 #include "opto/movenode.hpp"
 #include "opto/mulnode.hpp"
 #include "opto/narrowptrnode.hpp"
@@ -45,6 +46,7 @@
 #include "opto/subnode.hpp"
 #include "opto/valuetypenode.hpp"
 #include "opto/vectornode.hpp"
+#include "utilities/bitMap.hpp"
 #include "utilities/vmError.hpp"
 
 // Portions of code courtesy of Clifford Click
@@ -1603,7 +1605,7 @@ Node* PhiNode::Identity(PhaseGVN* phase) {
     for (DUIterator_Fast imax, i = phi_reg->fast_outs(imax); i < imax; i++) {
       Node* u = phi_reg->fast_out(i);
       assert(!u->is_Phi() || u->in(0) == phi_reg, "broken Phi/Region subgraph");
-      if (u->is_Phi() && u->req() == phi_len && can_be_replaced_by(u->as_Phi())) {
+      if (u->is_Phi() && u->req() == phi_len && can_be_replaced_by(phase, u->as_Phi())) {
         return u;
       }
     }
@@ -2231,44 +2233,110 @@ bool PhiNode::must_wait_for_region_in_irreducible_loop(PhaseGVN* phase) const {
   return false;
 }
 
-// Check if splitting a bot memory Phi through a parent MergeMem may lead to
-// non-termination. For more details, see comments at the call site in
-// PhiNode::Ideal.
-bool PhiNode::is_split_through_mergemem_terminating() const {
-  ResourceMark rm;
-  VectorSet visited;
-  GrowableArray<const Node*> worklist;
-  worklist.push(this);
-  visited.set(this->_idx);
-  auto maybe_add_to_worklist = [&](Node* input) {
-    if (input != nullptr &&
-        (input->is_MergeMem() || input->is_memory_phi()) &&
-        !visited.test_set(input->_idx)) {
-      worklist.push(input);
-      assert(input->adr_type() == TypePtr::BOTTOM,
-          "should only visit bottom memory");
+// Fix all cases when this bottom memory Phi has MergeMem inputs
+Node* PhiNode::split_through_mergemem(PhaseIterGVN& igvn) {
+  assert(type() == Type::MEMORY, "must be a memory Phi");
+  assert(adr_type() == TypePtr::BOTTOM, "must be a bottom memory Phi");
+
+  bool need_splitting = false;
+  bool need_process = false;
+  for (uint input_idx = 1; input_idx < req(); input_idx++) {
+    MergeMemNode* input = in(input_idx)->isa_MergeMem();
+    if (input == nullptr) {
+      continue;
     }
-  };
-  while (worklist.length() > 0) {
-    const Node* n = worklist.pop();
-    if (n->is_MergeMem()) {
-      Node* input = n->as_MergeMem()->base_memory();
-      if (input == this) {
-        return false;
+
+    need_process = true;
+    for (MergeMemStream mms(input); mms.next_non_empty();) {
+      if (mms.at_base_memory()) {
+        continue;
       }
-      maybe_add_to_worklist(input);
-    } else {
-      assert(n->is_memory_phi(), "invariant");
-      for (uint i = PhiNode::Input; i < n->req(); i++) {
-        Node* input = n->in(i);
-        if (input == this) {
-          return false;
-        }
-        maybe_add_to_worklist(input);
+
+      if (_excluded_idx == nullptr || !_excluded_idx->contains(mms.alias_idx())) {
+        need_splitting = true;
+        break;
+      }
+    }
+
+    if (need_splitting) {
+      break;
+    }
+  }
+
+  if (!need_process) {
+    return nullptr;
+  }
+
+  // If a MergeMem input of this bottom memory Phi has non-empty inputs only at alias classes which
+  // has been excluded from this Phi, then we can ignore all those non-empty inputs, rewire this
+  // Phi directly to the base memory of that MergeMem input
+  if (!need_splitting) {
+    for (uint input_idx = 1; input_idx < req(); input_idx++) {
+      MergeMemNode* input = in(input_idx)->isa_MergeMem();
+      if (input == nullptr) {
+        continue;
+      }
+      set_req_X(input_idx, input->base_memory(), &igvn);
+    }
+    return this;
+  }
+
+  // Split this Phi through its MergeMem inputs
+  // Phi(...MergeMem(m0, m1:AT1, m2:AT2)...) into
+  //     MergeMem(Phi(...m0...), Phi:AT1(...m1...), Phi:AT2(...m2...))
+  PhiNode* new_base = (PhiNode*) clone();
+  // Must eagerly register phis, since they participate in loops.
+  igvn.register_new_node_with_optimizer(new_base);
+
+  // Record the alias indices that are newly split
+  ResourceMark rm;
+  ResourceBitMap new_excluded_idx(igvn.C->num_alias_types());
+  if (_excluded_idx != nullptr) {
+    _excluded_idx->copy_into(new_excluded_idx);
+  }
+
+  MergeMemNode* result = MergeMemNode::make(new_base);
+  for (uint input_idx = 1; input_idx < req(); input_idx++) {
+    MergeMemNode* input = in(input_idx)->isa_MergeMem();
+    if (input == nullptr) {
+      continue;
+    }
+
+    // TODO revisit this with JDK-8247216
+    // Put 'input' on the worklist because it might be modified by MergeMemStream::iteration_setup
+    igvn.record_for_igvn(input);
+
+    for (MergeMemStream mms(result, input); mms.next_non_empty2();) {
+      // If we have not seen this slice yet, make a phi for it.
+      bool made_new_phi = false;
+      if (mms.is_empty()) {
+        Node* new_phi = new_base->slice_memory(mms.adr_type(igvn.C));
+        made_new_phi = true;
+        igvn.register_new_node_with_optimizer(new_phi);
+        mms.set_memory(new_phi);
+      }
+      Node* phi = mms.memory();
+      assert(made_new_phi || phi->in(input_idx) == input, "replace the i-th merge by a slice");
+      phi->set_req_X(input_idx, mms.memory2(), &igvn);
+      new_excluded_idx.set_bit(mms.alias_idx());
+    }
+  }
+  new_base->_excluded_idx = ExcludedAliasIdx::make(igvn.C, new_excluded_idx);
+
+  // Distribute all self-loops
+  for (MergeMemStream mms(result); mms.next_non_empty();) {
+    Node* phi = mms.memory();
+    for (uint i = 1; i < req(); i++) {
+      if (phi->in(i) == this) {
+        phi->set_req_X(i, phi, &igvn);
       }
     }
   }
-  return true;
+
+  // We could immediately transform the new Phi nodes here, but that can result in creating an
+  // excessive number of new nodes within a single IGVN iteration. We have put the Phi nodes on the
+  // IGVN worklist, so they are transformed later on in any case.
+  return result;
 }
 
 // Is one of the inputs a Cast that has not been processed by igvn yet?
@@ -2612,191 +2680,30 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // It would make the parser's memory-merge logic sick.)
   // (MergeMemNode is not dead_loop_safe - need to check for dead loop.)
   if (progress == nullptr && can_reshape && type() == Type::MEMORY) {
+    PhaseIterGVN* igvn = phase->is_IterGVN();
+    assert(igvn != nullptr, "must be during IGVN");
 
-    // See if this Phi should be sliced. Determine the merge width of input
-    // MergeMems and check if there is a direct loop to self, as illustrated
-    // below.
-    //
-    //               +-------------+
-    //               |             |
-    // (base_memory) v             |
-    //              MergeMem       |
-    //                 |           |
-    //                 v           |
-    //                Phi (this)   |
-    //                 |           |
-    //                 +-----------+
-    //
-    // Generally, there are issues with non-termination with such circularity
-    // (see comment further below). However, if there is a direct loop to self,
-    // splitting the Phi through the MergeMem will result in the below.
-    //
-    //               +---+
-    //               |   |
-    //               v   |
-    //              Phi  |
-    //               |\  |
-    //               | +-+
-    // (base_memory) v
-    //              MergeMem
-    //
-    // This split breaks the circularity and consequently does not lead to
-    // non-termination.
-    uint merge_width = 0;
-    // TODO revisit this with JDK-8247216
-    bool mergemem_only = true;
-    bool split_always_terminates = false; // Is splitting guaranteed to terminate?
-    for( uint i=1; i<req(); ++i ) {// For all paths in
-      Node *ii = in(i);
-      // TOP inputs should not be counted as safe inputs because if the
-      // Phi references itself through all other inputs then splitting the
-      // Phi through memory merges would create dead loop at later stage.
-      if (ii == top) {
-        return progress; // Delay optimization until graph is cleaned.
+    if (const TypePtr* at = adr_type(); at == TypePtr::BOTTOM) {
+      progress = split_through_mergemem(*igvn);
+      if (progress != nullptr && progress != this) {
+        return progress;
       }
-      if (ii->is_MergeMem()) {
-        MergeMemNode* n = ii->as_MergeMem();
-        merge_width = MAX2(merge_width, n->req());
-        if (n->base_memory() == this) {
-          split_always_terminates = true;
+    } else {
+      // Patch the existing phi to select an input from the merge:
+      // Phi:AT1(...MergeMem(m0, m1, m2)...) into
+      //     Phi:AT1(...m1...)
+      int alias_idx = igvn->C->get_alias_index(at);
+      for (uint input_idx = 1; input_idx < req(); input_idx++) {
+        MergeMemNode* input = in(input_idx)->isa_MergeMem();
+        if (input == nullptr) {
+          continue;
         }
-      } else {
-        mergemem_only = false;
+
+        set_req_X(input_idx, input->memory_at(alias_idx), igvn);
+        progress = this;
       }
     }
 
-    // There are cases with circular dependencies between bottom Phis
-    // and MergeMems. Below is a minimal example.
-    //
-    //               +------------+
-    //               |            |
-    // (base_memory) v            |
-    //              MergeMem      |
-    //                 |          |
-    //                 v          |
-    //                Phi (this)  |
-    //                 |          |
-    //                 v          |
-    //                Phi         |
-    //                 |          |
-    //                 +----------+
-    //
-    // Here, we cannot break the circularity through a self-loop as there
-    // are two Phis involved. Repeatedly splitting the Phis through the
-    // MergeMem leads to non-termination. We check for non-termination below.
-    // Only check for non-termination if necessary.
-    if (!mergemem_only && !split_always_terminates && adr_type() == TypePtr::BOTTOM &&
-        merge_width > Compile::AliasIdxRaw) {
-      split_always_terminates = is_split_through_mergemem_terminating();
-    }
-
-    if (merge_width > Compile::AliasIdxRaw) {
-      // found at least one non-empty MergeMem
-      const TypePtr* at = adr_type();
-      if (at != TypePtr::BOTTOM) {
-        // Patch the existing phi to select an input from the merge:
-        // Phi:AT1(...MergeMem(m0, m1, m2)...) into
-        //     Phi:AT1(...m1...)
-        int alias_idx = phase->C->get_alias_index(at);
-        for (uint i=1; i<req(); ++i) {
-          Node *ii = in(i);
-          if (ii->is_MergeMem()) {
-            MergeMemNode* n = ii->as_MergeMem();
-            // compress paths and change unreachable cycles to TOP
-            // If not, we can update the input infinitely along a MergeMem cycle
-            // Equivalent code is in MemNode::Ideal_common
-            Node *m  = phase->transform(n);
-            if (outcnt() == 0) {  // Above transform() may kill us!
-              return top;
-            }
-            // If transformed to a MergeMem, get the desired slice
-            // Otherwise the returned node represents memory for every slice
-            Node *new_mem = (m->is_MergeMem()) ?
-                             m->as_MergeMem()->memory_at(alias_idx) : m;
-            // Update input if it is progress over what we have now
-            if (new_mem != ii) {
-              set_req_X(i, new_mem, phase->is_IterGVN());
-              progress = this;
-            }
-          }
-        }
-      } else if (mergemem_only || split_always_terminates) {
-        // If all inputs reference this phi (directly or through data nodes) -
-        // it is a dead loop.
-        bool saw_safe_input = false;
-        for (uint j = 1; j < req(); ++j) {
-          Node* n = in(j);
-          if (n->is_MergeMem()) {
-            MergeMemNode* mm = n->as_MergeMem();
-            if (mm->base_memory() == this || mm->base_memory() == mm->empty_memory()) {
-              // Skip this input if it references back to this phi or if the memory path is dead
-              continue;
-            }
-          }
-          if (!is_unsafe_data_reference(n)) {
-            saw_safe_input = true; // found safe input
-            break;
-          }
-        }
-        if (!saw_safe_input) {
-          // There is a dead loop: All inputs are either dead or reference back to this phi
-          return top;
-        }
-
-        // Phi(...MergeMem(m0, m1:AT1, m2:AT2)...) into
-        //     MergeMem(Phi(...m0...), Phi:AT1(...m1...), Phi:AT2(...m2...))
-        PhaseIterGVN* igvn = phase->is_IterGVN();
-        assert(igvn != nullptr, "sanity check");
-        PhiNode* new_base = (PhiNode*) clone();
-        // Must eagerly register phis, since they participate in loops.
-        igvn->register_new_node_with_optimizer(new_base);
-
-        MergeMemNode* result = MergeMemNode::make(new_base);
-        for (uint i = 1; i < req(); ++i) {
-          Node *ii = in(i);
-          if (ii->is_MergeMem()) {
-            MergeMemNode* n = ii->as_MergeMem();
-            if (igvn) {
-              // TODO revisit this with JDK-8247216
-              // Put 'n' on the worklist because it might be modified by MergeMemStream::iteration_setup
-              igvn->_worklist.push(n);
-            }
-            for (MergeMemStream mms(result, n); mms.next_non_empty2(); ) {
-              // If we have not seen this slice yet, make a phi for it.
-              bool made_new_phi = false;
-              if (mms.is_empty()) {
-                Node* new_phi = new_base->slice_memory(mms.adr_type(phase->C));
-                made_new_phi = true;
-                igvn->register_new_node_with_optimizer(new_phi);
-                mms.set_memory(new_phi);
-              }
-              Node* phi = mms.memory();
-              assert(made_new_phi || phi->in(i) == n, "replace the i-th merge by a slice");
-              phi->set_req_X(i, mms.memory2(), phase);
-            }
-          }
-        }
-        // Distribute all self-loops.
-        { // (Extra braces to hide mms.)
-          for (MergeMemStream mms(result); mms.next_non_empty(); ) {
-            Node* phi = mms.memory();
-            for (uint i = 1; i < req(); ++i) {
-              if (phi->in(i) == this) {
-                phi->set_req_X(i, phi, phase);
-              }
-            }
-          }
-        }
-
-        // We could immediately transform the new Phi nodes here, but that can
-        // result in creating an excessive number of new nodes within a single
-        // IGVN iteration. We have put the Phi nodes on the IGVN worklist, so
-        // they are transformed later on in any case.
-
-        // Replace self with the result.
-        return result;
-      }
-    }
     //
     // Other optimizations on the memory chain
     //
@@ -2935,7 +2842,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     for (DUIterator_Fast imax, i = phi_reg->fast_outs(imax); i < imax; i++) {
       Node* u = phi_reg->fast_out(i);
       assert(!u->is_Phi() || (u->in(0) == phi_reg && u->req() == phi_len), "broken Phi/Region subgraph");
-      if (u->is_Phi() && u->as_Phi()->can_be_replaced_by(this)) {
+      if (u->is_Phi() && u->as_Phi()->can_be_replaced_by(phase, this)) {
         igvn->_worklist.push(u);
       }
     }
@@ -3383,9 +3290,15 @@ const TypeTuple* PhiNode::collect_types(PhaseGVN* phase) const {
   return TypeTuple::make(types.length(), flds);
 }
 
-bool PhiNode::can_be_replaced_by(const PhiNode* other) const {
-  return type() == Type::MEMORY && other->type() == Type::MEMORY && adr_type() != TypePtr::BOTTOM &&
-    other->adr_type() == TypePtr::BOTTOM && has_same_inputs_as(other);
+bool PhiNode::can_be_replaced_by(PhaseGVN* phase, const PhiNode* other) const {
+  const TypePtr* at = adr_type();
+  return type() == Type::MEMORY && other->type() == Type::MEMORY && at != TypePtr::BOTTOM &&
+         other->adr_type() == TypePtr::BOTTOM && has_same_inputs_as(other) &&
+         // Normally, the alias class corresponding to 'at' not being in '_exclude_idx' does not
+         // imply that it is contained in the bottom memory Phi 'other'. However, since 'this' and
+         // 'other' have the same inputs, either both represent the memory state of 'at', or
+         // neither does, both cases allow replacing 'this' with 'other'.
+         (other->_excluded_idx == nullptr || !other->_excluded_idx->contains(phase->C->get_alias_index(at)));
 }
 
 Node* PhiNode::clone_through_phi(Node* root_phi, const Type* t, uint c, PhaseIterGVN* igvn) {

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -31,6 +31,7 @@
 #include "opto/predicates_enums.hpp"
 #include "opto/type.hpp"
 #include "runtime/arguments.hpp"
+#include "utilities/bitMap.hpp"
 
 // Portions of code courtesy of Clifford Click
 
@@ -165,6 +166,145 @@ class PhiNode : public TypeNode {
   const int _inst_index;  // Alias index of the instance memory slice.
   // Array elements references have the same alias_idx but different offset.
   const int _inst_offset; // Offset of the instance memory slice.
+
+  // Bottom memory Phis are peculiar. Consider a bottom memory Phi bot_phi and an arbitrary alias
+  // class mem.
+  //
+  // 1. Sometimes, bot_phi does not contain the memory state corresponding to mem, and there is
+  // another memory Phi mem_phi at the same region representing the memory state corresponding to
+  // mem.
+  //
+  // if (b) {
+  //   Call1();
+  //   MemProj1(Call1);
+  // } else {
+  //   Call2();
+  //   MemProj2(Call2);
+  //   Store1(_, MemProj2, p, v): mem;
+  // }
+  // bot_phi = Phi(MemProj1, MemProj2);
+  // mem_phi = Phi(MemProj1, Store1);
+  //
+  // In this example, bot_phi cannot contain the memory state corresponding to mem, because
+  // MemProj2 does not capture the store into that memory.
+  //
+  // 2. Sometimes, bot_phi contains the memory state corresponding to mem, even if there is another
+  // memory Phi at the same region representing the memory state corresponding to mem.
+  //
+  // Call1();
+  // MemProj1(Call1);
+  // Store1(_, MemProj1, p1, v): mem;
+  // MergeMem1(MemProj1, Top, Store1);
+  // Load1(_, Store1, p2): mem;
+  // Load2(_, MergeMem, p3): mem;
+  //
+  // We somehow want to multiversion some statements:
+  //
+  // Call1();
+  // MemProj1(Call1);
+  // if (b) {
+  //   Store11(_, MemProj1, p1, v): mem;
+  //   MergeMem11(MemProj1, Top, Store11);
+  // } else {
+  //   Store12(_, MemProj1, p1, v): mem;
+  //   MergeMem12(MemProj1, Top, Store12);
+  // }
+  // bot_phi = Phi(MergeMem11, MergeMem12);
+  // mem_phi = Phi(Store11, Store12);
+  // Load1(_, mem_phi, p2): mem;
+  // Load2(_, bot_phi, p3): mem;
+  //
+  // In this example, bot_phi must contain the memory state corresponding to mem, because there is
+  // a load corresponding to mem from it. This pattern can be eventually simplified after IGVN, but
+  // until then, the existence of mem_phi does not mean that bot_phi does not contain the memory
+  // state corresponding to mem.
+  //
+  // 3. Sometimes, bot_phi does not contain the memory state corresponding to mem, even if there is
+  // not any memory Phi at the same region representing the memory state corresponding to mem.
+  //
+  // Call1();
+  // MemProj1(Call1);
+  // Store1(_, MemProj1, p, v);
+  // if (b) {
+  //   MergeMem1(MemProj1, Top, Store1);
+  // }
+  // bot_phi = Phi(MergeMem1, MemProj1);
+  //
+  // In this case, bot_phi does not contain the memory state corresponding to mem, because in one
+  // branch, its input is MemProj1, which does not capture the latest store Store1 of the alias
+  // class mem.
+  //
+  // Those situations can be solved by pushing the MergeMems down through their bottom memory Phi
+  // outputs. However, naively doing so can lead to infinite loop, because a Phi can be a
+  // transitive input of itself, which means keeping pushing the MergeMem down may eventually
+  // results in it being an input of the original Phi again. To tackle that issue, we observe that
+  // pushing a MergeMem down through a bottom memory Phi effectively splits that Phi into multiple
+  // Phis each of which represents an alias class, and the new bottom memory Phi must not contain
+  // the memory states of those alias classes that are split. For example, by transforming:
+  //
+  //   Proj1       Store
+  //      \       /
+  //       MergeMem        Proj2
+  //             \       /
+  //                Phi
+  //                 |
+  //                ...
+  //
+  // Into:
+  //
+  //   Proj1     Proj2    Store     Proj2(this is the same node as the other Proj2)
+  //       \     /            \     /
+  //         Phi1              Phi2
+  //             \            /
+  //                MergeMem
+  //                   |
+  //                  ...
+  //
+  // While it is uncertain which memory states the original Phi contains, it is certain that Phi1
+  // (the new bottom memory Phi) does not contain the memory state corresponding to Phi2, because
+  // it misses the latest Store into that alias class.
+  //
+  // As a result, if we record which alias classes have been split from each bottom memory Phi, it
+  // is certain that the transformation will terminate, because if a MergeMem input of a bottom
+  // memory Phi has all its non-top inputs being known to be excluded from that Phi, then the Phi
+  // does not have to be split anymore (i.e. it can simply skip the MergeMem and is rewired to the
+  // MergeMem's base input instead of having the MergeMem pushed through it). Otherwise, the split
+  // is performed, more alias classes are split from the Phi, which means some progress is made.
+  //
+  // This does not need to be exact, it is fine if it misses alias classes that a bottom memory Phi
+  // does not include, but it must not contain alias classes that the Phi includes.
+  class ExcludedAliasIdx {
+  private:
+    BitMapView _view;
+
+    ExcludedAliasIdx(BitMap::bm_word_t* payload, BitMap::idx_t bit_size) : _view(payload, bit_size) {}
+
+  public:
+    static const ExcludedAliasIdx* make(Compile* C, const BitMap& excluded_idx) {
+      Arena* arena = C->node_arena();
+      char* ptr = static_cast<char*>(arena->Amalloc(sizeof(ExcludedAliasIdx) + excluded_idx.size_in_bytes()));
+      BitMap::bm_word_t* payload = reinterpret_cast<BitMap::bm_word_t*>(ptr + sizeof(ExcludedAliasIdx));
+      memset(payload, 0, excluded_idx.size_in_bytes());
+      ExcludedAliasIdx* res = ::new(ptr) ExcludedAliasIdx(payload, excluded_idx.size());
+      res->_view.set_from(excluded_idx);
+      return res;
+    }
+
+    bool contains(int alias_idx) const {
+      assert(alias_idx >= 0, "invalid idx %d", alias_idx);
+      BitMap::idx_t idx = alias_idx;
+      return idx < _view.size() && _view.at(idx);
+    }
+
+    void copy_into(BitMap& dst) const {
+      for (BitMap::Iterator iter(_view); !iter.is_empty(); iter.step()) {
+        dst.set_bit(iter.index());
+      }
+    }
+  };
+
+  const ExcludedAliasIdx* _excluded_idx;
+
   // Size is bigger to hold the _adr_type field.
   virtual uint hash() const;    // Check the type
   virtual bool cmp( const Node &n ) const;
@@ -180,7 +320,7 @@ class PhiNode : public TypeNode {
 
   bool must_wait_for_region_in_irreducible_loop(PhaseGVN* phase) const;
 
-  bool is_split_through_mergemem_terminating() const;
+  Node* split_through_mergemem(PhaseIterGVN& igvn);
 
   void verify_type_stability(const PhaseGVN* phase, const Type* union_of_input_types, const Type* new_type) const NOT_DEBUG_RETURN;
   bool wait_for_cast_input_igvn(const PhaseIterGVN* igvn) const;
@@ -201,7 +341,8 @@ public:
       _inst_mem_id(imid),
       _inst_id(iid),
       _inst_index(iidx),
-      _inst_offset(ioffs)
+      _inst_offset(ioffs),
+      _excluded_idx(nullptr)
   {
     init_class_id(Class_Phi);
     init_req(0, r);
@@ -283,7 +424,7 @@ public:
 #endif //ASSERT
 
   const TypeTuple* collect_types(PhaseGVN* phase) const;
-  bool can_be_replaced_by(const PhiNode* other) const;
+  bool can_be_replaced_by(PhaseGVN* phase, const PhiNode* other) const;
 };
 
 //------------------------------GotoNode---------------------------------------

--- a/src/hotspot/share/opto/intrinsicnode.cpp
+++ b/src/hotspot/share/opto/intrinsicnode.cpp
@@ -36,25 +36,35 @@ uint StrIntrinsicNode::match_edge(uint idx) const {
   return idx == 2 || idx == 3;
 }
 
+static Node* ideal_mem_intrinsic_node(PhaseGVN* phase, bool can_reshape, Node* n) {
+  if (n->remove_dead_region(phase, can_reshape)) {
+    return n;
+  }
+
+  // Don't bother trying to transform a dead node
+  if (n->in(0) && n->in(0)->is_top()) {
+    return nullptr;
+  }
+
+  // If mem input is a MergeMem, get the desired slice
+  if (const TypePtr* adr_type = n->adr_type(); can_reshape && adr_type != TypePtr::BOTTOM) {
+    Node* mem = n->in(MemNode::Memory);
+    uint alias_idx = phase->C->get_alias_index(adr_type);
+    Node* new_mem = mem->is_MergeMem() ? mem->as_MergeMem()->memory_at(alias_idx) : mem;
+    if (new_mem != mem) {
+      n->set_req_X(MemNode::Memory, new_mem, phase);
+      return n;
+    }
+  }
+
+  return nullptr;
+}
+
 //------------------------------Ideal------------------------------------------
 // Return a node which is more "ideal" than the current node.  Strip out
 // control copies
 Node* StrIntrinsicNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  if (remove_dead_region(phase, can_reshape)) return this;
-  // Don't bother trying to transform a dead node
-  if (in(0) && in(0)->is_top())  return nullptr;
-
-  if (can_reshape) {
-    Node* mem = in(MemNode::Memory);
-    // If mem input is a MergeMem, get the desired slice
-    uint alias_idx = phase->C->get_alias_index(adr_type());
-    mem = mem->is_MergeMem() ? mem->as_MergeMem()->memory_at(alias_idx) : mem;
-    if (mem != in(MemNode::Memory)) {
-      set_req_X(MemNode::Memory, mem, phase);
-      return this;
-    }
-  }
-  return nullptr;
+  return ideal_mem_intrinsic_node(phase, can_reshape, this);
 }
 
 //------------------------------Value------------------------------------------
@@ -63,29 +73,13 @@ const Type* StrIntrinsicNode::Value(PhaseGVN* phase) const {
   return bottom_type();
 }
 
-//=============================================================================
-//------------------------------Ideal------------------------------------------
-// Return a node which is more "ideal" than the current node.  Strip out
-// control copies
-Node* StrCompressedCopyNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  return remove_dead_region(phase, can_reshape) ? this : nullptr;
-}
-
-//=============================================================================
-//------------------------------Ideal------------------------------------------
-// Return a node which is more "ideal" than the current node.  Strip out
-// control copies
-Node* StrInflatedCopyNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  return remove_dead_region(phase, can_reshape) ? this : nullptr;
-}
-
 uint VectorizedHashCodeNode::match_edge(uint idx) const {
   // Do not match memory edge.
   return idx >= 2 && idx <=  5; // VectorizedHashCodeNode (Binary ary1 cnt1) (Binary result bt)
 }
 
 Node* VectorizedHashCodeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  return remove_dead_region(phase, can_reshape) ? this : nullptr;
+  return ideal_mem_intrinsic_node(phase, can_reshape, this);
 }
 
 const Type* VectorizedHashCodeNode::Value(PhaseGVN* phase) const {
@@ -105,7 +99,7 @@ uint EncodeISOArrayNode::match_edge(uint idx) const {
 // Return a node which is more "ideal" than the current node.  Strip out
 // control copies
 Node* EncodeISOArrayNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  return remove_dead_region(phase, can_reshape) ? this : nullptr;
+  return ideal_mem_intrinsic_node(phase, can_reshape, this);
 }
 
 //------------------------------Value------------------------------------------

--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -147,7 +147,6 @@ public:
   StrIntrinsicNode(control, arymem, s1, s2, c, none), _adr_type(adr_type) {};
   virtual int Opcode() const override;
   virtual const Type* bottom_type() const override { return TypeInt::INT; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
 
 private:
   virtual uint size_of() const override { return sizeof(StrCompressedCopyNode); }
@@ -169,7 +168,6 @@ public:
   StrIntrinsicNode(control, arymem, s1, s2, c, none), _adr_type(adr_type) {};
   virtual int Opcode() const override;
   virtual const Type* bottom_type() const override { return Type::MEMORY; }
-  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape) override;
 
 private:
   virtual uint size_of() const override { return sizeof(StrInflatedCopyNode); }

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -525,22 +525,18 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
     return NodeSentinel; // caller will return null
   }
 
+  // Weird access to null+offset, either is a dead unsafe access that cannot be proved to be so, or
+  // should be folded later
+  if (t_adr->base() == Type::AnyPtr) {
+    assert(t_adr->is_ptr()->ptr() == TypePtr::Null, "must be null");
+    return NodeSentinel; // caller will return null
+  }
+
   // Do NOT remove or optimize the next lines: ensure a new alias index
   // is allocated for an oop pointer type before Escape Analysis.
   // Note: C++ will not remove it since the call has side effect.
   if (t_adr->isa_oopptr()) {
     int alias_idx = phase->C->get_alias_index(t_adr->is_ptr());
-  }
-
-  Node* base = nullptr;
-  if (address->is_AddP()) {
-    base = address->in(AddPNode::Base);
-  }
-  if (base != nullptr && phase->type(base)->higher_equal(TypePtr::NULL_PTR) &&
-      !t_adr->isa_rawptr()) {
-    // Note: raw address has TOP base and top->higher_equal(TypePtr::NULL_PTR) is true.
-    // Skip this node optimization if its address has TOP base.
-    return NodeSentinel; // caller will return null
   }
 
   // Avoid independent memory operations

--- a/src/hotspot/share/opto/multnode.cpp
+++ b/src/hotspot/share/opto/multnode.cpp
@@ -151,27 +151,25 @@ const Type *ProjNode::bottom_type() const {
   return proj_type(in(0)->bottom_type());
 }
 
-const TypePtr *ProjNode::adr_type() const {
-  if (bottom_type() == Type::MEMORY) {
-    // in(0) might be a narrow MemBar; otherwise we will report TypePtr::BOTTOM
-    Node* ctrl = in(0);
-    if (ctrl->Opcode() == Op_Tuple) {
-      // Jumping over Tuples: the i-th projection of a Tuple is the i-th input of the Tuple.
-      ctrl = ctrl->in(_con);
-    }
-    // node is dead or we are in the process of removing a dead subgraph
-    if (ctrl == nullptr || ctrl->is_top()) {
-      return nullptr;
-    }
-    const TypePtr* adr_type = ctrl->adr_type();
-    #ifdef ASSERT
-    if (!VMError::is_error_reported() && !Node::in_dump())
-      assert(adr_type != nullptr, "source must have adr_type");
-    #endif
-    return adr_type;
+const TypePtr* ProjNode::adr_type() const {
+  if (bottom_type() != Type::MEMORY) {
+    assert(bottom_type()->base() != Type::Memory, "no other memories?");
+    return nullptr;
   }
-  assert(bottom_type()->base() != Type::Memory, "no other memories?");
-  return nullptr;
+
+  Node* ctrl = in(0);
+  // node is dead or we are in the process of removing a dead subgraph
+  if (ctrl == nullptr || ctrl->is_top()) {
+    return nullptr;
+  }
+
+  const TypePtr* adr_type = ctrl->adr_type();
+#ifdef ASSERT
+  if (!VMError::is_error_reported() && !Node::in_dump()) {
+    assert(adr_type != nullptr, "source must have adr_type");
+  }
+#endif // ASSERT
+  return adr_type;
 }
 
 bool ProjNode::pinned() const { return in(0)->pinned(); }

--- a/src/hotspot/share/opto/multnode.hpp
+++ b/src/hotspot/share/opto/multnode.hpp
@@ -280,7 +280,11 @@ template <class Callback> ProjNode* MultiNode::apply_to_projs(DUIterator_Fast& i
  * after the current IGVN.
  */
 class TupleNode : public MultiNode {
+private:
   const TypeTuple* _tf;
+  const TypePtr* _adr_type;
+
+  TupleNode(const TypeTuple* tf, const TypePtr* adr_type) : MultiNode(tf->cnt()), _tf(tf), _adr_type(adr_type) {}
 
   template <typename... NN>
   static void make_helper(TupleNode* tn, uint i, Node* node, NN... nn) {
@@ -291,21 +295,21 @@ class TupleNode : public MultiNode {
   static void make_helper(TupleNode*, uint) {}
 
 public:
-  TupleNode(const TypeTuple* tf) : MultiNode(tf->cnt()), _tf(tf) {}
-
-  int Opcode() const override;
-  const Type* bottom_type() const override { return _tf; }
-
   /* Give as many `Node*` as you want in the `nn` pack:
    * TupleNode::make(tf, input1)
    * TupleNode::make(tf, input1, input2, input3, input4)
    */
   template <typename... NN>
-  static TupleNode* make(const TypeTuple* tf, NN... nn) {
-    TupleNode* tn = new TupleNode(tf);
+  static TupleNode* make(const TypeTuple* tf, const TypePtr* adr_type, NN... nn) {
+    TupleNode* tn = new TupleNode(tf, adr_type);
     make_helper(tn, 0, nn...);
     return tn;
   }
+
+  int            Opcode()      const override;
+  const Type*    bottom_type() const override { return _tf; }
+  const TypePtr* adr_type()    const override { return _adr_type; }
+  uint           size_of()     const override { return sizeof(TupleNode); }
 };
 
 #endif // SHARE_OPTO_MULTNODE_HPP

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -195,8 +195,6 @@ vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/Test
 #############################################################################
 
 # Value Objects failures start here:
-applications/ctw/modules/java_base.java 8375645 generic-all
-applications/ctw/modules/java_base_2.java 8375645 generic-all
 
 compiler/codegen/TestRedundantLea.java#Spill                            8361089 generic-all
 

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestSplitIncorrectPhi.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestSplitIncorrectPhi.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.escapeAnalysis;
+
+/*
+ * @test
+ * @bug 8375645
+ * @summary Ambiguous memory Phis may lead to EA choosing the wrong one in split_unique_types.
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileOnly=${test.main.class}::test
+ *                   ${test.main.class}
+ */
+public class TestSplitIncorrectPhi {
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test(i % 2 == 0);
+        }
+    }
+
+    private static void test(boolean flag) {
+        A a = null;
+        if (flag) {
+            C c = new C();
+            B b = new B();
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 8; j++) {
+                    switch (i) {
+                        case -1, -2, -3 :
+                            break;
+                        case 0 :
+                            b.c = c;
+                    }
+                }
+            }
+            b.c = c;
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 8; j++) {
+                    switch (i) {
+                        case -1, -2, -3 :
+                            break;
+                        case 0 :
+                            a = new A();
+                    }
+                }
+            }
+            for (int i = 0; i < 32; i++) {
+                if (i < 10) {
+                    a = new A();
+                }
+            }
+            a = new A();
+            for (int i = 1; i < 32; i++) {
+                a = new A();
+            }
+            for (int i = 1; i < 32; i++) {
+                a = new A();
+            }
+            for (int i = 1; i < 32; i++) {
+                a = new A();
+            }
+
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 8; j++) {
+                    switch (i) {
+                        case -1, -2, -3 :
+                            break;
+                        case 0 :
+                            a.b = b;
+                    }
+                }
+            }
+            a.b = b;
+        }
+        if (a != null) {
+            for (int i = 0; i < 4; i++) {
+                for (int j = 0; j < 8; j++) {
+                    switch (i) {
+                        case -1, -2, -3 :
+                            break;
+                        case 0 :
+                            a.b.c.f = java.lang.Integer.valueOf(0x42);
+                    }
+                }
+            }
+            a.b.c.f = java.lang.Integer.valueOf(0x42);
+        }
+    }
+
+    private static class A {
+        public B b;
+    }
+
+    private static class B {
+        public C c;
+    }
+
+    private static class C {
+        public int f;
+    }
+}


### PR DESCRIPTION
Hi,

This PR fixes the issue with EA splitting the wrong `Phi` during `split_unique_types`, which leads to the load observing the incorrect memory state, leading to erroneous NPEs. The cause has been investigated by @benoitmaillard in his previous PR (#30697):

> During escape analysis, we use `ConnectionGraph::split_memory_phi` to create a new `Phi` (or `MergeMem`) that "splits" a unified memory state into per-alias slices, effectively producing a refined copy of the memory graph based on the results of the analysis. While producing this copy, we need to be able to reliably tell if a memory phi for a given slice and region node already exists. This is based on the assumption that there is a unique memory phi per region and per slice.
>
> If there are several phi nodes per region for the same slice, we will simply pick the first one we find and base our copy on it. If the "ambiguous" phis are not functionally equivalent, we might build an incomplete subgraph. This can lead to all sorts of problems, including wrong executions (as it is the case here).

To understand the relationship between a bottom memory `Phi` and the memory state of a particular alias class, I have written down an explanation in `PhiNode::ExcludedAliasIdx`:

```
  // Bottom memory Phis are peculiar. Consider a bottom memory Phi bot_phi and an arbitrary alias
  // class mem.
  //
  // 1. Sometimes, bot_phi does not contain the memory state corresponding to mem, and there is
  // another memory Phi mem_phi at the same region representing the memory state corresponding to
  // mem.
  //
  // if (b) {
  //   Call1();
  //   MemProj1(Call1);
  // } else {
  //   Call2();
  //   MemProj2(Call2);
  //   Store1(_, MemProj2, p, v): mem;
  // }
  // bot_phi = Phi(MemProj1, MemProj2);
  // mem_phi = Phi(MemProj1, Store1);
  //
  // In this example, bot_phi cannot contain the memory state corresponding to mem, because
  // MemProj2 does not capture the store into that memory.
  //
  // 2. Sometimes, bot_phi contains the memory state corresponding to mem, even if there is another
  // memory Phi at the same region representing the memory state corresponding to mem.
  //
  // Call1();
  // MemProj1(Call1);
  // Store1(_, MemProj1, p1, v): mem;
  // MergeMem1(MemProj1, Top, Store1);
  // Load1(_, Store1, p2): mem;
  // Load2(_, MergeMem, p3): mem;
  //
  // We somehow want to multiversion some statements:
  //
  // Call1();
  // MemProj1(Call1);
  // if (b) {
  //   Store11(_, MemProj1, p1, v): mem;
  //   MergeMem11(MemProj1, Top, Store11);
  // } else {
  //   Store12(_, MemProj1, p1, v): mem;
  //   MergeMem12(MemProj1, Top, Store12);
  // }
  // bot_phi = Phi(MergeMem11, MergeMem12);
  // mem_phi = Phi(Store11, Store12);
  // Load1(_, mem_phi, p2): mem;
  // Load2(_, bot_phi, p3): mem;
  //
  // In this example, bot_phi must contain the memory state corresponding to mem, because there is
  // a load corresponding to mem from it. This pattern can be eventually simplified after IGVN, but
  // until then, the existence of mem_phi does not mean that bot_phi does not contain the memory
  // state corresponding to mem.
  //
  // 3. Sometimes, bot_phi does not contain the memory state corresponding to mem, even if there is
  // not any memory Phi at the same region representing the memory state corresponding to mem.
  //
  // Call1();
  // MemProj1(Call1);
  // Store1(_, MemProj1, p, v);
  // if (b) {
  //   MergeMem1(MemProj1, Top, Store1);
  // }
  // bot_phi = Phi(MergeMem1, MemProj1);
  //
  // In this case, bot_phi does not contain the memory state corresponding to mem, because in one
  // branch, its input is MemProj1, which does not capture the latest store Store1 of the alias
  // class mem.
```

As a result, we may create different memory `Phi`s for the same `adr_type` at the same `Region`, as explained in #30697:

> In `PhiNode::Ideal`, we attempt to split phis through memory merges, in the hope that the `MergeMem` nodes will eventually go away (for example by getting rid of stacked merges).

By splitting a bottom memory `Phi`, we create multiple memory `Phi`s, one for each of the alias classes. However, since the bottom memory `Phi` may not contain the correct memory state for a particular alias class, the memory `Phi` created for that alias class is not live. In principle, that `Phi` should eventually be considered dead and removed. However, it is used in the `MergeMem` that is pushed down, and the `MergeMem` may not be removed because it may be used in another bottom memory `Phi` which cannot split due to the possibility that such transformation may not terminate. As a result, a dead `Phi` is left in the graph, but determining that it is dead is non-trivial. This means that EA may not be able to distinguish a live memory `Phi` from a dead memory `Phi`.

The proposed solution in #30697 is incorrect, because it may be the case that the existing narrow `Phi` at a region is dead, while the bottom memory `Phi` contains the memory state of the alias class corresponding to that existing narrow `Phi`. We should transform the graph based solely on the inputs of the memory nodes.

As the reason why the `MergeMem` cannot be removed is that pushing it down through another `Phi` may lead to infinite loop, so we don't do it, this PR proposes to keep track of which alias classes have been split from the bottom memory `Phi`. This way, even if pushing the `MergeMem` down several times results in it being above the original `Phi`, the original `Phi` has already obtained additional information that some alias classes have been split from it. This ensures that progress is always made, and the transformation always terminates. Combined with #31827, we can reliably remove dead memory `Phi`s in all circumstances.

There are still cases when 2 memory `Phi`s can have the same `adr_type` and are at the same `Region`, but in those cases, they are both live, and EA choosing either of them for splitting will not lead to an incorrect graph. The reason they cannot be GVN-ed is that they may participate in cycles of different `Phi`s that are equivalent, but none of the individual nodes can easily be deemed equivalent to its counterpart in the other cycle. I will try to solve this case in [JDK-8382032](https://bugs.openjdk.org/browse/JDK-8382032).

Testing:

- [x] tier1-4,hs-comp-stress,valhalla-comp-stress

Please take a look and leave your reviews, thanks a lot.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8375645](https://bugs.openjdk.org/browse/JDK-8375645): C2: NPE in compiled method does not occur with interpreter (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) 🔄 Re-review required (review applies to [1fc415ab](https://git.openjdk.org/jdk/pull/32778/files/1fc415ab5ce47b56213a6f56d84db96b8b0d0a10))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32778/head:pull/32778` \
`$ git checkout pull/32778`

Update a local copy of the PR: \
`$ git checkout pull/32778` \
`$ git pull https://git.openjdk.org/jdk.git pull/32778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32778`

View PR using the GUI difftool: \
`$ git pr show -t 32778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32778.diff">https://git.openjdk.org/jdk/pull/32778.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32778#issuecomment-5597952979)
</details>
