### PR TITLE
8391998: Mutex name should be mtSynchronizer

### DIFF
--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -294,7 +294,7 @@ Mutex::~Mutex() {
 Mutex::Mutex(Rank rank, const char * name, bool allow_vm_block) : _owner(nullptr) {
   assert(os::mutex_init_done(), "Too early!");
   assert(name != nullptr, "Mutex requires a name");
-  _name = os::strdup(name, mtInternal);
+  _name = os::strdup(name, mtSynchronizer);
 #ifdef ASSERT
   _allow_vm_block  = allow_vm_block;
   _rank            = rank;


### PR DESCRIPTION
This will tag `Mutex` objects as `mtSynchronizer` in NMT instead of `mtInternal`. See https://github.com/openjdk/jdk/pull/32769 for other work related to reducing what all is in `mtInternal`.

Additional testing:
- Linux x86_64 server fastdebug, `tier1`

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391998](https://bugs.openjdk.org/browse/JDK-8391998): Mutex name should be mtSynchronizer (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32810/head:pull/32810` \
`$ git checkout pull/32810`

Update a local copy of the PR: \
`$ git checkout pull/32810` \
`$ git pull https://git.openjdk.org/jdk.git pull/32810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32810`

View PR using the GUI difftool: \
`$ git pr show -t 32810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32810.diff">https://git.openjdk.org/jdk/pull/32810.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32810#issuecomment-5617865502)
</details>
