### PR TITLE
8376023: Reconcile ClassUnloader with ClassUnloadCommon

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/ClassUnloader.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/ClassUnloader.java
@@ -34,14 +34,14 @@ import nsk.share.gc.gp.*;
 import nsk.share.test.ExecutionController;
 import nsk.share.test.Stresser;
 import jdk.test.lib.Utils;
-import jdk.test.whitebox.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 
 /**
  * The <code>ClassUnloader</code> class allows to force VM to unload class(es)
- * using WhiteBox.fullGC technique.
+ * using the full GC from ClassUnloadCommon.
  *
  * <p>The method <code>unloadClass()</code> is provided which calls
- * WhiteBox.fullGC to cleanup the heap. So, if all references to a class
+ * ClassUnloadCommon.triggerUnloading() to cleanup the heap. So, if all references to a class
  * and its loader are canceled, this may result in unloading the class.
  *
  * <p>ClassUnloader mainly intends to unload a class which was loaded
@@ -235,7 +235,7 @@ public class ClassUnloader {
      * @return  <i>true</i> if the class has been unloaded
              or <i>false</i> otherwise
      *
-     * @see WhiteBox.getWhiteBox().fullGC()
+     * @see ClassUnloadCommon#triggerUnloading()
      */
     public boolean unloadClass() {
         // free references to class and class loader to be able for collecting by GC
@@ -243,7 +243,7 @@ public class ClassUnloader {
         customClassLoader = null;
 
         // force class unloading by triggering full GC
-        WhiteBox.getWhiteBox().fullGC();
+        ClassUnloadCommon.triggerUnloading();
 
         if (isClassLoaderReclaimed()) {
             System.out.println("ClassUnloader: class loader has been reclaimed.");
@@ -263,18 +263,15 @@ public class ClassUnloader {
              or <i>false</i> otherwise
      */
     public boolean unloadClassAndWait(long timeout) {
-        timeout = Utils.adjustTimeout(timeout);
-        boolean wasUnloaded;
-        final long waitTime = 100;
-        do {
-            try {
-                Thread.sleep(waitTime);
-            } catch (InterruptedException e) {
-                // ignore
-            }
-            timeout -= waitTime;
-            wasUnloaded = unloadClass();
-        } while (!wasUnloaded && timeout > 0);
+        classObjects.removeAllElements();
+        customClassLoader = null;
+        boolean wasUnloaded = ClassUnloadCommon.triggerUnloadingUntil(this::isClassLoaderReclaimed,
+                                                                      Utils.adjustTimeout(timeout));
+        if (wasUnloaded) {
+            System.out.println("ClassUnloader: class loader has been reclaimed.");
+        } else {
+            System.out.println("ClassUnloader: class loader is still reachable.");
+        }
         return wasUnloaded;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/ClassUnloader.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/ClassUnloader.java
@@ -238,20 +238,24 @@ public class ClassUnloader {
      * @see ClassUnloadCommon#triggerUnloading()
      */
     public boolean unloadClass() {
-        // free references to class and class loader to be able for collecting by GC
+        releaseClassLoader();
+        ClassUnloadCommon.triggerUnloading();
+        return reportReclaimed(isClassLoaderReclaimed());
+    }
+
+    // free references to class and class loader to be able for collecting by GC
+    private void releaseClassLoader() {
         classObjects.removeAllElements();
         customClassLoader = null;
+    }
 
-        // force class unloading by triggering full GC
-        ClassUnloadCommon.triggerUnloading();
-
-        if (isClassLoaderReclaimed()) {
+    private static boolean reportReclaimed(boolean reclaimed) {
+        if (reclaimed) {
             System.out.println("ClassUnloader: class loader has been reclaimed.");
-            return true;
         } else {
             System.out.println("ClassUnloader: class loader is still reachable.");
-            return false;
         }
+        return reclaimed;
     }
 
     /**
@@ -263,15 +267,8 @@ public class ClassUnloader {
              or <i>false</i> otherwise
      */
     public boolean unloadClassAndWait(long timeout) {
-        classObjects.removeAllElements();
-        customClassLoader = null;
-        boolean wasUnloaded = ClassUnloadCommon.triggerUnloadingUntil(this::isClassLoaderReclaimed,
-                                                                      Utils.adjustTimeout(timeout));
-        if (wasUnloaded) {
-            System.out.println("ClassUnloader: class loader has been reclaimed.");
-        } else {
-            System.out.println("ClassUnloader: class loader is still reachable.");
-        }
-        return wasUnloaded;
+        releaseClassLoader();
+        return reportReclaimed(ClassUnloadCommon.triggerUnloadingUntil(this::isClassLoaderReclaimed,
+                                                                       Utils.adjustTimeout(timeout)));
     }
 }

--- a/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
+++ b/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Stream;
 
 public class ClassUnloadCommon {
@@ -89,24 +90,36 @@ public class ClassUnloadCommon {
     public static Set<String> triggerUnloading(List<String> classNames) {
         WhiteBox wb = WhiteBox.getWhiteBox();
         Set<String> aliveClasses = new HashSet<>(classNames);
-        int attempt = 0;
-        while (!aliveClasses.isEmpty() && attempt < 20) {
-            ClassUnloadCommon.triggerUnloading();
-            for (String className : classNames) {
-                if (aliveClasses.contains(className)) {
-                    if (wb.isClassAlive(className)) {
-                        try {
-                            Thread.sleep(100);
-                        } catch (InterruptedException ex) {
-                        }
-                    } else {
-                        aliveClasses.remove(className);
-                    }
-                }
-            }
-            attempt++;
-        }
+        triggerUnloadingUntil(() -> {
+            aliveClasses.removeIf(className -> !wb.isClassAlive(className));
+            return aliveClasses.isEmpty();
+        }, 2000);
         return aliveClasses;
+    }
+
+    /**
+     * Calls triggerUnloading() and checks {@code unloaded}, sleeping 100ms
+     * between attempts, until it returns true or the timeout expires.
+     *
+     * @param unloaded the condition that holds once the expected unloading happened
+     * @param timeoutMs how long to keep trying, in milliseconds
+     * @return whether {@code unloaded} returned true
+     */
+    public static boolean triggerUnloadingUntil(BooleanSupplier unloaded, long timeoutMs) {
+        long deadline = System.nanoTime() + timeoutMs * 1_000_000L;
+        while (true) {
+            triggerUnloading();
+            if (unloaded.getAsBoolean()) {
+                return true;
+            }
+            if (System.nanoTime() >= deadline) {
+                return false;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ex) {
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
The retry section has something in common with the other one, namely the full GC. Their checks are different and they should remain so. ClassUnloadCommon asks WhiteBox whether the classes are still alive and nsk ClassUnloader keeps an eye on the phantom reference on its loader.

The loop then goes to ClassUnloadCommon through the function triggerUnloadingUntil. The GC is carried out, the condition the caller provides is checked, a sleep is performed and the process is repeated until the condition is met or the timeout expires. triggerUnloading(List) is based on this approach and has the same two second limit as before. ClassUnloader retains its API together with the loader handling. unloadClass remains one GC followed by the check that the loader has been reclaimed. unloadClassAndWait makes use of the new loop including the phantom reference check and the timeout supplied by the caller. There are no changes to the tests. In the past unloadClassAndWait would sleep before the first GC which now it carries out the GC first and then sleeps between its attempts.

---------

Testing: 

- [x] runtime/ClassUnload, nsk/jvmti EM02, CompiledMethodUnload and ObjectFree, nsk/jdi ClassUnloadEvent and ClassUnloadRequest, nsk/sysdict on linux x64 and aarch64 debug. tier1 to 3 on x64


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8376023](https://bugs.openjdk.org/browse/JDK-8376023): Reconcile ClassUnloader with ClassUnloadCommon (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32844/head:pull/32844` \
`$ git checkout pull/32844`

Update a local copy of the PR: \
`$ git checkout pull/32844` \
`$ git pull https://git.openjdk.org/jdk.git pull/32844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32844`

View PR using the GUI difftool: \
`$ git pr show -t 32844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32844.diff">https://git.openjdk.org/jdk/pull/32844.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32844#issuecomment-5684075338)
</details>
