### PR TITLE
Replace NSAutoreleasepool with @autoreleasepool

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -391,9 +391,7 @@ static char * createConvertedException(CFStringRef cf_original) {
  */
 void setUserHome(java_props_t *sprops) {
     if (sprops == NULL) { return; }
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     sprops->user_home = createUTF8CString((CFStringRef)NSHomeDirectory());
-    [pool drain];
 }
 
 /*

--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -901,7 +901,7 @@ JVMInit(InvocationFunctions* ifn, jlong threadStackSize,
         // need to block this thread against the main thread
         // so signals get caught correctly
         __block int rslt = 0;
-        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+        @autoreleasepool
         {
             NSBlockOperation *op = [NSBlockOperation blockOperationWithBlock: ^{
                 JavaMainArgs args;
@@ -921,7 +921,6 @@ JVMInit(InvocationFunctions* ifn, jlong threadStackSize,
              */
             [op performSelectorOnMainThread:@selector(start) withObject:nil waitUntilDone:YES];
         }
-        [pool drain];
         return rslt;
     } else {
         return ContinueInNewThread(ifn, threadStackSize, argc, argv, mode, what, ret);

--- a/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
+++ b/src/java.base/macosx/native/libosxsecurity/KeystoreImpl.m
@@ -760,7 +760,6 @@ JNIEXPORT jlong JNICALL Java_apple_security_KeychainStore__1addItemToKeychain
     OSStatus err;
     jlong returnValue = 0;
 
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
     @try {
         jsize dataSize = (*env)->GetArrayLength(env, rawDataObj);
         jbyte *rawData = (*env)->GetByteArrayElements(env, rawDataObj, NULL);
@@ -848,8 +847,6 @@ JNIEXPORT jlong JNICALL Java_apple_security_KeychainStore__1addItemToKeychain
         }
     } @catch (NSException *e) {
         NSLog(@"%@", [e callStackSymbols]);
-    } @finally {
-        [pool drain];
     }
     return returnValue;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -359,65 +359,65 @@ static void AWT_NSUncaughtExceptionHandler(NSException *exception) {
 }
 
 + (void)starter:(BOOL)wasOnMainThread headless:(BOOL)headless {
-    NSAutoreleasePool *pool = [NSAutoreleasePool new];
-    // Add the exception handler of last resort
-    NSSetUncaughtExceptionHandler(AWT_NSUncaughtExceptionHandler);
+    @autoreleasepool {
+        // Add the exception handler of last resort
+        NSSetUncaughtExceptionHandler(AWT_NSUncaughtExceptionHandler);
 
-    // Headless mode trumps either ordinary AWT or SWT-in-AWT mode.  Declare us a daemon and return.
-    if (headless) {
-        // Note that we don't install run loop observers in headless mode
-        // because we don't need them (see 7174704)
-        if (!forceEmbeddedMode) {
-            setUpAWTAppKit(false);
+        // Headless mode trumps either ordinary AWT or SWT-in-AWT mode.  Declare us a daemon and return.
+        if (headless) {
+            // Note that we don't install run loop observers in headless mode
+            // because we don't need them (see 7174704)
+            if (!forceEmbeddedMode) {
+                setUpAWTAppKit(false);
+            }
+            [AWTStarter markAppAsDaemon];
+            return;
         }
-        [AWTStarter markAppAsDaemon];
-        return;
-    }
 
-    if (forceEmbeddedMode) {
-        AWT_STARTUP_LOG(@"in SWT or SWT/WebStart mode");
+        if (forceEmbeddedMode) {
+            AWT_STARTUP_LOG(@"in SWT or SWT/WebStart mode");
 
-        // Init a default NSApplication instance instead of the NSApplicationAWT.
-        // Note that [NSApp isRunning] will return YES after that, though
-        // this behavior isn't specified anywhere. We rely on that.
-        NSApplicationLoad();
-    }
+            // Init a default NSApplication instance instead of the NSApplicationAWT.
+            // Note that [NSApp isRunning] will return YES after that, though
+            // this behavior isn't specified anywhere. We rely on that.
+            NSApplicationLoad();
+        }
 
-    // This will create a NSApplicationAWT for standalone AWT programs, unless there is
-    //  already a NSApplication instance. If there is already a NSApplication instance,
-    //  and -[NSApplication isRunning] returns YES, AWT is embedded inside another
-    //  AppKit Application.
-    NSApplication *app = [NSApplicationAWT sharedApplication];
-    isEmbedded = ![NSApp isKindOfClass:[NSApplicationAWT class]];
+        // This will create a NSApplicationAWT for standalone AWT programs, unless there is
+        //  already a NSApplication instance. If there is already a NSApplication instance,
+        //  and -[NSApplication isRunning] returns YES, AWT is embedded inside another
+        //  AppKit Application.
+        NSApplication *app = [NSApplicationAWT sharedApplication];
+        isEmbedded = ![NSApp isKindOfClass:[NSApplicationAWT class]];
 
-    if (!isEmbedded) {
-        // Install run loop observers and set the AppKit Java thread name
-        setUpAWTAppKit(true);
-    }
+        if (!isEmbedded) {
+            // Install run loop observers and set the AppKit Java thread name
+            setUpAWTAppKit(true);
+        }
 
-    // AWT gets to this point BEFORE NSApplicationDidFinishLaunchingNotification is sent.
-    if (![app isRunning]) {
-        AWT_STARTUP_LOG(@"+[AWTStarter startAWT]: ![app isRunning]");
-        // This is where the AWT AppKit thread parks itself to process events.
-        [NSApplicationAWT runAWTLoopWithApp: app];
-    } else {
-        // We're either embedded, or showing a splash screen
-        if (isEmbedded) {
-            AWT_STARTUP_LOG(@"running embedded");
-
-            // We don't track if the runloop is busy, so set it free to let AWT finish when it needs
-            setBusy(NO);
+        // AWT gets to this point BEFORE NSApplicationDidFinishLaunchingNotification is sent.
+        if (![app isRunning]) {
+            AWT_STARTUP_LOG(@"+[AWTStarter startAWT]: ![app isRunning]");
+            // This is where the AWT AppKit thread parks itself to process events.
+            [NSApplicationAWT runAWTLoopWithApp: app];
         } else {
-            AWT_STARTUP_LOG(@"running after showing a splash screen");
+            // We're either embedded, or showing a splash screen
+            if (isEmbedded) {
+                AWT_STARTUP_LOG(@"running embedded");
+
+                // We don't track if the runloop is busy, so set it free to let AWT finish when it needs
+                setBusy(NO);
+            } else {
+                AWT_STARTUP_LOG(@"running after showing a splash screen");
+            }
+
+            // Signal so that JNI_OnLoad can proceed.
+            if (!wasOnMainThread) [AWTStarter appKitIsRunning:nil];
+
+            // Proceed to exit this call as there is no reason to run the NSApplication event loop.
         }
 
-        // Signal so that JNI_OnLoad can proceed.
-        if (!wasOnMainThread) [AWTStarter appKitIsRunning:nil];
-
-        // Proceed to exit this call as there is no reason to run the NSApplication event loop.
     }
-
-    [pool drain];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLGraphicsConfig.m
@@ -57,14 +57,12 @@ OGLGC_DestroyOGLGraphicsConfig(jlong pConfigInfo)
 
         CGLCtxInfo *ctxinfo = (CGLCtxInfo *)oglc->ctxInfo;
         if (ctxinfo != NULL) {
-            NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
             [NSOpenGLContext clearCurrentContext];
             [ctxinfo->context clearDrawable];
             [ctxinfo->context release];
-            if (ctxinfo->scratchSurface != 0) {
+            if (ctxinfo->scratchSurface != NULL) {
                 [ctxinfo->scratchSurface release];
             }
-            [pool drain];
             free(ctxinfo);
             oglc->ctxInfo = NULL;
         }
@@ -127,167 +125,165 @@ Java_sun_java2d_opengl_CGLGraphicsConfig_getCGLConfigInfo
 
         J2dRlsTraceLn(J2D_TRACE_INFO, "CGLGraphicsConfig_getCGLConfigInfo");
 
-        NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+        @autoreleasepool {
+            if (sharedContext == NULL) {
+                NSOpenGLPixelFormatAttribute attrs[] = {
+                    NSOpenGLPFAAllowOfflineRenderers,
+                    NSOpenGLPFAClosestPolicy,
+                    NSOpenGLPFAWindow,
+                    NSOpenGLPFAPixelBuffer,
+                    NSOpenGLPFADoubleBuffer,
+                    NSOpenGLPFAColorSize, 32,
+                    NSOpenGLPFAAlphaSize, 8,
+                    NSOpenGLPFADepthSize, 16,
+                    0
+                };
 
-        if (sharedContext == NULL) {
-
-            NSOpenGLPixelFormatAttribute attrs[] = {
-                NSOpenGLPFAAllowOfflineRenderers,
-                NSOpenGLPFAClosestPolicy,
-                NSOpenGLPFAWindow,
-                NSOpenGLPFAPixelBuffer,
-                NSOpenGLPFADoubleBuffer,
-                NSOpenGLPFAColorSize, 32,
-                NSOpenGLPFAAlphaSize, 8,
-                NSOpenGLPFADepthSize, 16,
-                0
-            };
-
-            sharedPixelFormat =
-                [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs];
-            if (sharedPixelFormat == nil) {
-                J2dRlsTraceLn(J2D_TRACE_ERROR,
+                sharedPixelFormat =
+                    [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs];
+                if (sharedPixelFormat == nil) {
+                    J2dRlsTraceLn(J2D_TRACE_ERROR,
                               "CGLGraphicsConfig_getCGLConfigInfo: shared NSOpenGLPixelFormat is NULL");
-               return;
+                    return;
+                }
+
+                sharedContext =
+                    [[NSOpenGLContext alloc]
+                        initWithFormat:sharedPixelFormat
+                        shareContext: NULL];
+                if (sharedContext == nil) {
+                    J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: shared NSOpenGLContext is NULL");
+                    return;
+                }
             }
 
-            sharedContext =
-                [[NSOpenGLContext alloc]
-                    initWithFormat:sharedPixelFormat
-                    shareContext: NULL];
-            if (sharedContext == nil) {
-                J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: shared NSOpenGLContext is NULL");
+#if USE_NSVIEW_FOR_SCRATCH
+            NSRect contentRect = NSMakeRect(0, 0, 64, 64);
+            NSWindow *window =
+                [[NSWindow alloc]
+                    initWithContentRect: contentRect
+                    styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                    defer: false];
+            if (window == nil) {
+                J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: NSWindow is NULL");
                 return;
             }
-        }
 
-#if USE_NSVIEW_FOR_SCRATCH
-        NSRect contentRect = NSMakeRect(0, 0, 64, 64);
-        NSWindow *window =
-            [[NSWindow alloc]
-                initWithContentRect: contentRect
-                styleMask: NSWindowStyleMaskBorderless
-                backing: NSBackingStoreBuffered
-                defer: false];
-        if (window == nil) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: NSWindow is NULL");
-            return;
-        }
-
-        NSView *scratchSurface =
-            [[NSView alloc]
-                initWithFrame: contentRect];
-        if (scratchSurface == nil) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: NSView is NULL");
-            return;
-        }
-        [window setContentView: scratchSurface];
+            NSView *scratchSurface =
+                [[NSView alloc]
+                    initWithFrame: contentRect];
+            if (scratchSurface == nil) {
+                J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: NSView is NULL");
+                return;
+            }
+            [window setContentView: scratchSurface];
 #else
-        NSOpenGLPixelBuffer *scratchSurface =
-            [[NSOpenGLPixelBuffer alloc]
-                initWithTextureTarget:GL_TEXTURE_2D
-                textureInternalFormat:GL_RGB
-                textureMaxMipMapLevel:0
-                pixelsWide:64
-                pixelsHigh:64];
+            NSOpenGLPixelBuffer *scratchSurface =
+                [[NSOpenGLPixelBuffer alloc]
+                    initWithTextureTarget:GL_TEXTURE_2D
+                    textureInternalFormat:GL_RGB
+                    textureMaxMipMapLevel:0
+                    pixelsWide:64
+                    pixelsHigh:64];
 #endif
 
-        NSOpenGLContext *context =
-            [[NSOpenGLContext alloc]
-                initWithFormat: sharedPixelFormat
-                shareContext: sharedContext];
-        if (context == nil) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: NSOpenGLContext is NULL");
-            return;
-        }
+            NSOpenGLContext *context =
+                [[NSOpenGLContext alloc]
+                    initWithFormat: sharedPixelFormat
+                    shareContext: sharedContext];
+            if (context == nil) {
+                J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: NSOpenGLContext is NULL");
+                return;
+            }
 
-        GLint contextVirtualScreen = [context currentVirtualScreen];
+            GLint contextVirtualScreen = [context currentVirtualScreen];
 #if USE_NSVIEW_FOR_SCRATCH
-        [context setView: scratchSurface];
+            [context setView: scratchSurface];
 #else
-        [context
-            setPixelBuffer: scratchSurface
-            cubeMapFace:0
-            mipMapLevel:0
-            currentVirtualScreen: contextVirtualScreen];
+            [context
+                setPixelBuffer: scratchSurface
+                cubeMapFace:0
+                mipMapLevel:0
+                currentVirtualScreen: contextVirtualScreen];
 #endif
-        [context makeCurrentContext];
+            [context makeCurrentContext];
 
-        // get version and extension strings
-        const unsigned char *versionstr = j2d_glGetString(GL_VERSION);
-        if (!OGLContext_IsVersionSupported(versionstr)) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: OpenGL 1.2 is required");
-            [NSOpenGLContext clearCurrentContext];
-            return;
-        }
-        J2dRlsTraceLn(J2D_TRACE_INFO, "CGLGraphicsConfig_getCGLConfigInfo: OpenGL version=%s", versionstr);
+            // get version and extension strings
+            const unsigned char *versionstr = j2d_glGetString(GL_VERSION);
+            if (!OGLContext_IsVersionSupported(versionstr)) {
+                J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: OpenGL 1.2 is required");
+                [NSOpenGLContext clearCurrentContext];
+                return;
+            }
+            J2dRlsTraceLn(J2D_TRACE_INFO, "CGLGraphicsConfig_getCGLConfigInfo: OpenGL version=%s", versionstr);
 
-        jint caps = CAPS_EMPTY;
-        OGLContext_GetExtensionInfo(env, &caps);
+            jint caps = CAPS_EMPTY;
+            OGLContext_GetExtensionInfo(env, &caps);
 
-        GLint value = 0;
-        [sharedPixelFormat
-            getValues: &value
-            forAttribute: NSOpenGLPFADoubleBuffer
-            forVirtualScreen: contextVirtualScreen];
-        if (value != 0) {
-            caps |= CAPS_DOUBLEBUFFERED;
-        }
+            GLint value = 0;
+            [sharedPixelFormat
+                getValues: &value
+                forAttribute: NSOpenGLPFADoubleBuffer
+                forVirtualScreen: contextVirtualScreen];
+            if (value != 0) {
+                caps |= CAPS_DOUBLEBUFFERED;
+            }
 
-        J2dRlsTraceLn(J2D_TRACE_INFO,
-                      "CGLGraphicsConfig_getCGLConfigInfo: db=%d",
-                      (caps & CAPS_DOUBLEBUFFERED) != 0);
+            J2dRlsTraceLn(J2D_TRACE_INFO,
+                        "CGLGraphicsConfig_getCGLConfigInfo: db=%d",
+                        (caps & CAPS_DOUBLEBUFFERED) != 0);
 
         // remove before shipping (?)
 #if 1
-        [sharedPixelFormat
-            getValues: &value
-            forAttribute: NSOpenGLPFAAccelerated
-            forVirtualScreen: contextVirtualScreen];
-        if (value == 0) {
             [sharedPixelFormat
                 getValues: &value
-                forAttribute: NSOpenGLPFARendererID
+                forAttribute: NSOpenGLPFAAccelerated
                 forVirtualScreen: contextVirtualScreen];
-            fprintf(stderr, "WARNING: GL pipe is running in software mode (Renderer ID=0x%x)\n", (int)value);
-        }
+            if (value == 0) {
+                [sharedPixelFormat
+                    getValues: &value
+                    forAttribute: NSOpenGLPFARendererID
+                    forVirtualScreen: contextVirtualScreen];
+                fprintf(stderr, "WARNING: GL pipe is running in software mode (Renderer ID=0x%x)\n", (int)value);
+            }
 #endif
-        CGLCtxInfo *ctxinfo = (CGLCtxInfo *)malloc(sizeof(CGLCtxInfo));
-        if (ctxinfo == NULL) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGC_InitOGLContext: could not allocate memory for ctxinfo");
-            [NSOpenGLContext clearCurrentContext];
-            return;
-        }
-        memset(ctxinfo, 0, sizeof(CGLCtxInfo));
-        ctxinfo->context = context;
-        ctxinfo->scratchSurface = scratchSurface;
+            CGLCtxInfo *ctxinfo = (CGLCtxInfo *)malloc(sizeof(CGLCtxInfo));
+            if (ctxinfo == NULL) {
+                J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGC_InitOGLContext: could not allocate memory for ctxinfo");
+                [NSOpenGLContext clearCurrentContext];
+                return;
+            }
+            memset(ctxinfo, 0, sizeof(CGLCtxInfo));
+            ctxinfo->context = context;
+            ctxinfo->scratchSurface = scratchSurface;
 
-        OGLContext *oglc = (OGLContext *)malloc(sizeof(OGLContext));
-        if (oglc == 0L) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGC_InitOGLContext: could not allocate memory for oglc");
-            [NSOpenGLContext clearCurrentContext];
-            free(ctxinfo);
-            return;
-        }
-        memset(oglc, 0, sizeof(OGLContext));
-        oglc->ctxInfo = ctxinfo;
-        oglc->caps = caps;
+            OGLContext *oglc = (OGLContext *)malloc(sizeof(OGLContext));
+            if (oglc == 0L) {
+                J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGC_InitOGLContext: could not allocate memory for oglc");
+                [NSOpenGLContext clearCurrentContext];
+                free(ctxinfo);
+                return;
+            }
+            memset(oglc, 0, sizeof(OGLContext));
+            oglc->ctxInfo = ctxinfo;
+            oglc->caps = caps;
 
-        // create the CGLGraphicsConfigInfo record for this config
-        CGLGraphicsConfigInfo *cglinfo = (CGLGraphicsConfigInfo *)malloc(sizeof(CGLGraphicsConfigInfo));
-        if (cglinfo == NULL) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: could not allocate memory for cglinfo");
-            [NSOpenGLContext clearCurrentContext];
-            free(oglc);
-            free(ctxinfo);
-            return;
-        }
-        memset(cglinfo, 0, sizeof(CGLGraphicsConfigInfo));
-        cglinfo->context = oglc;
+            // create the CGLGraphicsConfigInfo record for this config
+            CGLGraphicsConfigInfo *cglinfo = (CGLGraphicsConfigInfo *)malloc(sizeof(CGLGraphicsConfigInfo));
+            if (cglinfo == NULL) {
+                J2dRlsTraceLn(J2D_TRACE_ERROR, "CGLGraphicsConfig_getCGLConfigInfo: could not allocate memory for cglinfo");
+                [NSOpenGLContext clearCurrentContext];
+                free(oglc);
+                free(ctxinfo);
+                return;
+            }
+            memset(cglinfo, 0, sizeof(CGLGraphicsConfigInfo));
+            cglinfo->context = oglc;
 
-        [NSOpenGLContext clearCurrentContext];
-        ret = ptr_to_jlong(cglinfo);
-        [pool drain];
+            [NSOpenGLContext clearCurrentContext];
+            ret = ptr_to_jlong(cglinfo);
+        }
 
     }];
     JNI_COCOA_EXIT(env);

