### PR TITLE
8384073: VM does not build without g1gc

### DIFF
--- a/src/hotspot/share/cds/aotMappedHeapLoader.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapLoader.cpp
@@ -579,6 +579,7 @@ address AOTMappedHeapLoader::heap_region_requested_address(FileMapInfo* info) {
   }
 }
 
+#if INCLUDE_G1GC
 bool AOTMappedHeapLoader::map_heap_region(FileMapInfo* info) {
   if (map_heap_region_impl(info)) {
 #ifdef ASSERT
@@ -694,6 +695,8 @@ bool AOTMappedHeapLoader::map_heap_region_impl(FileMapInfo* info) {
   return true;
 }
 
+#endif // INCLUDE_G1GC
+
 narrowOop AOTMappedHeapLoader::encoded_heap_region_dumptime_address(FileMapInfo* info) {
   assert(CDSConfig::is_using_archive(), "runtime only");
   assert(UseCompressedOops, "sanity");
@@ -716,6 +719,7 @@ void AOTMappedHeapLoader::patch_heap_embedded_pointers(FileMapInfo* info) {
       r->oopmap_size_in_bits());
 }
 
+#if INCLUDE_G1GC
 void AOTMappedHeapLoader::fixup_mapped_heap_region(FileMapInfo* info) {
   if (is_mapped()) {
     assert(!_mapped_heap_memregion.is_empty(), "sanity");
@@ -732,6 +736,7 @@ void AOTMappedHeapLoader::fixup_mapped_heap_region(FileMapInfo* info) {
 void AOTMappedHeapLoader::dealloc_heap_region(FileMapInfo* info) {
   G1CollectedHeap::heap()->dealloc_archive_regions(_mapped_heap_memregion);
 }
+#endif // INCLUDE_G1GC
 
 AOTMapLogger::OopDataIterator* AOTMappedHeapLoader::oop_iterator(FileMapInfo* info, address buffer_start, address buffer_end) {
   class MappedLoaderOopIterator : public AOTMappedHeapOopIterator {

--- a/src/hotspot/share/cds/aotMappedHeapLoader.hpp
+++ b/src/hotspot/share/cds/aotMappedHeapLoader.hpp
@@ -170,12 +170,12 @@ private:
   static bool map_heap_region_impl(FileMapInfo* info);
   static narrowOop encoded_heap_region_dumptime_address(FileMapInfo* info);
   static void patch_heap_embedded_pointers(FileMapInfo* info);
-  static void fixup_mapped_heap_region(FileMapInfo* info);
+  static void fixup_mapped_heap_region(FileMapInfo* info) NOT_G1GC_RETURN;
   static void dealloc_heap_region(FileMapInfo* info);
 
 public:
 
-  static bool map_heap_region(FileMapInfo* info);
+  static bool map_heap_region(FileMapInfo* info) NOT_G1GC_RETURN_(false);
   static bool load_heap_region(FileMapInfo* mapinfo);
   static void assert_in_loaded_heap(uintptr_t o) {
     assert(is_in_loaded_heap(o), "must be");

--- a/src/hotspot/share/cds/aotMappedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotMappedHeapWriter.cpp
@@ -98,7 +98,7 @@ void AOTMappedHeapWriter::init() {
     _native_pointers = new GrowableArrayCHeap<NativePointerInfo, mtClassShared>(2048);
     _source_objs = new GrowableArrayCHeap<oop, mtClassShared>(10000);
 
-    guarantee(MIN_GC_REGION_ALIGNMENT <= G1HeapRegion::min_region_size_in_words() * HeapWordSize, "must be");
+    G1GC_ONLY(guarantee(MIN_GC_REGION_ALIGNMENT <= G1HeapRegion::min_region_size_in_words() * HeapWordSize, "must be");)
 
     if (CDSConfig::old_cds_flags_used()) {
       // With the old CDS workflow, we can guatantee determninistic output: given
@@ -624,6 +624,7 @@ void AOTMappedHeapWriter::set_requested_address_range(AOTMappedHeapInfo* info) {
         AOTMetaspace::unrecoverable_writing_error();
       }
       _requested_bottom = align_down(heap_end - heap_region_byte_size, alignment);
+#if INCLUDE_G1GC
     } else if (UseG1GC) {
       // For G1, pick the range at the top of the current heap. If the exact same heap sizes
       // are used in the production run, it's likely that we can map the archived objects
@@ -633,6 +634,7 @@ void AOTMappedHeapWriter::set_requested_address_range(AOTMappedHeapInfo* info) {
       _requested_bottom = align_down(heap_end - heap_region_byte_size, G1HeapRegion::GrainBytes);
       _requested_bottom = align_down(_requested_bottom, MIN_GC_REGION_ALIGNMENT);
       assert(is_aligned(_requested_bottom, G1HeapRegion::GrainBytes), "sanity");
+#endif
     } else {
       _requested_bottom = align_up(CompressedOops::begin(), MIN_GC_REGION_ALIGNMENT);
     }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1670,8 +1670,12 @@ bool FileMapInfo::can_use_heap_region() {
                       narrow_oop_mode(), p2i(narrow_oop_base()), narrow_oop_shift());
     aot_log_info(aot)("    AOTCompatibleOopCompression = %s", header()->compatible_oop_compression() ? "true" : "false");
   }
+#if INCLUDE_G1GC
   aot_log_info(aot)("The current max heap size = %zuM, G1HeapRegion::GrainBytes = %zu",
                 MaxHeapSize/M, G1HeapRegion::GrainBytes);
+#else
+  aot_log_info(aot)("The current max heap size = %zuM", MaxHeapSize/M);
+#endif
   aot_log_info(aot)("    narrow_klass_base = " PTR_FORMAT ", arrow_klass_pointer_bits = %d, narrow_klass_shift = %d",
                 p2i(CompressedKlassPointers::base()), CompressedKlassPointers::narrow_klass_pointer_bits(), CompressedKlassPointers::shift());
   if (UseCompressedOops) {
@@ -1682,9 +1686,9 @@ bool FileMapInfo::can_use_heap_region() {
   if (!object_streaming_mode()) {
     aot_log_info(aot)("    heap range = [" PTR_FORMAT " - "  PTR_FORMAT "]",
                       UseCompressedOops ? p2i(CompressedOops::begin()) :
-                      UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved().start()) : 0L,
+                      G1GC_ONLY(UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved().start()) :) 0L,
                       UseCompressedOops ? p2i(CompressedOops::end()) :
-                      UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved().end()) : 0L);
+                      G1GC_ONLY(UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved().end()) :) 0L);
   }
 
   int err = 0;

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -988,9 +988,9 @@ void HeapShared::start_scanning_for_oops() {
     if (HeapShared::is_writing_mapping_mode() && (UseG1GC || UseCompressedOops)) {
       aot_log_info(aot)("Heap range = [" PTR_FORMAT " - "  PTR_FORMAT "]",
                     UseCompressedOops ? p2i(CompressedOops::begin()) :
-                                        p2i((address)G1CollectedHeap::heap()->reserved().start()),
+                    G1GC_ONLY(UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved().start()) :) 0L,
                     UseCompressedOops ? p2i(CompressedOops::end()) :
-                                        p2i((address)G1CollectedHeap::heap()->reserved().end()));
+                    G1GC_ONLY(UseG1GC ? p2i((address)G1CollectedHeap::heap()->reserved().end()) :) 0L);
     }
 
     archive_subgraphs();

--- a/src/hotspot/share/code/aotCodeCache.cpp
+++ b/src/hotspot/share/code/aotCodeCache.cpp
@@ -2112,9 +2112,9 @@ void AOTCodeAddressTable::init_extrs() {
   ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_pre_narrow_oop_entry); // used by arraycopy stubs
   ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_pre_oop_entry); // used by arraycopy stubs
   ADD_EXTERNAL_ADDRESS(G1BarrierSetRuntime::write_ref_array_post_entry); // used by arraycopy stubs
+#endif
   ADD_EXTERNAL_ADDRESS(BarrierSetNMethod::nmethod_stub_entry_barrier); // used by method_entry_barrier
 
-#endif
 #if INCLUDE_SHENANDOAHGC
   ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::write_barrier_pre);
   ADD_EXTERNAL_ADDRESS(ShenandoahRuntime::write_barrier_pre_narrow);

--- a/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagCombo.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagCombo.java
@@ -25,6 +25,7 @@
 /*
  * @test CommandLineFlagCombo
  * @requires vm.cds.write.archived.java.heap
+ * @requires vm.gc.G1
  * @comment This test explicitly chooses the type of GC to be used by sub-processes. It may conflict with the GC type set
  * via the -vmoptions command line option of JTREG. vm.gc==null will help the test case to discard the explicitly passed
  * vm options.

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/HeapFragmentationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/HeapFragmentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Relocate CDS archived regions to the top of the G1 heap
  * @bug 8214455
  * @requires vm.cds.write.archived.java.heap
+ * @requires vm.gc.G1
  * @requires (sun.arch.data.model == "64" & os.maxMemory > 4g)
  * @requires vm.gc == "null"
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
@@ -32,6 +32,7 @@
  * @summary Test options that are incompatible with use of shared strings
  *          Also test mismatch in oops encoding between dump time and run time
  * @requires vm.cds.write.archived.java.heap
+ * @requires vm.gc.G1
  * @comment This test explicitly chooses the type of GC to be used by sub-processes. It may conflict with the GC type set
  * via the -vmoptions command line option of JTREG. vm.gc==null will help the test case to discard the explicitly passed
  * vm options.
@@ -48,6 +49,7 @@
 /*
  * @test
  * @requires vm.cds.write.archived.java.heap
+ * @requires vm.gc.G1
  * @requires (vm.gc=="null")
  * @requires vm.flagless
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
@@ -60,6 +62,7 @@
 /*
  * @test
  * @requires vm.cds.write.archived.java.heap
+ * @requires vm.gc.G1
  * @requires (vm.gc=="null")
  * @requires vm.flagless
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds


### PR DESCRIPTION
Please review this bug fix.

**Problem:**

Some G1-specific code in the CDS/AOT implementation was not properly guarded by build-time G1 conditions. As a result, building the JDK with G1 excluded failed

```text
$ bash configure --with-jvm-features=-g1gc
$ make images

=== Output from failing command(s) repeated here ===
* For target hotspot_variant-server_libjvm_objs_aotMappedHeapLoader.o:
/xxx/jdk/src/hotspot/share/cds/aotMappedHeapLoader.cpp: In static member function ‘static bool AOTMappedHeapLoader::map_heap_region_impl(FileMapInfo*)’:
```

**Fix:**

- Guard the G1-specific CDS/AOT heap mapping code with the existing `INCLUDE_G1GC` conditions, while keeping the non-G1 CDS/AOT loading paths available.
- Add `@requires vm.gc.G1` to CDS tests that explicitly require G1.

**Testing:**

- `bash configure --with-jvm-features=-g1gc` & `make images` with G1 excluded: passed
- `test/hotspot/jtreg/runtime/cds`:
  - G1 build: 402 passed, 1 skipped, 0 failed
  - No-G1 build with the default ParallelGC: 385 passed, 18 skipped, 0 failed
  - No-G1 build with `-XX:+UseSerialGC`: 341 passed, 62 skipped, 0 failed
  - No-G1 build with `-XX:+UseZGC`: 330 passed, 73 skipped, 0 failed
  - No-G1 build with `-XX:+UseShenandoahGC`: 342 passed, 61 skipped, 0 failed

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384073](https://bugs.openjdk.org/browse/JDK-8384073): VM does not build without g1gc (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32809/head:pull/32809` \
`$ git checkout pull/32809`

Update a local copy of the PR: \
`$ git checkout pull/32809` \
`$ git pull https://git.openjdk.org/jdk.git pull/32809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32809`

View PR using the GUI difftool: \
`$ git pr show -t 32809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32809.diff">https://git.openjdk.org/jdk/pull/32809.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32809#issuecomment-5616713404)
</details>
