### PR TITLE
8391695: [Valhalla] Timeouts due to unbounded GC stress threads in compiler tests

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/CorrectlyRestoreRfp.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/CorrectlyRestoreRfp.java
@@ -143,7 +143,7 @@ public class CorrectlyRestoreRfp {
                     var v = compile_me_C1_testLargeValueWithOopsHelper(val);
                     LargeValueWithOops.compile_me_C2_verify(v, "return", val, false);
                 }
-            }, task -> Thread.ofPlatform().start(task)).join();
+            }, Thread.ofPlatform()::start).join();
         } finally {
             garbage_producer.interrupt();
             garbage_producer.join();

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/CorrectlyRestoreRfp.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/CorrectlyRestoreRfp.java
@@ -44,7 +44,7 @@ package compiler.valhalla.valuetypes;
 import jdk.test.whitebox.WhiteBox;
 
 import java.lang.reflect.Method;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 
 public class CorrectlyRestoreRfp {
     static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
@@ -112,7 +112,7 @@ public class CorrectlyRestoreRfp {
 
     static class GarbageProducerThread extends Thread {
         public void run() {
-            for (;;) {
+            while (!isInterrupted()) {
                 // Produce some garbage and then let the GC do its work
                 Object[] arrays = new Object[1024];
                 for (int i = 0; i < arrays.length; i++) {
@@ -135,22 +135,18 @@ public class CorrectlyRestoreRfp {
         garbage_producer.setDaemon(true);
         garbage_producer.start();
 
-        CountDownLatch cdl = new CountDownLatch(1);
-        Thread.ofPlatform().start(() -> {
-            try {
+        try {
+            CompletableFuture.runAsync(() -> {
                 // Trigger compilation
                 for (int i = 0; i < 500_000; i++) {
                     Object val = new SmallValue(i);
                     var v = compile_me_C1_testLargeValueWithOopsHelper(val);
                     LargeValueWithOops.compile_me_C2_verify(v, "return", val, false);
                 }
-                cdl.countDown();
-            } catch (Exception e) {
-                System.out.println("Exception thrown: " + e);
-                e.printStackTrace(System.out);
-                System.exit(1);
-            }
-        });
-        cdl.await();
+            }, task -> Thread.ofPlatform().start(task)).join();
+        } finally {
+            garbage_producer.interrupt();
+            garbage_producer.join();
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestOopsInReturnConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestOopsInReturnConvention.java
@@ -215,7 +215,7 @@ public class TestOopsInReturnConvention {
 
     static class GarbageProducerThread extends Thread {
         public void run() {
-            for (;;) {
+            while (!isInterrupted()) {
                 // Produce some garbage and then let the GC do its work
                 Object[] arrays = new Object[1024];
                 for (int i = 0; i < arrays.length; i++) {
@@ -238,11 +238,16 @@ public class TestOopsInReturnConvention {
         garbage_producer.setDaemon(true);
         garbage_producer.start();
 
-        // Trigger compilation
-        for (int i = 0; i < 100_000; i++) {
-            boolean useNull = (i % 2) == 0;
-            LargeValueWithOops val = useNull ? null : new LargeValueWithOops(i);
-            caller(val, i, useNull);
+        try {
+            // Trigger compilation
+            for (int i = 0; i < 100_000; i++) {
+                boolean useNull = (i % 2) == 0;
+                LargeValueWithOops val = useNull ? null : new LargeValueWithOops(i);
+                caller(val, i, useNull);
+            }
+        } finally {
+            garbage_producer.interrupt();
+            garbage_producer.join();
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestVirtualThreads.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestVirtualThreads.java
@@ -828,3 +828,4 @@ public class TestVirtualThreads {
         }
     }
 }
+

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestVirtualThreads.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestVirtualThreads.java
@@ -225,8 +225,8 @@ import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.LockSupport;
-import java.util.concurrent.CountDownLatch;
 import java.util.Random;
 
 import jdk.test.lib.Platform;
@@ -746,7 +746,7 @@ public class TestVirtualThreads {
 
     static class GarbageProducerThread extends Thread {
         public void run() {
-            for (;;) {
+            while (!isInterrupted()) {
                 // Produce some garbage and then let the GC do its work
                 Object[] arrays = new Object[1024];
                 for (int i = 0; i < arrays.length; i++) {
@@ -757,36 +757,29 @@ public class TestVirtualThreads {
         }
     }
 
-    public static void startTest(CountDownLatch cdl, Thread.Builder builder, int iterations) {
-        builder.start(() -> {
-            try {
-                // Trigger compilation
-                boolean isVirtual = Thread.currentThread().isVirtual();
-                for (int i = 0; i < iterations; i++) {
-                    boolean park = (i % 1000) == 0;
-                    boolean useNull = RAND.nextBoolean();
-                    Object val = useNull ? null : new SmallValue(i);
-                    SmallValue.verify(testSmallHelper(i, useNull, park), "return", i, useNull);
-                    LargeValue.verify(testLargeHelper(i, useNull, park), "return", i, useNull);
-                    LargeValue.verify(testLargeManyArgsHelper(i, useNull, park), "return", i + 3, useNull);
-                    LargeValue2.verify(testLarge2Helper(i, useNull, park), "return", i, useNull);
-                    LargeValue2.verify(testLarge2ManyArgsHelper(i, useNull, park), "return", i + 3, useNull);
-                    testExtendsAbstractHelper(i, park).verify("return", i + 3);
-                    LargeValueWithOops.verify(testLargeValueWithOopsHelper(val, useNull, park), "return", val, useNull);
-                    LargeValueWithOops.verify(testLargeValueWithOops2Helper(val, useNull, park), "return", val, useNull);
-                    DoubleValue.verify(testDoubleValueHelper(i, useNull, park), "return", i, useNull);
-                    DoubleValue2.verify(testDoubleValue2Helper(i, useNull, park), "return", i, useNull);
-                    if (i % 1000 == 0) {
-                        System.out.format("%s => %s %d of %d%n", Instant.now(), isVirtual ? "Virtual: " : "Platform:", i, iterations);
-                    }
+    public static CompletableFuture<Void> startTest(Thread.Builder builder, int iterations) {
+        return CompletableFuture.runAsync(() -> {
+            // Trigger compilation
+            boolean isVirtual = Thread.currentThread().isVirtual();
+            for (int i = 0; i < iterations; i++) {
+                boolean park = (i % 1000) == 0;
+                boolean useNull = RAND.nextBoolean();
+                Object val = useNull ? null : new SmallValue(i);
+                SmallValue.verify(testSmallHelper(i, useNull, park), "return", i, useNull);
+                LargeValue.verify(testLargeHelper(i, useNull, park), "return", i, useNull);
+                LargeValue.verify(testLargeManyArgsHelper(i, useNull, park), "return", i + 3, useNull);
+                LargeValue2.verify(testLarge2Helper(i, useNull, park), "return", i, useNull);
+                LargeValue2.verify(testLarge2ManyArgsHelper(i, useNull, park), "return", i + 3, useNull);
+                testExtendsAbstractHelper(i, park).verify("return", i + 3);
+                LargeValueWithOops.verify(testLargeValueWithOopsHelper(val, useNull, park), "return", val, useNull);
+                LargeValueWithOops.verify(testLargeValueWithOops2Helper(val, useNull, park), "return", val, useNull);
+                DoubleValue.verify(testDoubleValueHelper(i, useNull, park), "return", i, useNull);
+                DoubleValue2.verify(testDoubleValue2Helper(i, useNull, park), "return", i, useNull);
+                if (i % 1000 == 0) {
+                    System.out.format("%s => %s %d of %d%n", Instant.now(), isVirtual ? "Virtual: " : "Platform:", i, iterations);
                 }
-                cdl.countDown();
-            } catch (Exception e) {
-                System.out.println("Exception thrown: " + e);
-                e.printStackTrace(System.out);
-                System.exit(1);
             }
-        });
+        }, task -> builder.start(task));
     }
 
     public static void main(String[] args) throws Exception {
@@ -821,16 +814,17 @@ public class TestVirtualThreads {
         garbage_producer.setDaemon(true);
         garbage_producer.start();
 
-        int iterations = args.length > 0 ? Integer.parseInt(args[0]) : 300_000;
-        if (Platform.isDebugBuild()) {
-            iterations /= 4;
+        try {
+            int iterations = args.length > 0 ? Integer.parseInt(args[0]) : 300_000;
+            if (Platform.isDebugBuild()) {
+                iterations /= 4;
+            }
+            CompletableFuture<Void> platform = startTest(Thread.ofPlatform(), iterations);
+            CompletableFuture<Void> virtual = startTest(Thread.ofVirtual(), iterations);
+            CompletableFuture.allOf(platform, virtual).join();
+        } finally {
+            garbage_producer.interrupt();
+            garbage_producer.join();
         }
-        CountDownLatch cdlPlatform = new CountDownLatch(1);
-        CountDownLatch cdlVirtual = new CountDownLatch(1);
-        startTest(cdlPlatform, Thread.ofPlatform(), iterations);
-        startTest(cdlVirtual, Thread.ofVirtual(), iterations);
-        cdlPlatform.await();
-        cdlVirtual.await();
     }
 }
-

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
@@ -105,3 +105,4 @@ public class TestVectorsNotSavedAtSafepoint {
         }
     }
 }
+

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
@@ -58,7 +58,7 @@ public class TestVectorsNotSavedAtSafepoint {
 
     static class GarbageProducerThread extends Thread {
         public void run() {
-            for(;;) {
+            while (!isInterrupted()) {
                 // Produce some garbage and then let the GC do its work which will
                 // corrupt vector registers if they are not saved at safepoints.
                 Object[] arrays = new Object[1024];
@@ -70,34 +70,38 @@ public class TestVectorsNotSavedAtSafepoint {
         }
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
         Thread garbage_producer = new GarbageProducerThread();
         garbage_producer.setDaemon(true);
         garbage_producer.start();
 
-        if (args[0].equals("test1")) {
-            byte[] bArr = new byte[10];
-            long[] lArr = new long[1000];
-            for (int i = 0; i < 10_000; ++i) {
-                test1(bArr, bArr, bArr, lArr, -1);
-                for (int j = 0; j < lArr.length; ++j) {
-                    if (bArr[j % 10] != 0 || lArr[j] != -1) {
-                        throw new RuntimeException("Test1 failed at iteration " + i + ": bArr[" + (j % 10) + "] = " + bArr[j % 10] + ", lArr[" + j + "] = " + lArr[j]);
+        try {
+            if (args[0].equals("test1")) {
+                byte[] bArr = new byte[10];
+                long[] lArr = new long[1000];
+                for (int i = 0; i < 10_000; ++i) {
+                    test1(bArr, bArr, bArr, lArr, -1);
+                    for (int j = 0; j < lArr.length; ++j) {
+                        if (bArr[j % 10] != 0 || lArr[j] != -1) {
+                            throw new RuntimeException("Test1 failed at iteration " + i + ": bArr[" + (j % 10) + "] = " + bArr[j % 10] + ", lArr[" + j + "] = " + lArr[j]);
+                        }
+                    }
+                }
+            } else {
+                int iArr[] = new int[100];
+                long lArr[] = new long[100];
+                for (int i = 0; i < 10_000; ++i) {
+                    test2(iArr, lArr);
+                    for (int j = 0; j < lArr.length; ++j) {
+                        if (iArr[j] != 1 || lArr[j] != 1) {
+                            throw new RuntimeException("Test2 failed at iteration " + i + ": iArr[" + j + "] = " + iArr[j] + ", lArr[" + j + "] = " + lArr[j]);
+                        }
                     }
                 }
             }
-        } else {
-            int iArr[] = new int[100];
-            long lArr[] = new long[100];
-            for (int i = 0; i < 10_000; ++i) {
-                test2(iArr, lArr);
-                for (int j = 0; j < lArr.length; ++j) {
-                    if (iArr[j] != 1 || lArr[j] != 1) {
-                        throw new RuntimeException("Test2 failed at iteration " + i + ": iArr[" + j + "] = " + iArr[j] + ", lArr[" + j + "] = " + lArr[j]);
-                    }
-                }
-            }
+        } finally {
+            garbage_producer.interrupt();
+            garbage_producer.join();
         }
     }
 }
-


### PR DESCRIPTION
`TestOopsInReturnConvention.java` intermittently timed out in our testing. Logs showed that the main thread was trying to exit:
```
"main" ... _at_safepoint
  at java.lang.Shutdown.logRuntimeExit
  at java.lang.System.exit
  at com.sun.javatest.regtest.agent.AStatus.exit
```

while a Java thread was still producing garbage:
```
"Thread-1" ... allocated=102G
  at compiler.valhalla.inlinetypes.TestOopsInReturnConvention$GarbageProducerThread.run(...:222)
```

We have a few such tests that spawn deamon threads that allocate some garbage and call `System.gc()` in a loop to trigger GC activity. Since we don't stop the thread once the main thread is done, this can delay shutdown until jtreg times out.

The fix is to interrupt the garbage producing thread and always join it. I also replaced the `CountDownLatch` "hack" for signalling completion and explicit `System.exit` for exception propagation by a `CompletableFuture` which will handle both.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391695](https://bugs.openjdk.org/browse/JDK-8391695): [Valhalla] Timeouts due to unbounded GC stress threads in compiler tests (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32816/head:pull/32816` \
`$ git checkout pull/32816`

Update a local copy of the PR: \
`$ git checkout pull/32816` \
`$ git pull https://git.openjdk.org/jdk.git pull/32816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32816`

View PR using the GUI difftool: \
`$ git pr show -t 32816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32816.diff">https://git.openjdk.org/jdk/pull/32816.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32816#issuecomment-5620609609)
</details>
