### PR TITLE
8391658: [Valhalla] Assert due to nested MergeMem after incremental inlining

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2390,7 +2390,11 @@ void GraphKit::replace_call(CallNode* call, Node* result, bool do_replaced_nodes
   // Clean up any MergeMems that feed other MergeMems since the
   // optimizer doesn't like that.
   while (wl.size() > 0) {
-    _gvn.transform(wl.pop());
+    Node* old_mem = wl.pop();
+    Node* new_mem = _gvn.transform(old_mem);
+    if (old_mem != new_mem) {
+      C->gvn_replace_by(old_mem, new_mem);
+    }
   }
 
   if (callprojs->fallthrough_catchproj != nullptr && !final_ctl->is_top() && do_replaced_nodes) {

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestMergeMemCleanup.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestMergeMemCleanup.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test cleanup of nested MergeMems after incremental inlining.
+ * @key stress randomness
+ * @requires vm.compiler2.enabled
+ * @enablePreview
+ * @run main ${test.main.class}
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+StressIncrementalInlining -XX:StressSeed=3860063970
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test 
+ *                   ${test.main.class}
+ */
+
+package compiler.valhalla;
+
+public class TestMergeMemCleanup {
+    static int count;
+
+    static Integer m1(Object obj) {
+        count++;
+        return (obj == null) ? null : (Integer)obj;
+    }
+
+    static Integer m2(Integer val) {
+        return m1(val);
+    }
+
+    static void test(Integer val) {
+        m1(val);
+        m2(val);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; i++) {
+            test(null);
+            test(i);
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestMergeMemCleanup.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestMergeMemCleanup.java
@@ -29,9 +29,9 @@
  * @requires vm.compiler2.enabled
  * @enablePreview
  * @run main ${test.main.class}
- * @run main/othervm -Xbatch -XX:-TieredCompilation
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+StressIncrementalInlining -XX:StressSeed=3860063970
- *                   -XX:CompileCommand=compileonly,${test.main.class}::test 
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+StressIGVN -XX:+StressIncrementalInlining -XX:StressSeed=3860063970
+ *                   -XX:CompileCommand=compileonly,${test.main.class}::test
  *                   ${test.main.class}
  */
 

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestMergeMemCleanup.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestMergeMemCleanup.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8391658
  * @summary Test cleanup of nested MergeMems after incremental inlining.
  * @key stress randomness
  * @requires vm.compiler2.enabled


### PR DESCRIPTION
We hit the same assert as in old [JDK-8221592](https://bugs.openjdk.org/browse/JDK-8221592) and [JDK-8223581](https://bugs.openjdk.org/browse/JDK-8223581), for the same reason: C2 does not like `MergeMemNodes` feeding into other `MergeMemNodes`. They should be cleaned up.

**Gory details:**
When C2 compiles `TestMergeMemCleanup::test`, `StressIncrementalInlining` leads to `m2` being inlined first. While parsing `m2`, its scalarized `Integer` argument must be buffered for the nested `m1(Object)` call which creates control and memory Phis.

Immediately before the call to `m1` in `test` is then inlined, the graph looks like this:

```
35  CallStaticJava  === 47 49 158 8 1 (94 94 ) [[ 95 96 97 107 106 ]] # Static  Test::m1 instptr:java/lang/Integer (java/io/Serializable,java/lang/Comparable,java/lang/constant/Constable,java/lang/constant/ConstantDesc):BotPTR:exact *,iid=bot ( instptr:java/lang/Object:BotPTR *,iid=bot ) Test::test @ bci:1 (line 14) !jvms: Test::test @ bci:1 (line 14)
107  Proj  === 35  [[ 177 ]] #2  Memory: @ptr:BotPTR+bot, idx=Bot; !jvms: Test::test @ bci:1 (line 14)
177  MergeMem  === _ 1 107 1  [[ 180 ]]  { - }  Memory: @ptr:BotPTR+bot, idx=Bot; !orig=197 !jvms: Test::m2 @ bci:-1 (line 10) Test::test @ bci:6 (line 15)
180  CallStaticJava  === 194 106 177 8 1 (237 1 1 ) [[ 238 239 240 250 249 ]] # Static  Test::m1 instptr:java/lang/Integer (java/io/Serializable,java/lang/Comparable,java/lang/constant/Constable,java/lang/constant/ConstantDesc):BotPTR:exact *,iid=bot ( instptr:java/lang/Object:BotPTR *,iid=bot ) Test::m2 @ bci:1 (line 10) Test::test @ bci:6 (line 15) !jvms: Test::m2 @ bci:1 (line 10) Test::test @ bci:6 (line 15)
``` 

The nested `m1` call `180` in `m2` uses `MergeMem 177`, whose base is memory projection `107` of the other `m1` call `35` in `test`. 

The call to `m1` is then inlined. Its `count++` creates memory slice `298` in MergeMem `283`. Replacing projection `107` changes the base of node `177` to MergeMem `283`:

```
298  StoreI  === 47 158 292 296  [[ 286 302 314 283 ]]  @instptr:java/lang/Class (java/io/Serializable,java/lang/constant/Constable,java/lang/reflect/AnnotatedElement,java/lang/invoke/TypeDescriptor,java/lang/reflect/GenericDeclaration,java/lang/reflect/Type,java/lang/invoke/TypeDescriptor$OfField):Constant:exact *+120,iid=bot, name=count, idx=7; barrier(0x0)  Memory: @instptr:java/lang/Class (java/io/Serializable,java/lang/constant/Constable,java/lang/reflect/AnnotatedElement,java/lang/invoke/TypeDescriptor,java/lang/reflect/GenericDeclaration,java/lang/reflect/Type,java/lang/invoke/TypeDescriptor$OfField):Constant:exact *+120,iid=bot, name=count, idx=7; !jvms: Test::m1 @ bci:5 (line 5) Test::test @ bci:1 (line 14)
283  MergeMem  === _ 1 158 1 1 1 1 298  [[ 279 177 ]]  { - - - - N298:instptr:java/lang/Class (java/io/Serializable,java/lang/constant/Constable,java/lang/reflect/AnnotatedElement,java/lang/invoke/TypeDescriptor,java/lang/reflect/GenericDeclaration,java/lang/reflect/Type,java/lang/invoke/TypeDescriptor$OfField):Constant:exact *+120,iid=bot }  Memory: @ptr:BotPTR+bot, idx=Bot; !jvms: Test::test @ bci:1 (line 14)
177  MergeMem  === _ 1 283 1  [[ 180 ]]  { - }  Memory: @ptr:BotPTR+bot, idx=Bot; !orig=197 !jvms: Test::m2 @ bci:-1 (line 10) Test::test @ bci:6 (line 15)
```

I touched the code that is supposed to clean this up already with [JDK-8221592](https://bugs.openjdk.org/browse/JDK-8221592) and [JDK-8223581](https://bugs.openjdk.org/browse/JDK-8223581), see [2f4393ec54d4](https://hg.openjdk.org/jdk/jdk/rev/2f4393ec54d4) and [4645b6d57f54](https://hg.openjdk.org/jdk/jdk/rev/4645b6d57f54) and the existing cleanup correctly transforms node `177`:
https://github.com/openjdk/jdk/blob/f5845185e146ad0cfd6e2375d0fc7aca423bae70/src/hotspot/share/opto/graphKit.cpp#L2390-L2393

However, `_gvn.transform(177)` returns node `283` through `MergeMemNode::Identity` without updating existing users. Call `180` therefore remains with the nested `177` -> `283` `MergeMem` input and we later hit the assert when `m1` is inlined as well.

I tried hard to create a non-Valhalla reproducer but I think it's not possible because only the Valhalla specific buffering creates that particular combination of `MergeMems`.

The fix explicitly replaces the old node with the new node returned by `_gvn.transform`.

Thanks,
Tobias

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391658](https://bugs.openjdk.org/browse/JDK-8391658): [Valhalla] Assert due to nested MergeMem after incremental inlining (**Bug** - P3)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32837/head:pull/32837` \
`$ git checkout pull/32837`

Update a local copy of the PR: \
`$ git checkout pull/32837` \
`$ git pull https://git.openjdk.org/jdk.git pull/32837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32837`

View PR using the GUI difftool: \
`$ git pr show -t 32837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32837.diff">https://git.openjdk.org/jdk/pull/32837.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32837#issuecomment-5633364668)
</details>
