### PR TITLE
8392144: RISC-V: Fuse ConvI2L with integer negation, division and remainder

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8538,6 +8538,20 @@ instruct convI2L_subI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %
   ins_pipe(ialu_reg_reg);
 %}
 
+instruct convI2L_negI_reg(iRegLNoSp dst, iRegIorL2I src, immI0 zero) %{
+  match(Set dst (ConvI2L (SubI zero src)));
+
+  ins_cost(ALU_COST);
+  format %{ "subw  $dst, x0, $src\t# int, #@convI2L_negI_reg" %}
+
+  ins_encode %{
+    __ negw(as_Register($dst$$reg),
+            as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
 instruct convI2L_mulI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (ConvI2L (MulI src1 src2)));
 
@@ -8551,6 +8565,66 @@ instruct convI2L_mulI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %
   %}
 
   ins_pipe(imul_reg_reg);
+%}
+
+instruct convI2L_divI(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (DivI src1 src2)));
+
+  ins_cost(IDIVSI_COST);
+  format %{ "divw  $dst, $src1, $src2\t#@convI2L_divI" %}
+
+  ins_encode %{
+    __ divw(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(idiv_reg_reg);
+%}
+
+instruct convI2L_UdivI(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (UDivI src1 src2)));
+
+  ins_cost(IDIVSI_COST);
+  format %{ "divuw  $dst, $src1, $src2\t#@convI2L_UdivI" %}
+
+  ins_encode %{
+    __ divuw(as_Register($dst$$reg),
+             as_Register($src1$$reg),
+             as_Register($src2$$reg));
+  %}
+
+  ins_pipe(idiv_reg_reg);
+%}
+
+instruct convI2L_modI(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (ModI src1 src2)));
+
+  ins_cost(IDIVSI_COST);
+  format %{ "remw  $dst, $src1, $src2\t#@convI2L_modI" %}
+
+  ins_encode %{
+    __ remw(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct convI2L_UmodI(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (ConvI2L (UModI src1 src2)));
+
+  ins_cost(IDIVSI_COST);
+  format %{ "remuw  $dst, $src1, $src2\t#@convI2L_UmodI" %}
+
+  ins_encode %{
+    __ remuw(as_Register($dst$$reg),
+             as_Register($src1$$reg),
+             as_Register($src2$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
 %}
 
 instruct convI2L_lShiftI_reg_reg(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{

--- a/test/hotspot/jtreg/compiler/c2/riscv64/TestConvI2LFusion.java
+++ b/test/hotspot/jtreg/compiler/c2/riscv64/TestConvI2LFusion.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026, ByteDance Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test that C2 folds ConvI2L into RISC-V word arithmetic instructions.
+ * @library /test/lib /
+ * @requires os.arch == "riscv64" & vm.compiler2.enabled
+ * @run driver compiler.c2.riscv64.TestConvI2LFusion
+ */
+
+package compiler.c2.riscv64;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+public class TestConvI2LFusion {
+    private static final String CONVI2L_REG = "convI2L_reg_reg";
+
+    private static final int[][] TEST_CASES = {
+        {0, 1},
+        {1, -1},
+        {-1, 1},
+        {Integer.MAX_VALUE, 1},
+        {Integer.MIN_VALUE, -1},
+        {Integer.MIN_VALUE, Integer.MAX_VALUE},
+        {0x76543210, 0x13579bdf},
+        {0x89abcdef, 0x2468ace0},
+        {-1, Integer.MIN_VALUE}
+    };
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Run(test = {"testAddReg", "testAddImm", "testSubReg", "testMulReg",
+                 "testNeg", "testDiv", "testUDiv", "testMod", "testUMod",
+                 "testLShiftReg", "testLShiftImm",
+                 "testURShiftReg", "testURShiftImm",
+                 "testRShiftReg", "testRShiftImm"})
+    public void run(RunInfo runInfo) {
+        if (runInfo.isWarmUp()) {
+            exercise(0x89abcdef, 0x2468ace0);
+            return;
+        }
+
+        for (int[] testCase : TEST_CASES) {
+            assertResult(testCase[0], testCase[1]);
+        }
+        assertDivisionByZero();
+    }
+
+    @DontCompile
+    private static void exercise(int x, int y) {
+        testAddReg(x, y);
+        testAddImm(x);
+        testSubReg(x, y);
+        testMulReg(x, y);
+        testNeg(x);
+        testDiv(x, y);
+        testUDiv(x, y);
+        testMod(x, y);
+        testUMod(x, y);
+        testLShiftReg(x, y);
+        testLShiftImm(x);
+        testURShiftReg(x, y);
+        testURShiftImm(x);
+        testRShiftReg(x, y);
+        testRShiftImm(x);
+    }
+
+    @DontCompile
+    private static void assertResult(int x, int y) {
+        Asserts.assertEQ((long) (x + y), testAddReg(x, y));
+        Asserts.assertEQ((long) (x + 123), testAddImm(x));
+        Asserts.assertEQ((long) (x - y), testSubReg(x, y));
+        Asserts.assertEQ((long) (x * y), testMulReg(x, y));
+        Asserts.assertEQ((long) -x, testNeg(x));
+        Asserts.assertEQ((long) (x / y), testDiv(x, y));
+        Asserts.assertEQ((long) Integer.divideUnsigned(x, y), testUDiv(x, y));
+        Asserts.assertEQ((long) (x % y), testMod(x, y));
+        Asserts.assertEQ((long) Integer.remainderUnsigned(x, y), testUMod(x, y));
+        Asserts.assertEQ((long) (x << y), testLShiftReg(x, y));
+        Asserts.assertEQ((long) (x << 7), testLShiftImm(x));
+        Asserts.assertEQ((long) (x >>> y), testURShiftReg(x, y));
+        Asserts.assertEQ((long) (x >>> 7), testURShiftImm(x));
+        Asserts.assertEQ((long) (x >> y), testRShiftReg(x, y));
+        Asserts.assertEQ((long) (x >> 7), testRShiftImm(x));
+    }
+
+    @DontCompile
+    private static void assertDivisionByZero() {
+        try {
+            testDiv(1, 0);
+            Asserts.fail("Expected ArithmeticException from signed division");
+        } catch (ArithmeticException expected) {
+        }
+
+        try {
+            testUDiv(1, 0);
+            Asserts.fail("Expected ArithmeticException from unsigned division");
+        } catch (ArithmeticException expected) {
+        }
+
+        try {
+            testMod(1, 0);
+            Asserts.fail("Expected ArithmeticException from signed remainder");
+        } catch (ArithmeticException expected) {
+        }
+
+        try {
+            testUMod(1, 0);
+            Asserts.fail("Expected ArithmeticException from unsigned remainder");
+        } catch (ArithmeticException expected) {
+        }
+    }
+
+    @Test
+    @IR(counts = {"convI2L_addI_reg_reg", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testAddReg(int x, int y) {
+        return (long) (x + y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_addI_reg_imm", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testAddImm(int x) {
+        return (long) (x + 123);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_subI_reg_reg", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testSubReg(int x, int y) {
+        return (long) (x - y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_mulI_reg_reg", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testMulReg(int x, int y) {
+        return (long) (x * y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_negI_reg", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testNeg(int x) {
+        return (long) -x;
+    }
+
+    @Test
+    @IR(counts = {"convI2L_divI", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testDiv(int x, int y) {
+        return (long) (x / y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_UdivI", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testUDiv(int x, int y) {
+        return (long) Integer.divideUnsigned(x, y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_modI", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testMod(int x, int y) {
+        return (long) (x % y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_UmodI", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testUMod(int x, int y) {
+        return (long) Integer.remainderUnsigned(x, y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_lShiftI_reg_reg", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testLShiftReg(int x, int y) {
+        return (long) (x << y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_lShiftI_reg_imm", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testLShiftImm(int x) {
+        return (long) (x << 7);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_urShiftI_reg_reg", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testURShiftReg(int x, int y) {
+        return (long) (x >>> y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_urShiftI_reg_imm", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testURShiftImm(int x) {
+        return (long) (x >>> 7);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_rShiftI_reg_reg", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testRShiftReg(int x, int y) {
+        return (long) (x >> y);
+    }
+
+    @Test
+    @IR(counts = {"convI2L_rShiftI_reg_imm", ">= 1"},
+        failOn = {CONVI2L_REG},
+        phase = CompilePhase.PRINT_OPTO_ASSEMBLY)
+    public static long testRShiftImm(int x) {
+        return (long) (x >> 7);
+    }
+}


### PR DESCRIPTION

JDK-8389378 added RISC-V C2 matcher rules that fuse ConvI2L with several
integer producers, including addition, subtraction, multiplication and shifts.

There are still redundant sign extensions for integer negation, division and
remainder. For example:

    (long) -x
    (long) (x / y)
    (long) (x % y)
    (long) Integer.divideUnsigned(x, y)
    (long) Integer.remainderUnsigned(x, y)

C2 currently emits a W-suffix instruction followed by a separate sext.w:

    divw dst, src1, src2
    sext.w dst, dst

The RISC-V W-suffix instructions subw, divw, divuw, remw and remuw already
sign-extend their 32-bit result to XLEN. The following ConvI2L is therefore
redundant.

Add fused matcher rules for the following patterns:

    (ConvI2L (SubI 0 src))
    (ConvI2L (DivI src1 src2))
    (ConvI2L (UDivI src1 src2))
    (ConvI2L (ModI src1 src2))
    (ConvI2L (UModI src1 src2))

Each pattern can be emitted as a single subw, divw, divuw, remw or remuw
instruction while preserving the original int-to-long conversion semantics.

This is a follow-up to JDK-8389378.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392144](https://bugs.openjdk.org/browse/JDK-8392144): RISC-V: Fuse ConvI2L with integer negation, division and remainder (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32830/head:pull/32830` \
`$ git checkout pull/32830`

Update a local copy of the PR: \
`$ git checkout pull/32830` \
`$ git pull https://git.openjdk.org/jdk.git pull/32830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32830`

View PR using the GUI difftool: \
`$ git pr show -t 32830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32830.diff">https://git.openjdk.org/jdk/pull/32830.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32830#issuecomment-5629072876)
</details>
