### PR TITLE
8392082: Missed a Klass in jfieldIDWorkaround.hpp

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -183,7 +183,7 @@ extern LONG WINAPI topLevelExceptionFilter(_EXCEPTION_POINTERS* );
 // out-of-line helpers for class jfieldIDWorkaround:
 
 bool jfieldIDWorkaround::is_valid_jfieldID(Klass* k, jfieldID id) {
-  if (jfieldIDWorkaround::is_instance_jfieldID(k, id)) {
+  if (jfieldIDWorkaround::is_instance_jfieldID(id)) {
     uintptr_t as_uint = (uintptr_t) id;
     int offset = raw_instance_offset(id);
     if (is_checked_jfieldID(id)) {
@@ -244,7 +244,7 @@ bool jfieldIDWorkaround::klass_hash_ok(Klass* k, jfieldID id) {
 }
 
 void jfieldIDWorkaround::verify_instance_jfieldID(Klass* k, jfieldID id) {
-  guarantee(jfieldIDWorkaround::is_instance_jfieldID(k, id), "must be an instance field" );
+  guarantee(jfieldIDWorkaround::is_instance_jfieldID(id), "must be an instance field" );
   uintptr_t as_uint = (uintptr_t) id;
   int offset = raw_instance_offset(id);
   if (VerifyJNIFields) {

--- a/src/hotspot/share/runtime/jfieldIDWorkaround.hpp
+++ b/src/hotspot/share/runtime/jfieldIDWorkaround.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ class jfieldIDWorkaround: AllStatic {
  public:
   static bool is_valid_jfieldID(Klass* k, jfieldID id);
 
-  static bool is_instance_jfieldID(Klass* k, jfieldID id) {
+  static bool is_instance_jfieldID(jfieldID id) {
     uintptr_t as_uint = (uintptr_t) id;
     return ((as_uint & instance_mask_in_place) != 0);
   }


### PR DESCRIPTION
I missed removing a Klass* argument in jfieldIDWorkaround.hpp that isn't used in my previous cleanup.  Please review this trivial change.
Ran some vm jck tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392082](https://bugs.openjdk.org/browse/JDK-8392082): Missed a Klass in jfieldIDWorkaround.hpp (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32797/head:pull/32797` \
`$ git checkout pull/32797`

Update a local copy of the PR: \
`$ git checkout pull/32797` \
`$ git pull https://git.openjdk.org/jdk.git pull/32797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32797`

View PR using the GUI difftool: \
`$ git pr show -t 32797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32797.diff">https://git.openjdk.org/jdk/pull/32797.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32797#issuecomment-5604400821)
</details>
