### PR TITLE
8391915: New test IdleConnectionTimeoutReuseTest times out on AIX

### DIFF
--- a/test/jdk/java/net/httpclient/IdleConnectionTimeoutReuseTest.java
+++ b/test/jdk/java/net/httpclient/IdleConnectionTimeoutReuseTest.java
@@ -68,9 +68,10 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  *          using platform threads, but it would be more difficult to reproduce
  *          reliably.
  *
- * @comment Why do we skip the test on Windows? On Windows, the selector
- *          implementation (i.e., `WEPollSelectorImpl`) blocks a virtual thread
- *          without releasing its carrier. With both
+ * @comment Why do we skip the test on Windows and AIX? On these platforms,
+ *          the selector implementation (`WEPollSelectorImpl` on Windows,
+ *          `PollSelectorImpl` on AIX) blocks a virtual thread without releasing
+ *          its carrier. With both
  *          `jdk.virtualThreadScheduler.{parallelism,maxPoolSize}` set to 1, no
  *          carrier remains to compensate for the blocked selector, and the
  *          initial client request cannot make progress. We could increase the
@@ -87,7 +88,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  *          carrier thread pool (i.e., FJP) requires `parallelism <= maxPoolSize`
  *          and having 1 thread in the pool is easier to make it starve.
  *
- * @requires os.family != "windows" & test.thread.factory != "Virtual"
+ * @requires os.family != "windows" & os.family != "aix" & test.thread.factory != "Virtual"
  *
  * @run junit/othervm
  *      -Djdk.httpclient.keepalive.timeout=1

--- a/test/jdk/java/net/httpclient/IdleConnectionTimeoutReuseTest.java
+++ b/test/jdk/java/net/httpclient/IdleConnectionTimeoutReuseTest.java
@@ -68,16 +68,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  *          using platform threads, but it would be more difficult to reproduce
  *          reliably.
  *
- * @comment Why do we skip the test on Windows and AIX? On these platforms,
- *          the selector implementation (`WEPollSelectorImpl` on Windows,
- *          `PollSelectorImpl` on AIX) blocks a virtual thread without releasing
- *          its carrier. With both
- *          `jdk.virtualThreadScheduler.{parallelism,maxPoolSize}` set to 1, no
- *          carrier remains to compensate for the blocked selector, and the
- *          initial client request cannot make progress. We could increase the
- *          VT scheduler capacity, but this contradicts with the reason we fix
- *          it to 1 in the first place: to starve the HTTP Client selector
- *          threads.
+ * @comment Why do we only test on Linux and macOS? These platforms are known to
+ *          have selector implementations that do *NOT* block the carrier thread
+ *          when selectors are called using VTs (via `useVirtualThreads=always`)
+ *          and `jdk.virtualThreadScheduler.{parallelism,maxPoolSize}` set to 1.
+ *          We could increase the VT scheduler capacity, but this contradicts
+ *          with the reason we fix it to 1 in the first place: to starve the
+ *          HTTP Client selector threads.
  *
  * @comment Why do we configure both `{quic,tcp}.selector.useVirtualThreads`?
  *          As of date, connection eviction is triggered by the selector of
@@ -88,7 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  *          carrier thread pool (i.e., FJP) requires `parallelism <= maxPoolSize`
  *          and having 1 thread in the pool is easier to make it starve.
  *
- * @requires os.family != "windows" & os.family != "aix" & test.thread.factory != "Virtual"
+ * @requires (os.family == "linux" | os.family == "mac") & test.thread.factory != "Virtual"
  *
  * @run junit/othervm
  *      -Djdk.httpclient.keepalive.timeout=1


### PR DESCRIPTION
Only run the test on platforms that have selector implementations that do *NOT* block the carrier thread. Currently these are macOS and Linux.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391915](https://bugs.openjdk.org/browse/JDK-8391915): New test IdleConnectionTimeoutReuseTest times out on AIX (**Bug** - P4)


### Reviewers
 * [Volkan Yazici](https://openjdk.org/census#vyazici) (@vy - **Reviewer**) Review applies to [04c9dd23](https://git.openjdk.org/jdk/pull/32836/files/04c9dd236b8d75eaac97b1d59eaec17ed36ed47a)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32836/head:pull/32836` \
`$ git checkout pull/32836`

Update a local copy of the PR: \
`$ git checkout pull/32836` \
`$ git pull https://git.openjdk.org/jdk.git pull/32836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32836`

View PR using the GUI difftool: \
`$ git pr show -t 32836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32836.diff">https://git.openjdk.org/jdk/pull/32836.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32836#issuecomment-5634610196)
</details>
