### PR TITLE
8391443: AOT training run fails with  --module-path=nosuchdir

### DIFF
--- a/src/hotspot/share/cds/aotClassLocation.cpp
+++ b/src/hotspot/share/cds/aotClassLocation.cpp
@@ -187,9 +187,8 @@ ModulePathClassLocationStream::ModulePathClassLocationStream() : ClassLocationSt
   while (cp_stream.has_next()) {
     const char* path = cp_stream.get_next();
     DIR* dirp = os::opendir(path);
-    if (dirp == nullptr && errno == ENOTDIR && has_jar_suffix(path)) {
-      add_one_path(path);
-    } else if (dirp != nullptr) {
+    if (dirp != nullptr) {
+      // Is a directory
       struct dirent* dentry;
       bool found_jar = false;
       while ((dentry = os::readdir(dirp)) != nullptr) {
@@ -204,7 +203,7 @@ ModulePathClassLocationStream::ModulePathClassLocationStream() : ClassLocationSt
         } else if (strcmp(file_name, ".") != 0 && strcmp(file_name, "..") != 0) {
           // Found some non jar entries
           _has_non_jar_modules = true;
-          log_info(class, path)("Found non-jar path: '%s%s%s'", path, os::file_separator(), file_name);
+          log_info(class, path)("Found non-JAR path: '%s%s%s'", path, os::file_separator(), file_name);
         }
       }
       if (!found_jar) {
@@ -213,7 +212,21 @@ ModulePathClassLocationStream::ModulePathClassLocationStream() : ClassLocationSt
       }
       os::closedir(dirp);
     } else {
-      _has_non_jar_modules = true;
+      // Not a directory
+      if (errno == ENOTDIR) {
+        if (has_jar_suffix(path)) {
+          log_info(class, path)("Module path points to a single JAR file: '%s'", path);
+          add_one_path(path);
+        } else {
+          log_info(class, path)("Module path points to a single non-JAR file: '%s'", path);
+          _has_non_jar_modules = true;
+        }
+      } else if (errno == ENOENT) {
+        log_info(class, path)("Found non-existent module path (ignored): '%s'", path);
+      }  else { 
+        aot_log_error(aot)("Unable to open file %s.", path);
+        AOTMetaspace::unrecoverable_loading_error();        
+      }
     }
   }
 

--- a/src/hotspot/share/cds/aotClassLocation.cpp
+++ b/src/hotspot/share/cds/aotClassLocation.cpp
@@ -223,9 +223,9 @@ ModulePathClassLocationStream::ModulePathClassLocationStream() : ClassLocationSt
         }
       } else if (errno == ENOENT) {
         log_info(class, path)("Found non-existent module path (ignored): '%s'", path);
-      }  else { 
+      }  else {
         aot_log_error(aot)("Unable to open file %s.", path);
-        AOTMetaspace::unrecoverable_loading_error();        
+        AOTMetaspace::unrecoverable_loading_error();
       }
     }
   }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ModuleOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ModuleOptions.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Edge cases of module options for AOT cache
