### PR TITLE
8389342: [Valhalla] C2: assert(false) failed: value_type does not fit field_type

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -999,7 +999,7 @@ void PhaseMacroExpand::undo_previous_scalarizations(Unique_Node_List& safepoints
 
 #ifdef ASSERT
   // Verify if a value can be written into a field.
-  void verify_type_compatibility(const Type* value_type, const Type* field_type) {
+  void verify_value_type_compatibility(const Type* value_type, const Type* field_type) {
     BasicType value_bt = value_type->basic_type();
     BasicType field_bt = field_type->basic_type();
 
@@ -1058,7 +1058,7 @@ void PhaseMacroExpand::process_field_value_at_safepoint(const Type* field_type, 
       value_worklist->push(field_val);
     }
   }
-  DEBUG_ONLY(verify_type_compatibility(field_val->bottom_type(), field_type);)
+  DEBUG_ONLY(verify_value_type_compatibility(field_val->bottom_type(), field_type);)
   sfpt->add_req(field_val);
 }
 

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -999,15 +999,18 @@ void PhaseMacroExpand::undo_previous_scalarizations(Unique_Node_List& safepoints
 
 #ifdef ASSERT
   // Verify if a value can be written into a field.
-  void verify_type_compatability(const Type* value_type, const Type* field_type) {
+  void verify_type_compatibility(const Type* value_type, const Type* field_type) {
     BasicType value_bt = value_type->basic_type();
     BasicType field_bt = field_type->basic_type();
 
-    // Primitive types must match.
-    if (is_java_primitive(value_bt) && value_bt == field_bt) { return; }
+    // Primitive types must match or have a matching reinterpreted variant
+    if (is_java_primitive(value_bt) &&
+        (value_bt == field_bt || MemNode::get_reinterpret_variant(value_bt) == field_bt)) {
+      return;
+    }
 
     // I have been struggling to make a similar assert for non-primitive
-    // types. I we can add one in the future. For now, I just let them
+    // types. If we can add one in the future. For now, I just let them
     // pass without checks.
     // In particular, I was struggling with a value that came from a call,
     // and had only a non-null check CastPP. There was also a checkcast
@@ -1055,7 +1058,7 @@ void PhaseMacroExpand::process_field_value_at_safepoint(const Type* field_type, 
       value_worklist->push(field_val);
     }
   }
-  DEBUG_ONLY(verify_type_compatability(field_val->bottom_type(), field_type);)
+  DEBUG_ONLY(verify_type_compatibility(field_val->bottom_type(), field_type);)
   sfpt->add_req(field_val);
 }
 

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1562,6 +1562,10 @@ BasicType MemNode::get_reinterpret_variant(BasicType bt) {
   }
 }
 
+bool MemNode::has_reinterpret_variant(const Type* vt) const {
+  return get_reinterpret_variant(value_basic_type()) == vt->basic_type();
+}
+
 //----------------------is_instance_field_load_with_local_phi------------------
 bool LoadNode::is_instance_field_load_with_local_phi(Node* ctrl) {
   if( in(Memory)->is_Phi() && in(Memory)->in(0) == ctrl &&
@@ -1690,10 +1694,6 @@ Node* LoadNode::convert_to_signed_load(PhaseGVN& gvn) {
                         false /*require_atomic_access*/, is_unaligned_access(), is_mismatched_access());
 }
 
-bool LoadNode::has_reinterpret_variant(const Type* rt) {
-  return get_reinterpret_variant(value_basic_type()) == rt->basic_type();
-}
-
 Node* LoadNode::convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt) {
   BasicType bt = rt->basic_type();
   assert(has_reinterpret_variant(rt), "no reinterpret variant: %s %s", Name(), type2name(bt));
@@ -1712,10 +1712,6 @@ Node* LoadNode::convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt) {
   return LoadNode::make(gvn, in(MemNode::Control), in(MemNode::Memory), in(MemNode::Address),
                         mem_t->is_ptr(), rt, bt, _mo, _control_dependency,
                         require_atomic_access, is_unaligned_access(), is_mismatched);
-}
-
-bool StoreNode::has_reinterpret_variant(const Type* vt) {
-  return get_reinterpret_variant(value_basic_type()) == vt->basic_type();
 }
 
 Node* StoreNode::convert_to_reinterpret_store(PhaseGVN& gvn, Node* val, const Type* vt) {

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1552,6 +1552,16 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseValues* phase) const {
   return nullptr;
 }
 
+BasicType MemNode::get_reinterpret_variant(BasicType bt) {
+  switch (bt) {
+    case T_INT: return T_FLOAT;
+    case T_FLOAT: return T_INT;
+    case T_LONG: return T_DOUBLE;
+    case T_DOUBLE: return T_LONG;
+    default: return T_ILLEGAL;
+  }
+}
+
 //----------------------is_instance_field_load_with_local_phi------------------
 bool LoadNode::is_instance_field_load_with_local_phi(Node* ctrl) {
   if( in(Memory)->is_Phi() && in(Memory)->in(0) == ctrl &&
@@ -1681,15 +1691,7 @@ Node* LoadNode::convert_to_signed_load(PhaseGVN& gvn) {
 }
 
 bool LoadNode::has_reinterpret_variant(const Type* rt) {
-  BasicType bt = rt->basic_type();
-  switch (Opcode()) {
-    case Op_LoadI: return (bt == T_FLOAT);
-    case Op_LoadL: return (bt == T_DOUBLE);
-    case Op_LoadF: return (bt == T_INT);
-    case Op_LoadD: return (bt == T_LONG);
-
-    default: return false;
-  }
+  return get_reinterpret_variant(value_basic_type()) == rt->basic_type();
 }
 
 Node* LoadNode::convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt) {
@@ -1713,15 +1715,7 @@ Node* LoadNode::convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt) {
 }
 
 bool StoreNode::has_reinterpret_variant(const Type* vt) {
-  BasicType bt = vt->basic_type();
-  switch (Opcode()) {
-    case Op_StoreI: return (bt == T_FLOAT);
-    case Op_StoreL: return (bt == T_DOUBLE);
-    case Op_StoreF: return (bt == T_INT);
-    case Op_StoreD: return (bt == T_LONG);
-
-    default: return false;
-  }
+  return get_reinterpret_variant(value_basic_type()) == vt->basic_type();
 }
 
 Node* StoreNode::convert_to_reinterpret_store(PhaseGVN& gvn, Node* val, const Type* vt) {

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -185,6 +185,9 @@ public:
 #endif
     return new_node;
   }
+
+  // Support for reinterpret variants used by StoreNode and LoadNode
+  static BasicType get_reinterpret_variant(BasicType bt);
 };
 
 // Analyze a MemNode to try to prove that it is independent from other memory accesses

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -188,6 +188,7 @@ public:
 
   // Support for reinterpret variants used by StoreNode and LoadNode
   static BasicType get_reinterpret_variant(BasicType bt);
+  bool has_reinterpret_variant(const Type* vt) const;
 };
 
 // Analyze a MemNode to try to prove that it is independent from other memory accesses
