### PR TITLE
8392037: Avoid switching off the unused-variable warning in BUILD_LIBNET and BUILD_LIBNIO

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -43,10 +43,9 @@ include lib/CoreLibraries.gmk
 $(eval $(call SetupJdkLibrary, BUILD_LIBNET, \
     NAME := net, \
     OPTIMIZATION := LOW, \
-    DISABLED_WARNINGS_gcc_net_util_md.c := format-nonliteral unused-variable, \
+    DISABLED_WARNINGS_gcc_net_util_md.c := format-nonliteral, \
     DISABLED_WARNINGS_gcc_NetworkInterface.c := unused-function, \
-    DISABLED_WARNINGS_clang_net_util_md.c := format-nonliteral \
-        unused-variable, \
+    DISABLED_WARNINGS_clang_net_util_md.c := format-nonliteral, \
     DISABLED_WARNINGS_clang_NetworkInterface.c := unused-function, \
     DISABLED_WARNINGS_clang_aix_DefaultProxySelector.c := \
         deprecated-non-prototype, \
@@ -78,8 +77,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBNIO, \
         libnio/ch \
         libnio/fs \
         libjvm, \
-    DISABLED_WARNINGS_clang_Net.c := unused-function unused-variable, \
-    DISABLED_WARNINGS_clang_UnixNativeDispatcher.c := unused-variable, \
+    DISABLED_WARNINGS_clang_Net.c := unused-function, \
     JDK_LIBS := libjava libnet, \
     LIBS_linux := $(LIBDL) $(LIBPTHREAD), \
     LIBS_aix := $(LIBDL), \

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -106,8 +106,6 @@ jint  IPv6_supported()
 {
     int fd;
     void *ipv6_fn;
-    SOCKETADDRESS sa;
-    socklen_t sa_len = sizeof(SOCKETADDRESS);
 
     fd = socket(AF_INET6, SOCK_STREAM, 0) ;
     if (fd < 0) {

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -101,32 +101,6 @@ static jboolean isIPv4MappedGroup(struct group_source_req *req) {
     return IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr) ? JNI_TRUE : JNI_FALSE;
 }
 
-/*
- * Checks whether or not "socket extensions for multicast source filters" is supported.
- * Returns JNI_TRUE if it is supported, JNI_FALSE otherwise
- */
-static jboolean isSourceFilterSupported(){
-    static jboolean alreadyChecked = JNI_FALSE;
-    static jboolean result = JNI_TRUE;
-    if (alreadyChecked != JNI_TRUE){
-        struct utsname uts;
-        memset(&uts, 0, sizeof(uts));
-        strcpy(uts.sysname, "?");
-        const int utsRes = uname(&uts);
-        int major = -1;
-        int minor = -1;
-        major = atoi(uts.version);
-        minor = atoi(uts.release);
-        if (strcmp(uts.sysname, "AIX") == 0) {
-            if (major < 6 || (major == 6 && minor < 1)) {// unsupported on aix < 6.1
-                result = JNI_FALSE;
-            }
-        }
-        alreadyChecked = JNI_TRUE;
-    }
-    return result;
-}
-
 #endif  /* _AIX */
 
 static jclass isa_class;        /* java.net.InetSocketAddress */
@@ -651,14 +625,6 @@ Java_sun_nio_ch_Net_joinOrDrop4(JNIEnv *env, jobject this, jboolean join, jobjec
         optval = (void*)&mreq;
         optlen = sizeof(mreq);
     } else {
-
-#ifdef _AIX
-        /* check AIX for support of source filtering */
-        if (isSourceFilterSupported() != JNI_TRUE){
-            return IOS_UNAVAILABLE;
-        }
-#endif
-
         mreq_source.imr_multiaddr.s_addr = htonl(group);
         mreq_source.imr_sourceaddr.s_addr = htonl(source);
         mreq_source.imr_interface.s_addr = htonl(interf);
@@ -704,14 +670,6 @@ Java_sun_nio_ch_Net_blockOrUnblock4(JNIEnv *env, jobject this, jboolean block, j
     struct ip_mreq_source mreq_source;
     int n;
     int opt = (block) ? IP_BLOCK_SOURCE : IP_UNBLOCK_SOURCE;
-
-#ifdef _AIX
-    /* check AIX for support of source filtering */
-    if (isSourceFilterSupported() != JNI_TRUE){
-        return IOS_UNAVAILABLE;
-    }
-#endif
-
     mreq_source.imr_multiaddr.s_addr = htonl(group);
     mreq_source.imr_sourceaddr.s_addr = htonl(source);
     mreq_source.imr_interface.s_addr = htonl(interf);
@@ -732,7 +690,9 @@ Java_sun_nio_ch_Net_joinOrDrop6(JNIEnv *env, jobject this, jboolean join, jobjec
                                 jbyteArray group, jint index, jbyteArray source)
 {
     struct ipv6_mreq mreq6;
+#ifndef __APPLE__
     struct group_source_req req;
+#endif
     int opt, n, optlen;
     void* optval;
 


### PR DESCRIPTION
BUILD_LIBNET and BUILD_LIBNIO switch off the unused-variable warning for some compilation units. This should be avoided.
Additionally isSourceFilterSupported in Net.c where one of those warnings pops up can be completely removed. That coding was only for AIX 6.X (old OS versions no longer supported).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392037](https://bugs.openjdk.org/browse/JDK-8392037): Avoid switching off the unused-variable warning in BUILD_LIBNET and BUILD_LIBNIO (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32782/head:pull/32782` \
`$ git checkout pull/32782`

Update a local copy of the PR: \
`$ git checkout pull/32782` \
`$ git pull https://git.openjdk.org/jdk.git pull/32782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32782`

View PR using the GUI difftool: \
`$ git pr show -t 32782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32782.diff">https://git.openjdk.org/jdk/pull/32782.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32782#issuecomment-5599608894)
</details>
