### PR TITLE
8391598: RISC-V: Add Ziccid

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -116,6 +116,8 @@ define_pd_global(bool, ValueTypeReturnedAsFields, false);
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \
   product(bool, UseZicboz, false, EXPERIMENTAL, "Use Zicboz instructions")       \
+  product(bool, UseZiccid, false, EXPERIMENTAL,                                  \
+          "Use Ziccid to omit icache flushes for atomic call patching")          \
   product(bool, UseZicond, false, DIAGNOSTIC, "Use Zicond instructions")         \
   product(bool, UseZihintpause, false, EXPERIMENTAL,                             \
           "Use Zihintpause instructions")                                        \

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -110,8 +110,19 @@ void NativeCall::optimize_call(address dest, bool mt_safe) {
   }
   // We changed instruction stream
   if (mt_safe) {
-    // IC invalidate provides a leading full fence, it thus happens after we changed the instruction stream.
-    ICache::invalidate_range(jmp_ins_pc, NativeInstruction::instruction_size);
+    if (UseZiccid) {
+      // Ziccid provides in-order instruction fetches and eventual store visibility
+      // without FENCE.I for cacheable, coherent memory. It requires Ziccif, which
+      // guarantees atomic, naturally aligned power-of-two instruction fetches up
+      // to min(ILEN, XLEN) bits. This aligned atomic 32-bit jal/jalr replacement
+      // satisfies Ziccif's patching rules, and old/new calls can safely execute
+      // concurrently, so ICache::invalidate_range can be omitted.
+      // Preserve the full data fence otherwise provided by ICache::invalidate_range.
+      OrderAccess::fence();
+    } else {
+      // IC invalidate provides a leading full fence after the instruction store.
+      ICache::invalidate_range(jmp_ins_pc, NativeInstruction::instruction_size);
+    }
   }
 }
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -275,6 +275,8 @@ class VM_Version : public Abstract_VM_Version {
   decl(Zicbop      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicbop))                                 \
   /* Zicboz Cache Block Zero Operations */                                                                \
   decl(Zicboz      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZicboz))                                 \
+  /* Ziccid Instruction/Data Coherence and Consistency */                                                 \
+  decl(Ziccid      ,  RV_NO_FLAG_BIT,  true ,  UPDATE_DEFAULT(UseZiccid))                                 \
   /* Base Counters and Timers */                                                                          \
   decl(Zicntr      ,  RV_NO_FLAG_BIT,  true ,  NO_UPDATE_DEFAULT)                                         \
   /* Zicond Conditional operations */                                                                     \

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -363,6 +363,7 @@ void VM_Version::xuantie_features() {
   ext_Zvkg.enable_feature();
 
 #ifndef PRODUCT
+  ext_Ziccid.enable_feature();
   ext_Zacas.enable_feature();
   ext_Zicboz.enable_feature();
   ext_Zicond.enable_feature();


### PR DESCRIPTION
### Summary
  
This change introduces experimental Ziccid support to avoid explicit I-cache invalidation when atomically
  patching individual call instructions.

  Ziccid guarantees in-order instruction fetches and eventual visibility of instruction stores without
  FENCE.I for cacheable, coherent memory. It depends on Ziccif, which guarantees atomic instruction fetches
  for naturally aligned, power-of-two accesses up to min(ILEN, XLEN) bits.
  
### Changes
- Add the experimental UseZiccid flag and register the Ziccid CPU feature.
- Enable the feature through the Xuantie vendor configuration.
- When UseZiccid is enabled, skip ICache::invalidate_range() for atomic call instruction updates in
    NativeCall::optimize_call().

  ### References

- Ziccid specification:
  https://github.com/riscv/riscv-isa-manual/blob/main/src/unpriv/ziccid.adoc
- RISC-V ratified ISA extensions:
  https://riscv.atlassian.net/wiki/spaces/HOME/pages/16154732/Ratified+ISA+Extensions
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391598](https://bugs.openjdk.org/browse/JDK-8391598): RISC-V: Add Ziccid (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32780/head:pull/32780` \
`$ git checkout pull/32780`

Update a local copy of the PR: \
`$ git checkout pull/32780` \
`$ git pull https://git.openjdk.org/jdk.git pull/32780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32780`

View PR using the GUI difftool: \
`$ git pr show -t 32780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32780.diff">https://git.openjdk.org/jdk/pull/32780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32780#issuecomment-5598244356)
</details>
