### PR TITLE
8392090: HashOverflowTest.java fails on PPC64 due to too small stack size

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/HashOverflowTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/HashOverflowTest.java
@@ -30,7 +30,7 @@
  * @enablePreview
  * @requires vm.flagless
  * @compile HashOverflowTest.java
- * @run main/othervm -Xint -Xss256K
+ * @run main/othervm -Xint -Xss384K
  *                   runtime.valhalla.valuetypes.HashOverflowTest
  */
 


### PR DESCRIPTION
Increase Xss to the minimum supported size on PPC64. (Test still works on x64 as well.)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392090](https://bugs.openjdk.org/browse/JDK-8392090): HashOverflowTest.java fails on PPC64 due to too small stack size (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32798/head:pull/32798` \
`$ git checkout pull/32798`

Update a local copy of the PR: \
`$ git checkout pull/32798` \
`$ git pull https://git.openjdk.org/jdk.git pull/32798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32798`

View PR using the GUI difftool: \
`$ git pr show -t 32798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32798.diff">https://git.openjdk.org/jdk/pull/32798.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32798#issuecomment-5604650651)
</details>
