### PR TITLE
8135174: javax/print/PrintSEUmlauts/PrintSEUmlauts.java failed

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -315,7 +315,6 @@ java/awt/Modal/ToBack/ToBackNonModal1Test.java 8196441 linux-all
 java/awt/Modal/ToBack/ToBackNonModal2Test.java 8196441 linux-all
 java/awt/Modal/ToBack/ToBackNonModal3Test.java 8196441 linux-all
 java/awt/Modal/ToBack/ToBackNonModal4Test.java 8196441 linux-all
-javax/print/PrintSEUmlauts/PrintSEUmlauts.java 8135174 generic-all
 java/awt/font/Rotate/RotatedTextTest.java 8219641 linux-all
 java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-all
 java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all

--- a/test/jdk/javax/print/PrintSEUmlauts/PrintSEUmlauts.java
+++ b/test/jdk/javax/print/PrintSEUmlauts/PrintSEUmlauts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ import javax.print.event.PrintJobEvent;
 /*
  * @test
  * @bug 8067364
+ * @requires (os.family == "linux" | os.family == "mac")
  * @summary Printing to Postscript doesn't support dieresis
  * @build PrintSEUmlauts
  * @run main/othervm PrintSEUmlauts


### PR DESCRIPTION
This updates the test to run only on Mac & Linux and removes it from the problem list.
The reason it fails on windows is that the wrong encoding is used there by the postscript generator.
The test doesn't need to run on Windows and fixing the encoding logic is a broader and separate issue for which a new bug has been submitted.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8135174](https://bugs.openjdk.org/browse/JDK-8135174): javax/print/PrintSEUmlauts/PrintSEUmlauts.java failed (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) Review applies to [f7e616ce](https://git.openjdk.org/jdk/pull/32825/files/f7e616cedd35ddd08134adba194f29e2fe6d1676)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) Review applies to [f7e616ce](https://git.openjdk.org/jdk/pull/32825/files/f7e616cedd35ddd08134adba194f29e2fe6d1676)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32825/head:pull/32825` \
`$ git checkout pull/32825`

Update a local copy of the PR: \
`$ git checkout pull/32825` \
`$ git pull https://git.openjdk.org/jdk.git pull/32825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32825`

View PR using the GUI difftool: \
`$ git pr show -t 32825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32825.diff">https://git.openjdk.org/jdk/pull/32825.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32825#issuecomment-5625558401)
</details>
