### PR TITLE
8392091: Replace RegQueryValueEx* function calls in hotspot that get byte and string data by RegGetValue

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2011,32 +2011,17 @@ void os::print_os_info(outputStream* st) {
 }
 
 static bool getWindowsInstallationType(char* buffer, int bufferSize) {
-  HKEY hKey;
   const char* subKey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
   const char* valueName = "InstallationType";
-
   DWORD valueLength = bufferSize;
-
   // Initialize buffer with empty string
   buffer[0] = '\0';
 
-  // Open the registry key
-  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, subKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
-    // Return empty buffer if key cannot be opened
-    return false;
-  }
-
-  // Query the value
-  if (RegQueryValueExA(hKey, valueName, nullptr, nullptr, (LPBYTE)buffer, &valueLength) != ERROR_SUCCESS) {
-    RegCloseKey(hKey);
+  if (RegGetValueA(HKEY_LOCAL_MACHINE, subKey, valueName,
+                   RRF_RT_REG_SZ, nullptr, buffer, &valueLength) != ERROR_SUCCESS) {
     buffer[0] = '\0';
     return false;
   }
-
-  // If the value being queried is a string the value returned is NOT guaranteed to be null-terminated
-  buffer[valueLength - 1] = '\0';
-
-  RegCloseKey(hKey);
   return true;
 }
 
@@ -2204,22 +2189,12 @@ void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {
 }
 
 void os::get_summary_cpu_info(char* buf, size_t buflen) {
-  HKEY key;
-  DWORD status = RegOpenKey(HKEY_LOCAL_MACHINE,
-               "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", &key);
-  if (status == ERROR_SUCCESS) {
-    DWORD size = (DWORD)buflen;
-    status = RegQueryValueEx(key, "ProcessorNameString", nullptr, nullptr, (byte*)buf, &size);
-    if (status != ERROR_SUCCESS) {
-        strncpy(buf, "## __CPU__", buflen);
-    } else {
-      if (size < buflen) {
-        buf[size] = '\0';
-      }
-    }
-    RegCloseKey(key);
-  } else {
-    // Put generic cpu info to return
+  DWORD size = (DWORD)buflen;
+  DWORD status = RegGetValueA(HKEY_LOCAL_MACHINE,
+                              "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+                              "ProcessorNameString",
+                              RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ, nullptr, buf, &size);
+  if (status != ERROR_SUCCESS) {
     strncpy(buf, "## __CPU__", buflen);
   }
 }

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -392,17 +392,13 @@ extern "C" int SpinPause () {
 juint os::cpu_microcode_revision() {
   juint result = 0;
   BYTE data[8] = {0};
-  HKEY key;
-  DWORD status = RegOpenKey(HKEY_LOCAL_MACHINE,
-               "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", &key);
+  DWORD size = sizeof(data);
+  DWORD status = RegGetValueA(HKEY_LOCAL_MACHINE,
+                              "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+                              "Update Revision", RRF_RT_ANY, nullptr, data, &size);
   if (status == ERROR_SUCCESS) {
-    DWORD size = sizeof(data);
-    status = RegQueryValueEx(key, "Update Revision", nullptr, nullptr, data, &size);
-    if (status == ERROR_SUCCESS) {
-      if (size == 4) result = *((juint*)data);
-      if (size == 8) result = *((juint*)data + 1); // upper 32-bits
-    }
-    RegCloseKey(key);
+    if (size == 4) result = *((juint*)data);
+    if (size == 8) result = *((juint*)data + 1); // upper 32-bits
   }
   return result;
 }


### PR DESCRIPTION
There are some RegQueryValueEx* calls in os_windows*, those can potentially be simplified by using RegGetValue*.
Benefit is that some null termination of string results might be not needed any more.

See https://learn.microsoft.com/de-de/windows/win32/api/winreg/nf-winreg-reggetvaluea .

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392091](https://bugs.openjdk.org/browse/JDK-8392091): Replace RegQueryValueEx* function calls in hotspot that get byte and string data by RegGetValue (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32807/head:pull/32807` \
`$ git checkout pull/32807`

Update a local copy of the PR: \
`$ git checkout pull/32807` \
`$ git pull https://git.openjdk.org/jdk.git pull/32807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32807`

View PR using the GUI difftool: \
`$ git pr show -t 32807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32807.diff">https://git.openjdk.org/jdk/pull/32807.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32807#issuecomment-5615551234)
</details>
