### PR TITLE
8271610: HeapMonitorInitialAllocationTest fails intermittently

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorInitialAllocationTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorInitialAllocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,7 +42,7 @@ public class HeapMonitorInitialAllocationTest {
       threads[i] = new Thread(new Task(), "Task " + i);
     }
 
-    HeapMonitor.setSamplingInterval(1024 * 1024);
+    HeapMonitor.setSamplingInterval(64 * 1024 * 1024);
     HeapMonitor.enableSamplingEvents();
 
     for (int i = 0; i < numThreads ; i++) {


### PR DESCRIPTION
Increasing SamplingInterval to avoid thread start allocation noise

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8271610](https://bugs.openjdk.org/browse/JDK-8271610): HeapMonitorInitialAllocationTest fails intermittently (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32801/head:pull/32801` \
`$ git checkout pull/32801`

Update a local copy of the PR: \
`$ git checkout pull/32801` \
`$ git pull https://git.openjdk.org/jdk.git pull/32801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32801`

View PR using the GUI difftool: \
`$ git pr show -t 32801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32801.diff">https://git.openjdk.org/jdk/pull/32801.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32801#issuecomment-5607031240)
</details>
