### PR TITLE
8338063: Passing "|" as argument to TEST fails

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -666,7 +666,7 @@ define SetupRunMicroTestBody
 	        $$($1_MICRO_ITER) $$($1_MICRO_FORK) $$($1_MICRO_TIME) \
 	        $$($1_MICRO_WARMUP_ITER) $$($1_MICRO_WARMUP_TIME) \
 	        $$($1_MICRO_VM_OPTIONS) $$($1_MICRO_BASIC_OPTIONS) $$(MICRO_OPTIONS) \
-	        $$($1_TEST_NAME) \
+	        $$(call ShellQuote,$$($1_TEST_NAME)) \
 	        > >($(TEE) $$($1_TEST_RESULTS_DIR)/micro.txt) \
 	    && $$(ECHO) $$$$? > $$($1_EXITCODE) \
 	    || $$(ECHO) $$$$? > $$($1_EXITCODE) \
@@ -1293,7 +1293,7 @@ UseSpecialTestHandler = \
 
 # Now process each test to run and setup a proper make rule
 $(foreach test, $(TESTS_TO_RUN), \
-  $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
+  $(eval TEST_ID := $(shell $(ECHO) $(call ShellQuote,$(strip $(test))) | \
       $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
   $(eval ALL_TEST_IDS += $(TEST_ID)) \
   $(if $(call UseCustomTestHandler, $(test)), \
@@ -1373,10 +1373,10 @@ run-test-report: post-run-test
 	$(PRINTF) >> $(TEST_SUMMARY) "%2s %-49s %5s %5s %5s %5s %5s %2s\n" "  " \
 	    TEST TOTAL PASS FAIL ERROR SKIP " "
 	$(foreach test, $(TESTS_TO_RUN), \
-	  $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
+	  $(eval TEST_ID := $(shell $(ECHO) $(call ShellQuote,$(strip $(test))) | \
 	      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
 	    $(ECHO) >> $(TEST_LAST_IDS) $(TEST_ID) $(NEWLINE) \
-	  $(eval NAME_PATTERN := $(shell $(ECHO) $(test) | $(TR) -c '\n' '_')) \
+	  $(eval NAME_PATTERN := $(shell $(ECHO) $(call ShellQuote,$(test)) | $(TR) -c '\n' '_')) \
 	  $(if $(filter __________________________________________________%, $(NAME_PATTERN)), \
 	    $(eval TEST_NAME := ) \
 	    $(PRINTF) >> $(TEST_SUMMARY) "%2s %-49s\n" "  " "$(test)"  $(NEWLINE) \


### PR DESCRIPTION
**Problem**:
`make test TEST="micro:java.lang.invoke.LazyStaticColdStart.methodHandleCreate(Eager|Lazy)"` fails
```
Test selection 'micro:java.lang.invoke.LazyStaticColdStart.methodHandleCreate(Eager|Lazy)', will run:
* micro:java.lang.invoke.LazyStaticColdStart.methodHandleCreate(Eager|Lazy)
/usr/bin/bash: -c: line 1: syntax error near unexpected token `('
```

**Fix:**

Use the existing `ShellQuote` helper when passing test names through `make/RunTests.gmk`, including:

- the command used to run microbenchmarks;
- generation of the internal `TEST_ID`;
- test result summary generation;
- generation of the report `NAME_PATTERN`.

**Testing**：
- `make test-make`: passed
- Microbenchmark selection with `|` and parentheses: passed.
- Non-matching selection with special characters: reported the expected JMH error without a shell syntax error.

`make test TEST="micro:java.lang.invoke.LazyStaticColdStart.methodHandleCreate(Eager|Lazy)"`
```
Benchmark                                    Mode  Cnt   Score   Error  Units
LazyStaticColdStart.methodHandleCreateEager    ss   10  62.816 ± 3.862  us/op
LazyStaticColdStart.methodHandleCreateLazy     ss   10  33.069 ± 2.383  us/op
Finished running test 'micro:java.lang.invoke.LazyStaticColdStart.methodHandleCreate(Eager|Lazy)'
Test report is stored in build/linux-aarch64-server-release/test-results/micro_java_lang_invoke_LazyStaticColdStart_methodHandleCreate_Eager_Lazy_

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:java.lang.invoke.LazyStaticColdStart.methodHandleCreate(Eager|Lazy)
                                                         1     1     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-aarch64-server-release'
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8338063](https://bugs.openjdk.org/browse/JDK-8338063): Passing "|" as argument to TEST fails (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32841/head:pull/32841` \
`$ git checkout pull/32841`

Update a local copy of the PR: \
`$ git checkout pull/32841` \
`$ git pull https://git.openjdk.org/jdk.git pull/32841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32841`

View PR using the GUI difftool: \
`$ git pr show -t 32841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32841.diff">https://git.openjdk.org/jdk/pull/32841.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32841#issuecomment-5637503654)
</details>
