### PR TITLE
8392129: Remove the usage of DONT_ENABLE_IPV6 macro in net_util_md.c

### DIFF
--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -94,14 +94,6 @@ jint  IPv4_supported()
     return JNI_TRUE;
 }
 
-#if defined(DONT_ENABLE_IPV6)
-jint  IPv6_supported()
-{
-    return JNI_FALSE;
-}
-
-#else /* !DONT_ENABLE_IPV6 */
-
 jint  IPv6_supported()
 {
     int fd;
@@ -149,7 +141,6 @@ jint  IPv6_supported()
         return JNI_TRUE;
     }
 }
-#endif /* DONT_ENABLE_IPV6 */
 
 jint reuseport_supported(int ipv6_available)
 {


### PR DESCRIPTION
Can I please get a review of this trivial clean up which removes the usage of the leftover `DONT_ENABLE_IPV6` macro from net_util_md.c?

History of this code suggests that this macro was in use during the early days of Java 7/8, when the macosx port was integrated into the JDK. This macro is no longer relevant or set anywhere in the JDK.

I've run tier1 through tier3 and the existing tests have all passed with this change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392129](https://bugs.openjdk.org/browse/JDK-8392129): Remove the usage of DONT_ENABLE_IPV6 macro in net_util_md.c (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32819/head:pull/32819` \
`$ git checkout pull/32819`

Update a local copy of the PR: \
`$ git checkout pull/32819` \
`$ git pull https://git.openjdk.org/jdk.git pull/32819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32819`

View PR using the GUI difftool: \
`$ git pr show -t 32819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32819.diff">https://git.openjdk.org/jdk/pull/32819.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32819#issuecomment-5622210399)
</details>
