### PR TITLE
8392187: JFR: Use-after-free bug in CPU-time profiler can crash JVM

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 SAP SE. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.cpp
@@ -82,14 +82,10 @@ JfrCPUTimeTraceQueue::~JfrCPUTimeTraceQueue() {
 bool JfrCPUTimeTraceQueue::enqueue(JfrCPUTimeSampleRequest& request) {
   assert(JavaThread::current()->jfr_thread_local()->is_cpu_time_jfr_enqueue_locked(), "invariant");
   assert(&JavaThread::current()->jfr_thread_local()->cpu_time_jfr_queue() == this, "invariant");
-  u4 elementIndex;
-  do {
-    elementIndex = AtomicAccess::load_acquire(&_head);
-    if (elementIndex >= _capacity) {
-      return false;
-    }
-  } while (AtomicAccess::cmpxchg(&_head, elementIndex, elementIndex + 1) != elementIndex);
-  _data[elementIndex] = request;
+  if (_head >= _capacity) {
+    return false;
+  }
+  _data[_head++] = request;
   return true;
 }
 
@@ -100,20 +96,8 @@ JfrCPUTimeSampleRequest& JfrCPUTimeTraceQueue::at(u4 index) {
 
 static volatile u4 _lost_samples_sum = 0;
 
-u4 JfrCPUTimeTraceQueue::size() const {
-  return AtomicAccess::load_acquire(&_head);
-}
-
-void JfrCPUTimeTraceQueue::set_size(u4 size) {
-  AtomicAccess::release_store(&_head, size);
-}
-
-u4 JfrCPUTimeTraceQueue::capacity() const {
-  return AtomicAccess::load_acquire(&_capacity);
-}
-
 void JfrCPUTimeTraceQueue::set_capacity(u4 capacity) {
-  if (capacity == AtomicAccess::load(&_capacity)) {
+  if (capacity == _capacity) {
     return;
   }
   _head = 0;
@@ -126,11 +110,7 @@ void JfrCPUTimeTraceQueue::set_capacity(u4 capacity) {
   } else {
     _data = nullptr;
   }
-  AtomicAccess::release_store(&_capacity, capacity);
-}
-
-bool JfrCPUTimeTraceQueue::is_empty() const {
-  return AtomicAccess::load_acquire(&_head) == 0;
+  _capacity = capacity;
 }
 
 u4 JfrCPUTimeTraceQueue::lost_samples() const {
@@ -155,11 +135,11 @@ u4 JfrCPUTimeTraceQueue::get_and_reset_lost_samples_due_to_queue_full() {
 }
 
 void JfrCPUTimeTraceQueue::init() {
-  set_capacity(JfrCPUTimeTraceQueue::CPU_TIME_QUEUE_INITIAL_CAPACITY);
+  set_capacity(CPU_TIME_QUEUE_INITIAL_CAPACITY);
 }
 
 void JfrCPUTimeTraceQueue::clear() {
-  AtomicAccess::release_store(&_head, (u4)0);
+  _head = 0;
 }
 
 void JfrCPUTimeTraceQueue::resize_if_needed() {
@@ -167,7 +147,7 @@ void JfrCPUTimeTraceQueue::resize_if_needed() {
   if (lost_samples_due_to_queue_full == 0) {
     return;
   }
-  u4 capacity = AtomicAccess::load(&_capacity);
+  u4 capacity = _capacity;
   if (capacity < CPU_TIME_QUEUE_MAX_CAPACITY) {
     float ratio = (float)lost_samples_due_to_queue_full / (float)capacity;
     int factor = 1;
@@ -364,8 +344,9 @@ void JfrCPUSamplerThread::disenroll() {
   if (!AtomicAccess::cmpxchg(&_disenrolled, false, true)) {
     log_trace(jfr)("Disenrolling CPU thread sampler");
     if (AtomicAccess::load_acquire(&_signal_handler_installed)) {
-      stop_timer();
+      // Ensure no signal handlers are running before deleting timers and queues
       stop_signal_handlers();
+      stop_timer();
     }
     _sample.wait();
     log_trace(jfr)("Disenrolled CPU thread sampler");
@@ -703,14 +684,19 @@ void JfrCPUSamplerThread::stop_signal_handlers() {
 
 // returns false if the stop signal bit was set, true otherwise
 bool JfrCPUSamplerThread::increment_signal_handler_count() {
-  // increment the count of active signal handlers
-  u4 old_value = AtomicAccess::fetch_then_add(&_active_signal_handlers, (u4)1, memory_order_acq_rel);
-  if ((old_value & STOP_SIGNAL_BIT) != 0) {
-    // if the stop signal bit was set, we are not allowed to increment
-    AtomicAccess::dec(&_active_signal_handlers, memory_order_acq_rel);
-    return false;
+  u4 count = AtomicAccess::load_acquire(&_active_signal_handlers);
+  while (true) {
+    if ((count & STOP_SIGNAL_BIT) != 0) {
+      // if the stop signal bit was set, we are not allowed to increment
+      return false;
+    }
+    // atomically increment the count of active signal handlers
+    u4 expected = count;
+    count = AtomicAccess::cmpxchg(&_active_signal_handlers, expected, expected + 1, memory_order_acq_rel);
+    if (count == expected) {
+      return true;
+    }
   }
-  return true;
 }
 
 void JfrCPUSamplerThread::decrement_signal_handler_count() {

--- a/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.hpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 SAP SE. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.hpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrCPUTimeThreadSampler.hpp
@@ -44,22 +44,19 @@ struct JfrCPUTimeSampleRequest {
 // Fixed size async-signal-safe SPSC linear queue backed by an array.
 // Designed to be only used under lock and read linearly
 class JfrCPUTimeTraceQueue {
-
-  // the default queue capacity, scaled if the sampling period is smaller than 10ms
-  // when the thread is started
-  static const u4 CPU_TIME_QUEUE_CAPACITY = 500;
-
+ private:
   JfrCPUTimeSampleRequest* _data;
-  volatile u4 _capacity;
+  u4 _capacity;
   // next unfilled index
-  volatile u4 _head;
+  u4 _head;
 
   volatile u4 _lost_samples;
   volatile u4 _lost_samples_due_to_queue_full;
 
   static const u4 CPU_TIME_QUEUE_INITIAL_CAPACITY = 20;
   static const u4 CPU_TIME_QUEUE_MAX_CAPACITY     = 2000;
-public:
+
+ public:
   JfrCPUTimeTraceQueue(u4 capacity);
 
   ~JfrCPUTimeTraceQueue();
@@ -69,16 +66,14 @@ public:
 
   JfrCPUTimeSampleRequest& at(u4 index);
 
-  u4 size() const;
+  u4 size() const { return _head; }
 
-  void set_size(u4 size);
-
-  u4 capacity() const;
+  u4 capacity() const { return _capacity; }
 
   // deletes all samples in the queue
   void set_capacity(u4 capacity);
 
-  bool is_empty() const;
+  bool is_empty() const { return _head == 0; }
 
   u4 lost_samples() const;
 

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -617,7 +617,6 @@ bool JfrThreadLocal::try_acquire_cpu_time_jfr_enqueue_lock() {
 }
 
 bool JfrThreadLocal::try_acquire_cpu_time_jfr_dequeue_lock() {
-  CPUTimeLockState got;
   while (true)  {
     CPUTimeLockState got = AtomicAccess::cmpxchg(&_cpu_time_jfr_locked, UNLOCKED, DEQUEUE);
     if (got == UNLOCKED) {


### PR DESCRIPTION
This PR fixes a race between `JfrCPUSamplerThread::disenroll()` called on the recording termination and CPU timer signal handlers. Timer signals can be delivered asynchronously even after original timer has been deleted, therefore an extra care must be taken to ensure that signal handlers never access structures that can be concurrently modified or released.

`JfrCPUTimeTraceQueue` is a per-thread structure used to pass sampling events from a profiling signal handler to the control thread - `JfrCPUSamplerThread`. All operations on `JfrCPUTimeTraceQueue` are guarded by a spin-lock `_cpu_time_jfr_locked`, except for the `deallocate_cpu_time_jfr_queue` operation executed at a global safepoint when the sampling thread is terminating. The problem is that `deallocate_cpu_time_jfr_queue` can be executed concurrently with timer signal handlers.

This PR closes the remaining gap by reordering the termination sequence. Before deallocating queues, we first ensure that no profiling signal handler is running. Late signals (delivered after JFR termination) will find the STOP flag set and return immediately without accessing volatile data structures.

So, the main change is to swap the order of `stop_signal_handlers()` and `stop_timer()`.
Accompanying changes:
1. Increment in-flight signal handler count using `cmpxchg` instead of `fetch_then_add` to ensure we never increment the counter, even temporarily, if the STOP bit is raised. This is to guarantee that the loop in `stop_signal_handlers` completes within a finite time.
2. Simplified access to the `JfrCPUTimeTraceQueue` fields. No need for atomic operations, since the queue access is guarded by a spin-lock (with an exception of the JFR termination that happens at a safepoint and cannot coincide with other operations on the queue).
3. Cleanup of unused members.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392187](https://bugs.openjdk.org/browse/JDK-8392187): JFR: Use-after-free bug in CPU-time profiler can crash JVM (**Bug** - P3)


### Reviewers
 * [Johannes Bechberger](https://openjdk.org/census#jbechberger) (@parttimenerd - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32842/head:pull/32842` \
`$ git checkout pull/32842`

Update a local copy of the PR: \
`$ git checkout pull/32842` \
`$ git pull https://git.openjdk.org/jdk.git pull/32842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32842`

View PR using the GUI difftool: \
`$ git pr show -t 32842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32842.diff">https://git.openjdk.org/jdk/pull/32842.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32842#issuecomment-5637815303)
</details>
