### PR TITLE
8392031: Crash in ThreadSnapshot::initialize

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1345,8 +1345,9 @@ void JavaThread::print_on(outputStream *st, bool print_extended_info) const {
   // print guess for valid stack memory region (assume 4K pages); helps lock debugging
   st->print_cr("[" INTPTR_FORMAT "]", (intptr_t)last_Java_sp() & ~right_n_bits(12));
   if (thread_oop != nullptr) {
-    if (is_vthread_mounted()) {
-      st->print_cr("   Carrying virtual thread #" INT64_FORMAT, java_lang_Thread::thread_id(vthread()));
+    oop vthread_oop = vthread();
+    if (java_lang_VirtualThread::is_instance(vthread_oop)) {
+      st->print_cr("   Carrying virtual thread #" INT64_FORMAT, java_lang_Thread::thread_id(vthread_oop));
     } else {
       st->print_cr("   java.lang.Thread.State: %s", java_lang_Thread::thread_status_name(thread_oop));
     }

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -175,6 +175,9 @@ bool JavaThread::is_vthread_mounted() const {
 }
 
 const ContinuationEntry* JavaThread::vthread_continuation() const {
+  assert(is_handshake_safe_for(Thread::current()) ||
+         SafepointSynchronize::is_at_safepoint()
+         JVMTI_ONLY(|| JavaThread::current()->is_vthread_transition_disabler()), "");
   for (ContinuationEntry* c = last_continuation(); c != nullptr; c = c->parent()) {
     if (c->is_virtual_thread())
       return c;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -494,7 +494,7 @@ void Thread::print_on(outputStream* st, bool print_extended_info) const {
     }
 
     st->print("tid=" INTPTR_FORMAT " ", p2i(this));
-    if (!is_Java_thread() || !JavaThread::cast(this)->is_vthread_mounted()) {
+    if (!is_Java_thread() || !java_lang_VirtualThread::is_instance(JavaThread::cast(this)->vthread())) {
       osthread()->print_on(st);
     }
   }

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -917,7 +917,7 @@ void ThreadSnapshot::initialize(ThreadsList * t_list, JavaThread* thread) {
   oop blocker_object_owner = nullptr;
 
   oop vthread = thread->vthread();
-  if (vthread != nullptr && vthread != threadObj) { // ThreadSnapshot only captures platform threads
+  if (java_lang_VirtualThread::is_instance(vthread)) { // ThreadSnapshot only captures platform threads
     _thread_status = JavaThreadStatus::IN_OBJECT_WAIT;
     blocker_object = vthread;
     blocker_object_owner = vthread;

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -916,10 +916,9 @@ void ThreadSnapshot::initialize(ThreadsList * t_list, JavaThread* thread) {
   oop blocker_object = nullptr;
   oop blocker_object_owner = nullptr;
 
-  if (thread->is_vthread_mounted() && thread->vthread() != threadObj) { // ThreadSnapshot only captures platform threads
+  oop vthread = thread->vthread();
+  if (vthread != nullptr && vthread != threadObj) { // ThreadSnapshot only captures platform threads
     _thread_status = JavaThreadStatus::IN_OBJECT_WAIT;
-    oop vthread = thread->vthread();
-    assert(vthread != nullptr, "");
     blocker_object = vthread;
     blocker_object_owner = vthread;
   } else if (_thread_status == JavaThreadStatus::BLOCKED_ON_MONITOR_ENTER ||

--- a/test/hotspot/jtreg/serviceability/threads/ThreadSnapshotRaceTest.java
+++ b/test/hotspot/jtreg/serviceability/threads/ThreadSnapshotRaceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+/*
+ * @test
+ * @bug 8392031
+ * @summary Make sure that ThreadSnapshot::initialize does not crash JVM
+ * @library /test/lib
+ * @modules java.management
+ * @run main/othervm -Djdk.virtualThreadScheduler.parallelism=8 ThreadSnapshotRaceTest
+ */
+public class ThreadSnapshotRaceTest {
+
+    public static void main(String[] args) throws Exception {
+        Thread producer = new Thread(() -> {
+            AtomicLong counter = new AtomicLong();
+            long total = 0;
+            while (true) {
+                long c = counter.incrementAndGet();
+                total++;
+                Thread.ofVirtual().name("vthread").start(() -> {
+                    counter.decrementAndGet();
+                });
+                if (c >= 20_000_000) {
+                    do {
+                        try {
+                            Thread.sleep(50);
+                        } catch (Exception e) {
+                        }
+                    } while (counter.get() > 0);
+                }
+            }
+        });
+        producer.start();
+
+        Thread.sleep(1000);
+
+        Thread consumer = new Thread(() -> {
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            long[] ids = carrierIds(bean);
+            while (true) {
+                ThreadInfo[] infos = bean.getThreadInfo(ids);
+                assertTrue(infos.length > 0);
+            }
+        });
+        consumer.start();
+
+        Thread.sleep(10_000);
+    }
+
+    static long[] carrierIds(ThreadMXBean bean) {
+        long[] all = bean.getAllThreadIds();
+        long[] carriers = Arrays.stream(bean.getThreadInfo(all))
+                .filter(Objects::nonNull)
+                .filter(ti -> ti.getThreadName().startsWith("ForkJoinPool-1-worker"))
+                .mapToLong(ThreadInfo::getThreadId)
+                .toArray();
+        return carriers;
+    }
+}

--- a/test/hotspot/jtreg/serviceability/threads/ThreadSnapshotRaceTest.java
+++ b/test/hotspot/jtreg/serviceability/threads/ThreadSnapshotRaceTest.java
@@ -34,40 +34,43 @@ import static jdk.test.lib.Asserts.assertTrue;
  * @test
  * @bug 8392031
  * @summary Make sure that ThreadSnapshot::initialize does not crash JVM
+ * @requires vm.continuations
  * @library /test/lib
  * @modules java.management
  * @run main/othervm -Djdk.virtualThreadScheduler.parallelism=8 ThreadSnapshotRaceTest
  */
 public class ThreadSnapshotRaceTest {
 
+    private static volatile boolean SHOULD_STOP = false;
+
     public static void main(String[] args) throws Exception {
+
         Thread producer = new Thread(() -> {
             AtomicLong counter = new AtomicLong();
-            long total = 0;
-            while (true) {
+            while (!SHOULD_STOP) {
                 long c = counter.incrementAndGet();
-                total++;
                 Thread.ofVirtual().name("vthread").start(() -> {
                     counter.decrementAndGet();
                 });
-                if (c >= 20_000_000) {
+                if (c >= 1_000_000) {
                     do {
                         try {
                             Thread.sleep(50);
                         } catch (Exception e) {
                         }
-                    } while (counter.get() > 0);
+                    } while (!SHOULD_STOP && counter.get() > 0);
                 }
             }
         });
         producer.start();
 
-        Thread.sleep(1000);
-
         Thread consumer = new Thread(() -> {
             ThreadMXBean bean = ManagementFactory.getThreadMXBean();
             long[] ids = carrierIds(bean);
-            while (true) {
+            while (!SHOULD_STOP && ids.length == 0) {
+                ids = carrierIds(bean);
+            }
+            while (!SHOULD_STOP) {
                 ThreadInfo[] infos = bean.getThreadInfo(ids);
                 assertTrue(infos.length > 0);
             }
@@ -75,6 +78,9 @@ public class ThreadSnapshotRaceTest {
         consumer.start();
 
         Thread.sleep(10_000);
+        SHOULD_STOP = true;
+        consumer.join();
+        producer.join();
     }
 
     static long[] carrierIds(ThreadMXBean bean) {


### PR DESCRIPTION
Hi,

Please help review this change that fixes crash in ThreadSnapshot::initialize.

After [JDK-8323792](https://bugs.openjdk.org/browse/JDK-8323792), we can still see the same crash reported in [JDK-8374820](https://bugs.openjdk.org/browse/JDK-8374820) and [JDK-8346980](https://bugs.openjdk.org/browse/JDK-8346980).

Here is a reproducer:

```
import java.lang.management.ManagementFactory;
import java.lang.management.ThreadInfo;
import java.lang.management.ThreadMXBean;
import java.util.Arrays;
import java.util.Objects;
import java.util.concurrent.atomic.AtomicLong;
import java.util.concurrent.locks.LockSupport;

public class ThreadSnapshotRace {

    public static void main(String[] args) throws Exception {
        Thread producer = new Thread(() -> {
            AtomicLong counter = new AtomicLong();
            long total = 0;
            while (true) {
                long c = counter.incrementAndGet();
                total++;
                Thread.ofVirtual().name("vthread").start(() -> {
                    counter.decrementAndGet(); 
                });
                if (total % 10_000_000 == 0) {
                    System.out.println(total);
                }
                if (c >= 20_000_000) {
                    do {
                        try {
                            Thread.sleep(50);
                        } catch (Exception e) {
                        }
                    } while (counter.get() > 0);
                }
            }
        });
        producer.start();

        Thread.sleep(1000);

        Thread consumer = new Thread(() -> {
            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
            long[] ids = carrierIds(bean);
            while (true) {
                ThreadInfo[] infos = bean.getThreadInfo(ids);
                if (infos.length == 0) {
                    System.out.println("?");
                }
            }
        });
        consumer.start();
    }

    static long[] carrierIds(ThreadMXBean bean) {
        long[] all = bean.getAllThreadIds();
        long[] carriers = Arrays.stream(bean.getThreadInfo(all))
                .filter(Objects::nonNull)
                .filter(ti -> ti.getThreadName().startsWith("ForkJoinPool-1-worker"))
                .mapToLong(ThreadInfo::getThreadId)
                .toArray();
        return carriers;
    }
}

```

Run with `java -Djdk.virtualThreadScheduler.parallelism=8 ThreadSnapshotRace`. Crash occurs for a few minutes.

IIUC, the root cause is that there is a race between `JavaThread::vthread_continuation` and writer of `ContinuationEntry` list.

This change removes the call to `thread->is_vthread_mounted()` and relies `thread->vthread()` only.

Tests:
- [x] TEST="jdk_management jdk_loom" on Linux x64 (release & fastdebug)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392031](https://bugs.openjdk.org/browse/JDK-8392031): Crash in ThreadSnapshot::initialize (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32788/head:pull/32788` \
`$ git checkout pull/32788`

Update a local copy of the PR: \
`$ git checkout pull/32788` \
`$ git pull https://git.openjdk.org/jdk.git pull/32788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32788`

View PR using the GUI difftool: \
`$ git pr show -t 32788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32788.diff">https://git.openjdk.org/jdk/pull/32788.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32788#issuecomment-5601607654)
</details>