--- a/src/java.desktop/macosx/native/libosxapp/JNIUtilities.h
+++ b/src/java.desktop/macosx/native/libosxapp/JNIUtilities.h
@@ -208,7 +208,7 @@
 
 /* Create a pool and initiate a try block to catch any exception */
 #define JNI_COCOA_ENTER(env) \
- NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
+ @autoreleasepool { \
  @try {
 
 /* Don't allow NSExceptions to escape to Java.
@@ -220,8 +220,6 @@
  @catch (NSException *e) { \
      NSLog(@"%@", [e callStackSymbols]); \
  } \
- @finally { \
-    [pool drain]; \
  };
 
 /* Same as above but adds a clean up action.
@@ -233,9 +231,7 @@
      { action; }; \
      NSLog(@"%@", [e callStackSymbols]); \
  } \
- @finally { \
-    [pool drain]; \
- };
+};
 
 /********        STRING CONVERSION SUPPORT    *********/
 

--- a/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
+++ b/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
@@ -297,24 +297,22 @@ AWT_ASSERT_APPKIT_THREAD;
 }
 
 + (void) runAWTLoopWithApp:(NSApplication*)app {
-    NSAutoreleasePool *pool = [NSAutoreleasePool new];
+    @autorelasepool {
+        // Make sure that when we run in javaRunLoopMode we don't exit randomly
+        [[NSRunLoop currentRunLoop] addPort:[NSPort port] forMode:[ThreadUtilities javaRunLoopMode]];
 
-    // Make sure that when we run in javaRunLoopMode we don't exit randomly
-    [[NSRunLoop currentRunLoop] addPort:[NSPort port] forMode:[ThreadUtilities javaRunLoopMode]];
+        do {
+            @try {
+                [app run];
+            } @catch (NSException* e) {
+                NSLog(@"Apple AWT Startup Exception: %@", [e description]);
+                NSLog(@"Apple AWT Startup Exception callstack: %@", [e callStackSymbols]);
+                NSLog(@"Apple AWT Restarting Native Event Thread");
 
-    do {
-        @try {
-            [app run];
-        } @catch (NSException* e) {
-            NSLog(@"Apple AWT Startup Exception: %@", [e description]);
-            NSLog(@"Apple AWT Startup Exception callstack: %@", [e callStackSymbols]);
-            NSLog(@"Apple AWT Restarting Native Event Thread");
-
-            [app stop:app];
-        }
-    } while (YES);
-
-    [pool drain];
+                [app stop:app];
+            }
+        } while (YES);
+    }
 }
 
 - (BOOL)usingDefaultNib {
@@ -388,43 +386,43 @@ untilDate:(NSDate *)expiration inMode:(NSString *)mode dequeue:(BOOL)deqFlag {
 {
     void (^copy)() = [block copy];
     NSInteger encode = (NSInteger) copy;
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    NSEvent* event = [NSEvent otherEventWithType: NSApplicationDefined
-                                        location: NSMakePoint(0,0)
-                                   modifierFlags: 0
-                                       timestamp: 0
-                                    windowNumber: 0
-                                         context: nil
-                                         subtype: ExecuteBlockEvent
-                                           data1: encode
-                                           data2: ExecuteBlockEvent];
+    @autoreleasepool {
+        NSEvent* event = [NSEvent otherEventWithType: NSApplicationDefined
+                                            location: NSMakePoint(0,0)
+                                    modifierFlags: 0
+                                        timestamp: 0
+                                        windowNumber: 0
+                                            context: nil
+                                            subtype: ExecuteBlockEvent
+                                            data1: encode
+                                            data2: ExecuteBlockEvent];
 
-    [NSApp postEvent: event atStart: NO];
-    [pool drain];
+        [NSApp postEvent: event atStart: NO];
+    }
 }
 
 - (void)postDummyEvent:(bool)useCocoa {
     seenDummyEventLock = [[NSConditionLock alloc] initWithCondition:NO];
     dummyEventTimestamp = [NSProcessInfo processInfo].systemUptime;
 
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    NSEvent* event = [NSEvent otherEventWithType: NSApplicationDefined
-                                        location: NSMakePoint(0,0)
-                                   modifierFlags: 0
-                                       timestamp: dummyEventTimestamp
-                                    windowNumber: 0
-                                         context: nil
-                                         subtype: NativeSyncQueueEvent
-                                           data1: NativeSyncQueueEvent
-                                           data2: NativeSyncQueueEvent];
-    if (useCocoa) {
-        [NSApp postEvent:event atStart:NO];
-    } else {
-        ProcessSerialNumber psn;
-        GetCurrentProcess(&psn);
-        CGEventPostToPSN(&psn, [event CGEvent]);
+    @autoreleasepool {
+        NSEvent* event = [NSEvent otherEventWithType: NSApplicationDefined
+                                            location: NSMakePoint(0,0)
+                                    modifierFlags: 0
+                                        timestamp: dummyEventTimestamp
+                                        windowNumber: 0
+                                            context: nil
+                                            subtype: NativeSyncQueueEvent
+                                            data1: NativeSyncQueueEvent
+                                            data2: NativeSyncQueueEvent];
+        if (useCocoa) {
+            [NSApp postEvent:event atStart:NO];
+        } else {
+            ProcessSerialNumber psn;
+            GetCurrentProcess(&psn);
+            CGEventPostToPSN(&psn, [event CGEvent]);
+        }
     }
-    [pool drain];
 }
 
 - (void)waitForDummyEvent:(double)timeout {

--- a/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
+++ b/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
@@ -146,41 +146,39 @@ jboolean SplashGetScaledImageName(const char* jar, const char* file,
         return JNI_FALSE;
     }
 
-    NSAutoreleasePool *pool = [NSAutoreleasePool new];
-    __block float screenScaleFactor = 1;
+    @autoreleasepool {
+        __block float screenScaleFactor = 1;
 
-    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
-        // initialize NSApplication and AWT stuff
-        [NSApplicationAWT sharedApplication];
-        screenScaleFactor = [SplashNSScreen() backingScaleFactor];
-    }];
+        [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
+            // initialize NSApplication and AWT stuff
+            [NSApplicationAWT sharedApplication];
+            screenScaleFactor = [SplashNSScreen() backingScaleFactor];
+        }];
 
-    if (screenScaleFactor > 1) {
-        NSString *fileName = [NSString stringWithUTF8String: file];
-        NSUInteger length = [fileName length];
-        NSRange range = [fileName rangeOfString: @"."
+        if (screenScaleFactor > 1) {
+            NSString *fileName = [NSString stringWithUTF8String: file];
+            NSUInteger length = [fileName length];
+            NSRange range = [fileName rangeOfString: @"."
                                         options:NSBackwardsSearch];
-        NSUInteger dotIndex = range.location;
-        NSString *fileName2x = nil;
+            NSUInteger dotIndex = range.location;
+            NSString *fileName2x = nil;
 
-        fileName2x = findScaledImageName(fileName, dotIndex, @"@2x");
-        if(![[NSFileManager defaultManager]
-                fileExistsAtPath: fileName2x]) {
-            fileName2x = findScaledImageName(fileName, dotIndex, @"@200pct");
-        }
-        if (jar || [[NSFileManager defaultManager]
-                fileExistsAtPath: fileName2x]){
-            if (strlen([fileName2x UTF8String]) > scaledImageLength) {
-                [pool drain];
-                return JNI_FALSE;
+            fileName2x = findScaledImageName(fileName, dotIndex, @"@2x");
+            if(![[NSFileManager defaultManager]
+                    fileExistsAtPath: fileName2x]) {
+                fileName2x = findScaledImageName(fileName, dotIndex, @"@200pct");
             }
-            *scaleFactor = 2;
-            strcpy(scaledFile, [fileName2x UTF8String]);
-            [pool drain];
-            return JNI_TRUE;
+            if (jar || [[NSFileManager defaultManager]
+                    fileExistsAtPath: fileName2x]){
+                if (strlen([fileName2x UTF8String]) > scaledImageLength) {
+                    return JNI_FALSE;
+                }
+                *scaleFactor = 2;
+                strcpy(scaledFile, [fileName2x UTF8String]);
+                return JNI_TRUE;
+            }
         }
     }
-    [pool drain];
     return JNI_FALSE;
 }
 
@@ -239,16 +237,15 @@ SplashCleanupPlatform(Splash * splash) {
 
 void
 SplashDonePlatform(Splash * splash) {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-
-    pthread_mutex_destroy(&splash->lock);
-    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
-        if (splash->window) {
-            [splash->window orderOut:nil];
-            [splash->window release];
-        }
-    }];
-    [pool drain];
+    @autoreleasepool {
+        pthread_mutex_destroy(&splash->lock);
+        [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
+            if (splash->window) {
+                [splash->window orderOut:nil];
+                [splash->window release];
+            }
+        }];
+    }
 }
 
 void
@@ -283,7 +280,7 @@ SplashCreateThread(Splash * splash) {
 
 void
 SplashRedrawWindow(Splash * splash) {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    @autoreleasepool {
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         // drop the reference to the old view and image
@@ -338,12 +335,11 @@ SplashRedrawWindow(Splash * splash) {
         [splash->window orderFrontRegardless];
     }];
 
-    [pool drain];
+    }
 }
 
 void SplashReconfigureNow(Splash * splash) {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-
+    @autoreleasepool {
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         SplashCenter(splash);
 
@@ -355,8 +351,7 @@ void SplashReconfigureNow(Splash * splash) {
         [splash->window setFrame: NSMakeRect(splash->x, splash->y, splash->width, splash->height)
                          display: NO];
     }];
-
-    [pool drain];
+    }
 
     SplashRedrawWindow(splash);
 }
@@ -424,42 +419,41 @@ SplashEventLoop(Splash * splash) {
 
 void *
 SplashScreenThread(void *param) {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    Splash *splash = (Splash *) param;
+    @autoreleasepool {
+        Splash *splash = (Splash *) param;
 
-    SplashLock(splash);
-    pipe(splash->controlpipe);
-    fcntl(splash->controlpipe[0], F_SETFL,
-        fcntl(splash->controlpipe[0], F_GETFL, 0) | O_NONBLOCK);
-    splash->time = SplashTime();
-    splash->currentFrame = 0;
-    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
-        SplashCenter(splash);
-
-        splash->window = (void*) [[NSWindow alloc]
-            initWithContentRect: NSMakeRect(splash->x, splash->y, splash->width, splash->height)
-                      styleMask: NSWindowStyleMaskBorderless
-                        backing: NSBackingStoreBuffered
-                          defer: NO
-                         screen: SplashNSScreen()];
-
-        [splash->window setOpaque: NO];
-        [splash->window setBackgroundColor: [NSColor clearColor]];
-    }];
-    fflush(stdout);
-    if (splash->window) {
+        SplashLock(splash);
+        pipe(splash->controlpipe);
+        fcntl(splash->controlpipe[0], F_SETFL,
+            fcntl(splash->controlpipe[0], F_GETFL, 0) | O_NONBLOCK);
+        splash->time = SplashTime();
+        splash->currentFrame = 0;
         [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
-            [splash->window orderFrontRegardless];
+            SplashCenter(splash);
+
+            splash->window = (void*) [[NSWindow alloc]
+                initWithContentRect: NSMakeRect(splash->x, splash->y, splash->width, splash->height)
+                        styleMask: NSWindowStyleMaskBorderless
+                            backing: NSBackingStoreBuffered
+                            defer: NO
+                            screen: SplashNSScreen()];
+
+            [splash->window setOpaque: NO];
+            [splash->window setBackgroundColor: [NSColor clearColor]];
         }];
-        SplashRedrawWindow(splash);
-        SplashEventLoop(splash);
+        fflush(stdout);
+        if (splash->window) {
+            [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
+                [splash->window orderFrontRegardless];
+            }];
+            SplashRedrawWindow(splash);
+            SplashEventLoop(splash);
+        }
+        SplashUnlock(splash);
+        SplashDone(splash);
+
+        splash->isVisible=-1;
     }
-    SplashUnlock(splash);
-    SplashDone(splash);
-
-    splash->isVisible=-1;
-
-    [pool drain];
 
     return 0;
 }

