### PR TITLE
8081489: [macosx] Test java/awt/Focus/FocusOwnerFrameOnClick/FocusOwnerFrameOnClick.java fails in Mac 10.10 but passes in 10.9

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -115,7 +115,6 @@
 
 java/awt/event/MouseEvent/MouseClickTest/MouseClickTest.java 8168389 windows-all,macosx-all
 java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java 8224055 macosx-all
-java/awt/Focus/FocusOwnerFrameOnClick/FocusOwnerFrameOnClick.java 8081489 generic-all
 java/awt/Focus/IconifiedFrameFocusChangeTest/IconifiedFrameFocusChangeTest.java 6849364 generic-all
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java 6848406 generic-all
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java 6848407 generic-all


### PR DESCRIPTION
The external bug in macOS 10.10 that is not present in the currently supported versions caused this test to fail. Tested on all platforms, the test is passing so i propose to remove it from the problem list. Also that was a macOS specific issue so no reason to problemlist it on all platforms in the first place.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8081489](https://bugs.openjdk.org/browse/JDK-8081489): [macosx] Test java/awt/Focus/FocusOwnerFrameOnClick/FocusOwnerFrameOnClick.java fails in Mac 10.10 but passes in 10.9 (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32828/head:pull/32828` \
`$ git checkout pull/32828`

Update a local copy of the PR: \
`$ git checkout pull/32828` \
`$ git pull https://git.openjdk.org/jdk.git pull/32828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32828`

View PR using the GUI difftool: \
`$ git pr show -t 32828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32828.diff">https://git.openjdk.org/jdk/pull/32828.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32828#issuecomment-5640058893)
</details>
