### PR TITLE
8392076: Sporadic failure of test InvalidateServerSessionRenegotiate.java

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java
@@ -56,6 +56,7 @@ public class InvalidateServerSessionRenegotiate implements
             System.out.println("Session: " + event.getSession().toString());
             System.out.println("Seen handshake completed #" +
                 handshakesCompleted);
+            notifyAll();
         }
     }
 
@@ -273,11 +274,16 @@ public class InvalidateServerSessionRenegotiate implements
         }
 
         /*
-         * Give the Handshaker Thread a chance to run
+         * Wait until both HandshakeCompleted events have been delivered,
+         * with a timeout to avoid hanging forever if something goes wrong.
          */
-        Thread.sleep(1000);
-
         synchronized (this) {
+            long deadline = System.currentTimeMillis() + 5000;
+            while (handshakesCompleted < 2) {
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) break;
+                wait(remaining);
+            }
             if (handshakesCompleted != 2) {
                 throw new Exception("Didn't see 2 handshake completed events.");
             }

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java
@@ -278,7 +278,7 @@ public class InvalidateServerSessionRenegotiate implements
          * Wait until both HandshakeCompleted events have been delivered,
          * with a timeout to avoid hanging forever if something goes wrong.
          */
-        if (!handshakeLatch.await(5, TimeUnit.SECONDS)) {
+        if (!handshakeLatch.await(10, TimeUnit.SECONDS)) {
             throw new Exception("Didn't see 2 handshake completed events.");
         }
     }

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java
@@ -40,23 +40,24 @@
 import java.io.*;
 import java.net.*;
 import java.security.Security;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.*;
 
 public class InvalidateServerSessionRenegotiate implements
         HandshakeCompletedListener {
 
-    static byte handshakesCompleted = 0;
+    final CountDownLatch handshakeLatch = new CountDownLatch(2);
 
     /*
      * Define what happens when handshaking is completed
      */
     public void handshakeCompleted(HandshakeCompletedEvent event) {
         synchronized (this) {
-            handshakesCompleted++;
+            handshakeLatch.countDown();
             System.out.println("Session: " + event.getSession().toString());
             System.out.println("Seen handshake completed #" +
-                handshakesCompleted);
-            notifyAll();
+                (2 - handshakeLatch.getCount()));
         }
     }
 
@@ -277,16 +278,8 @@ public class InvalidateServerSessionRenegotiate implements
          * Wait until both HandshakeCompleted events have been delivered,
          * with a timeout to avoid hanging forever if something goes wrong.
          */
-        synchronized (this) {
-            long deadline = System.currentTimeMillis() + 5000;
-            while (handshakesCompleted < 2) {
-                long remaining = deadline - System.currentTimeMillis();
-                if (remaining <= 0) break;
-                wait(remaining);
-            }
-            if (handshakesCompleted != 2) {
-                throw new Exception("Didn't see 2 handshake completed events.");
-            }
+        if (!handshakeLatch.await(5, TimeUnit.SECONDS)) {
+            throw new Exception("Didn't see 2 handshake completed events.");
         }
     }
 


### PR DESCRIPTION
Avoid a race condition in test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java. The HandshakeCompletedListener is invoked asynchronously, but the test only uses a fixed Thread.sleep(1000) before checking the completion count. Under load or slow systems, one or both listener callbacks could arrive after the sleep expired, causing a spurious failure even though the handshakes completed successfully.
Use a CountDownLatch to avoid this.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392076](https://bugs.openjdk.org/browse/JDK-8392076): Sporadic failure of test InvalidateServerSessionRenegotiate.java (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32834/head:pull/32834` \
`$ git checkout pull/32834`

Update a local copy of the PR: \
`$ git checkout pull/32834` \
`$ git pull https://git.openjdk.org/jdk.git pull/32834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32834`

View PR using the GUI difftool: \
`$ git pr show -t 32834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32834.diff">https://git.openjdk.org/jdk/pull/32834.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32834#issuecomment-5665312217)
</details>