+ * @bug 8391443
+ * @requires vm.cds
+ * @requires vm.flagless
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @build ModuleOptions
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello.jar Hello
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller Hello
+ * @run driver ModuleOptions AOT
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class ModuleOptions {
+    static final String appJar = ClassFileInstaller.getJarPath("hello.jar");
+    static final String mainClass = Hello.class.getName();
+
+    public static void main(String[] args) throws Exception {
+        nonExistentPath(args);
+        notJar();
+    }
+
+    // Non-existent paths specified by --module-path should be ignored by AOTClassLocation checks
+    static void nonExistentPath(String[] args) throws Exception {
+        nonExistentPath(args, true, false);
+        nonExistentPath(args, false, true);
+        nonExistentPath(args, true, true);
+    }
+
+    static void nonExistentPath(String[] args, boolean train, boolean production) throws Exception {
+        CDSAppTester tester = new CDSAppTester(mainClass) {
+                private boolean useNoSuchFile(RunMode runMode) {
+                    if (train && (runMode == RunMode.TRAINING || runMode == RunMode.ASSEMBLY)) {
+                        return true;
+                    }
+                    if (production && runMode == RunMode.PRODUCTION) {
+                        return true;
+                    }
+                    return false;
+                }
+
+                @Override
+                public String[] vmArgs(RunMode runMode) {
+                    if (useNoSuchFile(runMode)) {
+                        return new String [] { "--module-path", "nosuchfile", "-Xlog:class+path" };
+                    } else {
+                        return new String[] {};
+                    }
+                }
+
+                @Override
+                public String classpath(RunMode runMode) {
+                    return appJar;
+                }
+
+                @Override
+                public String[] appCommandLine(RunMode runMode) {
+                    return new String[] { mainClass };
+                }
+
+                @Override
+                public void checkExecution(OutputAnalyzer out, RunMode runMode) {
+                    if (useNoSuchFile(runMode)) {
+                        out.shouldContain("Found non-existent module path (ignored): 'nosuchfile'");
+                    }
+                }
+            };
+        tester.run(args);
+    }
+
+    static void notJar() throws Exception {
+        Files.writeString(Path.of("file.notjar"), "");
+        notJar(true,  false, false);
+        notJar(false, true,  false);
+        notJar(false, false, true);
+    }
+
+    static void notJar(boolean train, boolean assembly, boolean production) throws Exception {
+        CDSAppTester tester = new CDSAppTester(mainClass) {
+                private boolean useNotJarFile(RunMode runMode) {
+                    return (train && runMode == RunMode.TRAINING) ||
+                           (assembly && runMode == RunMode.ASSEMBLY) ||
+                           (production && runMode == RunMode.PRODUCTION);
+                }
+
+                @Override
+                public String[] vmArgs(RunMode runMode) {
+                    if (useNotJarFile(runMode)) {
+                        return new String [] { "--module-path", "file.notjar", "-Xlog:class+path" };
+                    } else {
+                        return new String[] {};
+                    }
+                }
+
+                @Override
+                public String[] appCommandLine(RunMode runMode) {
+                    return new String[] { mainClass };
+                }
+
+                @Override
+                public void checkExecution(OutputAnalyzer out, RunMode runMode) {
+                    if (useNotJarFile(runMode)) {
+                        out.shouldContain("Module path points to a single non-JAR file: 'file.notjar'");
+                        out.shouldNotHaveExitValue(0);
+                        if (runMode != RunMode.TRAINING) {
+                            out.shouldContain("module path contains sub-directories or non-JAR files (incompatible with full module graph");
+                        }
+                    }
+                }
+            };
+
+        if (train) {
+            tester.setCheckExitValue(false);
+            tester.recordAOTConfiguration();
+        } else if (assembly) {
+            tester.recordAOTConfiguration();
+            tester.setCheckExitValue(false);
+            tester.createAOTCache();
+        } else if (production) {
+            tester.recordAOTConfiguration();
+            tester.createAOTCache();
+            tester.setCheckExitValue(false);
+            tester.productionRun();
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ModuleOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ModuleOptions.java
@@ -38,6 +38,8 @@
 import java.nio.file.Files;
 import java.nio.file.Path;
 import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.cds.CDSAppTester.RunMode;
+import jdk.test.lib.cds.CDSAppTester.TerminateWorkflowException;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -47,7 +49,7 @@ public class ModuleOptions {
 
     public static void main(String[] args) throws Exception {
         nonExistentPath(args);
-        notJar();
+        notJar(args);
     }
 
     // Non-existent paths specified by --module-path should be ignored by AOTClassLocation checks
@@ -98,24 +100,24 @@ public class ModuleOptions {
         tester.run(args);
     }
 
-    static void notJar() throws Exception {
+    static void notJar(String[] args) throws Exception {
         Files.writeString(Path.of("file.notjar"), "");
-        notJar(true,  false, false);
-        notJar(false, true,  false);
-        notJar(false, false, true);
+        notJar(args, RunMode.TRAINING);
+        notJar(args, RunMode.ASSEMBLY);
+        notJar(args, RunMode.PRODUCTION);
     }
 
-    static void notJar(boolean train, boolean assembly, boolean production) throws Exception {
+    // Add argument {--module-path file.notjar} when the AOT workflow is at the specified
+    // testPhase. The workflow should fail at this phase.
+    static void notJar(String[] args, RunMode testPhase) throws Exception {
         CDSAppTester tester = new CDSAppTester(mainClass) {
-                private boolean useNotJarFile(RunMode runMode) {
-                    return (train && runMode == RunMode.TRAINING) ||
-                           (assembly && runMode == RunMode.ASSEMBLY) ||
-                           (production && runMode == RunMode.PRODUCTION);
+                private boolean isTestPhase(RunMode runMode) {
+                    return runMode == testPhase;
                 }
 
                 @Override
                 public String[] vmArgs(RunMode runMode) {
-                    if (useNotJarFile(runMode)) {
+                    if (isTestPhase(runMode)) {
                         return new String [] { "--module-path", "file.notjar", "-Xlog:class+path" };
                     } else {
                         return new String[] {};
@@ -129,28 +131,19 @@ public class ModuleOptions {
 
                 @Override
                 public void checkExecution(OutputAnalyzer out, RunMode runMode) {
-                    if (useNotJarFile(runMode)) {
+                    if (isTestPhase(runMode)) {
                         out.shouldContain("Module path points to a single non-JAR file: 'file.notjar'");
                         out.shouldNotHaveExitValue(0);
                         if (runMode != RunMode.TRAINING) {
                             out.shouldContain("module path contains sub-directories or non-JAR files (incompatible with full module graph");
                         }
+
+                        // We can't go on with the AOT workflow. Terminate it now.
+                        throw new TerminateWorkflowException();
                     }
                 }
             };
 
-        if (train) {
-            tester.setCheckExitValue(false);
-            tester.recordAOTConfiguration();
-        } else if (assembly) {
-            tester.recordAOTConfiguration();
-            tester.setCheckExitValue(false);
-            tester.createAOTCache();
-        } else if (production) {
-            tester.recordAOTConfiguration();
-            tester.createAOTCache();
-            tester.setCheckExitValue(false);
-            tester.productionRun();
-        }
+        tester.run(args);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndFMG.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndFMG.java
@@ -74,7 +74,7 @@ public class ModulePathAndFMG {
 
     private static String CLASS_FOUND_MESSAGE = "com.foos.Test found";
     private static String CLASS_NOT_FOUND_MESSAGE = "java.lang.ClassNotFoundException: com.foos.Test";
-    private static String FIND_EXCEPTION_MESSAGE = "java.lang.module.FindException: Module com.foos not found, required by com.bars";
+    private static String JMOD_NOT_SUPPORTED = "JMOD format not supported at execution time";
     private static String MODULE_NOT_RECOGNIZED = "Module format not recognized:.*modylibs.*com.bars.JAR";
     private static String FMG_ENABLED = "] full module graph: enabled";
     private static String FMG_DISABLED = "] full module graph: disabled";
@@ -321,7 +321,7 @@ public class ModulePathAndFMG {
         TestCommon.checkDump(output);
 
         String runModulePath = mainJar.toString() + PATH_SEPARATOR +
-            jmodDir.toString() + TEST_MODULE + ".jmod";
+            jmodDir.toString() + File.separator + TEST_MODULE + ".jmod";
         tty("11. run with CDS on, with module path com.bars.jar:com.foos.jmod");
         TestCommon.runWithModules(prefix,
                                  null,               // --upgrade-module-path
@@ -331,28 +331,11 @@ public class ModulePathAndFMG {
                 out.shouldContain(FMG_DISABLED)
                    .shouldNotContain(FMG_ENABLED)
                    .shouldContain(NON_JAR_FILES)
-                   .shouldContain(FIND_EXCEPTION_MESSAGE);
-            });
-
-        runModulePath += PATH_SEPARATOR + testJar.toString();
-
-        // non-jar files in runtime --module is incompatible with FMG
-        tty("12. run with CDS on, with module path com.bars.jar:com.foos.jmod:com.foos.jar");
-        TestCommon.runWithModules(prefix,
-                                 null,               // --upgrade-module-path
-                                 runModulePath, // --module-path
-                                 MAIN_MODULE)        // -m
-            .assertNormalExit(out -> {
-                out.shouldContain(FMG_DISABLED)
-                   .shouldNotContain(FMG_ENABLED)
-                   .shouldContain(NON_JAR_FILES)
-                   .shouldMatch(TEST_FROM_CDS)
-                   .shouldMatch(MAIN_FROM_CDS)
-                   .shouldContain(CLASS_FOUND_MESSAGE);
+                   .shouldContain(JMOD_NOT_SUPPORTED);
             });
 
         runModulePath = badJar.toString() + PATH_SEPARATOR + testJar.toString();
-        tty("13. run with CDS on, with module path com.bars.JAR:com.foos.jar");
+        tty("12. run with CDS on, with module path com.bars.JAR:com.foos.jar");
         TestCommon.runWithModules(prefix,
                                  null,               // --upgrade-module-path
                                  runModulePath, // --module-path

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -169,7 +169,7 @@ abstract public class CDSAppTester {
     // optional
     public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {}
 
-    private Workflow workflow;
+    private Workflow workflow = Workflow.AOT; // Use this by default.
     private boolean checkExitValue = true;
 
     public final void setCheckExitValue(boolean b) {
@@ -268,7 +268,7 @@ abstract public class CDSAppTester {
         return cmdLine;
     }
 
-    private OutputAnalyzer recordAOTConfiguration() throws Exception {
+    public OutputAnalyzer recordAOTConfiguration() throws Exception {
         RunMode runMode = RunMode.TRAINING;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -284,7 +284,7 @@ abstract public class CDSAppTester {
         return executeAndCheck(cmdLine, runMode, aotConfigurationFile, aotConfigurationFileLog);
     }
 
-    private OutputAnalyzer createAOTCacheOneStep() throws Exception {
+    public OutputAnalyzer createAOTCacheOneStep() throws Exception {
         RunMode runMode = RunMode.TRAINING;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -302,7 +302,7 @@ abstract public class CDSAppTester {
         return out;
     }
 
-    private OutputAnalyzer createClassList() throws Exception {
+    public OutputAnalyzer createClassList() throws Exception {
         RunMode runMode = RunMode.TRAINING;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -315,7 +315,7 @@ abstract public class CDSAppTester {
         return executeAndCheck(cmdLine, runMode, classListFile, classListFileLog);
     }
 
-    private OutputAnalyzer dumpStaticArchive() throws Exception {
+    public OutputAnalyzer dumpStaticArchive() throws Exception {
         RunMode runMode = RunMode.DUMP_STATIC;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -336,7 +336,7 @@ abstract public class CDSAppTester {
         return executeAndCheck(cmdLine, runMode, staticArchiveFile, staticArchiveFileLog);
     }
 
-    private OutputAnalyzer createAOTCache() throws Exception {
+    public OutputAnalyzer createAOTCache() throws Exception {
         RunMode runMode = RunMode.ASSEMBLY;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -395,7 +395,7 @@ abstract public class CDSAppTester {
         return this;
     }
 
-    private OutputAnalyzer dumpDynamicArchive() throws Exception {
+    public OutputAnalyzer dumpDynamicArchive() throws Exception {
         RunMode runMode = RunMode.DUMP_DYNAMIC;
         String[] cmdLine = new String[0];
         String baseArchive = getBaseArchiveForDynamicArchive();

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -131,6 +131,10 @@ abstract public class CDSAppTester {
         }
     }
 
+    public class TerminateWorkflowException extends RuntimeException {
+        private static final long serialVersionUID = 1L; // Value is not important.
+    }
+
     public boolean isDumping(RunMode runMode) {
         if (isStaticWorkflow()) {
             return runMode == RunMode.DUMP_STATIC;
@@ -167,9 +171,11 @@ abstract public class CDSAppTester {
     abstract public String[] appCommandLine(RunMode runMode);
 
     // optional
-    public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {}
+    // @throws TerminateWorkflowException if the AOT workflow should be terminated (any remaining AOT
+    // steps in the AOT workflow will be skipped).
+    public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception, TerminateWorkflowException {}
 
-    private Workflow workflow = Workflow.AOT; // Use this by default.
+    private Workflow workflow;
     private boolean checkExitValue = true;
 
     public final void setCheckExitValue(boolean b) {
@@ -219,12 +225,12 @@ abstract public class CDSAppTester {
         for (String logFile : logFiles) {
             listOutputFile(logFile);
         }
-        if (checkExitValue) {
-            output.shouldHaveExitValue(0);
-        }
         output.shouldNotContain(CDSTestUtils.MSG_STATIC_FIELD_MAY_HOLD_DIFFERENT_VALUE);
         CDSTestUtils.checkCommonExecExceptions(output);
         checkExecution(output, runMode);
+        if (checkExitValue) {
+            output.shouldHaveExitValue(0);
+        }
         return output;
     }
 
@@ -268,7 +274,7 @@ abstract public class CDSAppTester {
         return cmdLine;
     }
 
-    public OutputAnalyzer recordAOTConfiguration() throws Exception {
+    private OutputAnalyzer recordAOTConfiguration() throws Exception {
         RunMode runMode = RunMode.TRAINING;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -284,7 +290,7 @@ abstract public class CDSAppTester {
         return executeAndCheck(cmdLine, runMode, aotConfigurationFile, aotConfigurationFileLog);
     }
 
-    public OutputAnalyzer createAOTCacheOneStep() throws Exception {
+    private OutputAnalyzer createAOTCacheOneStep() throws Exception {
         RunMode runMode = RunMode.TRAINING;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -302,7 +308,7 @@ abstract public class CDSAppTester {
         return out;
     }
 
-    public OutputAnalyzer createClassList() throws Exception {
+    private OutputAnalyzer createClassList() throws Exception {
         RunMode runMode = RunMode.TRAINING;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -315,7 +321,7 @@ abstract public class CDSAppTester {
         return executeAndCheck(cmdLine, runMode, classListFile, classListFileLog);
     }
 
-    public OutputAnalyzer dumpStaticArchive() throws Exception {
+    private OutputAnalyzer dumpStaticArchive() throws Exception {
         RunMode runMode = RunMode.DUMP_STATIC;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -336,7 +342,7 @@ abstract public class CDSAppTester {
         return executeAndCheck(cmdLine, runMode, staticArchiveFile, staticArchiveFileLog);
     }
 
-    public OutputAnalyzer createAOTCache() throws Exception {
+    private OutputAnalyzer createAOTCache() throws Exception {
         RunMode runMode = RunMode.ASSEMBLY;
         String[] cmdLine = addCommonVMArgs(runMode);
         cmdLine = StringArrayUtils.concat(cmdLine, vmArgs(runMode));
@@ -395,7 +401,7 @@ abstract public class CDSAppTester {
         return this;
     }
 
-    public OutputAnalyzer dumpDynamicArchive() throws Exception {
+    private OutputAnalyzer dumpDynamicArchive() throws Exception {
         RunMode runMode = RunMode.DUMP_DYNAMIC;
         String[] cmdLine = new String[0];
         String baseArchive = getBaseArchiveForDynamicArchive();
@@ -527,18 +533,23 @@ abstract public class CDSAppTester {
             }
         }
 
-        if (oneStepTraining) {
-            try {
-                inOneStepTraining = true;
-                createAOTCacheOneStep();
-            } finally {
-                inOneStepTraining = false;
+        try {
+            if (oneStepTraining) {
+                try {
+                    inOneStepTraining = true;
+                    createAOTCacheOneStep();
+                } finally {
+                    inOneStepTraining = false;
+                }
+            } else {
+                recordAOTConfiguration();
+                createAOTCache();
             }
-        } else {
-            recordAOTConfiguration();
-            createAOTCache();
+            productionRun();
+        } catch (TerminateWorkflowException e) {
+            System.out.println("AOT workflow is terminated by tester's checkExecution() method");
+            e.printStackTrace(System.out);
         }
-        productionRun();
     }
 
     // See JEP 483; stop at the assembly run; do not execute production run


### PR DESCRIPTION
**The bug:**

In a "one-step" AOT training run, when `--module-path` points to a non-existent path, the old code treated it as pointing to an existing file that's not a JAR file. As a result, the AOT cache assembly step fails:

```
$ java --module-path=nosuchdir -cp HelloWorld.jar -XX:AOTCacheOutput=hw.aot HelloWorld
Hello World
[...]
[0.005s][error][aot] module path contains sub-directories or non-JAR files (incompatible with full module graph)
[...]
[0.005s][error][aot] An error has occurred while writing the AOT cache.
```

**The fix:**

In aotClassLocation.cpp, ignore all non-existent paths specified in `--module-path`. This is the same behavior as in the module system Java code -- an non-existent path is treated as if it supplied an empty set of modules, so it is effectively ignored. 

https://github.com/openjdk/jdk/blob/53f88f932f25ce8ab4dde3c41abec9cd7e2d2fd8/src/java.base/share/classes/jdk/internal/module/ModulePath.java#L241-L247

```
Exception <a 'java/nio/file/NoSuchFileException'{0x0000000438109d80}>
[..]
jdk.internal.module.ModulePath.scan(ModulePath.java:245)
jdk.internal.module.ModulePath.scanNextEntry(ModulePath.java:216)
jdk.internal.module.ModulePath.findAll(ModulePath.java:192)
java.lang.module.ModuleFinder$2.lambda$findAll$0(ModuleFinder.java:339)
java.lang.module.ModuleFinder$2$$Lambda/0x800000006.apply(Unknown Source)
java.util.stream.ReferencePipeline$7$1FlatMap.accept(ReferencePipeline.java:288)
java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)
java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:153)
java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:176)
java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:632)
java.lang.module.ModuleFinder$2.findAll(ModuleFinder.java:340)
java.lang.module.Resolver.findAll(Resolver.java:885)
java.lang.module.Resolver.bind(Resolver.java:234)
java.lang.module.Configuration.resolveAndBind(Configuration.java:365)
java.lang.module.ModuleDescriptor$1.resolveAndBind(ModuleDescriptor.java:2761)
jdk.internal.module.Modules.newBootLayerConfiguration(Modules.java:225)
jdk.internal.module.ModuleBootstrap.boot2(ModuleBootstrap.java:378)
jdk.internal.module.ModuleBootstrap.boot(ModuleBootstrap.java:169)
java.lang.System.initPhase2(System.java:1947)
```

Note:

I also fixed a bug in ModulePathAndFMG.java, which was missing a `/` in the path name, so while it intended to specify a jmod file,  it inadvertently gave a non-existent path instead. I fixed it to specify the jmod file, and updated the check for the new error condition.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391443](https://bugs.openjdk.org/browse/JDK-8391443): AOT training run fails with  --module-path=nosuchdir (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32847/head:pull/32847` \
`$ git checkout pull/32847`

Update a local copy of the PR: \
`$ git checkout pull/32847` \
`$ git pull https://git.openjdk.org/jdk.git pull/32847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32847`

View PR using the GUI difftool: \
`$ git pr show -t 32847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32847.diff">https://git.openjdk.org/jdk/pull/32847.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32847#issuecomment-5643479032)
</details>
