### PR TITLE
8392195: [PPC64] Several vector tests fail on Power8

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorFallbackInlining.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorFallbackInlining.java
@@ -78,12 +78,17 @@ public class TestVectorFallbackInlining {
             "-XX:CompileCommand=inline,jdk.internal.vm.vector.VectorSupport::insert";
 
     public static void main(String[] args) {
+        // Note: Some platforms don't activate EnableVectorSupport by default. Required here.
         TestFramework.runWithFlags("--add-modules=jdk.incubator.vector",
                                    FORCE_INLINE_FALLBACK,
-                                   "-XX:+IncrementalInlineVector");
+                                   "-XX:+IncrementalInlineVector",
+                                   "-XX:+UnlockExperimentalVMOptions",
+                                   "-XX:+EnableVectorSupport");
         TestFramework.runWithFlags("--add-modules=jdk.incubator.vector",
                                    FORCE_INLINE_FALLBACK,
-                                   "-XX:-IncrementalInlineVector");
+                                   "-XX:-IncrementalInlineVector",
+                                   "-XX:+UnlockExperimentalVMOptions",
+                                   "-XX:+EnableVectorSupport");
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorFallbackInlining.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorFallbackInlining.java
@@ -36,8 +36,7 @@ import jdk.incubator.vector.VectorSpecies;
  *          is enabled.
  * @modules jdk.incubator.vector
  * @library /test/lib /
- * @requires vm.compiler2.enabled &
- *           (vm.opt.final.EnableVectorSupport == null | vm.opt.final.EnableVectorSupport == true)
+ * @requires vm.compiler2.enabled
  * @run driver ${test.main.class}
  */
 

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorFallbackInlining.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorFallbackInlining.java
@@ -36,7 +36,8 @@ import jdk.incubator.vector.VectorSpecies;
  *          is enabled.
  * @modules jdk.incubator.vector
  * @library /test/lib /
- * @requires vm.compiler2.enabled
+ * @requires vm.compiler2.enabled &
+ *           (vm.opt.final.EnableVectorSupport == null | vm.opt.final.EnableVectorSupport == "true")
  * @run driver ${test.main.class}
  */
 

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorFallbackInlining.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorFallbackInlining.java
@@ -37,7 +37,7 @@ import jdk.incubator.vector.VectorSpecies;
  * @modules jdk.incubator.vector
  * @library /test/lib /
  * @requires vm.compiler2.enabled &
- *           (vm.opt.final.EnableVectorSupport == null | vm.opt.final.EnableVectorSupport == "true")
+ *           (vm.opt.final.EnableVectorSupport == null | vm.opt.final.EnableVectorSupport == true)
  * @run driver ${test.main.class}
  */
 

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMaskCompareNotTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMaskCompareNotTest.java
@@ -35,7 +35,7 @@ import jdk.test.lib.Asserts;
  * @library /test/lib /
  * @summary test combining vector not operation with compare
  * @modules jdk.incubator.vector
- * @requires vm.opt.final.MaxVectorSize == "null" | vm.opt.final.MaxVectorSize >= 16
+ * @requires vm.opt.final.MaxVectorSize == null | vm.opt.final.MaxVectorSize >= 16
  *
  * @run driver compiler.vectorapi.VectorMaskCompareNotTest
  */

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
@@ -39,7 +39,7 @@ import jdk.incubator.vector.VectorSpecies;
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector reinterpret intrinsics work as intended.
- * @requires os.arch != "riscv64" | vm.cpu.features ~= ".*rvv.*"
+ * @requires vm.opt.final.MaxVectorSize == null | vm.opt.final.MaxVectorSize >= 16
  * @library /test/lib /
  * @run main compiler.vectorapi.reshape.TestVectorReinterpret
  */

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -328,6 +328,7 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlag(map, "ClassUnloadingWithConcurrentMark");
         vmOptFinalFlag(map, "CriticalJNINatives");
         vmOptFinalFlag(map, "EliminateAllocations");
+        vmOptFinalFlag(map, "EnableVectorSupport");
         vmOptFinalFlag(map, "TieredCompilation");
         vmOptFinalFlag(map, "UnlockExperimentalVMOptions");
         vmOptFinalFlag(map, "UseAdaptiveSizePolicy");

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -328,7 +328,6 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlag(map, "ClassUnloadingWithConcurrentMark");
         vmOptFinalFlag(map, "CriticalJNINatives");
         vmOptFinalFlag(map, "EliminateAllocations");
-        vmOptFinalFlag(map, "EnableVectorSupport");
         vmOptFinalFlag(map, "TieredCompilation");
         vmOptFinalFlag(map, "UnlockExperimentalVMOptions");
         vmOptFinalFlag(map, "UseAdaptiveSizePolicy");


### PR DESCRIPTION
As explained in the JBS issue, some Vector API tests are failing on Power8 processors because features are disabled. This PR adapts these tests.
Note that such changes have already been done starting with https://github.com/openjdk/jdk/commit/6e911d819efa0f14ab1f9009b5bf325d99edb26c, but that one contains a small bug: Should be `null` instead of `"null"`.
GHA and local tests on Power8 have passed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392195](https://bugs.openjdk.org/browse/JDK-8392195): [PPC64] Several vector tests fail on Power8 (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32827/head:pull/32827` \
`$ git checkout pull/32827`

Update a local copy of the PR: \
`$ git checkout pull/32827` \
`$ git pull https://git.openjdk.org/jdk.git pull/32827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32827`

View PR using the GUI difftool: \
`$ git pr show -t 32827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32827.diff">https://git.openjdk.org/jdk/pull/32827.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32827#issuecomment-5626097644)
</details>
