### PR TITLE
8392123: JFR: Harden jdk.jfr.AnnotationElement

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/AnnotationElement.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/AnnotationElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package jdk.jfr;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -148,7 +149,8 @@ public final class AnnotationElement {
             if (object == null) {
                 throw new IllegalArgumentException("No method in annotation interface " + annotationType.getName() + " matching name " + fieldName);
             }
-            Class<?> fieldType = object.getClass();
+            object = safeObject(object);
+            Class<?> fieldType = method.getReturnType();
 
             if (fieldType == Class.class) {
                 throw new IllegalArgumentException("Annotation value for " + fieldName + " can't be class");
@@ -156,8 +158,9 @@ public final class AnnotationElement {
             if (object instanceof Enum) {
                 throw new IllegalArgumentException("Annotation value for " + fieldName + " can't be enum");
             }
-            if (!fieldType.equals(object.getClass())) {
-                throw new IllegalArgumentException("Return type of annotation " + fieldType.getName() + " must match type of object" + object.getClass());
+            Class<?> objectType = Utils.unboxType(object.getClass());
+            if (objectType != fieldType) {
+                throw new IllegalArgumentException("Return type of annotation " + fieldType.getName() + " must match type of object " + objectType.getName());
             }
 
             if (fieldType.isArray()) {
@@ -172,7 +175,6 @@ public final class AnnotationElement {
                     }
                 }
             } else {
-                fieldType = Utils.unboxType(object.getClass());
                 checkType(fieldType);
             }
             if (nameSet!= null) {
@@ -245,7 +247,7 @@ public final class AnnotationElement {
      * @return list of values, not {@code null}
      */
     public List<Object> getValues() {
-        return annotationValues;
+        return safeList(annotationValues);
     }
 
     /**
@@ -294,7 +296,7 @@ public final class AnnotationElement {
         Objects.requireNonNull(name, "name");
         int index = type.indexOf(name);
         if (index != -1) {
-            return annotationValues.get(index);
+            return safeObject(annotationValues.get(index));
         }
         StringJoiner valueNames = new StringJoiner(",", "[", "]");
         for (ValueDescriptor v : type.getFields()) {
@@ -383,5 +385,36 @@ public final class AnnotationElement {
     // package private
     boolean isInBoot() {
         return inBootClassLoader;
+    }
+
+    private static Object safeObject(Object object) {
+        return object.getClass().isArray() ? safeArray(object) : object;
+    }
+
+    private static Object safeArray(Object source) {
+        Class<?> type = source.getClass().getComponentType();
+        int length = Array.getLength(source);
+        if (length == 0) {
+            return source;
+        }
+        Object result = Array.newInstance(type, length);
+        System.arraycopy(source, 0, result, 0, length);
+        return result;
+    }
+
+    // Assumes list is created by List.copyOf(...);
+    private static List<Object> safeList(List<Object> list) {
+        if (list.isEmpty()) {
+            return list;
+        }
+        if (list.size() == 1) {
+            Object element = list.get(0);
+            return element.getClass().isArray() ? List.of(safeObject(element)) : list;
+        }
+        List<Object> result = new ArrayList<>(list.size());
+        for (Object element : list) {
+            result.add(safeObject(element));
+        }
+        return List.copyOf(result);
     }
 }

--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestDynamicAnnotation.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestDynamicAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,13 +41,30 @@ import jdk.jfr.MetadataDefinition;
 public class TestDynamicAnnotation {
     @MetadataDefinition
     @interface CustomAnnotation {
-        String value();
+        String stringValue();
         int intValue();
     }
 
     public static void main(String[] args) throws Exception {
+        testCustomAnnotation();
+        testTypeMismatch();
+    }
+
+    private static void testTypeMismatch() throws Exception {
         Map<String, Object> values = new HashMap<>();
-        values.put("value", "MyValue");
+        values.put("stringValue", 1);
+        values.put("intValue", "text");
+        try {
+            new AnnotationElement(CustomAnnotation.class, values);
+            throw new Exception("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+            // As expected
+        }
+    }
+
+    public static void testCustomAnnotation() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("stringValue", "text");
         values.put("intValue", 1);
         new AnnotationElement(CustomAnnotation.class, values);
     }

--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestGetValues.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestGetValues.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.api.metadata.annotations;
+
+import java.util.List;
+import java.util.Map;
+
+import jdk.jfr.AnnotationElement;
+import jdk.jfr.Category;
+import jdk.jfr.MetadataDefinition;
+import jdk.jfr.ValueDescriptor;
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @requires vm.flagless
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.api.metadata.annotations.TestGetValues
+ */
+@MetadataDefinition
+@interface Animal {
+    String value();
+}
+
+@MetadataDefinition
+@interface Elephant {
+    String color();
+    boolean mammal();
+}
+public class TestGetValues {
+
+    public static void main(String[] args) throws Exception {
+        testGetValue();
+        testImmutableGetValue();
+        testGetValues();
+        testImmutableGetValues();
+    }
+
+    public static void testGetValue() {
+        AnnotationElement animal = new AnnotationElement(Animal.class, "tiger");
+        Asserts.assertEquals("tiger", animal.getValue("value"));
+
+        AnnotationElement elephant = new AnnotationElement(Elephant.class, Map.of("color", "gray", "mammal", true));
+        Asserts.assertEquals("gray", elephant.getValue("color"));
+        Asserts.assertEquals(true, elephant.getValue("mammal"));
+    }
+
+    public static void testImmutableGetValue() {
+        String[] initial = { "tree", "leaf" };
+        AnnotationElement a = new AnnotationElement(Category.class, initial);
+
+        // Mutate array after construction
+        initial[0] = "foo";
+        String[] s1 = (String[]) a.getValue("value");
+        Asserts.assertEquals(s1[0], "tree");
+
+        // Mutate returned array
+        s1[0] = "syntax error";
+        String[] s2 = (String[]) a.getValue("value");
+        Asserts.assertEquals(s2[0], "tree");
+    }
+
+    public static void testGetValues() {
+        AnnotationElement animal = new AnnotationElement(Animal.class, "tiger");
+        Asserts.assertEquals("tiger", animal.getValues().get(0));
+
+        AnnotationElement elephant = new AnnotationElement(Elephant.class, Map.of("color", "gray", "mammal", true));
+        Asserts.assertEquals(getValue(elephant, "color"), "gray");
+        Asserts.assertEquals(getValue(elephant, "mammal"), true);
+    }
+
+    public static void testImmutableGetValues() throws Exception {
+        String[] initial = { "tree", "leaf" };
+        AnnotationElement a = new AnnotationElement(Category.class, initial);
+
+        // Mutate array after construction
+        initial[0] = "foo";
+        String[] s1 = (String[]) a.getValues().get(0);
+        Asserts.assertEquals(s1[0], "tree");
+
+        // Mutate returned array
+        s1[0] = "syntax error";
+        String[] s2 = (String[]) a.getValues().get(0);
+        Asserts.assertEquals(s2[0], "tree");
+
+        // Mutate returned list
+        try {
+            a.getValues().add("modify");
+            throw new Exception("Expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException uoe) {
+            // as expected
+        }
+    }
+
+    private static Object getValue(AnnotationElement a, String name) {
+        int index = 0;
+        List<Object> values = a.getValues();
+        for (ValueDescriptor v : a.getValueDescriptors()) {
+            if (v.getName().equals(name)) {
+                return values.get(index);
+            }
+            index++;
+        }
+        throw new IllegalStateException("No annotation value named " + name);
+    }
+}

--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestTypesIdentical.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestTypesIdentical.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,11 @@
  */
 
 package jdk.jfr.api.metadata.annotations;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
 
 import jdk.jfr.AnnotationElement;
 import jdk.jfr.BooleanFlag;
@@ -57,7 +62,6 @@ import jdk.test.lib.Asserts;
  * @run main/othervm jdk.jfr.api.metadata.annotations.TestTypesIdentical
  */
 public class TestTypesIdentical {
-
     @MetadataDefinition
     @interface CustomAnnotation {
         String value();
@@ -79,15 +83,30 @@ public class TestTypesIdentical {
         assertTypeId(CustomAnnotation.class);
     }
 
-    private static void assertTypeId(Class<? extends java.lang.annotation.Annotation> clz) {
-        AnnotationElement a1, a2;
-        try {
-            a1 = new AnnotationElement(clz, "value");
-            a2 = new AnnotationElement(clz, "value2");
-        } catch(IllegalArgumentException x) {
-            a1 = new AnnotationElement(clz);
-            a2 = new AnnotationElement(clz);
-        }
+    private static void assertTypeId(Class<? extends java.lang.annotation.Annotation> clz) throws Exception {
+        AnnotationElement a1 = new AnnotationElement(clz, createDefaultMap(clz));
+        AnnotationElement a2 = new AnnotationElement(clz, createDefaultMap(clz));
         Asserts.assertEquals(a1.getTypeId(), a2.getTypeId());
+    }
+
+    private static Map<String, Object> createDefaultMap(Class<?> annotationClass) throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        for (Method method : annotationClass.getDeclaredMethods()) {
+            int modifiers = method.getModifiers();
+            if (Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers)) {
+                Class<?> type = method.getReturnType();
+                String name = method.getName();
+                if (type == String.class) {
+                    map.put(name, "text");
+                } else if (type == boolean.class) {
+                    map.put(name, true);
+                } else if (type == String[].class) {
+                    map.put(name, new String[] { "text" });
+                } else {
+                    throw new Exception("Test error. No default value for type " + type.getName());
+                }
+            }
+        }
+        return map;
     }
 }

--- a/test/jdk/jdk/jfr/api/metadata/eventtype/TestGetAnnotationElements.java
+++ b/test/jdk/jdk/jfr/api/metadata/eventtype/TestGetAnnotationElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,6 @@ import jdk.test.lib.Asserts;
  * @run main/othervm jdk.jfr.api.metadata.eventtype.TestGetAnnotationElements
  */
 public class TestGetAnnotationElements {
-
     @SuppressWarnings("unchecked")
     public static void main(String[] args) throws Throwable {
         Class<?>[] jfrAnnotations = {
@@ -83,11 +82,11 @@ public class TestGetAnnotationElements {
         };
 
         for (Class<?> clz : jfrAnnotations) {
-            Class<? extends Annotation> annptationClass = (Class<? extends Annotation>) clz;
-            System.out.println("AnnotationElement: " + annptationClass);
-            Map<String, Object> values = createValueMapForAnnotation(annptationClass);
-            List<Annotation> persistableAnnotation = createPersistableAnnotationList(annptationClass);
-            AnnotationElement ae = new AnnotationElement(annptationClass, values);
+            Class<? extends Annotation> annotationClass = (Class<? extends Annotation>) clz;
+            System.out.println("AnnotationElement: " + annotationClass);
+            Map<String, Object> values = createDefaultMap(annotationClass);
+            List<Annotation> persistableAnnotation = createPersistableAnnotationList(annotationClass);
+            AnnotationElement ae = new AnnotationElement(annotationClass, values);
             List<AnnotationElement> aes = ae.getAnnotationElements();
             Asserts.assertEquals(persistableAnnotation.size(), aes.size());
         }
@@ -131,12 +130,22 @@ public class TestGetAnnotationElements {
         Asserts.fail("Class " + clz + " not found in the annotation elements");
     }
 
-    private static Map<String, Object> createValueMapForAnnotation(Class<?> clz) {
+    private static Map<String, Object> createDefaultMap(Class<?> annotationClass) throws Exception {
         Map<String, Object> map = new HashMap<>();
-        for (Method method : clz.getDeclaredMethods()) {
+        for (Method method : annotationClass.getDeclaredMethods()) {
             int modifiers = method.getModifiers();
             if (Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers)) {
-                map.put(method.getName(), "value");
+                Class<?> type = method.getReturnType();
+                String name = method.getName();
+                if (type == String.class) {
+                    map.put(name, "text");
+                } else if (type == boolean.class) {
+                    map.put(name, true);
+                } else if (type == String[].class) {
+                    map.put(name, new String[] { "text" });
+                } else {
+                    throw new Exception("Test error. No default value for type " + type.getName());
+                }
             }
         }
         return map;


### PR DESCRIPTION
Could I have a review of a PR that fixes various issues with the AnnotationElement class. 

- Constructors do not properly validate types of argument values
- Arrays can be mutated, either after the AnnotationElement is created or when they are returned by getValue(String) and getValues()
- A couple of tests relied on missing validation, so they were updated
- Missing unit tests for getValue(String) and getValues() were added.

Testing: test/jdk/jdk/jfr

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392123](https://bugs.openjdk.org/browse/JDK-8392123): JFR: Harden jdk.jfr.AnnotationElement (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32805/head:pull/32805` \
`$ git checkout pull/32805`

Update a local copy of the PR: \
`$ git checkout pull/32805` \
`$ git pull https://git.openjdk.org/jdk.git pull/32805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32805`

View PR using the GUI difftool: \
`$ git pr show -t 32805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32805.diff">https://git.openjdk.org/jdk/pull/32805.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32805#issuecomment-5611166567)
</details>
