### PR TITLE
8392216: Use more mtCompiler NMT tags in compiler code

### DIFF
--- a/src/hotspot/share/compiler/compilerEvent.cpp
+++ b/src/hotspot/share/compiler/compilerEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ int CompilerEvent::PhaseEvent::get_phase_id(const char* phase_name, bool may_exi
   {
     PhaseTypeGuard guard(sync);
     if (_phase_names == nullptr) {
-      _phase_names = new (mtInternal) GrowableArray<const char*>(100, mtCompiler);
+      _phase_names = new (mtCompiler) GrowableArray<const char*>(100, mtCompiler);
       register_jfr_serializer = true;
     } else if (may_exist) {
       index = lookup_phase(phase_name);

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -1043,7 +1043,7 @@ class LineCopy : StackObj {
   const char* _copy;
 public:
     LineCopy(char* line) {
-      _copy = os::strdup(line, mtInternal);
+      _copy = os::strdup(line, mtCompiler);
     }
     ~LineCopy() {
       os::free((void*)_copy);


### PR DESCRIPTION
There are some NMT tags `mtInternal` in compiler code that should better be replaced by `mtCompiler`.
There are also a couple of os::strdup usages in the compiler code, where we do not (yet) use the mtCompiler tag, but can consider using it 

```
compilationFailureInfo.cpp-48-CompilationFailureInfo::CompilationFailureInfo(const char* failure_reason) :
compilationFailureInfo.cpp-49- _stack(2),
compilationFailureInfo.cpp:50: _failure_reason(os::strdup(failure_reason)),
compilationFailureInfo.cpp-51- _elapsed_seconds(os::elapsedTime()),
compilationFailureInfo.cpp-52- _compile_id(current_compile_id_or_0())
--
compilerEvent.cpp-102-
compilerEvent.cpp-103- index = _phase_names->length();
compilerEvent.cpp:104: _phase_names->append(use_strdup ? os::strdup(phase_name) : phase_name);
compilerEvent.cpp-105- }
compilerEvent.cpp-106- if (register_jfr_serializer) {
--
compilerOracle.cpp-256-
compilerOracle.cpp-257-template<> void TypedMethodOptionMatcher::set_value(ccstr value) {
compilerOracle.cpp:258: _u.ccstr_value = (ccstr)os::strdup_check_oom(value);
compilerOracle.cpp-259-}
compilerOracle.cpp-260-
--
compilerOracle.cpp-1044-public:
compilerOracle.cpp-1045- LineCopy(char* line) {
compilerOracle.cpp:1046: _copy = os::strdup(line, mtCompiler);
compilerOracle.cpp-1047- }
compilerOracle.cpp-1048- ~LineCopy() {
--
compilerOracle.cpp-1256- // supersede these default commands.
compilerOracle.cpp-1257- for (int i = 0; default_compile_commands[i] != nullptr; i ++) {
compilerOracle.cpp:1258: char* s = os::strdup(default_compile_commands[i]);
compilerOracle.cpp-1259- success = CompilerOracle::parse_from_line_quietly(s);
compilerOracle.cpp-1260- os::free(s);
--
disassembler.cpp-282- line[len-1] = '\0';
disassembler.cpp-283- }
disassembler.cpp:284: _cached_src_lines->append(os::strdup(line));
disassembler.cpp-285- }
disassembler.cpp-286- fclose(fp);
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392216](https://bugs.openjdk.org/browse/JDK-8392216): Use more mtCompiler NMT tags in compiler code (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Manuel Hässig](https://openjdk.org/census#mhaessig) (@mhaessig - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32838/head:pull/32838` \
`$ git checkout pull/32838`

Update a local copy of the PR: \
`$ git checkout pull/32838` \
`$ git pull https://git.openjdk.org/jdk.git pull/32838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32838`

View PR using the GUI difftool: \
`$ git pr show -t 32838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32838.diff">https://git.openjdk.org/jdk/pull/32838.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32838#issuecomment-5633870349)
</details>
