### PR TITLE
8390747: C2: Improve VerifyIterativeGVN flag description

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -743,7 +743,7 @@
           range(1, 100)                                                     \
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \
-          "Verify Iterative Global Value Numbering. Set the corresponding"  \
+          "Verify Iterative Global Value Numbering. Set the corresponding " \
           "decimal place to 1 to enable a check, or 0 to disable it:"       \
           "  100000: verify IGVN method return invariants"                  \
           "   10000: verify node specific invariants"                       \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -743,14 +743,14 @@
           range(1, 100)                                                     \
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \
-          "Verify Iterative Global Value Numbering =FEDCBA, with:"          \
-          "  F: verify IGVN method return invariants"                       \
-          "  E: verify node specific invariants"                            \
-          "  D: verify Node::Identity did not miss opportunities"           \
-          "  C: verify Node::Ideal did not miss opportunities"              \
-          "  B: verify that type(n) == n->Value() after IGVN"               \
-          "  A: verify Def-Use modifications during IGVN"                   \
-          "Each can be 0=off or 1=on")                                      \
+          "Verify Iterative Global Value Numbering. Set the corresponding"  \
+          "decimal place to 1 to enable a check, or 0 to disable it:"       \
+          "  100000: verify IGVN method return invariants"                  \
+          "   10000: verify node specific invariants"                       \
+          "    1000: verify Node::Identity did not miss opportunities"      \
+          "     100: verify Node::Ideal did not miss opportunities"         \
+          "      10: verify that type(n) == n->Value() after IGVN"          \
+          "       1: verify Def-Use modifications during IGVN")             \
           constraint(VerifyIterativeGVNConstraintFunc, AtParse)             \
                                                                             \
   develop(bool, TraceCISCSpill, false,                                      \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -744,13 +744,13 @@
                                                                             \
   develop(uint, VerifyIterativeGVN, 0,                                      \
           "Verify Iterative Global Value Numbering. Set the corresponding " \
-          "decimal place to 1 to enable a check, or 0 to disable it:"       \
-          "  100000: verify IGVN method return invariants"                  \
-          "   10000: verify node specific invariants"                       \
-          "    1000: verify Node::Identity did not miss opportunities"      \
-          "     100: verify Node::Ideal did not miss opportunities"         \
-          "      10: verify that type(n) == n->Value() after IGVN"          \
-          "       1: verify Def-Use modifications during IGVN. "            \
+          "decimal place to 1 to enable a check, or 0 to disable it:\n"     \
+          "100000: verify IGVN method return invariants\n"                  \
+          " 10000: verify node specific invariants\n"                       \
+          "  1000: verify Node::Identity did not miss opportunities\n"      \
+          "   100: verify Node::Ideal did not miss opportunities\n"         \
+          "    10: verify that type(n) == n->Value() after IGVN\n"          \
+          "     1: verify Def-Use modifications during IGVN\n"              \
           "Example: -XX:VerifyIterativeGVN=101 enables Node::Ideal and "    \
           "Def-Use checks.")                                                \
           constraint(VerifyIterativeGVNConstraintFunc, AtParse)             \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -750,7 +750,9 @@
           "    1000: verify Node::Identity did not miss opportunities"      \
           "     100: verify Node::Ideal did not miss opportunities"         \
           "      10: verify that type(n) == n->Value() after IGVN"          \
-          "       1: verify Def-Use modifications during IGVN")             \
+          "       1: verify Def-Use modifications during IGVN. "            \
+          "Example: -XX:VerifyIterativeGVN=101 enables Node::Ideal and "    \
+          "Def-Use checks.")                                                \
           constraint(VerifyIterativeGVNConstraintFunc, AtParse)             \
                                                                             \
   develop(bool, TraceCISCSpill, false,                                      \


### PR DESCRIPTION
Please review this change. Thanks.

**Description:**

The current description of `-XX:VerifyIterativeGVN` is confusing because it uses the `FEDCBA` notation to describe the individual checks, while the actual flag value is specified as a sequence of decimal digits.

**Solution:**

Update the `VerifyIterativeGVN` flag description to replace the confusing `FEDCBA` notation with the actual decimal values used by the flag.

**Test:**

GHA

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390747](https://bugs.openjdk.org/browse/JDK-8390747): C2: Improve VerifyIterativeGVN flag description (**Enhancement** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32794/head:pull/32794` \
`$ git checkout pull/32794`

Update a local copy of the PR: \
`$ git checkout pull/32794` \
`$ git pull https://git.openjdk.org/jdk.git pull/32794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32794`

View PR using the GUI difftool: \
`$ git pr show -t 32794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32794.diff">https://git.openjdk.org/jdk/pull/32794.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32794#issuecomment-5603446490)
</details>
