### PR TITLE
8392079: ConcurrentSkipListMap.lowerKey() has non-linearizable outcomes 

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -912,6 +912,8 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     if ((n = b.next) == null) {
                         if (b.key == null) // empty
                             break outer;
+                        else if (b.val == null)
+                            break;
                         else
                             return b;
                     }
@@ -1023,8 +1025,16 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
             for (;;) {
                 Node<K,V> n; K k; int c;
                 if ((n = b.next) == null) {
-                    result = ((rel & LT) != 0 && b.key != null) ? b : null;
-                    break outer;
+                    if ((rel & LT) == 0 || b.key == null) {
+                        result = null;
+                        break outer;
+                    }
+                    else if (b.val == null)
+                        break;
+                    else {
+                        result = b;
+                        break outer;
+                    }
                 }
                 else if ((k = n.key) == null)
                     break;
@@ -1036,8 +1046,16 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                     break outer;
                 }
                 else if (c <= 0 && (rel & LT) != 0) {
-                    result = (b.key != null) ? b : null;
-                    break outer;
+                    if (b.key == null) {
+                        result = null;
+                        break outer;
+                    }
+                    else if (b.val == null)
+                        break;
+                    else {
+                        result = b;
+                        break outer;
+                    }
                 }
                 else
                     b = n;
@@ -2632,13 +2650,8 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                 }
                 return null;
             }
-            for (;;) {
-                Node<K,V> n = m.findNear(key, rel, cmp);
-                if (n == null || !inBounds(n.key, cmp))
-                    return null;
-                if (n.val != null)
-                    return n.key;
-            }
+            Node<K,V> n = m.findNear(key, rel, cmp);
+            return (n == null || !inBounds(n.key, cmp)) ? null : n.key;
         }
 
         /* ----------------  Map API methods -------------- */


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392079](https://bugs.openjdk.org/browse/JDK-8392079): ConcurrentSkipListMap.lowerKey() has non-linearizable outcomes (**Bug** - P3)


### Reviewers
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32793/head:pull/32793` \
`$ git checkout pull/32793`

Update a local copy of the PR: \
`$ git checkout pull/32793` \
`$ git pull https://git.openjdk.org/jdk.git pull/32793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32793`

View PR using the GUI difftool: \
`$ git pr show -t 32793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32793.diff">https://git.openjdk.org/jdk/pull/32793.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32793#issuecomment-5666705931)
</details>
