### PR TITLE
8392175: Remove VtableStub::receiver_location

### DIFF
--- a/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
@@ -77,7 +77,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index, bool caller_is_c1)
 #endif
 
   // get receiver (need to skip return address on top of stack)
-  assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
+  assert(SharedRuntime::name_for_receiver() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
 
   // get receiver klass
   address npe_addr = __ pc();
@@ -169,7 +169,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index, bool caller_is_c1)
 #endif
 
   // get receiver (need to skip return address on top of stack)
-  assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
+  assert(SharedRuntime::name_for_receiver() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
 
   // Entry arguments:
   //  rscratch2: CompiledICData

--- a/src/hotspot/cpu/arm/vtableStubs_arm.cpp
+++ b/src/hotspot/cpu/arm/vtableStubs_arm.cpp
@@ -72,7 +72,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index, bool caller_is_c1)
   }
 #endif
 
-  assert(VtableStub::receiver_location() == R0->as_VMReg(), "receiver expected in R0");
+  assert(SharedRuntime::name_for_receiver() == R0->as_VMReg(), "receiver expected in R0");
 
   const Register tmp = Rtemp; // Rtemp OK, should be free at call sites
 
@@ -141,7 +141,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index, bool caller_is_c1)
   }
 #endif
 
-  assert(VtableStub::receiver_location() == R0->as_VMReg(), "receiver expected in R0");
+  assert(SharedRuntime::name_for_receiver() == R0->as_VMReg(), "receiver expected in R0");
 
   // R0-R3 / R0-R7 registers hold the arguments and cannot be spoiled
   const Register Rclass  = R4;

--- a/src/hotspot/cpu/ppc/vtableStubs_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/vtableStubs_ppc_64.cpp
@@ -78,7 +78,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index, bool caller_is_c1)
   }
 #endif
 
-  assert(VtableStub::receiver_location() == R3_ARG1->as_VMReg(), "receiver expected in R3_ARG1");
+  assert(SharedRuntime::name_for_receiver() == R3_ARG1->as_VMReg(), "receiver expected in R3_ARG1");
 
   const Register rcvr_klass = R11_scratch1;
   address npe_addr = __ pc(); // npe = null pointer exception
@@ -164,7 +164,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index, bool caller_is_c1)
   }
 #endif
 
-  assert(VtableStub::receiver_location() == R3_ARG1->as_VMReg(), "receiver expected in R3_ARG1");
+  assert(SharedRuntime::name_for_receiver() == R3_ARG1->as_VMReg(), "receiver expected in R3_ARG1");
 
   // Entry arguments:
   //  R19_method: Interface

--- a/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
@@ -80,7 +80,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index, bool caller_is_c1)
 #endif
 
   // get receiver (need to skip return address on top of stack)
-  assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
+  assert(SharedRuntime::name_for_receiver() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
 
   // get receiver klass
   address npe_addr = __ pc();
@@ -182,7 +182,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index, bool caller_is_c1)
 #endif
 
   // get receiver (need to skip return address on top of stack)
-  assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
+  assert(SharedRuntime::name_for_receiver() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
 
   // Arguments from this point:
   //  t1 (moved from t0): CompiledICData

--- a/src/hotspot/cpu/s390/vtableStubs_s390.cpp
+++ b/src/hotspot/cpu/s390/vtableStubs_s390.cpp
@@ -78,7 +78,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index, bool caller_is_c1)
   }
 #endif
 
-  assert(VtableStub::receiver_location() == Z_R2->as_VMReg(), "receiver expected in Z_ARG1");
+  assert(SharedRuntime::name_for_receiver() == Z_R2->as_VMReg(), "receiver expected in Z_ARG1");
 
   const Register rcvr_klass   = Z_R1_scratch;
   address        npe_addr     = __ pc(); // npe is short for null pointer exception
@@ -181,7 +181,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index, bool caller_is_c1)
   }
 #endif
 
-  assert(VtableStub::receiver_location() == Z_R2->as_VMReg(), "receiver expected in Z_ARG1");
+  assert(SharedRuntime::name_for_receiver() == Z_R2->as_VMReg(), "receiver expected in Z_ARG1");
 
   // Entry arguments:
   //  Z_method: Interface

--- a/src/hotspot/cpu/x86/vtableStubs_x86_64.cpp
+++ b/src/hotspot/cpu/x86/vtableStubs_x86_64.cpp
@@ -74,7 +74,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index, bool caller_is_c1)
 #endif
 
   // get receiver (need to skip return address on top of stack)
-  assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
+  assert(SharedRuntime::name_for_receiver() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
 
   // Free registers (non-args) are rax, rbx
 
@@ -188,7 +188,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index, bool caller_is_c1)
   Label L_no_such_interface;
 
   // get receiver klass (also an implicit null-check)
