### PR TITLE
8391688: Add test to check that InetAddress.getByName doesn't throw NumberFormatException

### DIFF
--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8272215 8315767 8332686
+ * @bug 8272215 8315767 8332686 8391603
  * @summary Test for ofLiteral, ofPosixLiteral APIs in InetAddress classes
  * @run junit/othervm -Djdk.net.hosts.file=nonExistingHostsFile.txt
  *                     OfLiteralTest
@@ -330,6 +330,18 @@ public class OfLiteralTest {
                 // IPv4 address literal with BSD-formatting
                 Arguments.of(InetAddressClass.INET_ADDRESS, "1.2.3.0256"),
                 Arguments.of(InetAddressClass.INET4_ADDRESS, "1.2.3.0256"),
+
+                // IPv4 with oversized octet
+                Arguments.of(InetAddressClass.INET_ADDRESS, "1.2.256.4"),
+                Arguments.of(InetAddressClass.INET_ADDRESS, "1.2.3.4" + Long.MAX_VALUE),
+                Arguments.of(InetAddressClass.INET4_ADDRESS, "1.2.256.4"),
+                Arguments.of(InetAddressClass.INET4_ADDRESS, "1.2.3.4" + Long.MAX_VALUE),
+
+                // IPv4-mapped IPv6 with oversized IPv4 octet
+                Arguments.of(InetAddressClass.INET_ADDRESS, "::FFFF:1.2.256.4"),
+                Arguments.of(InetAddressClass.INET_ADDRESS, "::FFFF:1.2.3.4" + Long.MAX_VALUE),
+                Arguments.of(InetAddressClass.INET6_ADDRESS, "::FFFF:1.2.256.4"),
+                Arguments.of(InetAddressClass.INET6_ADDRESS, "::FFFF:1.2.3.4" + Long.MAX_VALUE),
 
                 // Invalid IPv4-mapped IPv6 address forms
                 //      ::FFFF:d.d.d

--- a/test/jdk/java/net/ipv6tests/BadIPv6Addresses.java
+++ b/test/jdk/java/net/ipv6tests/BadIPv6Addresses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4742177 8019834
+ * @bug 4742177 8019834 8391603
  * @summary Re-test IPv6 (and specifically MulticastSocket) with latest Linux & USAGI code
  */
 import java.net.*;
@@ -56,6 +56,8 @@ public class BadIPv6Addresses {
             ":::ffff:192.168.0.1",      // with compressed ipv4, too many adjacent :
             "::fffff:192.168.0.1",      // with compressed ipv4, too many ipv6 digits
             "::ffff:1923.168.0.1",      // with compressed ipv4, too many ipv4 digits
+            "::ffff:192.256.0.1",       // with compressed ipv4, oversized ipv4 octet
+            "::ffff:192.168.0.1" + Long.MAX_VALUE,  // with compressed ipv4, oversized ipv4 octet stressing `NumberFormatException`
             ":ffff:192.168.0.1",        // with compressed ipv4, not enough :
             "::ffff:192.168.0.1.2",     // with compressed ipv4, too many .
             "::ffff:192.168.0",         // with compressed ipv4, not enough .


### PR DESCRIPTION
Improve `InetAddress.getByName` et al. test coverage for oversized IPv4 octets, in particular, in IPv4-mapped IPv6 addresses.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391688](https://bugs.openjdk.org/browse/JDK-8391688): Add test to check that InetAddress.getByName doesn't throw NumberFormatException (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32784/head:pull/32784` \
`$ git checkout pull/32784`

Update a local copy of the PR: \
`$ git checkout pull/32784` \
`$ git pull https://git.openjdk.org/jdk.git pull/32784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32784`

View PR using the GUI difftool: \
`$ git pr show -t 32784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32784.diff">https://git.openjdk.org/jdk/pull/32784.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32784#issuecomment-5600081354)
</details>
