### PR TITLE
8392002: Improve BCEscapeAnalyzer tracing readability

### DIFF
--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1440,11 +1440,15 @@ void BCEscapeAnalyzer::read_escape_info() {
 
 #ifndef PRODUCT
 
+static const char* const COMMA_SEPARATOR = ", ";
+
 void BCEscapeAnalyzer::dump_arg_set(const VectorSet &set) {
   tty->print("{");
+  const char* sep = "";
   for (int i = 0; i < _arg_size; i++) {
     if (set.test(i)) {
-      tty->print("%d ", i);
+      tty->print("%s%d", sep, i);
+      sep = COMMA_SEPARATOR;
     }
   }
   tty->print("}");
@@ -1477,22 +1481,32 @@ void BCEscapeAnalyzer::dump() {
   print_header(level());
   tty->print("- modified args:          ");
   tty->print("[");
+  const char* sep = "";
   for (int i = 0; i < _arg_size; i++) {
-    if (_arg_modified[i] == 0)
+    tty->print("%s", sep);
+    if (_arg_modified[i] == 0) {
       tty->print("0");
-    else
+    } else {
       tty->print("0x%x", _arg_modified[i]);
-    tty->print(" ");
+    }
+    sep = COMMA_SEPARATOR;
   }
   tty->print_cr("]");
   print_header(level());
   tty->print("- flags:                  {");
-  if (_return_allocated)
-    tty->print("return_allocated ");
-  if (_allocated_escapes)
-    tty->print("allocated_escapes ");
-  if (_unknown_modified)
-    tty->print("unknown_modified ");
+  sep = "";
+  if (_return_allocated) {
+    tty->print("%sreturn_allocated", sep);
+    sep = COMMA_SEPARATOR;
+  }
+  if (_allocated_escapes) {
+    tty->print("%sallocated_escapes", sep);
+    sep = COMMA_SEPARATOR;
+  }
+  if (_unknown_modified) {
+    tty->print("%sunknown_modified", sep);
+    sep = COMMA_SEPARATOR;
+  }
   tty->print_cr("}");
 }
 #endif

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,12 +38,20 @@
 
 #ifndef PRODUCT
   #define TRACE_BCEA(level, code)                                            \
-    if (EstimateArgEscape && BCEATraceLevel >= level) {                        \
+    if (EstimateArgEscape && BCEATraceLevel >= level) {                      \
+      print_header(_level);                                                  \
       code;                                                                  \
     }
 #else
   #define TRACE_BCEA(level, code)
 #endif
+
+static void print_header(int level) {
+  tty->print("[EA] ");
+  for (int i = 0; i < level; i++) {
+    tty->print("    ");
+  }
+}
 
 // Maintain a map of which arguments a local variable or
 // stack slot may contain.  In addition to tracking
@@ -298,7 +306,7 @@ void BCEscapeAnalyzer::invoke(StateInfo &state, Bytecodes::Code code, ciMethod* 
     skip_callee = true;
   }
   if (skip_callee) {
-    TRACE_BCEA(3, tty->print_cr("[EA] skipping method %s::%s", holder->name()->as_utf8(), target->name()->as_utf8()));
+    TRACE_BCEA(3, tty->print_cr("skipping method %s::%s", holder->name()->as_klass_external_name(), target->name()->as_utf8()));
     for (i = 0; i < arg_size; i++) {
       set_method_escape(state.raw_pop());
     }
@@ -360,7 +368,7 @@ void BCEscapeAnalyzer::invoke(StateInfo &state, Bytecodes::Code code, ciMethod* 
       _dependencies.appendAll(analyzer.dependencies());
     }
   } else {
-    TRACE_BCEA(1, tty->print_cr("[EA] virtual method %s is not monomorphic.",
+    TRACE_BCEA(1, tty->print_cr("virtual method %s is not monomorphic.",
                                 target->name()->as_utf8()));
     // conservatively mark all actual parameters as escaping globally
     for (i = 0; i < arg_size; i++) {
@@ -1326,7 +1334,8 @@ void BCEscapeAnalyzer::compute_escape_info() {
       || _level > MaxBCEAEstimateLevel
       || method()->code_size() > MaxBCEAEstimateSize)) {
     if (BCEATraceLevel >= 1) {
-      tty->print("Skipping method because: ");
+      print_header(level());
+      tty->print("skipping method because: ");
       if (method()->is_abstract())
         tty->print_cr("method is abstract.");
       else if (method()->is_native())
@@ -1348,7 +1357,8 @@ void BCEscapeAnalyzer::compute_escape_info() {
   }
 
   if (BCEATraceLevel >= 1) {
-    tty->print("[EA] estimating escape information for");
+    print_header(level());
+    tty->print("estimating escape information for");
     if (iid != vmIntrinsics::_none)
       tty->print(" intrinsic");
     method()->print_short_name();
@@ -1429,38 +1439,61 @@ void BCEscapeAnalyzer::read_escape_info() {
 }
 
 #ifndef PRODUCT
-void BCEscapeAnalyzer::dump() {
-  tty->print("[EA] estimated escape information for");
-  method()->print_short_name();
-  tty->print_cr(has_dependencies() ? " (not stored)" : "");
-  tty->print("     non-escaping args:      ");
-  _arg_local.print();
-  tty->print("     stack-allocatable args: ");
-  _arg_stack.print();
-  if (_return_local) {
-    tty->print("     returned args:          ");
-    _arg_returned.print();
-  } else if (is_return_allocated()) {
-    tty->print_cr("     return allocated value");
-  } else {
-    tty->print_cr("     return non-local value");
+
+void BCEscapeAnalyzer::dump_arg_set(const VectorSet &set) {
+  tty->print("{");
+  for (int i = 0; i < _arg_size; i++) {
+    if (set.test(i)) {
+      tty->print("%d ", i);
+    }
   }
-  tty->print("     modified args: ");
+  tty->print("}");
+}
+
+void BCEscapeAnalyzer::dump() {
+  print_header(level());
+  tty->print("estimated escape information for");
+  method()->print_short_name();
+  tty->print(has_dependencies() ? " (not stored)" : "");
+  tty->print_cr(_arg_size == 1 ? " (%d arg slot):" : " (%d arg slots):", _arg_size);
+  print_header(level());
+  tty->print("- non-escaping args:      ");
+  dump_arg_set(_arg_local);
+  tty->cr();
+  print_header(level());
+  tty->print("- stack-allocatable args: ");
+  dump_arg_set(_arg_stack);
+  tty->cr();
+  print_header(level());
+  if (_return_local) {
+    tty->print("- returned args:          ");
+    dump_arg_set(_arg_returned);
+    tty->cr();
+  } else if (is_return_allocated()) {
+    tty->print_cr("- return allocated value");
+  } else {
+    tty->print_cr("- return non-local value");
+  }
+  print_header(level());
+  tty->print("- modified args:          ");
+  tty->print("[");
   for (int i = 0; i < _arg_size; i++) {
     if (_arg_modified[i] == 0)
-      tty->print("    0");
+      tty->print("0");
     else
-      tty->print("    0x%x", _arg_modified[i]);
+      tty->print("0x%x", _arg_modified[i]);
+    tty->print(" ");
   }
-  tty->cr();
-  tty->print("     flags: ");
+  tty->print_cr("]");
+  print_header(level());
+  tty->print("- flags:                  {");
   if (_return_allocated)
-    tty->print(" return_allocated");
+    tty->print("return_allocated ");
   if (_allocated_escapes)
-    tty->print(" allocated_escapes");
+    tty->print("allocated_escapes ");
   if (_unknown_modified)
-    tty->print(" unknown_modified");
-  tty->cr();
+    tty->print("unknown_modified ");
+  tty->print_cr("}");
 }
 #endif
 
@@ -1491,15 +1524,14 @@ BCEscapeAnalyzer::BCEscapeAnalyzer(ciMethod* method, BCEscapeAnalyzer* parent)
     if (methodData() == nullptr)
       return;
     if (methodData()->has_escape_info()) {
-      TRACE_BCEA(2, tty->print_cr("[EA] Reading previous results for %s.%s",
-                                  method->holder()->name()->as_utf8(),
+      TRACE_BCEA(2, tty->print_cr("reading previous results for %s::%s",
+                                  method->holder()->name()->as_klass_external_name(),
                                   method->name()->as_utf8()));
       read_escape_info();
     } else {
-      TRACE_BCEA(2, tty->print_cr("[EA] computing results for %s.%s",
-                                  method->holder()->name()->as_utf8(),
+      TRACE_BCEA(2, tty->print_cr("computing results for %s::%s",
+                                  method->holder()->name()->as_klass_external_name(),
                                   method->name()->as_utf8()));
-
       compute_escape_info();
       methodData()->update_escape_info();
     }

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -46,11 +46,11 @@
   #define TRACE_BCEA(level, code)
 #endif
 
+static const int INDENTATION_WIDTH = 4;
+
 static void print_header(int level) {
   tty->print("[EA] ");
-  for (int i = 0; i < level; i++) {
-    tty->print("    ");
-  }
+  tty->sp(INDENTATION_WIDTH * clamp(level, 0, max_jint / INDENTATION_WIDTH));
 }
 
 // Maintain a map of which arguments a local variable or

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -46,7 +46,7 @@
   #define TRACE_BCEA(level, code)
 #endif
 
-static const int INDENTATION_WIDTH = 4;
+static const int INDENTATION_WIDTH = 2;
 
 static void print_header(int level) {
   tty->print("[EA] ");

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,6 +160,8 @@ class BCEscapeAnalyzer : public ArenaObj {
   static bool datasize_overflow(uint numblocks, uint stkSize, uint numLocals, size_t& datasize);
 
 #ifndef PRODUCT
+  // Dump indices within an argument set
+  void dump_arg_set(const VectorSet &set);
   // dump escape information
   void dump();
 #endif


### PR DESCRIPTION
This changeset improves the readability of bytecode-level escape analysis tracing (`-XX:BCEATraceLevel=N`) by:

- indenting entries according to analysis depth (`BCEscapeAnalyzer::_level`),

- dumping the actual argument set contents in `BCEscapeAnalyzer::dump()` (`_arg_local`, `_arg_stack`, `_arg_returned`) instead of current `AnyObj(0x...)` noise,

- printing `[EA]` prefixes consistently in every line, and

- formatting qualified method names consistently using Java style dot-separated class names and `::` to separate class and method (e.g. `java.lang.Integer::<init>`).

Here is an excerpt of how `-XX:BCEATraceLevel=3` looks before the changeset:

```
[EA] computing results for java/lang/Integer.<init>
[EA] estimating escape information for java.lang.Integer::<init> (10 bytes)
[EA] computing results for java/lang/Number.<init>
[EA] estimating escape information for java.lang.Number::<init> (5 bytes)
[EA] computing results for java/lang/Object.<init>
[EA] estimating escape information for java.lang.Object::<init> (1 bytes)
[EA] estimated escape information for java.lang.Object::<init>
     non-escaping args:      AnyObj(0x00007f68b3af6698)
     stack-allocatable args: AnyObj(0x00007f68b3af66d0)
     return non-local value
     modified args:     0
     flags:
[EA] estimated escape information for java.lang.Number::<init>
     non-escaping args:      AnyObj(0x00007f68b3af6ae8)
     stack-allocatable args: AnyObj(0x00007f68b3af6b20)
     return non-local value
     modified args:     0
     flags:
[EA] estimated escape information for java.lang.Integer::<init>
     non-escaping args:      AnyObj(0x00007f68d863e4f8)
     stack-allocatable args: AnyObj(0x00007f68d863e530)
     return non-local value
     modified args:     0x2    0
     flags:
```

And here is how it looks after the changeset:

```
[EA] computing results for java.lang.Integer::<init>
[EA] estimating escape information for java.lang.Integer::<init> (10 bytes)
[EA]     computing results for java.lang.Number::<init>
[EA]     estimating escape information for java.lang.Number::<init> (5 bytes)
[EA]         computing results for java.lang.Object::<init>
[EA]         estimating escape information for java.lang.Object::<init> (1 bytes)
[EA]         estimated escape information for java.lang.Object::<init> (1 arg slot):
[EA]         - non-escaping args:      {0 }
[EA]         - stack-allocatable args: {0 }
[EA]         - return non-local value
[EA]         - modified args:          [0 ]
[EA]         - flags:                  {}
[EA]     estimated escape information for java.lang.Number::<init> (1 arg slot):
[EA]     - non-escaping args:      {}
[EA]     - stack-allocatable args: {0 }
[EA]     - return non-local value
[EA]     - modified args:          [0 ]
[EA]     - flags:                  {}
[EA] estimated escape information for java.lang.Integer::<init> (2 arg slots):
[EA] - non-escaping args:      {}
[EA] - stack-allocatable args: {0 }
[EA] - return non-local value
[EA] - modified args:          [0x2 0 ]
[EA] - flags:                  {}
```

**Testing:** tier1-3 (linux-x64, windows-x64, linux-aarch64, macosx-aarch64).


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392002](https://bugs.openjdk.org/browse/JDK-8392002): Improve BCEscapeAnalyzer tracing readability (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32783/head:pull/32783` \
`$ git checkout pull/32783`

Update a local copy of the PR: \
`$ git checkout pull/32783` \
`$ git pull https://git.openjdk.org/jdk.git pull/32783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32783`

View PR using the GUI difftool: \
`$ git pr show -t 32783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32783.diff">https://git.openjdk.org/jdk/pull/32783.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32783#issuecomment-5600070039)
</details>
