### PR TITLE
8392151: Disable IP_TOS support on ServerSocket by default

### DIFF
--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
- Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 1998, 2026, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,21 @@ If there is no special note, a property value is checked every time it is used.<
     returned by the system-wide {@linkplain java.net.spi.InetAddressResolver resolver}.</P>
 </UL>
 <P>Both of these properties are checked only once, at startup.</P>
+<a id="ServerSocket"></a>
+<H2>Server sockets</H2>
+<UL>
+    <LI><P><B>{@systemProperty jdk.net.ServerSocket.IP_TOS}</B> (default: false)<BR>
+    When set to {@code true}, ignoring case, this property allows applications to set
+    and query {@link java.net.StandardSocketOptions#IP_TOS IP_TOS} on a server socket
+    using the JDK's default {@link java.net.ServerSocket ServerSocket} implementation,
+    including before a connection is accepted. Otherwise, the option is not supported.
+    This property also controls whether {@code IP_TOS} is included in the option
+    set returned by {@code jdk.net.Sockets.supportedOptions(ServerSocket.class)}.
+    The option's effects, including inheritance by accepted sockets, are
+    platform dependent. Support on {@code Socket} and
+    {@code DatagramSocket} is not affected.</P>
+</UL>
+<P>This property is checked only once, at startup.</P>
 <a id="Proxies"></a>
 <H2>Proxies</H2>
 <P>A proxy server allows indirect connection to network services and

--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.lang.LazyConstant;
 import java.util.function.Supplier;
 
+import jdk.internal.misc.VM;
 import sun.net.ext.ExtendedSocketOptions;
 import sun.net.util.IPAddressUtil;
 
@@ -87,6 +88,14 @@ public class Net {
      */
     static boolean isReusePortAvailable() {
         return SO_REUSEPORT_AVAILABLE;
+    }
+
+    /**
+     * Returns whether IP_TOS support is enabled for the default ServerSocket
+     * implementation by the startup property.
+     */
+    public static boolean isServerSocketIPTosEnabled() {
+        return Boolean.parseBoolean(VM.getSavedProperty("jdk.net.ServerSocket.IP_TOS"));
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -919,6 +919,9 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             options.add(StandardSocketOptions.SO_RCVBUF);
             options.add(StandardSocketOptions.SO_REUSEADDR);
             if (server) {
+                if (Net.isServerSocketIPTosEnabled()) {
+                    options.add(StandardSocketOptions.IP_TOS);
+                }
                 options.addAll(ExtendedSocketOptions.serverSocketOptions());
             } else {
                 options.add(StandardSocketOptions.IP_TOS);

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -919,8 +919,6 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             options.add(StandardSocketOptions.SO_RCVBUF);
             options.add(StandardSocketOptions.SO_REUSEADDR);
             if (server) {
-                // IP_TOS added for server socket to maintain compatibility
-                options.add(StandardSocketOptions.IP_TOS);
                 options.addAll(ExtendedSocketOptions.serverSocketOptions());
             } else {
                 options.add(StandardSocketOptions.IP_TOS);

--- a/src/jdk.net/share/classes/jdk/net/Sockets.java
+++ b/src/jdk.net/share/classes/jdk/net/Sockets.java
@@ -40,6 +40,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import sun.nio.ch.Net;
+
 /**
  * Defines static methods to set and get socket options defined by the
  * {@link java.net.SocketOption} interface. All of the standard options defined
@@ -327,6 +329,9 @@ public class Sockets {
             set.addAll(Set.of(ExtendedSocketOptions.TCP_KEEPCOUNT,
                     ExtendedSocketOptions.TCP_KEEPIDLE,
                     ExtendedSocketOptions.TCP_KEEPINTERVAL));
+        }
+        if (Net.isServerSocketIPTosEnabled()) {
+            set.add(StandardSocketOptions.IP_TOS);
         }
         if (incomingNapiIdsupported) {
             set.add(ExtendedSocketOptions.SO_INCOMING_NAPI_ID);

--- a/src/jdk.net/share/classes/jdk/net/Sockets.java
+++ b/src/jdk.net/share/classes/jdk/net/Sockets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -328,7 +328,6 @@ public class Sockets {
                     ExtendedSocketOptions.TCP_KEEPIDLE,
                     ExtendedSocketOptions.TCP_KEEPINTERVAL));
         }
-        set.add(StandardSocketOptions.IP_TOS);
         if (incomingNapiIdsupported) {
             set.add(ExtendedSocketOptions.SO_INCOMING_NAPI_ID);
         }

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -30,7 +30,6 @@
  * @run main/othervm --limit-modules=java.base OptionsTest
  */
 
-import java.lang.reflect.Method;
 import java.net.*;
 import java.util.*;
 
@@ -73,10 +72,7 @@ public class OptionsTest {
     static Test<?>[] serverSocketTests = new Test<?>[] {
         Test.create(StandardSocketOptions.SO_RCVBUF, Integer.valueOf(8 * 100)),
         Test.create(StandardSocketOptions.SO_REUSEADDR, Boolean.FALSE),
-        Test.create(StandardSocketOptions.SO_REUSEPORT, Boolean.FALSE),
-        Test.create(StandardSocketOptions.IP_TOS, Integer.valueOf(0)),  // lower-bound
-        Test.create(StandardSocketOptions.IP_TOS, Integer.valueOf(100)),
-        Test.create(StandardSocketOptions.IP_TOS, Integer.valueOf(255))  //upper-bound
+        Test.create(StandardSocketOptions.SO_REUSEPORT, Boolean.FALSE)
     };
 
     static Test<?>[] datagramSocketTests = new Test<?>[] {
@@ -268,8 +264,6 @@ public class OptionsTest {
                 return Boolean.valueOf(socket.getReuseAddress());
             } else if (option.equals(StandardSocketOptions.SO_REUSEPORT) && reuseport) {
                 return Boolean.valueOf(socket.getOption(StandardSocketOptions.SO_REUSEPORT));
-            } else if (option.equals(StandardSocketOptions.IP_TOS)) {
-                return getServerSocketTrafficClass(socket);
             } else {
                 throw new RuntimeException("unexpected socket option");
             }
@@ -330,21 +324,5 @@ public class OptionsTest {
         doServerSocketTests();
         doDatagramSocketTests();
         doMulticastSocketTests();
-    }
-
-    // Reflectively access jdk.net.Sockets.getOption so that the test can run
-    // without the jdk.net module.
-    static Object getServerSocketTrafficClass(ServerSocket ss) throws Exception {
-        try {
-            Class<?> c = Class.forName("jdk.net.Sockets");
-            Method m = c.getMethod("getOption", ServerSocket.class, SocketOption.class);
-            return m.invoke(null, ss, StandardSocketOptions.IP_TOS);
-        } catch (ClassNotFoundException e) {
-            // Ok, jdk.net module not present, just fall back
-            System.out.println("jdk.net module not present, falling back.");
-            return Integer.valueOf(ss.getOption(StandardSocketOptions.IP_TOS));
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError(e);
-        }
     }
 }

--- a/test/jdk/jdk/net/Sockets/SupportedOptions.java
+++ b/test/jdk/jdk/net/Sockets/SupportedOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,27 +23,37 @@
 
 /*
  * @test
- * @bug 8062744
+ * @bug 8062744 8210362
+ * @summary Check that IP_TOS is not supported by ServerSocket
  * @modules jdk.net
- * @run main SupportedOptions
+ * @run junit ${test.main.class}
  */
 
 import java.net.*;
-import java.io.IOException;
 import jdk.net.*;
 
-public class SupportedOptions {
+import org.junit.jupiter.api.Test;
 
-    public static void main(String[] args) throws Exception {
-        if (!Sockets.supportedOptions(ServerSocket.class)
-              .contains(StandardSocketOptions.IP_TOS)) {
-            throw new RuntimeException("Test failed");
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SupportedOptions {
+
+    @Test
+    void serverSocketOptions() throws Exception {
+        var option = StandardSocketOptions.IP_TOS;
+
+        assertFalse(Sockets.supportedOptions(ServerSocket.class).contains(option),
+                "ServerSocket class options unexpectedly include IP_TOS");
+
+        try (var ss = new ServerSocket()) {
+            assertFalse(ss.supportedOptions().contains(option),
+                    "ServerSocket options unexpectedly include IP_TOS");
+
+            assertThrows(UnsupportedOperationException.class,
+                    () -> Sockets.setOption(ss, option, 128));
+            assertThrows(UnsupportedOperationException.class,
+                    () -> Sockets.getOption(ss, option));
         }
-        // Now set the option
-        ServerSocket ss = new ServerSocket();
-        if (!ss.supportedOptions().contains(StandardSocketOptions.IP_TOS)) {
-            throw new RuntimeException("Test failed");
-        }
-        Sockets.setOption(ss, java.net.StandardSocketOptions.IP_TOS, 128);
     }
 }

--- a/test/jdk/jdk/net/Sockets/SupportedOptions.java
+++ b/test/jdk/jdk/net/Sockets/SupportedOptions.java
@@ -23,10 +23,14 @@
 
 /*
  * @test
- * @bug 8062744 8210362
- * @summary Check that IP_TOS is not supported by ServerSocket
+ * @bug 8062744 8392151
+ * @summary Check opt-in IP_TOS support on ServerSocket
  * @modules jdk.net
- * @run junit ${test.main.class}
+ * @run junit/othervm ${test.main.class}
+ * @run junit/othervm -Djdk.net.ServerSocket.IP_TOS ${test.main.class}
+ * @run junit/othervm -Djdk.net.ServerSocket.IP_TOS=false ${test.main.class}
+ * @run junit/othervm -Djdk.net.ServerSocket.IP_TOS=true ${test.main.class}
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true -Djdk.net.ServerSocket.IP_TOS=TrUe ${test.main.class}
  */
 
 import java.net.*;
@@ -34,7 +38,7 @@ import jdk.net.*;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SupportedOptions {
@@ -42,18 +46,34 @@ class SupportedOptions {
     @Test
     void serverSocketOptions() throws Exception {
         var option = StandardSocketOptions.IP_TOS;
+        var property = "jdk.net.ServerSocket.IP_TOS";
+        boolean enabled = Boolean.getBoolean(property);
 
-        assertFalse(Sockets.supportedOptions(ServerSocket.class).contains(option),
-                "ServerSocket class options unexpectedly include IP_TOS");
+        // The startup value determines support, even before either option set is initialized.
+        System.setProperty(property, Boolean.toString(!enabled));
+
+        assertEquals(enabled, Sockets.supportedOptions(ServerSocket.class).contains(option),
+                "Unexpected IP_TOS support in ServerSocket class options");
 
         try (var ss = new ServerSocket()) {
-            assertFalse(ss.supportedOptions().contains(option),
-                    "ServerSocket options unexpectedly include IP_TOS");
+            assertEquals(enabled, ss.supportedOptions().contains(option),
+                    "Unexpected IP_TOS support in ServerSocket options");
 
-            assertThrows(UnsupportedOperationException.class,
-                    () -> Sockets.setOption(ss, option, 128));
-            assertThrows(UnsupportedOperationException.class,
-                    () -> Sockets.getOption(ss, option));
+            if (enabled) {
+                ss.setOption(option, 128);
+                ss.getOption(option);
+                Sockets.setOption(ss, option, 128);
+                Sockets.getOption(ss, option);
+            } else {
+                assertThrows(UnsupportedOperationException.class,
+                        () -> ss.setOption(option, 128));
+                assertThrows(UnsupportedOperationException.class,
+                        () -> ss.getOption(option));
+                assertThrows(UnsupportedOperationException.class,
+                        () -> Sockets.setOption(ss, option, 128));
+                assertThrows(UnsupportedOperationException.class,
+                        () -> Sockets.getOption(ss, option));
+            }
         }
     }
 }


### PR DESCRIPTION
Disable `IP_TOS` support by default in the JDK's default `ServerSocket` implementation. Applications can restore support with `-Djdk.net.ServerSocket.IP_TOS=true` on the JVM command line.

The `jdk.net.Sockets` option sets are derived from socket instances, exposing previously omitted datagram options. `IP_TOS` support on `Socket` and `DatagramSocket` is unchanged.

Testing on macOS/aarch64 at `828e5c2b7e76`:

- Affected socket-option tests passed, including five `SupportedOptions` configurations.
- Tier 2 reported five locale failures also seen on baseline, the previously observed `UdpTest` timeout, a docs link-check failure due to missing files, and a `CreateCoredumpOnCrash` failure due to the core dump limit.
- `PromiscuousIPv6`, `SSLSocketExplorer`, and `MultiNSTClient` failed or timed out in Tier 2; all passed on individual reruns.

Linux and Windows test suites were not run.

Release note: [JDK-8392329](https://bugs.openjdk.org/browse/JDK-8392329)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issues
 * [JDK-8392151](https://bugs.openjdk.org/browse/JDK-8392151): Disable IP_TOS support on ServerSocket by default (**Enhancement** - P4) ⚠️ Issue is not open.
 * [JDK-8392199](https://bugs.openjdk.org/browse/JDK-8392199): Disable IP_TOS support on ServerSocket by default (**CSR**) (Withdrawn)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32808/head:pull/32808` \
`$ git checkout pull/32808`

Update a local copy of the PR: \
`$ git checkout pull/32808` \
`$ git pull https://git.openjdk.org/jdk.git pull/32808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32808`

View PR using the GUI difftool: \
`$ git pr show -t 32808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32808.diff">https://git.openjdk.org/jdk/pull/32808.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32808#issuecomment-5615990355)
</details>
