### PR TITLE
8196432: Many ModalFocusTransfer tests fail on Linux and macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
@@ -25,6 +25,7 @@
 
 package sun.lwawt;
 
+import java.lang.ref.WeakReference;
 import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Component;
@@ -137,7 +138,15 @@ public class LWWindowPeer
 
     private static LWWindowPeer grabbingWindow;
 
+    /*
+     * The last native window which was logically focused when it was hidden.
+     * Its focus restore target may be a simple Window, which cannot become a
+     * native key window on macOS.
+     */
+    private static volatile WeakReference<LWWindowPeer> hiddenFocusedWindow;
+
     private volatile boolean skipNextFocusChange;
+    private volatile LWWindowPeer focusRestoreWindow;
 
     private static final Color nonOpaqueBackground = new Color(0, 0, 0, 0);
 
@@ -248,6 +257,7 @@ public class LWWindowPeer
 
     @Override
     protected void disposeImpl() {
+        rememberHiddenFocusedWindow();
         deactivateDisplayListener();
         SurfaceData oldData = getSurfaceData();
         synchronized (surfaceDataLock){
@@ -276,6 +286,9 @@ public class LWWindowPeer
 
     @Override
     protected void setVisibleImpl(final boolean visible) {
+        if (!visible) {
+            rememberHiddenFocusedWindow();
+        }
         updateFocusableWindowState();
         super.setVisibleImpl(visible);
         // TODO: update graphicsConfig, see 4868278
@@ -754,6 +767,12 @@ public class LWWindowPeer
     @Override
     public void notifyActivation(boolean activation, LWWindowPeer opposite) {
         Window oppositeWindow = (opposite == null)? null : opposite.getTarget();
+        if (activation) {
+            if (restoreFocusAfterHide()) {
+                return;
+            }
+            rememberFocusRestoreWindow();
+        }
         changeFocusedWindow(activation, oppositeWindow);
     }
 
@@ -1407,6 +1426,53 @@ public class LWWindowPeer
             }
             return blocker;
         }
+    }
+
+    // Records this focused native top-level before it is hidden, so its
+    // logical simple-Window focus target can be restored during native activation.
+    private void rememberHiddenFocusedWindow() {
+        KeyboardFocusManagerPeer kfmPeer = LWKeyboardFocusManagerPeer.getInstance();
+        if (kfmPeer.getCurrentFocusedWindow() == getTarget()) {
+            hiddenFocusedWindow = new WeakReference<>(this);
+        }
+    }
+
+    // Saves the currently focused simple Window as this native top-level's
+    // Java focus restore target when it becomes active.
+    private void rememberFocusRestoreWindow() {
+        Window focusedWindow = LWKeyboardFocusManagerPeer.getInstance()
+                .getCurrentFocusedWindow();
+        LWWindowPeer focusedPeer = focusedWindow == null ? null
+                : (LWWindowPeer) AWTAccessor.getComponentAccessor()
+                        .getPeer(focusedWindow);
+
+        focusRestoreWindow = focusedPeer != null && focusedPeer.isSimpleWindow()
+                ? focusedPeer : null;
+    }
+
+    // Restores Java focus to the simple Window saved by the just-hidden peer,
+    // if this peer is that Window's native owner and restoration is allowed.
+    private boolean restoreFocusAfterHide() {
+        WeakReference<LWWindowPeer> reference = hiddenFocusedWindow;
+        LWWindowPeer hiddenPeer = reference == null ? null : reference.get();
+        if (hiddenPeer == null || hiddenPeer.getTarget().isVisible()) {
+            hiddenFocusedWindow = null;
+            return false;
+        }
+
+        hiddenFocusedWindow = null;
+        LWWindowPeer simpleWindow = hiddenPeer.focusRestoreWindow;
+        hiddenPeer.focusRestoreWindow = null;
+
+        if (simpleWindow == null
+                || getOwnerFrameDialog(simpleWindow) != this
+                || !simpleWindow.focusAllowedFor()
+                || simpleWindow.getBlocker() != null) {
+            return false;
+        }
+
+        simpleWindow.changeFocusedWindow(true, hiddenPeer.getTarget());
+        return true;
     }
 
     @Override

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -262,28 +262,6 @@ java/awt/Modal/ModalExclusionTests/ToolkitExcludeFramePrintSetupTest.java 819643
 java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFAppModal2Test.java 8058813 windows-all
 java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFModeless2Test.java 8196191 windows-all
 
