### PR TITLE
8389627: Overflow in AbstractMemorySegmentImpl.copy leads to wrong behavior

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -651,7 +651,12 @@ public abstract sealed class AbstractMemorySegmentImpl
         if (!dstImpl.isAlignedForElement(dstOffset, dstElementLayout)) {
             throw new IllegalArgumentException("Destination segment incompatible with alignment constraints");
         }
-        long size = elementCount * srcElementLayout.byteSize();
+        final long size;
+        try {
+            size = Math.multiplyExact(elementCount, srcElementLayout.byteSize());
+        } catch (ArithmeticException _) {
+            throw new IndexOutOfBoundsException("Illegal elementCount for " + srcElementLayout + ": " + elementCount);
+        }
         srcImpl.checkAccess(srcOffset, size, true);
         dstImpl.checkAccess(dstOffset, size, false);
         if (srcElementLayout.byteSize() == 1 || srcElementLayout.order() == dstElementLayout.order()) {

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -48,11 +48,9 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterator;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -640,34 +638,56 @@ public abstract sealed class AbstractMemorySegmentImpl
         Utils.checkNonNegativeIndex(elementCount, "elementCount");
         AbstractMemorySegmentImpl srcImpl = (AbstractMemorySegmentImpl)srcSegment;
         AbstractMemorySegmentImpl dstImpl = (AbstractMemorySegmentImpl)dstSegment;
-        if (srcElementLayout.byteSize() != dstElementLayout.byteSize()) {
-            throw new IllegalArgumentException("Source and destination layouts must have same size");
+        long elementSize = srcElementLayout.byteSize();
+        if (elementSize != dstElementLayout.byteSize()) {
+            throw illegalArgument("Source and destination layouts must have same size");
         }
-        Utils.checkElementAlignment(srcElementLayout, "Source layout alignment greater than its size");
-        Utils.checkElementAlignment(dstElementLayout, "Destination layout alignment greater than its size");
+        if (!Utils.isElementAligned(srcElementLayout)) {
+            throw illegalArgument("Source layout alignment greater than its size");
+        }
+        if (!Utils.isElementAligned(dstElementLayout)) {
+            throw illegalArgument("Destination layout alignment greater than its size");
+        }
         if (!srcImpl.isAlignedForElement(srcOffset, srcElementLayout)) {
-            throw new IllegalArgumentException("Source segment incompatible with alignment constraints");
+            throw illegalArgument("Source segment incompatible with alignment constraints");
         }
         if (!dstImpl.isAlignedForElement(dstOffset, dstElementLayout)) {
-            throw new IllegalArgumentException("Destination segment incompatible with alignment constraints");
+            throw illegalArgument("Destination segment incompatible with alignment constraints");
         }
         final long size;
         try {
-            size = Math.multiplyExact(elementCount, srcElementLayout.byteSize());
+            size = Math.multiplyExact(elementCount, elementSize);
         } catch (ArithmeticException _) {
-            throw new IndexOutOfBoundsException("Illegal elementCount for " + srcElementLayout + ": " + elementCount);
+            throw overflowingElementCount(srcElementLayout, elementCount);
         }
         srcImpl.checkAccess(srcOffset, size, true);
         dstImpl.checkAccess(dstOffset, size, false);
-        if (srcElementLayout.byteSize() == 1 || srcElementLayout.order() == dstElementLayout.order()) {
-            ScopedMemoryAccess.getScopedMemoryAccess().copyMemory(srcImpl.sessionImpl(), dstImpl.sessionImpl(),
-                    srcImpl.unsafeGetBase(), srcImpl.unsafeGetOffset() + srcOffset,
-                    dstImpl.unsafeGetBase(), dstImpl.unsafeGetOffset() + dstOffset, size);
-        } else {
-            ScopedMemoryAccess.getScopedMemoryAccess().copySwapMemory(srcImpl.sessionImpl(), dstImpl.sessionImpl(),
-                    srcImpl.unsafeGetBase(), srcImpl.unsafeGetOffset() + srcOffset,
-                    dstImpl.unsafeGetBase(), dstImpl.unsafeGetOffset() + dstOffset, size, srcElementLayout.byteSize());
+        if (elementSize != 1 && srcElementLayout.order() != dstElementLayout.order()) {
+            copySwapMemory(srcImpl, srcOffset, dstImpl, dstOffset, size, elementSize);
+            return;
         }
+        ScopedMemoryAccess.getScopedMemoryAccess().copyMemory(srcImpl.sessionImpl(), dstImpl.sessionImpl(),
+                srcImpl.unsafeGetBase(), srcImpl.unsafeGetOffset() + srcOffset,
+                dstImpl.unsafeGetBase(), dstImpl.unsafeGetOffset() + dstOffset, size);
+    }
+
+    @DontInline
+    private static IllegalArgumentException illegalArgument(String message) {
+        return new IllegalArgumentException(message);
+    }
+
+    @DontInline
+    private static IndexOutOfBoundsException overflowingElementCount(ValueLayout elementLayout, long elementCount) {
+        return new IndexOutOfBoundsException("Illegal elementCount for " + elementLayout + ": " + elementCount);
+    }
+
+    // Leave it up to C2 to decide inlining of this method.
+    private static void copySwapMemory(AbstractMemorySegmentImpl srcImpl, long srcOffset,
+                                       AbstractMemorySegmentImpl dstImpl, long dstOffset,
+                                       long size, long elementSize) {
+        ScopedMemoryAccess.getScopedMemoryAccess().copySwapMemory(srcImpl.sessionImpl(), dstImpl.sessionImpl(),
+                srcImpl.unsafeGetBase(), srcImpl.unsafeGetOffset() + srcOffset,
+                dstImpl.unsafeGetBase(), dstImpl.unsafeGetOffset() + dstOffset, size, elementSize);
     }
 
     @ForceInline
@@ -682,7 +702,7 @@ public abstract sealed class AbstractMemorySegmentImpl
         AbstractMemorySegmentImpl srcImpl = (AbstractMemorySegmentImpl)srcSegment;
         Utils.checkElementAlignment(srcLayout, "Source layout alignment greater than its size");
         if (!srcImpl.isAlignedForElement(srcOffset, srcLayout)) {
-            throw new IllegalArgumentException("Source segment incompatible with alignment constraints");
+            throw illegalArgument("Source segment incompatible with alignment constraints");
         }
         srcImpl.checkAccess(srcOffset, elementCount * dstInfo.scale(), true);
         Objects.checkFromIndexSize(dstIndex, elementCount, Array.getLength(dstArray));
@@ -709,7 +729,7 @@ public abstract sealed class AbstractMemorySegmentImpl
         AbstractMemorySegmentImpl destImpl = (AbstractMemorySegmentImpl)dstSegment;
         Utils.checkElementAlignment(dstLayout, "Destination layout alignment greater than its size");
         if (!destImpl.isAlignedForElement(dstOffset, dstLayout)) {
-            throw new IllegalArgumentException("Destination segment incompatible with alignment constraints");
+            throw illegalArgument("Destination segment incompatible with alignment constraints");
         }
         destImpl.checkAccess(dstOffset, elementCount * srcInfo.scale(), false);
         if (srcInfo.scale() == 1 || dstLayout.order() == ByteOrder.nativeOrder()) {

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package jdk.internal.foreign;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.misc.Unsafe;
+import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import sun.invoke.util.Wrapper;
 
@@ -259,8 +260,13 @@ public final class Utils {
     @ForceInline
     public static void checkNonNegativeIndex(long value, String name) {
         if (value < 0) {
-            throw new IndexOutOfBoundsException("The provided " + name + " is negative: " + value);
+            throw indexOutOfBounds(value, name);
         }
+    }
+
+    @DontInline
+    private static IndexOutOfBoundsException indexOutOfBounds(long value, String name) {
+        return new IndexOutOfBoundsException("The provided " + name + " is negative: " + value);
     }
 
     private static long computePadding(long offset, long align) {

--- a/test/jdk/java/foreign/TestSegmentCopy.java
+++ b/test/jdk/java/foreign/TestSegmentCopy.java
@@ -39,7 +39,6 @@ import java.util.function.IntFunction;
 
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
-
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Assumptions;
@@ -329,8 +328,9 @@ public class TestSegmentCopy {
     void testCopyOverflow() {
         MemorySegment segment = MemorySegment.ofArray(new long[1]);
         long elementCount = 1L << 61;
-        var x = assertThrows(IndexOutOfBoundsException.class, () ->MemorySegment.copy(segment, JAVA_LONG, 0, segment, JAVA_LONG, 0, elementCount));
-        assertEquals("Illegal elementCount for " + JAVA_LONG + ": " + elementCount,  x.getMessage());
+        var x = assertThrows(IndexOutOfBoundsException.class, () ->
+                MemorySegment.copy(segment, JAVA_LONG, 0, segment, JAVA_LONG, 0, elementCount));
+        assertEquals("Illegal elementCount for " + JAVA_LONG + ": " + elementCount, x.getMessage());
     }
 
     enum Type {

--- a/test/jdk/java/foreign/TestSegmentCopy.java
+++ b/test/jdk/java/foreign/TestSegmentCopy.java
@@ -40,6 +40,7 @@ import java.util.function.IntFunction;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -322,6 +323,14 @@ public class TestSegmentCopy {
         assertThrows(IndexOutOfBoundsException.class, () ->
                 MemorySegment.copy(src, 0, dst, JAVA_BYTE, 0, -1)
         );
+    }
+
+    @Test
+    void testCopyOverflow() {
+        MemorySegment segment = MemorySegment.ofArray(new long[1]);
+        long elementCount = 1L << 61;
+        var x = assertThrows(IndexOutOfBoundsException.class, () ->MemorySegment.copy(segment, JAVA_LONG, 0, segment, JAVA_LONG, 0, elementCount));
+        assertEquals("Illegal elementCount for " + JAVA_LONG + ": " + elementCount,  x.getMessage());
     }
 
     enum Type {


### PR DESCRIPTION
This PR proposes to fix a bug when dealing with overflows in one of the `AMSI::copy` overloads.

The PR further proposes to relieve the inlining pressure by consolidating exception suppliers into separate static methods.

Additionally, a reproducing test is proposed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389627](https://bugs.openjdk.org/browse/JDK-8389627): Overflow in AbstractMemorySegmentImpl.copy leads to wrong behavior (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32790/head:pull/32790` \
`$ git checkout pull/32790`

Update a local copy of the PR: \
`$ git checkout pull/32790` \
`$ git pull https://git.openjdk.org/jdk.git pull/32790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32790`

View PR using the GUI difftool: \
`$ git pr show -t 32790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32790.diff">https://git.openjdk.org/jdk/pull/32790.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32790#issuecomment-5602064152)
</details>
