### PR TITLE
length should be size_t, not int

### DIFF
--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -320,7 +320,7 @@ int SystemProcessInterface::SystemProcesses::system_processes(SystemProcess** sy
       char buffer[PROC_PIDPATHINFO_MAXSIZE];
       memset(buffer, 0 , sizeof(buffer));
       if (proc_pidpath(pid, buffer, sizeof(buffer)) != -1) {
-        int length = strlen(buffer);
+        size_t length = strlen(buffer);
         if (length > 0) {
           SystemProcess* current = new SystemProcess();
           char * path = NEW_C_HEAP_ARRAY(char, length + 1, mtInternal);

--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -163,7 +163,7 @@ char *getMacOSXLocale(int cat) {
 const char * convertToPOSIXLocale(const char* src) {
     char* scriptRegion = strchr(src, '-');
     if (scriptRegion != NULL) {
-        int length = strlen(scriptRegion);
+        size_t length = strlen(scriptRegion);
         char* region = strchr(scriptRegion + 1, '-');
         char* atMark = NULL;
 


### PR DESCRIPTION


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32796/head:pull/32796` \
`$ git checkout pull/32796`

Update a local copy of the PR: \
`$ git checkout pull/32796` \
`$ git pull https://git.openjdk.org/jdk.git pull/32796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32796`

View PR using the GUI difftool: \
`$ git pr show -t 32796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32796.diff">https://git.openjdk.org/jdk/pull/32796.diff</a>

</details>
