### PR TITLE
8392156: RISC-V: Inverted VerifyStackAtCalls condition in in_preserve_stack_slots()

### DIFF
--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2429,7 +2429,7 @@ void SharedRuntime::generate_deopt_blob() {
 // EPILOG must remove this many slots.
 // RISCV needs two words for RA (return address) and FP (frame pointer).
 uint SharedRuntime::in_preserve_stack_slots() {
-  return 2 * VMRegImpl::slots_per_word + (VerifyStackAtCalls ? 0 : 2) ;
+  return 2 * VMRegImpl::slots_per_word + (VerifyStackAtCalls ? 2 : 0);
 }
 
 uint SharedRuntime::out_preserve_stack_slots() {


### PR DESCRIPTION
Hi, please consider.

The `(VerifyStackAtCalls ? 0 : 2)` condition added by [JDK-8370708](https://bugs.openjdk.org/browse/JDK-8370708) is inverted. The extra word holds the majik cookie, which `MachPrologNode::emit()` stores at `framesize - 3 * wordSize` and `riscv_enc_call_epilog()` reads back at `_old_SP - 3 * VMRegImpl::slots_per_word`, one word below the saved FP/RA pair. So the preserve area needs 6 slots when the flag is on and 4 when it is off, matching x86_64's `4 + 2 * VerifyStackAtCalls`.

As it stands, product builds (where this develop flag is constantly false) reserve 6 slots instead of 4, and with the flag on the cookie lands outside the preserve area, so the check never worked.

[JDK-8392015](https://bugs.openjdk.org/browse/JDK-8392015) removes `VerifyStackAtCalls` from mainline altogether and makes this line correct again. This separate fix is mainly so that there is something to backport to jdk25u-dev, where JDK-8370708 already landed as [JDK-8372690](https://bugs.openjdk.org/browse/JDK-8372690).

### Testing
 
- [x] `hotspot:tier1` on linux-riscv64 fastdebug, w/ and w/o `-XX:+VerifyStackAtCalls`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392156](https://bugs.openjdk.org/browse/JDK-8392156): RISC-V: Inverted VerifyStackAtCalls condition in in_preserve_stack_slots() (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32812/head:pull/32812` \
`$ git checkout pull/32812`

Update a local copy of the PR: \
`$ git checkout pull/32812` \
`$ git pull https://git.openjdk.org/jdk.git pull/32812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32812`

View PR using the GUI difftool: \
`$ git pr show -t 32812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32812.diff">https://git.openjdk.org/jdk/pull/32812.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32812#issuecomment-5619165779)
</details>
