### PR TITLE
8381336: SA FlatArray support is incomplete

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -192,6 +192,7 @@
   nonstatic_field(ConstantPoolCache,           _resolved_indy_entries,                        Array<ResolvedIndyEntry>*)             \
   nonstatic_field(ResolvedIndyEntry,           _cpool_index,                                  u2)                                    \
   nonstatic_field(ValueFieldLayoutInfo,        _klass,                                        ValueKlass*)                           \
+  nonstatic_field(ValueFieldLayoutInfo,        _kind,                                         LayoutKind)                            \
   volatile_nonstatic_field(InstanceKlass,      _array_klasses,                                ObjArrayKlass*)                        \
   nonstatic_field(InstanceKlass,               _methods,                                      Array<Method*>*)                       \
   nonstatic_field(InstanceKlass,               _default_methods,                              Array<Method*>*)                       \
@@ -272,6 +273,7 @@
   nonstatic_field(ConstMethod,                 _num_stack_arg_slots,                          u2)                                    \
   nonstatic_field(ObjArrayKlass,               _element_klass,                                Klass*)                                \
   nonstatic_field(ObjArrayKlass,               _bottom_klass,                                 Klass*)                                \
+  nonstatic_field(FlatArrayKlass,              _layout_kind,                                  LayoutKind)                            \
   volatile_nonstatic_field(Symbol,             _hash_and_refcount,                            unsigned int)                          \
   nonstatic_field(Symbol,                      _length,                                       u2)                                    \
   unchecked_nonstatic_field(Symbol,            _body,                                         sizeof(u1)) /* NOTE: no type */        \
@@ -1198,6 +1200,7 @@
                                                                           \
    declare_integer_type(AOTCompressedPointers::narrowPtr)                 \
    declare_integer_type(Bytecodes::Code)                                  \
+   declare_integer_type(LayoutKind)                                       \
    declare_integer_type(InstanceKlass::ClassState)                        \
    declare_integer_type(Klass::KlassKind)                                 \
    declare_integer_type(JavaThreadState)                                  \
@@ -1480,6 +1483,18 @@
   /*****************************************************/                 \
                                                                           \
   declare_constant(InstanceKlass::enclosing_method_attribute_size)        \
+                                                                          \
+  /*******************/                                                   \
+  /* LayoutKind enum */                                                   \
+  /*******************/                                                   \
+                                                                          \
+  declare_constant(LayoutKind::REFERENCE)                                 \
+  declare_constant(LayoutKind::BUFFERED)                                  \
+  declare_constant(LayoutKind::NULL_FREE_NON_ATOMIC_FLAT)                 \
+  declare_constant(LayoutKind::NULL_FREE_ATOMIC_FLAT)                     \
+  declare_constant(LayoutKind::NULLABLE_ATOMIC_FLAT)                      \
+  declare_constant(LayoutKind::NULLABLE_NON_ATOMIC_FLAT)                  \
+  declare_constant(LayoutKind::UNKNOWN)                                   \
                                                                           \
   /*********************************/                                     \
   /* InstanceKlass ClassState enum */                                     \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Array.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Array.java
