### PR TITLE
8392085: ConcurrentSkipListMap.clone() on an emptied map shares state

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -1133,6 +1133,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
             clone.values = null;
             clone.descendingMap = null;
             clone.adder = null;
+            clone.head = null;
             clone.buildFromSorted(this);
             return clone;
         } catch (CloneNotSupportedException e) {

--- a/test/jdk/java/util/concurrent/tck/MapTest.java
+++ b/test/jdk/java/util/concurrent/tck/MapTest.java
@@ -208,11 +208,17 @@ public class MapTest extends JSR166TestCase {
 
     /**
      * 8222930: ConcurrentSkipListMap.clone() shares size variable between original and clone
+     * 8392085: CSLM.clone() on an emptied map shares state
      */
     public void testClone() {
         final ThreadLocalRandom rnd = ThreadLocalRandom.current();
         final int size = rnd.nextInt(4);
         final Map map = impl.emptyMap();
+        if (rnd.nextBoolean()) {
+            // 8392085: an emptied map behaves differently than a fresh empty map
+            map.put(impl.makeKey(-1), impl.makeValue(-1));
+            map.clear();
+        }
         for (int i = 0; i < size; i++)
             map.put(impl.makeKey(i), impl.makeValue(i));
         final Map clone = cloneableClone(map);
@@ -225,6 +231,8 @@ public class MapTest extends JSR166TestCase {
         clone.put(impl.makeKey(-1), impl.makeValue(-1));
         mustEqual(size, map.size());
         mustEqual(size + 1, clone.size());
+        assertFalse(map.containsKey(impl.makeKey(-1)));
+        mustEqual(size == 0, map.isEmpty());
 
         clone.clear();
         mustEqual(size, map.size());


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392085](https://bugs.openjdk.org/browse/JDK-8392085): ConcurrentSkipListMap.clone() on an emptied map shares state (**Bug** - P4)


### Reviewers
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32795/head:pull/32795` \
`$ git checkout pull/32795`

Update a local copy of the PR: \
`$ git checkout pull/32795` \
`$ git pull https://git.openjdk.org/jdk.git pull/32795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32795`

View PR using the GUI difftool: \
`$ git pr show -t 32795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32795.diff">https://git.openjdk.org/jdk/pull/32795.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32795#issuecomment-5666591557)
</details>
