### PR TITLE
8392041: RISC-V: TestFloat16ScalarOperations.java fails after JDK-8391717 with fastdebug

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2035,9 +2035,10 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_ReinterpretS2HF:
     case Op_ReinterpretHF2S:
       return UseZfh || UseZfhmin;
+    case Op_FmaHF:
+      return UseFMA && UseZfh;
     case Op_AddHF:
     case Op_DivHF:
-    case Op_FmaHF:
     case Op_MaxHF:
     case Op_MinHF:
     case Op_MulHF:


### PR DESCRIPTION
Hi, I ran `make test TEST="compiler/c2/irTests/TestFloat16ScalarOperations.java"` on RISC-V SG2044 with fastdebug model, and the test failed. 
JDK-8391717 added a `-XX:-UseFMA` scenario to `TestFloat16ScalarOperations`. On RISC-V systems with Zfh support, `Matcher::match_rule_supported(Op_FmaHF)` only checks `UseZfh`.
As a result, C2 considers the Float16 FMA intrinsic supported even when `UseFMA` is disabled and attempts to create an `FmaHFNode`, triggering:
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/zifeihan/jdk/src/hotspot/share/opto/mulnode.hpp:462), pid=1084157, tid=1084178
#  assert(UseFMA) failed: Needs FMA instructions support.
#
```

https://github.com/openjdk/jdk/blob/8857e2c28193ac265cbfbdda8dc0959f9d5538de/src/hotspot/share/opto/mulnode.hpp#L459-L465


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392041](https://bugs.openjdk.org/browse/JDK-8392041): RISC-V: TestFloat16ScalarOperations.java fails after JDK-8391717 with fastdebug (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32785/head:pull/32785` \
`$ git checkout pull/32785`

Update a local copy of the PR: \
`$ git checkout pull/32785` \
`$ git pull https://git.openjdk.org/jdk.git pull/32785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32785`

View PR using the GUI difftool: \
`$ git pr show -t 32785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32785.diff">https://git.openjdk.org/jdk/pull/32785.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32785#issuecomment-5602062204)
</details>
