### PR TITLE
8391669: [Valhalla] C2 hits assert due to expensive node with StoreFlat control input

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -224,7 +224,7 @@ Node *PhaseIdealLoop::get_early_ctrl_for_expensive(Node *n, Node* earliest) {
         if (nb_ctl_proj > 1) {
           break;
         }
-        assert(parent_ctl->is_Start() || parent_ctl->is_MemBar() || parent_ctl->is_Call(), "unexpected node");
+        assert(parent_ctl->is_Start() || parent_ctl->is_MemBar() || parent_ctl->is_SafePoint(), "unexpected node");
         assert(idom(ctl) == parent_ctl, "strange");
         next = idom(parent_ctl);
       }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestExpensiveWithStoreFlatCtrl.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestExpensiveWithStoreFlatCtrl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8391669
+ * @summary Test expensive node with StoreFlat control input.
+ * @enablePreview
+ * @library /test/lib
+ * @run main ${test.main.class}
+ * @run main/othervm -Xcomp -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
+ *                   ${test.main.class}
+ */
+
+package compiler.loopopts;
+
+import jdk.test.lib.Asserts;
+
+public class TestExpensiveWithStoreFlatCtrl {
+    static double test() {
+        // Trigger loop opts
+        for (int i = 0; i < 1; i++) {
+        }
+
+        Integer[] array = new Integer[1];
+        array[0] = 42; // StoreFlat
+        double res = Math.sqrt(-1.0); // Expensive SqrtDNode
+        array[0] = 43;
+        res += Math.sqrt(-1.0);
+        return res;
+    }
+
+    public static void main(String[] args) {
+        Math.sqrt(4.0); // Make sure it's loaded
+        Asserts.assertTrue(Double.isNaN(test()));
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestExpensiveWithStoreFlatCtrl.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestExpensiveWithStoreFlatCtrl.java
@@ -44,9 +44,11 @@ public class TestExpensiveWithStoreFlatCtrl {
         }
 
         Integer[] array = new Integer[1];
-        array[0] = 42; // StoreFlat
-        double res = Math.sqrt(-1.0); // Expensive SqrtDNode
+        // Expensive SqrtDNode
+        double res = Math.sqrt(-1.0);
+        // StoreFlat
         array[0] = 43;
+        // Equivalent SqrtDNode to prevent cleanup from removing control
         res += Math.sqrt(-1.0);
         return res;
     }


### PR DESCRIPTION
Valhalla added `StoreFlatNodes` that are `SafePointNodes`. In the test, which was reduced from a JavaFuzzer generated test, an expensive `SqrtDNode` has an `StoreFlatNode` control input:

```
 215  StoreFlat  === 158 1 164 8 1 147 185 167 147 1 1 147 21 299 22 150  [[ 216 217 ]]  SafePoint  !jvms: TestExpensiveWithStoreFlatCtrl::test @ bci:25 (line 47)
 225  ConD  === 0  [[ 226 294 ]]  #dblcon:-1.000000
 216  Proj  === 215  [[ 226 228 ]] #0 !jvms: TestExpensiveWithStoreFlatCtrl::test @ bci:25 (line 47)
 226  SqrtD  === 216 225  [[ 295 228 284 ]]  !jvms: TestExpensiveWithStoreFlatCtrl::test @ bci:29 (line 48)
```

The assert in `PhaseIdealLoop::get_early_ctrl_for_expensive` does not expect that and needs to be adjusted.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391669](https://bugs.openjdk.org/browse/JDK-8391669): [Valhalla] C2 hits assert due to expensive node with StoreFlat control input (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32813/head:pull/32813` \
`$ git checkout pull/32813`

Update a local copy of the PR: \
`$ git checkout pull/32813` \
`$ git pull https://git.openjdk.org/jdk.git pull/32813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32813`

View PR using the GUI difftool: \
`$ git pr show -t 32813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32813.diff">https://git.openjdk.org/jdk/pull/32813.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32813#issuecomment-5619496259)
</details>