@@ -61,6 +61,9 @@ public class Array extends Oop {
   // aligned 0 mod 8.  The arrayOop itself must be aligned at least this
   // strongly.
   private static boolean elementTypeShouldBeAligned(BasicType type) {
+    if (type == BasicType.T_FLAT_ELEMENT) {
+      return true;
+    }
     if (VM.getVM().isLP64()) {
       if (type == BasicType.T_OBJECT || type == BasicType.T_ARRAY) {
         return !VM.getVM().isCompressedOopsEnabled();
@@ -117,6 +120,7 @@ public class Array extends Oop {
   }
 
   public boolean isArray()             { return true; }
+  public boolean isFlatArray()         { return false; }
 
   public void iterateFields(OopVisitor visitor, boolean doVMFields) {
     super.iterateFields(visitor, doVMFields);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/FlatArray.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/FlatArray.java
@@ -34,7 +34,7 @@ import sun.jvm.hotspot.utilities.Observer;
 
 // A FlatArray is an array containing flattened value objects.
 
-public class FlatArray extends Array {
+public class FlatArray extends ObjArray {
   static {
     VM.registerVMInitializedObserver(new Observer() {
         public void update(Observable o, Object data) {
@@ -50,6 +50,7 @@ public class FlatArray extends Array {
     super(handle, heap);
   }
 
+  @Override
   public boolean isFlatArray()         { return true; }
 
   public void printValueOn(PrintStream tty) {
@@ -57,14 +58,16 @@ public class FlatArray extends Array {
     klass.printValueOn(tty);
   }
 
-  public void iterateFields(OopVisitor visitor, boolean doVMFields) {
-    super.iterateFields(visitor, doVMFields);
-    FlatArrayKlass klass = (FlatArrayKlass) getKlass();
-    int length = (int) getLength();
-    int type   = klass.getElementType();
-    //System.out.println("FlatArray.iterateFields: length:" + length + " type:" + type);
+  @Override
+  protected void iterateFieldsInternal(OopVisitor visitor, int length) {
+    int shift = Klass.layoutHelperLog2ElementSize(getKlass().getLayoutHelper());
+    long baseOffset = baseOffsetInBytes(BasicType.T_FLAT_ELEMENT);
+    int elementSize = 1 << shift; // from FlatArrayKlass::oop_oop_iterate_elements_specialized_bounded() (addr_incr)
+
     for (int index = 0; index < length; index++) {
-        // FIXME - call visitor.doXXX() for each component of each value object
+      long offset = baseOffset + (index * elementSize);
+      OopField field = new OopField(new IndexableFieldIdentifier(index), offset, false);
+      visitor.doOop(field, false);
     }
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/FlatArrayKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/FlatArrayKlass.java
@@ -36,6 +36,9 @@ import sun.jvm.hotspot.utilities.Observer;
 // FlatArrayKlass is a proxy for FlatArrayKlass in the JVM
 
 public class FlatArrayKlass extends ObjArrayKlass {
+
+  private static CIntegerField layoutKindField;
+
   static {
     VM.registerVMInitializedObserver(new Observer() {
         public void update(Observable o, Object data) {
@@ -46,11 +49,16 @@ public class FlatArrayKlass extends ObjArrayKlass {
 
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type t = db.lookupType("FlatArrayKlass");
-    // TODO: implement similar features as in ObjArrayKlass
+
+    layoutKindField = t.getCIntegerField("_layout_kind");
   }
 
   public FlatArrayKlass(Address addr) {
     super(addr);
+  }
+
+  public LayoutKind getLayoutKind() {
+    return LayoutKind.valueOf((int)layoutKindField.getValue(addr));
   }
 
   public void printValueOn(PrintStream tty) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Klass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Klass.java
@@ -123,6 +123,7 @@ public class Klass extends Metadata implements ClassConstants {
   // anon-enum constants for _layout_helper.
   public static int LH_INSTANCE_SLOW_PATH_BIT;
   public static int LH_LOG2_ELEMENT_SIZE_SHIFT;
+  public static int LH_LOG2_ELEMENT_SIZE_MASK;
   public static int LH_ELEMENT_TYPE_SHIFT;
   public static int LH_HEADER_SIZE_SHIFT;
   public static int LH_ARRAY_TAG_SHIFT;
@@ -148,6 +149,7 @@ public class Klass extends Metadata implements ClassConstants {
 
     LH_INSTANCE_SLOW_PATH_BIT  = db.lookupIntConstant("Klass::_lh_instance_slow_path_bit").intValue();
     LH_LOG2_ELEMENT_SIZE_SHIFT = db.lookupIntConstant("Klass::_lh_log2_element_size_shift").intValue();
+    LH_LOG2_ELEMENT_SIZE_MASK  = db.lookupIntConstant("Klass::_lh_log2_element_size_mask").intValue();
     LH_ELEMENT_TYPE_SHIFT      = db.lookupIntConstant("Klass::_lh_element_type_shift").intValue();
     LH_HEADER_SIZE_SHIFT       = db.lookupIntConstant("Klass::_lh_header_size_shift").intValue();
     LH_ARRAY_TAG_SHIFT         = db.lookupIntConstant("Klass::_lh_array_tag_shift").intValue();
@@ -279,4 +281,9 @@ public class Klass extends Metadata implements ClassConstants {
   // The subclasses override this to produce the correct form, eg
   //   Ljava/lang/String; For ArrayKlasses getName itself is the signature.
   public String signature() { return getName().asString(); }
+
+  public static int layoutHelperLog2ElementSize(int lh) {
+    int l2esz = (lh >>> LH_LOG2_ELEMENT_SIZE_SHIFT) & LH_LOG2_ELEMENT_SIZE_MASK;
+    return l2esz;
+  }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/LayoutKind.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/LayoutKind.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, NTT DATA
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package sun.jvm.hotspot.oops;
+
+import sun.jvm.hotspot.runtime.VM;
+import sun.jvm.hotspot.runtime.VMObject;
+import sun.jvm.hotspot.types.Type;
+import sun.jvm.hotspot.types.TypeDataBase;
+import sun.jvm.hotspot.types.WrongTypeException;
+
+
+public final class LayoutKind {
+
+    public static LayoutKind REFERENCE;
+    public static LayoutKind BUFFERED;
+    public static LayoutKind NULL_FREE_NON_ATOMIC_FLAT;
+    public static LayoutKind NULL_FREE_ATOMIC_FLAT;
+    public static LayoutKind NULLABLE_ATOMIC_FLAT;
+    public static LayoutKind NULLABLE_NON_ATOMIC_FLAT;
+    public static LayoutKind UNKNOWN;
+
+    private final int value;
+
+    static {
+        VM.registerVMInitializedObserver((_, _) -> initialize(VM.getVM().getTypeDataBase()));
+    }
+
+    private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
+        Type type = db.lookupType("LayoutKind");
+
+        REFERENCE = new LayoutKind(db.lookupIntConstant("LayoutKind::REFERENCE").intValue());
+        BUFFERED = new LayoutKind(db.lookupIntConstant("LayoutKind::BUFFERED").intValue());
+        NULL_FREE_NON_ATOMIC_FLAT = new LayoutKind(db.lookupIntConstant("LayoutKind::NULL_FREE_NON_ATOMIC_FLAT").intValue());
+        NULL_FREE_ATOMIC_FLAT = new LayoutKind(db.lookupIntConstant("LayoutKind::NULL_FREE_ATOMIC_FLAT").intValue());
+        NULLABLE_ATOMIC_FLAT = new LayoutKind(db.lookupIntConstant("LayoutKind::NULLABLE_ATOMIC_FLAT").intValue());
+        NULLABLE_NON_ATOMIC_FLAT = new LayoutKind(db.lookupIntConstant("LayoutKind::NULLABLE_NON_ATOMIC_FLAT").intValue());
+        UNKNOWN = new LayoutKind(db.lookupIntConstant("LayoutKind::UNKNOWN").intValue());
+    }
+
+    private LayoutKind(int value) {
+        this.value = value;
+    }
+
+    public static LayoutKind valueOf(int rawValue) {
+        if (rawValue == REFERENCE.value) {
+            return REFERENCE;
+        } else if (rawValue == BUFFERED.value) {
+            return BUFFERED;
+        } else if (rawValue == NULL_FREE_NON_ATOMIC_FLAT.value) {
+            return NULL_FREE_NON_ATOMIC_FLAT;
+        } else if (rawValue == NULL_FREE_ATOMIC_FLAT.value) {
+            return NULL_FREE_ATOMIC_FLAT;
+        } else if (rawValue == NULLABLE_ATOMIC_FLAT.value) {
+            return NULLABLE_ATOMIC_FLAT;
+        } else if (rawValue == NULLABLE_NON_ATOMIC_FLAT.value) {
+            return NULLABLE_NON_ATOMIC_FLAT;
+        } else if (rawValue == UNKNOWN.value) {
+            return UNKNOWN;
+        } else {
+            throw new IllegalArgumentException("Out of range");
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof LayoutKind k) {
+            return k.value == this.value;
+        }
+        return false;
+    }
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/LayoutKindHelper.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/LayoutKindHelper.java
@@ -24,41 +24,12 @@
  */
 package sun.jvm.hotspot.oops;
 
-import sun.jvm.hotspot.debugger.Address;
-import sun.jvm.hotspot.runtime.VM;
-import sun.jvm.hotspot.runtime.VMObject;
-import sun.jvm.hotspot.types.Type;
-import sun.jvm.hotspot.types.TypeDataBase;
-import sun.jvm.hotspot.types.WrongTypeException;
 
+public class LayoutKindHelper {
 
-public class ValueFieldLayoutInfo extends VMObject {
-
-    private static MetadataField klassField;
-    private static CIntField kindField;
-
-    static {
-        VM.registerVMInitializedObserver((_, _) -> initialize(VM.getVM().getTypeDataBase()));
-    }
-
-    private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
-        Type type = db.lookupType("ValueFieldLayoutInfo");
-
-        klassField = new MetadataField(type.getAddressField("_klass"), 0);
-        kindField = new CIntField(type.getCIntegerField("_kind"), 0);
-    }
-
-    public ValueFieldLayoutInfo(Address addr) {
-        super(addr);
-    }
-
-    public ValueKlass getKlass() {
-        return (ValueKlass)klassField.getValue(this);
-    }
-
-    public LayoutKind getKind() {
-        int rawVal = (int)kindField.getValue(this);
-        return LayoutKind.valueOf(rawVal);
+    public static boolean isNullableFlat(LayoutKind layoutKind) {
+        return layoutKind.equals(LayoutKind.NULLABLE_ATOMIC_FLAT) ||
+               layoutKind.equals(LayoutKind.NULLABLE_NON_ATOMIC_FLAT);
     }
 
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjArray.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,9 +73,7 @@ public class ObjArray extends Array {
     tty.print("ObjArray");
   }
 
-  public void iterateFields(OopVisitor visitor, boolean doVMFields) {
-    super.iterateFields(visitor, doVMFields);
-    int length = (int) getLength();
+  protected void iterateFieldsInternal(OopVisitor visitor, int length) {
     long baseOffset = baseOffsetInBytes(BasicType.T_OBJECT);
     for (int index = 0; index < length; index++) {
       long offset = baseOffset + (index * elementSize);
@@ -87,5 +85,11 @@ public class ObjArray extends Array {
       }
       visitor.doOop(field, false);
     }
+  }
+
+  public void iterateFields(OopVisitor visitor, boolean doVMFields) {
+    super.iterateFields(visitor, doVMFields);
+    int length = (int) getLength();
+    iterateFieldsInternal(visitor, length);
   }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
@@ -199,13 +199,25 @@ public class ObjectHeap {
 
   // This method is used to instantiate a holder object that contains
   // the flattened field payload.
-  public Oop newOop(Address payload, ValueKlass klass, OopField field) {
-    if (Assert.ASSERTS_ENABLED) {
-      Assert.that(payload != null, "payload should not be null");
+  public Oop newFlattenedOop(Oop obj, OopField field) {
+    ValueKlass vk;
+    boolean needNullCheck = false;
+    if (obj.isArray() && ((Array)obj).isFlatArray()) {
+      FlatArrayKlass k = (FlatArrayKlass)obj.getKlass();
+      vk = (ValueKlass)k.getElementKlass();
+      needNullCheck = LayoutKindHelper.isNullableFlat(k.getLayoutKind());
+    } else {
+      var layout = ((InstanceKlass)obj.getKlass()).getValueFieldLayoutInfoArray().at(field.getFieldIndex());
+      vk = layout.getKlass();
+      needNullCheck = field.hasNullMarker();
     }
-    return field.hasNullMarker() && klass.isPayloadMarkedAsNull(payload)
+
+    // OopHandle does not allow to call addOffsetTo() due to prevent interior
+    // object pointers. So addOffsetToAsOopHandle() is required here.
+    Address payload = obj.getHandle().addOffsetToAsOopHandle(field.getOffset());
+    return needNullCheck && vk.isPayloadMarkedAsNull(payload)
                ? null
-               : new FlattenedValue(payload, this, klass);
+               : new FlattenedValue(payload, this, vk);
   }
 
   // Print all objects in the object heap

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/OopField.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/OopField.java
@@ -48,14 +48,14 @@ public class OopField extends Field {
       throw new InternalError();
     }
     var heap = obj.getHeap();
-    if (isFlat()) {
-      var layout = ((InstanceKlass)obj.getKlass()).getValueFieldLayoutInfoArray().at(getFieldIndex());
-      ValueKlass vk = layout.getKlass();
-
-      // OopHandle does not allow to call addOffsetTo() due to prevent interior
-      // object pointers. So addOffsetToAsOopHandle() is required here.
-      Address payload = obj.getHandle().addOffsetToAsOopHandle(getOffset());
-      return heap.newOop(payload, vk, this);
+    if (obj.isArray()) {
+      if (((Array)obj).isFlatArray()) {
+        return heap.newFlattenedOop(obj, this);
+      } else {
+        return heap.newOop(getValueAsOopHandle(obj));
+      }
+    } else if (isFlat()) {
+      return heap.newFlattenedOop(obj, this);
     } else {
       return heap.newOop(getValueAsOopHandle(obj));
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/BasicType.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/BasicType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ public class BasicType {
   public static final BasicType T_OBJECT = new BasicType();
   public static final BasicType T_ARRAY = new BasicType();
   public static final BasicType T_VOID = new BasicType();
+  public static final BasicType T_FLAT_ELEMENT = new BasicType();
   public static final BasicType T_ADDRESS = new BasicType();
   public static final BasicType T_NARROWOOP = new BasicType();
   public static final BasicType T_METADATA = new BasicType();

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbInspectWithValueObject.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbInspectWithValueObject.java
@@ -77,7 +77,9 @@ public class ClhsdbInspectWithValueObject {
             var cmds = List.of(
                 "inspect " + addresses.getProperty("valObj"),
                 "inspect " + addresses.getProperty("nonNullValObj"),
-                "inspect " + addresses.getProperty("nonFlattenedValObj")
+                "inspect " + addresses.getProperty("nonFlattenedValObj"),
+                "inspect " + addresses.getProperty("valObjArray"),
+                "inspect " + addresses.getProperty("nonFlattenedValObjArray")
             );
 
             var expStrMap = Map.of(
@@ -97,6 +99,28 @@ public class ClhsdbInspectWithValueObject {
               cmds.get(2) /* nonFlattenedValObj */ , List.of(
                 "a: 100",
                 "obj: Oop for java/lang/Object"
+              ),
+              cmds.get(3) /* valObjArray */ , List.of(
+                "0:",
+                  "a: 1",
+                  "rec:",
+                    "recA: 10",
+                    "recB: 20",
+                  "nullField: null",
+                "1:",
+                  "a: 2",
+                  "rec:",
+                    "recA: 30",
+                    "recB: 40",
+                  "nullField: null"
+              ),
+              cmds.get(4) /* nonFlattenedValObjArray */ , List.of(
+                "0:",
+                  "a: 100",
+                  "obj: Oop for java/lang/Object",
+                "1:",
+                  "a: 200",
+                  "obj: Oop for java/lang/Object"
               )
             );
             test.run(theApp.getPid(), cmds, expStrMap, null);

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithValueObject.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithValueObject.java
@@ -83,10 +83,23 @@ public class LingeredAppWithValueObject extends LingeredApp {
 
     private static NonFlattenedValueObj nonFlattenedValObj;
 
+    private static ValueObj[] valObjArray;
+
+    private static NonFlattenedValueObj[] nonFlattenedValObjArray;
+
     static {
         valObj = new ValueObj((byte)1, (byte)10, (byte)20);
         nonNullValObj = new NonNullValueObj((byte)2, (byte)30, (byte)40);
         nonFlattenedValObj = new NonFlattenedValueObj(100, new Object());
+
+        valObjArray = new ValueObj[] {
+          new ValueObj((byte)1, (byte)10, (byte)20),
+          new ValueObj((byte)2, (byte)30, (byte)40)
+        };
+        nonFlattenedValObjArray = new NonFlattenedValueObj[] {
+          new NonFlattenedValueObj(100, new Object()),
+          new NonFlattenedValueObj(200, new Object())
+        };
     }
 
     public static void main(String[] args) {
@@ -95,6 +108,8 @@ public class LingeredAppWithValueObject extends LingeredApp {
         addresses.setProperty("valObj", String.format("0x%x", wb.getObjectAddress(valObj)));
         addresses.setProperty("nonNullValObj", String.format("0x%x", wb.getObjectAddress(nonNullValObj)));
         addresses.setProperty("nonFlattenedValObj", String.format("0x%x", wb.getObjectAddress(nonFlattenedValObj)));
+        addresses.setProperty("valObjArray", String.format("0x%x", wb.getObjectAddress(valObjArray)));
+        addresses.setProperty("nonFlattenedValObjArray", String.format("0x%x", wb.getObjectAddress(nonFlattenedValObjArray)));
 
         try (var out = Files.newOutputStream(ADDR_FILE_PATH)) {
             addresses.store(out, null);


### PR DESCRIPTION
Valhalla introduced new array type which hosts flattened value object, however SA cannot inspect it.
Actually `FlatArray.iterateFields()` has following lines:

```java
for (int index = 0; index < length; index++) {
    // FIXME - call visitor.doXXX() for each component of each value object
}
```

This PR addressed it.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381336](https://bugs.openjdk.org/browse/JDK-8381336): SA FlatArray support is incomplete (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32849/head:pull/32849` \
`$ git checkout pull/32849`

Update a local copy of the PR: \
`$ git checkout pull/32849` \
`$ git pull https://git.openjdk.org/jdk.git pull/32849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32849`

View PR using the GUI difftool: \
`$ git pr show -t 32849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32849.diff">https://git.openjdk.org/jdk/pull/32849.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32849#issuecomment-5644121670)
</details>