@@ -352,7 +353,6 @@ public:
   Node* convert_to_unsigned_load(PhaseGVN& gvn);
   Node* convert_to_signed_load(PhaseGVN& gvn);
 
-  bool  has_reinterpret_variant(const Type* rt);
   Node* convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt);
 
   ControlDependency control_dependency() const { return _control_dependency; }
@@ -714,7 +714,6 @@ public:
   // have all possible loads of the value stored been optimized away?
   bool value_never_loaded(PhaseValues* phase) const;
 
-  bool  has_reinterpret_variant(const Type* vt);
   Node* convert_to_reinterpret_store(PhaseGVN& gvn, Node* val, const Type* vt);
 
   MemBarNode* trailing_membar() const;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestReinterpretValueAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestReinterpretValueAtSafepoint.java
@@ -26,11 +26,11 @@
  * @summary Test type verification of writes of scalarized object at safepoint
  * @bug 8389342
  * @requires vm.compiler2.enabled
- * @library /test/lib /
  * @enablePreview
  * @modules java.base/jdk.internal.value
- * @run main/othervm -Xbatch -XX:RepeatCompilation=100 -XX:+StressEliminateAllocations
- *                   -XX:CompileOnly=${test.main.class}::test  ${test.main.class}
+ * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:RepeatCompilation=100
+ *                   -XX:+StressEliminateAllocations -XX:CompileOnly=${test.main.class}::test
+ *                   ${test.main.class}
  */
 
 package compiler.valhalla.valuetypes;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestReinterpretValueAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestReinterpretValueAtSafepoint.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test type verification of writes of scalarized object at safepoint
+ * @bug 8389342
+ * @requires vm.compiler2.enabled
+ * @library /test/lib /
+ * @enablePreview
+ * @modules java.base/jdk.internal.value
+ * @run main/othervm -Xbatch -XX:RepeatCompilation=100 -XX:+StressEliminateAllocations
+ *                   -XX:CompileOnly=${test.main.class}::test  ${test.main.class}
+ */
+
+package compiler.valhalla.valuetypes;
+
+public class TestReinterpretValueAtSafepoint {
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test(i);
+        }
+    }
+
+    static V1 test(int i) {
+        return new V1(i);
+    }
+
+    static value class V1 {
+        double d;
+        V2 v2;
+
+        V1(int i) {
+            // Folding of a reinterpret cast into memory operation would
+            // transform the StoreD into a StoreL
+            d = Double.longBitsToDouble(i);
+            v2 = i == -1 ? null : new V2();
+        }
+    }
+
+    static value class V2 {}
+}


### PR DESCRIPTION
Please review this small fix extending the verification of type compatibility at safepoint to cover the case where a reinterpret cast has been folded into a memory operation.

Tested with tier 1-3 and hs-comp-stress.

Thank you,

Fred

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389342](https://bugs.openjdk.org/browse/JDK-8389342): [Valhalla] C2: assert(false) failed: value_type does not fit field_type (**Bug** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32824/head:pull/32824` \
`$ git checkout pull/32824`

Update a local copy of the PR: \
`$ git checkout pull/32824` \
`$ git pull https://git.openjdk.org/jdk.git pull/32824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32824`

View PR using the GUI difftool: \
`$ git pr show -t 32824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32824.diff">https://git.openjdk.org/jdk/pull/32824.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32824#issuecomment-5625310148)
</details>
