### PR TITLE
8392180: Enable JSON unit tests in CI

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -114,7 +114,8 @@ tier3_part1 = \
     :jdk_svc \
     -:jdk_svc_sanity \
     -:svc_tools \
-    :jdk_since_checks
+    :jdk_since_checks \
+    :jdk_json
 
 # The jpackage tests on Windows require permissions that aren't always present
 tier3_jpackage = \
@@ -429,6 +430,9 @@ jdk_vector_sanity = \
     jdk/incubator/vector/PreferredSpeciesTest.java \
     jdk/incubator/vector/VectorHash.java \
     jdk/incubator/vector/VectorRuns.java
+
+jdk_json = \
+    jdk/incubator/json
 
 #############################
 


### PR DESCRIPTION
Making the unit tests for JSON API run in the tier 3 layer in CI.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392180](https://bugs.openjdk.org/browse/JDK-8392180): Enable JSON unit tests in CI (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32820/head:pull/32820` \
`$ git checkout pull/32820`

Update a local copy of the PR: \
`$ git checkout pull/32820` \
`$ git pull https://git.openjdk.org/jdk.git pull/32820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32820`

View PR using the GUI difftool: \
`$ git pr show -t 32820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32820.diff">https://git.openjdk.org/jdk/pull/32820.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32820#issuecomment-5622215219)
</details>