-  assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
+  assert(SharedRuntime::name_for_receiver() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
   address npe_addr = __ pc();
   __ load_klass(recv_klass_reg, j_rarg0, temp_reg);
 

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -36,7 +36,6 @@
 #include "prims/jvmtiExport.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/mutexLocker.hpp"
-#include "runtime/sharedRuntime.hpp"
 #include "utilities/align.hpp"
 #include "utilities/powerOfTwo.hpp"
 
@@ -45,7 +44,6 @@
 
 address VtableStub::_chunk             = nullptr;
 address VtableStub::_chunk_end         = nullptr;
-VMReg   VtableStub::_receiver_location = VMRegImpl::Bad();
 
 
 void* VtableStub::operator new(size_t size, int code_size) throw() {
@@ -81,8 +79,8 @@ void* VtableStub::operator new(size_t size, int code_size) throw() {
 
 
 void VtableStub::print_on(outputStream* st) const {
-  st->print("vtable stub (index = %d, receiver_location = %zd, code = [" INTPTR_FORMAT ", " INTPTR_FORMAT "])",
-             index(), p2i(receiver_location()), p2i(code_begin()), p2i(code_end()));
+  st->print("vtable stub (index = %d, code = [" INTPTR_FORMAT ", " INTPTR_FORMAT "])",
+             index(), p2i(code_begin()), p2i(code_end()));
 }
 
 void VtableStub::print() const { print_on(tty); }
@@ -124,9 +122,6 @@ int VtableStubs::_itab_stub_size = 0;
 
 
 void VtableStubs::initialize() {
-  assert(VtableStub::_receiver_location == VMRegImpl::Bad(), "initialized multiple times?");
-
-  VtableStub::_receiver_location = SharedRuntime::name_for_receiver();
   {
     MutexLocker ml(VtableStubs_lock, Mutex::_no_safepoint_check_flag);
     for (int i = 0; i < N; i++) {
@@ -228,9 +223,9 @@ address VtableStubs::find_stub(bool is_vtable_stub, int vtable_index, bool calle
 
       enter(is_vtable_stub, vtable_index, caller_is_c1, s);
       if (PrintAdapterHandlers) {
-        tty->print_cr("Decoding VtableStub (%s) %s[%d]@" PTR_FORMAT " [" PTR_FORMAT ", " PTR_FORMAT "] (%zu bytes)",
+        tty->print_cr("Decoding VtableStub (%s) %s[%d] [" PTR_FORMAT ", " PTR_FORMAT "] (%zu bytes)",
                       caller_is_c1 ? "c1" : "full opt",
-                      is_vtable_stub? "vtbl": "itbl", vtable_index, p2i(VtableStub::receiver_location()),
+                      is_vtable_stub? "vtbl": "itbl", vtable_index,
                       p2i(s->code_begin()), p2i(s->code_end()), pointer_delta(s->code_end(), s->code_begin(), 1));
         Disassembler::decode(s->code_begin(), s->code_end());
       }
@@ -250,8 +245,7 @@ address VtableStubs::find_stub(bool is_vtable_stub, int vtable_index, bool calle
 
 
 inline uint VtableStubs::hash(bool is_vtable_stub, int vtable_index, bool caller_is_c1) {
-  // Assumption: receiver_location < 4 in most cases.
-  int hash = ((vtable_index << 2) ^ VtableStub::receiver_location()->value()) + vtable_index;
+  int hash = vtable_index;
   if (caller_is_c1) {
     // We have different vtable stubs for C1 and C2. We therefore make sure to get different hashes.
     hash = 7 - hash;

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -245,12 +245,8 @@ address VtableStubs::find_stub(bool is_vtable_stub, int vtable_index, bool calle
 
 
 inline uint VtableStubs::hash(bool is_vtable_stub, int vtable_index, bool caller_is_c1) {
-  int hash = vtable_index;
-  if (caller_is_c1) {
-    // We have different vtable stubs for C1 and C2. We therefore make sure to get different hashes.
-    hash = 7 - hash;
-  }
-  return (is_vtable_stub ? ~hash : hash)  & mask;
+  int hash = (vtable_index << 2) + (is_vtable_stub ? 2 : 0) + (caller_is_c1 ? 1 : 0);
+  return hash & mask;
 }
 
 

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -137,7 +137,6 @@ class VtableStub {
 
   static address _chunk;             // For allocation
   static address _chunk_end;         // For allocation
-  static VMReg   _receiver_location; // Where to find receiver
 
   VtableStub*    _next;              // Pointer to next entry in hash table
   const short    _index;             // vtable index
@@ -155,7 +154,6 @@ class VtableStub {
           _type(is_vtable_stub ? Type::vtable_stub : Type::itable_stub),
           _caller_type(caller_is_c1 ? CallerType::c1 : CallerType::unspecified) {}
   VtableStub* next() const                       { return _next; }
-  static VMReg receiver_location()               { return _receiver_location; }
   void set_next(VtableStub* n)                   { _next = n; }
 
  public:


### PR DESCRIPTION
This static member was simply an alias of `SharedRuntime::name_for_receiver()`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392175](https://bugs.openjdk.org/browse/JDK-8392175): Remove VtableStub::receiver_location (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32821/head:pull/32821` \
`$ git checkout pull/32821`

Update a local copy of the PR: \
`$ git checkout pull/32821` \
`$ git pull https://git.openjdk.org/jdk.git pull/32821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32821`

View PR using the GUI difftool: \
`$ git pr show -t 32821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32821.diff">https://git.openjdk.org/jdk/pull/32821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32821#issuecomment-5623347235)
</details>
