### PR TITLE
8392326: JFR: Custom .jfc-files in lib/jfr can't be resolved

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFC.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,7 +193,7 @@ public final class JFC {
         Path path = JFC_DIRECTORY;
         if (path != null && Files.exists(path)) {
             for (String extension : Arrays.asList("", JFCParser.FILE_EXTENSION)) {
-                Path file = path.resolveSibling(name + extension);
+                Path file = path.resolve(name + extension);
                 if (Files.exists(file) && !Files.isDirectory(file)) {
                     try (Reader r = Files.newBufferedReader(file)) {
                         String jfcName = nameFromPath(file);


### PR DESCRIPTION
Could i have review of a PR that fixes an incorrect lookup of user-added .jfc files in JDK_HOME/lib/jfr?

Testing: 
Added a custom file to JDK_HOME/lib/jfr and checked that it could be used with -XX:StartFlightRecording:settings=custom

Thanks
Erik

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392326](https://bugs.openjdk.org/browse/JDK-8392326): JFR: Custom .jfc-files in lib/jfr can't be resolved (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32843/head:pull/32843` \
`$ git checkout pull/32843`

Update a local copy of the PR: \
`$ git checkout pull/32843` \
`$ git pull https://git.openjdk.org/jdk.git pull/32843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32843`

View PR using the GUI difftool: \
`$ git pr show -t 32843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32843.diff">https://git.openjdk.org/jdk/pull/32843.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32843#issuecomment-5649426534)
</details>
