### PR TITLE
8391687: Add a test to check that java.net.URI doesn't throw NumberFormatException

### DIFF
--- a/test/jdk/java/net/URI/Test.java
+++ b/test/jdk/java/net/URI/Test.java
@@ -25,6 +25,7 @@
  * @summary Unit test for java.net.URI
  * @bug 4464135 4505046 4503239 4438319 4991359 4866303 7023363 7041800
  *      7171415 6339649 6933879 8037396 8272072 8051627 8297687 8353013
+ *      8391603
  * @author Mark Reinhold
  * @run main/othervm Test
  */
@@ -1042,7 +1043,14 @@ public class Test {
         test("http://[1:2:3:4:5:6:7:8:9]").x().z();
         test("http://[1:2:3:4:5:6:7:8%]").x().z();
         test("http://[1:2:3:4:5:6:7:8%!/]").x().z();
+        // Oversized IPv4 octet
         test("http://[::1.2.3.300]").x().z();
+        // Oversized IPv4 octet, stressing NFE
+        test("http://[::1.2.3.4" + Long.MAX_VALUE + "]").x().z();
+        // Oversized IPv4 octet in IPv4-mapped IPv6 address
+        test("http://[::FFFF:1.2.3.300]").x().z();
+        // Oversized IPv4 octet in IPv4-mapped IPv6 address, stressing NFE
+        test("http://[::FFFF:1.2.3.4" + Long.MAX_VALUE + "]").x().z();
         test("http://1.2.3").psa().x().z();
         test("http://1.2.3.300").psa().x().z();
         test("http://1.2.3.4.5").psa().x().z();

--- a/test/jdk/java/net/URI/Test.java
+++ b/test/jdk/java/net/URI/Test.java
@@ -1043,16 +1043,19 @@ public class Test {
         test("http://[1:2:3:4:5:6:7:8:9]").x().z();
         test("http://[1:2:3:4:5:6:7:8%]").x().z();
         test("http://[1:2:3:4:5:6:7:8%!/]").x().z();
-        // Oversized IPv4 octet
+        // Oversized IPv4 octet in IPv4-compatible IPv6 address
         test("http://[::1.2.3.300]").x().z();
-        // Oversized IPv4 octet, stressing NFE
+        // Oversized IPv4 octet in IPv4-compatible IPv6 address, stressing NFE
         test("http://[::1.2.3.4" + Long.MAX_VALUE + "]").x().z();
         // Oversized IPv4 octet in IPv4-mapped IPv6 address
         test("http://[::FFFF:1.2.3.300]").x().z();
         // Oversized IPv4 octet in IPv4-mapped IPv6 address, stressing NFE
         test("http://[::FFFF:1.2.3.4" + Long.MAX_VALUE + "]").x().z();
         test("http://1.2.3").psa().x().z();
+        // Oversized IPv4 octet
         test("http://1.2.3.300").psa().x().z();
+        // Oversized IPv4 octet, stressing NFE
+        test("http://1.2.3.4" + Long.MAX_VALUE).psa().x().z();
         test("http://1.2.3.4.5").psa().x().z();
         test("http://[1.2.3.4:5]").x().z();
         test("http://1:2:3:4:5:6:7:8").psa().x().z();


### PR DESCRIPTION
Improve `java.net.URI` test coverage for oversized IPv4 octets, in particular, in IPv4-mapped IPv6 addresses.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391687](https://bugs.openjdk.org/browse/JDK-8391687): Add a test to check that java.net.URI doesn't throw NumberFormatException (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32786/head:pull/32786` \
`$ git checkout pull/32786`

Update a local copy of the PR: \
`$ git checkout pull/32786` \
`$ git pull https://git.openjdk.org/jdk.git pull/32786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32786`

View PR using the GUI difftool: \
`$ git pr show -t 32786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32786.diff">https://git.openjdk.org/jdk/pull/32786.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32786#issuecomment-5600434950)
</details>
