### PR TITLE
"permanent" class loaders can have oops in vm_global OopStorage rather

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -841,26 +841,37 @@ ClassLoaderMetaspace* ClassLoaderData::metaspace_non_null() {
 
 OopHandle ClassLoaderData::add_handle(Handle h) {
   MutexLocker ml(metaspace_lock(),  Mutex::_no_safepoint_check_flag);
-  record_modified_oops();
-  return _handles.add(h());
+  return add_handle_locked(h);
+}
+
+OopHandle ClassLoaderData::add_handle_locked(Handle h) {
+  if (is_permanent_class_loader_data()) {
+    return OopHandle(Universe::vm_global(), h());
+  } else {
+    record_modified_oops();
+    return _handles.add(h());
+  }
 }
 
 void ClassLoaderData::remove_handle(OopHandle h) {
   assert(!is_unloading(), "Do not remove a handle for a CLD that is unloading");
   if (!h.is_empty()) {
-    assert(_handles.owner_of(h.ptr_raw()),
-           "Got unexpected handle " PTR_FORMAT, p2i(h.ptr_raw()));
-    h.replace(oop(nullptr));
+    if (is_permanent_class_loader_data()) {
+      h.release(Universe::vm_global());
+    } else {
+      assert(_handles.owner_of(h.ptr_raw()),
+             "Got unexpected handle " PTR_FORMAT, p2i(h.ptr_raw()));
+      h.replace(oop(nullptr));
+    }
   }
 }
 
-void ClassLoaderData::init_handle_locked(OopHandle& dest, Handle h) {
+void ClassLoaderData::init_handle(OopHandle& dest, Handle h) {
   MutexLocker ml(metaspace_lock(),  Mutex::_no_safepoint_check_flag);
   if (dest.resolve() != nullptr) {
     return;
   } else {
-    record_modified_oops();
-    dest = _handles.add(h());
+    dest = add_handle_locked(h);
   }
 }
 

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,6 +225,7 @@ private:
 
   void initialize_name(Handle class_loader);
 
+  OopHandle add_handle_locked(Handle h); // called whilst already holding the lock
  public:
   // GC interface.
 
@@ -324,7 +325,7 @@ private:
 
   OopHandle add_handle(Handle h);
   void remove_handle(OopHandle h);
-  void init_handle_locked(OopHandle& pd, Handle h);  // used for concurrent access to ModuleEntry::_pd field
+  void init_handle(OopHandle& pd, Handle h);  // used for concurrent access to ModuleEntry::_pd field
   void add_class(Klass* k, bool publicize = true);
   void remove_class(Klass* k);
   bool contains_klass(Klass* k);

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -117,8 +117,8 @@ oop ModuleEntry::shared_protection_domain() {
 void ModuleEntry::set_shared_protection_domain(ClassLoaderData *loader_data,
                                                Handle pd_h) {
   // Create a handle for the shared ProtectionDomain and save it atomically.
-  // init_handle_locked checks if someone beats us setting the _shared_pd cache.
-  loader_data->init_handle_locked(_shared_pd, pd_h);
+  // init_handle checks if someone beats us setting the _shared_pd cache.
+  loader_data->init_handle(_shared_pd, pd_h);
 }
 
 // Returns true if this module can read module m

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2516,36 +2516,41 @@ class SimpleRootsClosure : public OopClosure {
 };
 
 // A supporting closure used to process ClassLoaderData roots.
-class CLDRootsClosure: public OopClosure {
+class CLDRootsClosure: public CLDClosure {
 private:
   bool _continue;
 public:
   CLDRootsClosure(): _continue(true) {}
 
-  inline bool stopped() {
-    return !_continue;
+  class CLDKlassClosure : public KlassClosure {
+    bool _continue;
+   public:
+    CLDKlassClosure(): _continue(true) {}
+    inline bool stopped() {
+      return !_continue;
+    }
+
+    void do_klass(Klass* k) {
+      if (stopped()) {
+        return;
+      }
+
+      oop o = k->java_mirror();
+      if (o != nullptr) {
+        jvmtiHeapReferenceKind kind = JVMTI_HEAP_REFERENCE_SYSTEM_CLASS;
+        // invoke the callback
+        _continue = CallbackInvoker::report_simple_root(kind, o);
+      }
+    }
+  };
+
+  void do_cld(ClassLoaderData* cld) {
+    CLDKlassClosure clk;
+    cld->classes_do(&clk);
+    _continue = clk.stopped();
   }
 
-  void do_oop(oop* obj_p) {
-    if (stopped()) {
-      return;
-    }
-
-    oop o = NativeAccess<AS_NO_KEEPALIVE>::oop_load(obj_p);
-    // ignore null
-    if (o == nullptr) {
-      return;
-    }
-
-    jvmtiHeapReferenceKind kind = JVMTI_HEAP_REFERENCE_OTHER;
-    if (o->klass() == vmClasses::Class_klass()) {
-      kind = JVMTI_HEAP_REFERENCE_SYSTEM_CLASS;
-    }
-
-    // invoke the callback
-    _continue = CallbackInvoker::report_simple_root(kind, o);
-  }
-  virtual void do_oop(narrowOop* obj_p) { ShouldNotReachHere(); }
+  inline bool stopped() const { return !_continue; }
 };
 
 // A supporting closure used to process JNI locals
@@ -3177,8 +3182,9 @@ inline bool VM_HeapWalkOperation::collect_simple_roots() {
 
   // Preloaded classes and loader from the system dictionary
   CLDRootsClosure cld_roots_closure;
-  CLDToOopClosure cld_closure(&cld_roots_closure, ClassLoaderData::_claim_none);
-  ClassLoaderDataGraph::always_strong_cld_do(&cld_closure);
+  // CLDToOopClosure cld_closure(&cld_roots_closure, ClassLoaderData::_claim_none);
+
+  ClassLoaderDataGraph::always_strong_cld_do(&cld_roots_closure);
   if (cld_roots_closure.stopped()) {
     return false;
   }

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2547,7 +2547,7 @@ public:
   void do_cld(ClassLoaderData* cld) {
     CLDKlassClosure clk;
     cld->classes_do(&clk);
-    _continue = clk.stopped();
+    _continue = !clk.stopped();
   }
 
   inline bool stopped() const { return !_continue; }
@@ -3182,8 +3182,6 @@ inline bool VM_HeapWalkOperation::collect_simple_roots() {
 
   // Preloaded classes and loader from the system dictionary
   CLDRootsClosure cld_roots_closure;
-  // CLDToOopClosure cld_closure(&cld_roots_closure, ClassLoaderData::_claim_none);
-
   ClassLoaderDataGraph::always_strong_cld_do(&cld_roots_closure);
   if (cld_roots_closure.stopped()) {
     return false;


### PR DESCRIPTION
than CLD::_handles.  This is an experiment FYI.

Passes jck and tier1 tests.  Needed to fix FollowReferences again.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32804/head:pull/32804` \
`$ git checkout pull/32804`

Update a local copy of the PR: \
`$ git checkout pull/32804` \
`$ git pull https://git.openjdk.org/jdk.git pull/32804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32804`

View PR using the GUI difftool: \
`$ git pr show -t 32804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32804.diff">https://git.openjdk.org/jdk/pull/32804.diff</a>

</details>