-java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFDocModalTest.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFModelessTest.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFNonModalTest.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsModelessTest.java 8196432 linux-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsNonModalTest.java 8196432 linux-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal1Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal2Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal3Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal4Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal1Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal2Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal3Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal4Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless1Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless2Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless3Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless4Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal1Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal2Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal3Test.java 8196432 macosx-all
-java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal4Test.java 8196432 macosx-all
-
 java/awt/Mouse/EnterExitEvents/DragWindowOutOfFrameTest.java 8177326 macosx-all
 java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021 macosx-all
 java/awt/Mouse/EnterExitEvents/FullscreenEnterEventTest.java 8051455 macosx-all


### PR DESCRIPTION
Few ModalFocusTransferTests tests were failing in macos due to focus not coming back to expected component.
The `FocusTransferDWFDocModalTest, FocusTransferDWFModelessTest, FocusTransferDWFNonModalTest`
tests opens in this sequence Dialog → Window → Frame (DWF) and when Frame closes, 
it expects the focus to come back to Window but it goes back to Dialog. 
It does not seem to be timing failures as waiting longer in the test doesn't fix this. 
The tests expose a macOS AWT focus-model gap for java.awt.Window.
On macOS, an ordinary Window is treated as a “simple window” 
https://github.com/openjdk/jdk/blob/7f068889b2d65a5ae2e10124da0f79eb20067521/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java#L1304-L1306
A simple Window is deliberately not made the native macOS key window. 
Instead, AWT gives native focus to its nearest Frame or Dialog owner, then synthesizes Java-level focus events for the Window 

When Frame closes, AppKit activates the native Dialog and
`LWWindowPeer.notifyActivation()` translated that Java focus for the Dialog. 
But the logical previous focused window was the Window, so its Open button never regained focus.  

The same issue occurs in the Frame → Window → Dialog (FWD) tests which are 
`FocusTransferFWDAppModal*Test, FocusTransferFWDDocModal*Test, FocusTransferFWDModeless*Test and FocusTransferFWDNonModal*Test`
The native Frame is reactivated after the Dialog closes, but Java focus should return to the intermediate Window.

As mentioned, waiting longer in the test doesn't fix this...the wrong Java focused window is selected deterministically after the native activation event.

I tried with a native Cocoa program mimicking Dialog->Window->Frame opening
 testing which component regains focus when Frame is closed and it turns out to be Window unlike Java's Dialog so it is a product issue.
 
 A product fix is done so that it preserves the existing macOS design—an AWT Window is still not made natively focusable. 
 Instead it restores the correct Java-level focus history
When a native Frame or Dialog gains focus while a simple Window has Java focus, it records that Window as its possible restore target
When the simple Window’s nearest native owner becomes active, 
AWT restores Java focus to the remembered Window, but only when it is still visible, focusable, and unblocked.

The static handoff reference is made WeakReference as 
a strong static reference retained a disposed peer, which retained its MainFrame and all child components, causing a regression test `ComponentLeakTest` failure 
so for
DWF tests: before fix: Dialog native activation after Frame closes → after fix: restore Java focus to Window 
FWD tests: before fix: Frame native activation after Dialog closes -> restore Java focus to Window

CI testing is good.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8196432](https://bugs.openjdk.org/browse/JDK-8196432): Many ModalFocusTransfer tests fail on Linux and macOS (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32831/head:pull/32831` \
`$ git checkout pull/32831`

Update a local copy of the PR: \
`$ git checkout pull/32831` \
`$ git pull https://git.openjdk.org/jdk.git pull/32831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32831`

View PR using the GUI difftool: \
`$ git pr show -t 32831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32831.diff">https://git.openjdk.org/jdk/pull/32831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32831#issuecomment-5630107533)
</details>
