### PR TITLE
8365968: Error in FFM tests due to swallowing exception

### DIFF
--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -333,6 +333,7 @@ public class TestByteBuffer {
                 } catch (IOException e) {
                     assumeFalse(e.getMessage().equals("Function not implemented"),
                             e.getMessage());
+                    throw e;
                 } finally {
                     if (arena.scope() != Arena.global().scope()) {
                         arena.close();
@@ -365,6 +366,7 @@ public class TestByteBuffer {
         } catch(IOException e) {
             assumeFalse(e.getMessage().equals("Function not implemented"),
                     e.getMessage());
+            throw e;
         }
     }
 


### PR DESCRIPTION
This PR proposes throwing exceptions rather than swallowing them in two tests in `TestByteBuffer`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8365968](https://bugs.openjdk.org/browse/JDK-8365968): Error in FFM tests due to swallowing exception (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32791/head:pull/32791` \
`$ git checkout pull/32791`

Update a local copy of the PR: \
`$ git checkout pull/32791` \
`$ git pull https://git.openjdk.org/jdk.git pull/32791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32791`

View PR using the GUI difftool: \
`$ git pr show -t 32791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32791.diff">https://git.openjdk.org/jdk/pull/32791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32791#issuecomment-5602646143)
</details>
