### PR TITLE
8382938: Jar tool misses difference in superinterfaces in MR-JAR API compatibility check

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.lang.reflect.AccessFlag;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.lang.classfile.AccessFlags;
@@ -179,6 +180,8 @@ final class FingerPrint {
                 cm.flags(),
                 cm.thisClass().asInternalName(),
                 cm.superclass().map(ClassEntry::asInternalName).orElse(null),
+                // TODO cm.isInterface() ? cm.interfaces().stream().map(ClassEntry::asInternalName).toList() : List.of(),
+                cm.interfaces().stream().map(ClassEntry::asInternalName).toList(),
                 cm.majorVersion());
         cm.forEach(attrs);
         return attrs;
@@ -254,6 +257,7 @@ final class FingerPrint {
         private final String name;
         private String outerClassName;
         private final String superName;
+        private final List<String> interfaceNames;
         private final int majorVersion;
         private final int access;
         private final boolean publicClass;
@@ -261,12 +265,13 @@ final class FingerPrint {
         private final Set<Field> fields = new HashSet<>();
         private final Set<Method> methods = new HashSet<>();
 
-        public ClassAttributes(AccessFlags access, String name, String superName, int majorVersion) {
+        public ClassAttributes(AccessFlags access, String name, String superName, List<String> interfaceNames, int majorVersion) {
             this.majorVersion = majorVersion; // JDK-8296329: extract major version only
             this.access = access.flagsMask();
             this.name = name;
             this.maybeNestedClass = name.contains("$");
             this.superName = superName;
+            this.interfaceNames = interfaceNames;
             this.publicClass = isPublic(access);
         }
 
@@ -329,6 +334,7 @@ final class FingerPrint {
                     ? superName.equals(clsAttrs.superName) : true;
             return access == clsAttrs.access
                     && superNameOkay
+                    && interfaceNames.equals(clsAttrs.interfaceNames)
                     && fields.equals(clsAttrs.fields)
                     && methods.equals(clsAttrs.methods);
         }
@@ -338,6 +344,7 @@ final class FingerPrint {
             int result = 17;
             result = 37 * result + access;
             result = 37 * result + superName != null ? superName.hashCode() : 0;
+            result = 37 * result + interfaceNames.hashCode();
             result = 37 * result + fields.hashCode();
             result = 37 * result + methods.hashCode();
             return result;

--- a/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
@@ -181,22 +181,10 @@ final class FingerPrint {
                 cm.flags(),
                 cm.thisClass().asInternalName(),
                 cm.superclass().map(ClassEntry::asInternalName).orElse(null),
-                getInternalNamesOfInterfaces(cm),
+                cm.interfaces().stream().map(ClassEntry::asInternalName).collect(Collectors.toSet()),
                 cm.majorVersion());
         cm.forEach(attrs);
         return attrs;
-    }
-
-    private static Set<String> getInternalNamesOfInterfaces(ClassModel cm) {
-        boolean isInterface = cm.flags().has(AccessFlag.INTERFACE);
-        // only care for names of interfaces extended by an interface
-        if (isInterface) {
-            return cm.interfaces().stream().map(ClassEntry::asInternalName).collect(Collectors.toSet());
-        }
-        // keep existing behavior by ignoring names of interfaces implemented by classes
-        else {
-            return Set.of();
-        }
     }
 
     private static final class Field {

--- a/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
@@ -30,13 +30,14 @@ import java.lang.reflect.AccessFlag;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.lang.classfile.AccessFlags;
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassElement;
 import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
 import java.lang.classfile.constantpool.*;
 import java.lang.classfile.FieldModel;
 import java.lang.classfile.MethodModel;
@@ -175,16 +176,27 @@ final class FingerPrint {
     }
 
     private static ClassAttributes getClassAttributes(byte[] bytes) {
-        var cm = ClassFile.of().parse(bytes);
+        ClassModel cm = ClassFile.of().parse(bytes);
         ClassAttributes attrs = new ClassAttributes(
                 cm.flags(),
                 cm.thisClass().asInternalName(),
                 cm.superclass().map(ClassEntry::asInternalName).orElse(null),
-                // TODO cm.isInterface() ? cm.interfaces().stream().map(ClassEntry::asInternalName).toList() : List.of(),
-                cm.interfaces().stream().map(ClassEntry::asInternalName).toList(),
+                getInternalNamesOfInterfaces(cm),
                 cm.majorVersion());
         cm.forEach(attrs);
         return attrs;
+    }
+
+    private static Set<String> getInternalNamesOfInterfaces(ClassModel cm) {
+        boolean isInterface = cm.flags().has(AccessFlag.INTERFACE);
+        // only care for names of interfaces extended by an interface
+        if (isInterface) {
+            return cm.interfaces().stream().map(ClassEntry::asInternalName).collect(Collectors.toSet());
+        }
+        // keep existing behavior by ignoring names of interfaces implemented by classes
+        else {
+            return Set.of();
+        }
     }
 
     private static final class Field {
@@ -257,7 +269,7 @@ final class FingerPrint {
         private final String name;
         private String outerClassName;
         private final String superName;
-        private final List<String> interfaceNames;
+        private final Set<String> interfaceNames;
         private final int majorVersion;
         private final int access;
         private final boolean publicClass;
@@ -265,7 +277,7 @@ final class FingerPrint {
         private final Set<Field> fields = new HashSet<>();
         private final Set<Method> methods = new HashSet<>();
 
-        public ClassAttributes(AccessFlags access, String name, String superName, List<String> interfaceNames, int majorVersion) {
+        public ClassAttributes(AccessFlags access, String name, String superName, Set<String> interfaceNames, int majorVersion) {
             this.majorVersion = majorVersion; // JDK-8296329: extract major version only
             this.access = access.flagsMask();
             this.name = name;

--- a/test/jdk/tools/jar/ValidatorTest.java
+++ b/test/jdk/tools/jar/ValidatorTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8345431 8375433
+ * @bug 8345431 8375433 8382938
  * @summary test validator to report malformed jar file
  * @run junit/othervm ValidatorTest
  */
@@ -306,6 +306,66 @@ class ValidatorTest {
             for (var entryName : invalidEntryNames) {
                 assertTrue(err.contains("Warning: entry name " + entryName + " is not valid"), "missing warning for " + entryName);
             }
+        }
+    }
+
+    @Test
+    public void testClassWithDifferentExtendsClause() throws Exception {
+        var foo21 = Path.of("21", "Foo.java");
+        Files.createDirectories(foo21.getParent());
+        Files.writeString(foo21,
+                """
+                abstract class Foo extends java.util.AbstractCollection {}
+                """);
+        var foo25 = Path.of("25", "Foo.java");
+        Files.createDirectories(foo25.getParent());
+        Files.writeString(foo25,
+                """
+                abstract class Foo extends java.util.AbstractList {}
+                """);
+        JAVAC_TOOL.run(System.out, System.err, "--release", "21", "-d", "21", foo21.toString());
+        JAVAC_TOOL.run(System.out, System.err, "--release", "25", "-d", "25", foo25.toString());
+        try {
+            jar("--create --file mr.jar -C 21 . --release 25 -C 25 .");
+            fail("Expecting non-zero exit code");
+        } catch (IOException e) {
+            var err = e.getMessage();
+            System.out.println(err);
+            assertLinesMatch(
+                    """
+                    entry: META-INF/versions/25/Foo.class, contains a class with different api from earlier version
+                    invalid multi-release jar file mr.jar deleted
+                    """.lines(), err.lines());
+        }
+    }
+
+    @Test
+    public void testInterfaceWithDifferentExtendsClause() throws Exception {
+        var foo21 = Path.of("21", "Foo.java");
+        Files.createDirectories(foo21.getParent());
+        Files.writeString(foo21,
+                """
+                interface Foo<E> extends java.util.Collection<E> {}
+                """);
+        var foo25 = Path.of("25", "Foo.java");
+        Files.createDirectories(foo25.getParent());
+        Files.writeString(foo25,
+                """
+                interface Foo<E> extends java.util.SequencedCollection<E> {}
+                """);
+        JAVAC_TOOL.run(System.out, System.err, "--release", "21", "-d", "21", foo21.toString());
+        JAVAC_TOOL.run(System.out, System.err, "--release", "25", "-d", "25", foo25.toString());
+        try {
+            jar("--create --file mr.jar -C 21 . --release 25 -C 25 .");
+            fail("Expecting non-zero exit code");
+        } catch (IOException e) {
+            var err = e.getMessage();
+            System.out.println(err);
+            assertLinesMatch(
+                    """
+                    entry: META-INF/versions/25/Foo.class, contains a class with different api from earlier version
+                    invalid multi-release jar file mr.jar deleted
+                    """.lines(), err.lines());
         }
     }
 

--- a/test/jdk/tools/jar/ValidatorTest.java
+++ b/test/jdk/tools/jar/ValidatorTest.java
@@ -33,12 +33,17 @@ import java.io.ByteArrayOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.IOException;
 import java.io.FileInputStream;
@@ -309,64 +314,53 @@ class ValidatorTest {
         }
     }
 
-    @Test
-    public void testClassWithDifferentExtendsClause() throws Exception {
-        var foo21 = Path.of("21", "Foo.java");
+    @ParameterizedTest
+    @MethodSource("superTypeApiCompatCases")
+    public void testSuperTypeApiCompat(String source21, String source25) throws Exception {
+        Path scratch = Path.of("testSuperTypeApiCompat");
+
+        Path foo21 = scratch.resolve("21", "Foo.java");
         Files.createDirectories(foo21.getParent());
-        Files.writeString(foo21,
-                """
-                abstract class Foo extends java.util.AbstractCollection {}
-                """);
-        var foo25 = Path.of("25", "Foo.java");
+        Files.writeString(foo21, source21);
+
+        Path foo25 = scratch.resolve("25", "Foo.java");
         Files.createDirectories(foo25.getParent());
-        Files.writeString(foo25,
-                """
-                abstract class Foo extends java.util.AbstractList {}
-                """);
+        Files.writeString(foo25, source25);
+
         JAVAC_TOOL.run(System.out, System.err, "--release", "21", "-d", "21", foo21.toString());
         JAVAC_TOOL.run(System.out, System.err, "--release", "25", "-d", "25", foo25.toString());
-        try {
-            jar("--create --file mr.jar -C 21 . --release 25 -C 25 .");
-            fail("Expecting non-zero exit code");
-        } catch (IOException e) {
-            var err = e.getMessage();
-            System.out.println(err);
-            assertLinesMatch(
-                    """
-                    entry: META-INF/versions/25/Foo.class, contains a class with different api from earlier version
-                    invalid multi-release jar file mr.jar deleted
-                    """.lines(), err.lines());
-        }
+
+        IOException e = assertThrows(IOException.class,
+                () -> jar("--create --file mr.jar -C 21 . --release 25 -C 25 ."));
+        assertLinesMatch("""
+                entry: META-INF/versions/25/Foo.class, contains a class with different api from earlier version
+                invalid multi-release jar file mr.jar deleted
+                """.lines(), e.getMessage().lines());
     }
 
-    @Test
-    public void testInterfaceWithDifferentExtendsClause() throws Exception {
-        var foo21 = Path.of("21", "Foo.java");
-        Files.createDirectories(foo21.getParent());
-        Files.writeString(foo21,
+    static Stream<Arguments> superTypeApiCompatCases() {
+        return Stream.of(
+            arguments(
+                """
+                abstract class Foo extends java.util.AbstractCollection {}
+                """,
+                """
+                abstract class Foo extends java.util.AbstractList {}
+                """),
+            arguments(
+                """
+                abstract class Foo implements java.util.List<String> {}
+                """,
+                """
+                abstract class Foo implements java.util.Set<String> {}
+                """),
+            arguments(
                 """
                 interface Foo<E> extends java.util.Collection<E> {}
-                """);
-        var foo25 = Path.of("25", "Foo.java");
-        Files.createDirectories(foo25.getParent());
-        Files.writeString(foo25,
+                """,
                 """
                 interface Foo<E> extends java.util.SequencedCollection<E> {}
-                """);
-        JAVAC_TOOL.run(System.out, System.err, "--release", "21", "-d", "21", foo21.toString());
-        JAVAC_TOOL.run(System.out, System.err, "--release", "25", "-d", "25", foo25.toString());
-        try {
-            jar("--create --file mr.jar -C 21 . --release 25 -C 25 .");
-            fail("Expecting non-zero exit code");
-        } catch (IOException e) {
-            var err = e.getMessage();
-            System.out.println(err);
-            assertLinesMatch(
-                    """
-                    entry: META-INF/versions/25/Foo.class, contains a class with different api from earlier version
-                    invalid multi-release jar file mr.jar deleted
-                    """.lines(), err.lines());
-        }
+                """));
     }
 
     @Test


### PR DESCRIPTION
Consider this set of classes:

```
interface I1 { void m(); }
interface I2 { void m(); }
```
```
class Widget implements I1 { // version 1
    @Override
    public void m() {}
}
```
```
class Widget implements I2 { // version 2
    @Override
    public void m() {}
}
```

The current jar tool validator, which checks if different versions of a class in a multi-release jar file have the same API, will accept the above two versions of `Widget` as valid, given that they both have a method called `m` with the same signature.

However, when version 2 of the Widget class is loaded by code that was compiled against version 1, we can run into problems:

```
I1 x = new Widget(); // 1
System.out.println(x instanceof I1); // 2
x.m(); // 3
```

Depending on the implementation of the verifier, the assignment on line (1) will succeed and cause heap pollution. The print statement on line (2) will print `false`, even though the type of `x` is `I1`, and the method call on line (3) will fail with an `IncompatibleClassChangeError`.

Clearly, version 1 and 2 of the `Widget` class are incompatible, but the current jar file validator doesn't catch this because it ignores super interfaces.

This patch adds a check for the super interfaces of a type to the validator as well, to catch cases like these.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] Change requires CSR request [JDK-8388125](https://bugs.openjdk.org/browse/JDK-8388125) to be approved
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8382938](https://bugs.openjdk.org/browse/JDK-8382938): Jar tool misses difference in superinterfaces in MR-JAR API compatibility check (**Bug** - P4)
 * [JDK-8388125](https://bugs.openjdk.org/browse/JDK-8388125): Jar tool misses difference in superinterfaces in MR-JAR API compatibility check (**CSR**)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Contributors
 * Christian Stein `<cstein@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32787/head:pull/32787` \
`$ git checkout pull/32787`

Update a local copy of the PR: \
`$ git checkout pull/32787` \
`$ git pull https://git.openjdk.org/jdk.git pull/32787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32787`

View PR using the GUI difftool: \
`$ git pr show -t 32787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32787.diff">https://git.openjdk.org/jdk/pull/32787.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32787#issuecomment-5602121340)
</details>
