### PR TITLE
8391988: Disable stringop-overflow in shenandoahInPlacePromoter.cpp

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -211,6 +211,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_safepointMechanism.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_shenandoahGenerationalHeap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_shenandoahHeap.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_shenandoahInPlacePromoter.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_shenandoahLock.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_stubGenerator_s390.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \


### PR DESCRIPTION
Zero builds with GCC 15.2 still fail after JDK-8391235. That fix only moved RegionPromotionStats::update() out of the header; GCC still inlines it in the same translation unit through get_region(), which may return null, into linux_zero's __atomic_load and misreports a stringop-overflow.

This is the same GCC false positive worked around for shenandoahGenerationalHeap.cpp (JDK-8382395), safepointMechanism.cpp (JDK-8382522) and shenandoahHeap.cpp (JDK-8390033). Disable the warning for the affected file.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391988](https://bugs.openjdk.org/browse/JDK-8391988): Disable stringop-overflow in shenandoahInPlacePromoter.cpp (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32832/head:pull/32832` \
`$ git checkout pull/32832`

Update a local copy of the PR: \
`$ git checkout pull/32832` \
`$ git pull https://git.openjdk.org/jdk.git pull/32832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32832`

View PR using the GUI difftool: \
`$ git pr show -t 32832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32832.diff">https://git.openjdk.org/jdk/pull/32832.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32832#issuecomment-5630227487)
</details>
