### PR TITLE
8392167: [arm32] safepoint poll always takes slow path

### DIFF
--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -1706,8 +1706,8 @@ void MacroAssembler::access_store_at(BasicType type, DecoratorSet decorators,
 
 void MacroAssembler::safepoint_poll(Register tmp1, Label& slow_path) {
   ldr_u32(tmp1, Address(Rthread, JavaThread::polling_word_offset()));
-  tst(tmp1, exact_log2(SafepointMechanism::poll_bit()));
-  b(slow_path, eq);
+  tst(tmp1, SafepointMechanism::poll_bit());
+  b(slow_path, ne);
 }
 
 void MacroAssembler::get_polling_page(Register dest) {


### PR DESCRIPTION
Fix ARM32 safepoint_poll to test the poll bit correctly

`MacroAssembler::safepoint_poll` on the arm32 port passes `exact_log2(SafepointMechanism::poll_bit())` to `tst`. `tst` instruction performs a bitwise AND against a mask, but instead bit index is provided. The emitted instruction is therefore `tst tmp1, #0`, which always sets the Z flag, so the following `b(slow_path, eq)` branches unconditionally and the polling word is never actually examined.

This is functionally safe but wasteful: every inline poll detours through the slow path, which re-checks and returns when no safepoint/handshake is pending.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392167](https://bugs.openjdk.org/browse/JDK-8392167): [arm32] safepoint poll always takes slow path (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32815/head:pull/32815` \
`$ git checkout pull/32815`

Update a local copy of the PR: \
`$ git checkout pull/32815` \
`$ git pull https://git.openjdk.org/jdk.git pull/32815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32815`

View PR using the GUI difftool: \
`$ git pr show -t 32815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32815.diff">https://git.openjdk.org/jdk/pull/32815.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32815#issuecomment-5620377437)
</details>
