### PR TITLE
8392198: JFR: JFR.stop again allows a missing recording name

### DIFF
--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -509,7 +509,7 @@ The following commands are available:
     **Note:**
 
     The *options* must be specified using either *key* or *key*`=`*value*
-    syntax. If no parameters are entered, then no recording is stopped.
+    syntax.
 
     *options*:
 
@@ -519,7 +519,8 @@ The following commands are available:
         timestamp, respectively. If no path is provided, the data from the
         recording is discarded. (FILE, no default value)
 
-    -   `name`: (Optional) Name of the recording (STRING, no default value)
+    -   `name`: Name of the recording. Use `JFR.check` to list the names of
+        the running recordings. (STRING, no default value)
 
 
 `JFR.view` \[*options*\]

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,9 @@ final class DCmdStop extends AbstractDCmd {
     @Override
     protected void execute(ArgumentParser parser)  throws DCmdException {
         parser.checkUnknownArguments();
+        if (!parser.checkMandatory()) {
+            throw new DCmdException("Missing mandatory argument 'name'. Use JFR.check to list recording names.");
+        }
         String name = parser.getOption("name");
         String filename = parser.getOption("filename");
         try {
@@ -85,7 +88,8 @@ final class DCmdStop extends AbstractDCmd {
                            Note: If a path is given, '%%p' in the path will be replaced by the PID,
                            and '%%t' will be replaced by the time in 'yyyy_MM_dd_HH_mm_ss' format.
 
-                 name      Name of the recording (STRING, no default value)
+                 name      (Mandatory) Name of the recording. Use JFR.check to list the names of the
+                           running recordings. (STRING, no default value)
 
                Options must be specified using the <key> or <key>=<value> syntax.
 

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdStopMissingName.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdStopMissingName.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jcmd;
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+/**
+ * @test
+ * @summary Verify JFR.stop reports an error when the name parameter is missing
+ * @requires vm.flagless
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.jcmd.TestJcmdStopMissingName
+ */
+public class TestJcmdStopMissingName {
+    public static void main(String[] args) throws Exception {
+        String name = "foo";
+        OutputAnalyzer output = JcmdHelper.jcmd("JFR.start", "name=" + name);
+        JcmdAsserts.assertRecordingHasStarted(output);
+        JcmdHelper.waitUntilRunning(name);
+        output = JcmdHelper.jcmd("JFR.stop");
+        output.shouldContain("Missing mandatory argument 'name'. Use JFR.check to list recording names.");
+        JcmdHelper.assertRecordingIsRunning(name);
+        JcmdHelper.stopAndCheck(name);
+    }
+}


### PR DESCRIPTION
Could I have review of a PR that makes the name parameter for JFR.stop mandatory?

Testing: test/jdk/jdk/jfr

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change requires CSR request [JDK-8392206](https://bugs.openjdk.org/browse/JDK-8392206) to be approved

### Issues
 * [JDK-8392198](https://bugs.openjdk.org/browse/JDK-8392198): JFR: JFR.stop again allows a missing recording name (**Bug** - P3)
 * [JDK-8392206](https://bugs.openjdk.org/browse/JDK-8392206): JFR: JFR.stop again allows a missing recording name (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32839/head:pull/32839` \
`$ git checkout pull/32839`

Update a local copy of the PR: \
`$ git checkout pull/32839` \
`$ git pull https://git.openjdk.org/jdk.git pull/32839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32839`

View PR using the GUI difftool: \
`$ git pr show -t 32839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32839.diff">https://git.openjdk.org/jdk/pull/32839.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32839#issuecomment-5636641113)
</details>
