### PR TITLE
8247504: SA: InstanceKlass.getSize() needs an update because of value types

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -278,6 +278,9 @@ public class InstanceKlass extends Klass {
     if (isInterface()) {
       size += wordLength;
     }
+    if (this instanceof ValueKlass) {
+      size += ValueKlass.Members.getSize();
+    }
     return alignSize(size);
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ValueKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ValueKlass.java
@@ -40,6 +40,8 @@ public class ValueKlass extends InstanceKlass {
 
   public static class Members extends VMObject {
 
+    private static long size;
+
     private static CIntField payloadOffsetField;
     private static CIntField nullMarkerOffsetField;
 
@@ -49,6 +51,7 @@ public class ValueKlass extends InstanceKlass {
 
     private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
       Type type = db.lookupType("ValueKlass::Members");
+      size = type.getSize();
       payloadOffsetField = new CIntField(type.getCIntegerField("_payload_offset"), 0);
       nullMarkerOffsetField = new CIntField(type.getCIntegerField("_null_marker_offset"), 0);
     }
@@ -63,6 +66,10 @@ public class ValueKlass extends InstanceKlass {
 
     public int nullMarkerOffset() {
       return (int)nullMarkerOffsetField.getValue(this);
+    }
+
+    public static long getSize() {
+      return size;
     }
 
   }

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
@@ -70,6 +70,7 @@ public class TestInstanceKlassSize {
                                                 "java.util.ArrayList",
                                                 "java.lang.String",
                                                 "java.lang.Thread",
+                                                "java.lang.Byte"
                                              };
 
     private static void startMeWithArgs() throws Exception {


### PR DESCRIPTION
After Valhalla, `InstanceKlass::size()` in HotSpot adds sizeof `ValueKlass::Members` for value class, however SA does not do. It caused the failure in TestInstanceKlassSize.java with `--enable-preview`.

This PR fixes the problem, and adds the test for `java.lang.Byte` to TestInstanceKlassSize.java again (removed by JEP 401).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8247504](https://bugs.openjdk.org/browse/JDK-8247504): SA: InstanceKlass.getSize() needs an update because of value types (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32848/head:pull/32848` \
`$ git checkout pull/32848`

Update a local copy of the PR: \
`$ git checkout pull/32848` \
`$ git pull https://git.openjdk.org/jdk.git pull/32848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32848`

View PR using the GUI difftool: \
`$ git pr show -t 32848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32848.diff">https://git.openjdk.org/jdk/pull/32848.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32848#issuecomment-5644052251)
</details>
