### PR TITLE
8392080: RISC-V: Remove unnecessary restrictions on CAS membar elision

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1066,8 +1066,6 @@ public:
 
 bool is_CAS(int opcode, bool maybe_volatile);
 
-// predicate controlling emit of fence before and after CAS
-bool cas_membar_elidable(int opcode);
 bool unnecessary_acquire(const Node *barrier);
 bool unnecessary_release(const Node *barrier);
 
@@ -1179,83 +1177,6 @@ bool is_CAS(int opcode, bool maybe_volatile)
   }
 }
 
-// predicates controlling emit of fence before and after CAS
-
-// Return true if the leading MemBarRelease and trailing MemBarAcquire around a
-// CAS-like LoadStore node may be elided, that is if the node is matched to a
-// single AMO instruction carrying both the aq and rl annotations:
-// amoswap/amoadd/amocas with .aqrl.
-//
-// Such an AMO is fully-ordered under RVWMO: PPO rule 5 orders it, including
-// its store, before every subsequent memory access, and PPO rule 6 orders
-// every preceding access before it. That subsumes both membars.
-//
-// An LR/SC based CAS is weaker. lr.aq + sc.rl only provides release-acquire,
-// not a sequentially consistent read-modify-write: the aq annotation sits on
-// the LR, so PPO rule 5 orders the *load* before later accesses, while the rl
-// annotation sits on the SC, so PPO rule 6 only orders earlier accesses before
-// the *store*. Nothing orders the SC's store before a subsequent load, so that
-// store may still be buffered when a load of an unrelated address is
-// satisfied.
-//
-// Emitting the membars does not supply that missing StoreLoad edge either,
-// since MemBarAcquire lowers to `fence r,rw`, whose predecessor set holds only
-// reads. Java code that needs the edge has to request it explicitly, and code
-// which fails to do so can lose a wakeup; see JDK-8387644. Elision is
-// nevertheless restricted here to the fully-ordered AMO forms, so that the
-// LR/SC path keeps the strength it had before the membars started being
-// elided. The leading MemBarRelease on its own would be safe to elide for
-// LR/SC too, since the rl annotation on the SC covers it by PPO rule 6, but
-// both are gated together to keep the two predicates symmetric.
-//
-// Whether the aq annotation is actually set is decided per node by
-// needs_acquiring_load_reserved(), which selects the *Acq instruct variants.
-// It holds for every opcode listed below on the paths reaching the two callers,
-// which assert as much.
-bool cas_membar_elidable(int opcode)
-{
-  assert(is_CAS(opcode, true), "expecting a compare and swap");
-
-  switch (opcode) {
-    // Always matched to the acquiring variant, hence amoswap/amoadd.aqrl.
-    case Op_GetAndSetI:
-    case Op_GetAndSetL:
-    case Op_GetAndSetP:
-    case Op_GetAndSetN:
-    case Op_GetAndAddI:
-    case Op_GetAndAddL:
-      return true;
-    // Matched to amocas.{w|d}.aqrl only when Zacas is available.
-    case Op_CompareAndSwapI:
-    case Op_CompareAndSwapL:
-    case Op_CompareAndSwapP:
-    case Op_CompareAndSwapN:
-    case Op_CompareAndExchangeI:
-    case Op_CompareAndExchangeL:
-    case Op_CompareAndExchangeP:
-    case Op_CompareAndExchangeN:
-    case Op_WeakCompareAndSwapI:
-    case Op_WeakCompareAndSwapL:
-    case Op_WeakCompareAndSwapP:
-    case Op_WeakCompareAndSwapN:
-      return UseZacas;
-    // Sub-word forms additionally require Zabha for amocas.{b|h}. Without it
-    // they are open coded around a narrow lr.w/sc.w or amocas.w, see
-    // cmpxchg_narrow_value(). The Zacas variant of that sequence can leave
-    // through its failure path having executed nothing but a plain lw, so it
-    // carries no ordering at all and its membars must be kept.
-    case Op_CompareAndSwapB:
-    case Op_CompareAndSwapS:
-    case Op_CompareAndExchangeB:
-    case Op_CompareAndExchangeS:
-    case Op_WeakCompareAndSwapB:
-    case Op_WeakCompareAndSwapS:
-      return UseZacas && UseZabha;
-    default:
-      return false;
-  }
-}
-
 bool unnecessary_acquire(const Node *barrier)
 {
   assert(barrier->is_MemBar(), "expecting a membar");
@@ -1272,7 +1193,7 @@ bool unnecessary_acquire(const Node *barrier)
   if (mb->trailing_load_store()) {
     Node* load_store = mb->in(MemBarNode::Precedent);
     assert(load_store->is_LoadStore(), "unexpected graph shape");
-    return cas_membar_elidable(load_store->Opcode());
+    return is_CAS(load_store->Opcode(), true);
   }
 
   return false;
@@ -1305,7 +1226,7 @@ bool unnecessary_release(const Node *barrier)
     } else {
       assert(mem->is_LoadStore(), "");
       assert(trailing_mb->Opcode() == Op_MemBarAcquire, "");
-      return cas_membar_elidable(mem->Opcode());
+      return is_CAS(mem->Opcode(), true);
     }
   }
   return false;


### PR DESCRIPTION
This is a follow-up to JDK-8387725, which conservatively limits C2 CAS membar elision to fully ordered AMO implementations.
The intended change is to extend membar elision to CAS operations implemented with `lr.aq`/`sc.rl` once the ordering issue tracked by JDK-8386428 has been resolved.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392080](https://bugs.openjdk.org/browse/JDK-8392080): RISC-V: Remove unnecessary restrictions on CAS membar elision (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32792/head:pull/32792` \
`$ git checkout pull/32792`

Update a local copy of the PR: \
`$ git checkout pull/32792` \
`$ git pull https://git.openjdk.org/jdk.git pull/32792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32792`

View PR using the GUI difftool: \
`$ git pr show -t 32792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32792.diff">https://git.openjdk.org/jdk/pull/32792.diff</a>

</details>
