### PR TITLE
8392095: EventLogs memory allocations should be mtLogging

### DIFF
--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -48,7 +48,7 @@
 // crash time.  This is a very generic interface that is mainly here
 // for completeness.  Normally the templated EventLogBase would be
 // subclassed to provide different log types.
-class EventLog : public CHeapObj<mtInternal> {
+class EventLog : public CHeapObj<mtLogging> {
   friend class Events;
 
  private:
@@ -79,7 +79,7 @@ class EventLog : public CHeapObj<mtInternal> {
 // semantics aren't appropriate.  The name is used as the label of the
 // log when it is dumped during a crash.
 template <class T> class EventLogBase : public EventLog {
-  template <class X> class EventRecord : public CHeapObj<mtInternal> {
+  template <class X> class EventRecord : public CHeapObj<mtLogging> {
    public:
     double  timestamp;
     Thread* thread;


### PR DESCRIPTION
Further decluttering of `mtInternal` NMT category. With Shenandoah and ZGC, these can easily take 1M of space! Ouch.

Additional testing:
 - [x] Eyeballing NMT logs

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392095](https://bugs.openjdk.org/browse/JDK-8392095): EventLogs memory allocations should be mtLogging (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32799/head:pull/32799` \
`$ git checkout pull/32799`

Update a local copy of the PR: \
`$ git checkout pull/32799` \
`$ git pull https://git.openjdk.org/jdk.git pull/32799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32799`

View PR using the GUI difftool: \
`$ git pr show -t 32799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32799.diff">https://git.openjdk.org/jdk/pull/32799.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32799#issuecomment-5604886937)
</details>
