### PR TITLE
8389457: GC.class_histogram reports duplicate rows for refined array layouts

### DIFF
--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,24 +99,45 @@ const char* KlassInfoEntry::name() const {
   return name;
 }
 
+const char* KlassInfoEntry::layout() const {
+  if (_klass->is_flatArray_klass()) {
+    switch (FlatArrayKlass::cast(_klass)->layout_kind()) {
+    case LayoutKind::NULL_FREE_NON_ATOMIC_FLAT:
+      return " [flat, null-restricted, non-atomic]";
+    case LayoutKind::NULL_FREE_ATOMIC_FLAT:
+      return " [flat, null-restricted, atomic]";
+    case LayoutKind::NULLABLE_NON_ATOMIC_FLAT:
+      return " [flat, nullable, non-atomic]";
+    case LayoutKind::NULLABLE_ATOMIC_FLAT:
+      return " [flat, nullable, atomic]";
+    default:
+      return " [unknown layout]";
+    }
+  }
+  return "";
+}
+
+
 void KlassInfoEntry::print_on(outputStream* st) const {
   ResourceMark rm;
 
   // simplify the formatting (ILP32 vs LP64) - always cast the numbers to 64-bit
   ModuleEntry* module = _klass->module();
   if (module->is_named()) {
-    st->print_cr(INT64_FORMAT_W(13) "  " UINT64_FORMAT_W(13) "  %s (%s%s%s)",
+    st->print_cr(INT64_FORMAT_W(13) "  " UINT64_FORMAT_W(13) "  %s%s (%s%s%s)",
                  (int64_t)_instance_count,
                  (uint64_t)_instance_words * HeapWordSize,
                  name(),
+                 layout(),
                  module->name()->as_C_string(),
                  module->version() != nullptr ? "@" : "",
                  module->version() != nullptr ? module->version()->as_C_string() : "");
   } else {
-    st->print_cr(INT64_FORMAT_W(13) "  " UINT64_FORMAT_W(13) "  %s",
+    st->print_cr(INT64_FORMAT_W(13) "  " UINT64_FORMAT_W(13) "  %s%s",
                  (int64_t)_instance_count,
                  (uint64_t)_instance_words * HeapWordSize,
-                 name());
+                 name(),
+                 layout());
   }
 }
 

--- a/src/hotspot/share/memory/heapInspection.hpp
+++ b/src/hotspot/share/memory/heapInspection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ class KlassInfoEntry: public CHeapObj<mtInternal> {
   int compare(KlassInfoEntry* e1, KlassInfoEntry* e2);
   void print_on(outputStream* st) const;
   const char* name() const;
+  const char* layout() const;
 };
 
 class KlassInfoClosure : public StackObj {

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/ClassHistogramFlattenedArrayTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/ClassHistogramFlattenedArrayTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.regex.Pattern;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.dcmd.CommandExecutor;
+import jdk.test.lib.dcmd.JMXExecutor;
+
+import jdk.internal.value.ValueClass;
+
+
+/*
+ * @test
+ * @summary Test of diagnostic command GC.class_histogram for arrays with different layouts
+ * @enablePreview
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run main ${test.main.class}
+ */
+public class ClassHistogramFlattenedArrayTest {
+
+    @jdk.internal.vm.annotation.LooselyConsistentValue
+    public static value record TestClassNA(short s1, short s2) {}
+
+    @jdk.internal.vm.annotation.LooselyConsistentValue
+    public static value record TestClassNRA(short s1, short s2) {}
+
+    @jdk.internal.vm.annotation.LooselyConsistentValue
+    public static value record TestClassNRNA(short s1, short s2) {}
+
+
+    public static Object[] arrays = {
+        ValueClass.newNullableAtomicArray(TestClassNA.class, 1024),
+        ValueClass.newNullRestrictedAtomicArray(TestClassNRA.class, 1024, new TestClassNRA((short)1, (short)1)),
+        ValueClass.newNullRestrictedNonAtomicArray(TestClassNRNA.class, 1024, new TestClassNRNA((short)1, (short)1)),
+        ValueClass.newReferenceArray(TestClassR.class, 1024),
+    };
+
+    public static void main(String[] args) {
+        CommandExecutor executor = new JMXExecutor();
+        OutputAnalyzer output = executor.execute("GC.class_histogram ");
+
+        assertType(output, TestClassNA[].class, "flat, nullable, atomic");
+        assertType(output, TestClassNRA[].class, "flat, null-restricted, atomic");
+        assertType(output, TestClassNRNA[].class, "flat, null-restricted, non-atomic");
+    }
+
+    private static void assertType(OutputAnalyzer output, Class<?> arrayClass, String type) {
+        output.shouldMatch("^\\s+\\d+:\\s+\\d+\\s+\\d+\\s+" +
+            Pattern.quote(arrayClass.getName()) +
+            "\\s+\\[" + Pattern.quote(type) + "\\](?:\\s+\\(.*\\))?\\s*$");
+    }
+
+}

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/ClassHistogramFlattenedArrayTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/ClassHistogramFlattenedArrayTest.java
@@ -59,7 +59,6 @@ public class ClassHistogramFlattenedArrayTest {
         ValueClass.newNullableAtomicArray(TestClassNA.class, 1024),
         ValueClass.newNullRestrictedAtomicArray(TestClassNRA.class, 1024, new TestClassNRA((short)1, (short)1)),
         ValueClass.newNullRestrictedNonAtomicArray(TestClassNRNA.class, 1024, new TestClassNRNA((short)1, (short)1)),
-        ValueClass.newReferenceArray(TestClassR.class, 1024),
     };
 
     public static void main(String[] args) {


### PR DESCRIPTION
The flattened arrays might have different layout an thus different size. 

So it makes sense to update GC.class_histogram report to reflect this.

The layout is not printed for plain reference-based arrays. 

Here is the example of new output:

  23:             1           8208  [LClassHistogramFlattenedArrayTest$TestClassNA; [flat, nullable, atomic]
  40:             1           4112  [LClassHistogramFlattenedArrayTest$TestClassNRA; [flat, null-restricted, atomic]
  41:             1           4112  [LClassHistogramFlattenedArrayTest$TestClassNRNA; [flat, null-restricted, non-atomic]
  
For plain reference arrays it should be the same, like:
42:             1           4112  [LClassHistogramFlattenedArrayTest$TestClass; 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389457](https://bugs.openjdk.org/browse/JDK-8389457): GC.class_histogram reports duplicate rows for refined array layouts (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32845/head:pull/32845` \
`$ git checkout pull/32845`

Update a local copy of the PR: \
`$ git checkout pull/32845` \
`$ git pull https://git.openjdk.org/jdk.git pull/32845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32845`

View PR using the GUI difftool: \
`$ git pr show -t 32845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32845.diff">https://git.openjdk.org/jdk/pull/32845.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32845#issuecomment-5641171629)
</details>