--- a/src/java.security.jgss/macosx/native/libosxkrb5/SCDynamicStoreConfig.m
+++ b/src/java.security.jgss/macosx/native/libosxkrb5/SCDynamicStoreConfig.m
@@ -65,28 +65,27 @@ void _SCDynamicStoreCallBack(SCDynamicStoreRef store, CFArrayRef changedKeys, vo
  * Method:    installNotificationCallback
  */
 JNIEXPORT void JNICALL Java_sun_security_krb5_SCDynamicStoreConfig_installNotificationCallback(JNIEnv *env, jclass klass) {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
-    @try {
-        (*env)->GetJavaVM(env, &localVM);
-        SCDynamicStoreRef store = SCDynamicStoreCreate(NULL, CFSTR("java"), _SCDynamicStoreCallBack, NULL);
-        if (store == NULL) {
-            return;
+    @autoreleasepool {
+        @try {
+            (*env)->GetJavaVM(env, &localVM);
+            SCDynamicStoreRef store = SCDynamicStoreCreate(NULL, CFSTR("java"), _SCDynamicStoreCallBack, NULL);
+            if (store == NULL) {
+                return;
+            }
+
+            NSArray *keys = [NSArray arrayWithObjects:KERBEROS_DEFAULT_REALMS, KERBEROS_DEFAULT_REALM_MAPPINGS, nil];
+            SCDynamicStoreSetNotificationKeys(store, (CFArrayRef) keys, NULL);
+
+            CFRunLoopSourceRef rls = SCDynamicStoreCreateRunLoopSource(NULL, store, 0);
+            if (rls != NULL) {
+                CFRunLoopAddSource(CFRunLoopGetMain(), rls, kCFRunLoopDefaultMode);
+                CFRelease(rls);
+            }
+
+            CFRelease(store);
+        } @catch (NSException *e) {
+            NSLog(@"%@", [e callStackSymbols]);
         }
-
-        NSArray *keys = [NSArray arrayWithObjects:KERBEROS_DEFAULT_REALMS, KERBEROS_DEFAULT_REALM_MAPPINGS, nil];
-        SCDynamicStoreSetNotificationKeys(store, (CFArrayRef) keys, NULL);
-
-        CFRunLoopSourceRef rls = SCDynamicStoreCreateRunLoopSource(NULL, store, 0);
-        if (rls != NULL) {
-            CFRunLoopAddSource(CFRunLoopGetMain(), rls, kCFRunLoopDefaultMode);
-            CFRelease(rls);
-        }
-
-        CFRelease(store);
-    } @catch (NSException *e) {
-        NSLog(@"%@", [e callStackSymbols]);
-    } @finally {
-        [pool drain];
     }
 }
 
@@ -112,62 +111,62 @@ JNIEXPORT jobject JNICALL Java_sun_security_krb5_SCDynamicStoreConfig_getKerbero
     CFTypeRef realmMappings = NULL;
     CFTypeRef realmInfo = NULL;
 
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
-    @try {
-        SCDynamicStoreRef store = SCDynamicStoreCreate(NULL, CFSTR("java-kerberos"), NULL, NULL);
-        if (store == NULL) {
-            return NULL;
-        }
-
-        CFTypeRef realms = SCDynamicStoreCopyValue(store, (CFStringRef) KERBEROS_DEFAULT_REALMS);
-        if (realms == NULL || CFGetTypeID(realms) != CFArrayGetTypeID()) {
-            return NULL;
-        }
-
-        // This methods returns a ArrayList<String>:
-        // (realm kdc* null) null (mapping-domain mapping-realm)*
-        jclass jc_arrayListClass = (*env)->FindClass(env, "java/util/ArrayList");
-        CHECK_NULL_RETURN(jc_arrayListClass, NULL);
-        jmethodID jm_arrayListCons = (*env)->GetMethodID(env, jc_arrayListClass, "<init>", "()V");
-        CHECK_NULL_RETURN(jm_arrayListCons, NULL);
-        jmethodID jm_listAdd = (*env)->GetMethodID(env, jc_arrayListClass, "add", "(Ljava/lang/Object;)Z");
-        CHECK_NULL_RETURN(jm_listAdd, NULL);
-        newList = (*env)->NewObject(env, jc_arrayListClass, jm_arrayListCons);
-        CHECK_NULL_RETURN(newList, NULL);
-
-        for (NSString *realm in (NSArray*)realms) {
-            if (realmInfo) CFRelease(realmInfo); // for the previous realm
-            realmInfo = SCDynamicStoreCopyValue(store, (CFStringRef) [NSString stringWithFormat:KERBEROS_REALM_INFO, realm]);
-            if (realmInfo == NULL || CFGetTypeID(realmInfo) != CFDictionaryGetTypeID()) {
-                continue;
+    @autorelasepool {
+        @try {
+            store = SCDynamicStoreCreate(NULL, CFSTR("java-kerberos"), NULL, NULL);
+            if (store == NULL) {
+                return NULL;
             }
 
-            ADD(newList, realm);
-            NSDictionary* ri = (NSDictionary*)realmInfo;
-            for (NSDictionary* k in (NSArray*)ri[@"kdc"]) {
-                ADD(newList, k[@"host"]);
+            realms = SCDynamicStoreCopyValue(store, (CFStringRef) KERBEROS_DEFAULT_REALMS);
+            if (realms == NULL || CFGetTypeID(realms) != CFArrayGetTypeID()) {
+                return NULL;
+            }
+
+            // This methods returns a ArrayList<String>:
+            // (realm kdc* null) null (mapping-domain mapping-realm)*
+            jclass jc_arrayListClass = (*env)->FindClass(env, "java/util/ArrayList");
+            CHECK_NULL_RETURN(jc_arrayListClass, NULL);
+            jmethodID jm_arrayListCons = (*env)->GetMethodID(env, jc_arrayListClass, "<init>", "()V");
+            CHECK_NULL_RETURN(jm_arrayListCons, NULL);
+            jmethodID jm_listAdd = (*env)->GetMethodID(env, jc_arrayListClass, "add", "(Ljava/lang/Object;)Z");
+            CHECK_NULL_RETURN(jm_listAdd, NULL);
+            newList = (*env)->NewObject(env, jc_arrayListClass, jm_arrayListCons);
+            CHECK_NULL_RETURN(newList, NULL);
+
+            for (NSString *realm in (NSArray*)realms) {
+                if (realmInfo) CFRelease(realmInfo); // for the previous realm
+                realmInfo = SCDynamicStoreCopyValue(store, (CFStringRef) [NSString stringWithFormat:KERBEROS_REALM_INFO, realm]);
+                if (realmInfo == NULL || CFGetTypeID(realmInfo) != CFDictionaryGetTypeID()) {
+                    continue;
+                }
+
+                ADD(newList, realm);
+                NSDictionary* ri = (NSDictionary*)realmInfo;
+                for (NSDictionary* k in (NSArray*)ri[@"kdc"]) {
+                    ADD(newList, k[@"host"]);
+                }
+                ADDNULL(newList);
             }
             ADDNULL(newList);
-        }
-        ADDNULL(newList);
 
-        CFTypeRef realmMappings = SCDynamicStoreCopyValue(store, (CFStringRef) KERBEROS_DEFAULT_REALM_MAPPINGS);
-        if (realmMappings != NULL && CFGetTypeID(realmMappings) == CFArrayGetTypeID()) {
-            for (NSDictionary* d in (NSArray *)realmMappings) {
-                for (NSString* s in d) {
-                    ADD(newList, s);
-                    ADD(newList, d[s]);
+            realmMappings = SCDynamicStoreCopyValue(store, (CFStringRef) KERBEROS_DEFAULT_REALM_MAPPINGS);
+            if (realmMappings != NULL && CFGetTypeID(realmMappings) == CFArrayGetTypeID()) {
+                for (NSDictionary* d in (NSArray *)realmMappings) {
+                    for (NSString* s in d) {
+                        ADD(newList, s);
+                        ADD(newList, d[s]);
+                    }
                 }
             }
+        } @catch (NSException *e) {
+            NSLog(@"%@", [e callStackSymbols]);
+        } @finally {
+            if (realmInfo) CFRelease(realmInfo);
+            if (realmMappings) CFRelease(realmMappings);
+            if (realms) CFRelease(realms);
+            if (store) CFRelease(store);
         }
-    } @catch (NSException *e) {
-        NSLog(@"%@", [e callStackSymbols]);
-    } @finally {
-        [pool drain];
-        if (realmInfo) CFRelease(realmInfo);
-        if (realmMappings) CFRelease(realmMappings);
-        if (realms) CFRelease(realms);
-        if (store) CFRelease(store);
     }
     return newList;
 }

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -257,7 +257,7 @@ jlong lookupByNameIncore(
 
 /* Create a pool and initiate a try block to catch any exception */
 #define JNI_COCOA_ENTER(env) \
- NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
+ @autoreleasepool { \
  @try {
 
 /* Don't allow NSExceptions to escape to Java.
@@ -269,9 +269,7 @@ jlong lookupByNameIncore(
  @catch (NSException *e) { \
      NSLog(@"%@", [e callStackSymbols]); \
  } \
- @finally { \
-    [pool drain]; \
- };
+};
 
 static NSString* JavaStringToNSString(JNIEnv *env, jstring jstr) {
 

--- a/test/jdk/java/awt/Window/MainKeyWindowTest/libTestMainKeyWindow.m
+++ b/test/jdk/java/awt/Window/MainKeyWindowTest/libTestMainKeyWindow.m
@@ -28,7 +28,7 @@ static NSWindow *testWindow;
 static NSColorPanel *colorPanel;
 
 #define JNI_COCOA_ENTER(env) \
- NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
+ @autorelease pool { \
  @try {
 
 #define JNI_COCOA_EXIT(env) \
@@ -36,9 +36,7 @@ static NSColorPanel *colorPanel;
  @catch (NSException *e) { \
      NSLog(@"%@", [e callStackSymbols]); \
  } \
- @finally { \
-    [pool drain]; \
-  };
+};
 
 /*
  * Pass the block to a selector of a class that extends NSObject


### PR DESCRIPTION
Two things:

1. This is safe. NSAutoreleasePool objects just wrap around these push pops anyway, so this is faster.

2. In some places, we return without draining the pool. Instead of putting drain in those places, @autoreleasepool deals with that automatically.

To be safe, I only did this in files which use __block, which requires the same runtime that supports @autoreleasepool anyway.




---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32800/head:pull/32800` \
`$ git checkout pull/32800`

Update a local copy of the PR: \
`$ git checkout pull/32800` \
`$ git pull https://git.openjdk.org/jdk.git pull/32800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32800`

View PR using the GUI difftool: \
`$ git pr show -t 32800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32800.diff">https://git.openjdk.org/jdk/pull/32800.diff</a>

</details>
