### PR TITLE
8373730: Missing identity optimization in arithmetic Or

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -964,6 +964,17 @@ Node* OrINode::Identity(PhaseGVN* phase) {
     return in(1);
   }
 
+  // x | (y | x) => y | x
+  if (in(2)->Opcode() == Op_OrI &&
+      (in(2)->in(1) == in(1) || in(2)->in(2) == in(1))) {
+    return in(2);
+  }
+  // (x | y) | x => x | y
+  if (in(1)->Opcode() == Op_OrI &&
+      (in(1)->in(1) == in(2) || in(1)->in(2) == in(2))) {
+    return in(1);
+  }
+
   return AddNode::Identity(phase);
 }
 
@@ -1034,6 +1045,17 @@ const Type* OrINode::add_ring(const Type* t1, const Type* t2) const {
 Node* OrLNode::Identity(PhaseGVN* phase) {
   // x | x => x
   if (in(1) == in(2)) {
+    return in(1);
+  }
+
+  // x | (y | x) => y | x
+  if (in(2)->Opcode() == Op_OrL &&
+      (in(2)->in(1) == in(1) || in(2)->in(2) == in(1))) {
+    return in(2);
+  }
+  // (x | y) | x => x | y
+  if (in(1)->Opcode() == Op_OrL &&
+      (in(1)->in(1) == in(2) || in(1)->in(2) == in(2))) {
     return in(1);
   }
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
@@ -38,7 +38,7 @@ public class OrINodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test1", "test2", "test3" })
+    @Run(test = { "test1", "test2", "test3", "test4", "test5" })
     public void runMethod() {
         int a = RunInfo.getRandom().nextInt();
         int b = RunInfo.getRandom().nextInt();
@@ -57,6 +57,8 @@ public class OrINodeIdealizationTests {
         Asserts.assertEQ((~a) | (~b), test1(a, b));
         Asserts.assertEQ((a | 3) | 6, test2(a));
         Asserts.assertEQ((a | 3) | a, test3(a));
+        Asserts.assertEQ(a | b, test4(a, b));
+        Asserts.assertEQ(a | b, test5(a, b));
     }
 
     // Checks (~a) | (~b) => ~(a & b)
@@ -80,5 +82,19 @@ public class OrINodeIdealizationTests {
     @IR(counts = { IRNode.OR, "1"})
     public int test3(int a) {
         return (a | 3) | a;
+    }
+
+    // Checks a | (b | a) => a | b
+    @Test
+    @IR(counts = { IRNode.OR, "1" })
+    public int test4(int a, int b) {
+        return a | (b | a);
+    }
+
+    // Checks (a | b) | a => a | b
+    @Test
+    @IR(counts = { IRNode.OR, "1" })
+    public int test5(int a, int b) {
+        return (a | b) | a;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
@@ -38,7 +38,7 @@ public class OrINodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test1", "test2", "test3", "test4", "test5" })
+    @Run(test = { "test1", "test2", "test3", "test4", "test5", "test6", "test7" })
     public void runMethod() {
         int a = RunInfo.getRandom().nextInt();
         int b = RunInfo.getRandom().nextInt();
@@ -57,8 +57,10 @@ public class OrINodeIdealizationTests {
         Asserts.assertEQ((~a) | (~b), test1(a, b));
         Asserts.assertEQ((a | 3) | 6, test2(a));
         Asserts.assertEQ((a | 3) | a, test3(a));
-        Asserts.assertEQ(a | b, test4(a, b));
-        Asserts.assertEQ(a | b, test5(a, b));
+        Asserts.assertEQ(a | (b | a), test4(a, b));
+        Asserts.assertEQ((a | b) | a, test5(a, b));
+        Asserts.assertEQ((a | 0) | a, test6(a));
+        Asserts.assertEQ(a | (a | 0), test7(a));
     }
 
     // Checks (~a) | (~b) => ~(a & b)
@@ -96,5 +98,19 @@ public class OrINodeIdealizationTests {
     @IR(counts = { IRNode.OR, "1" })
     public int test5(int a, int b) {
         return (a | b) | a;
+    }
+
+    // Checks (a | 0) | a => a | a => a
+    @Test
+    @IR(failOn = { IRNode.OR })
+    public int test6(int a) {
+        return (a | 0) | a;
+    }
+
+    // Checks a | (a | 0) => a | a => a
+    @Test
+    @IR(failOn = { IRNode.OR })
+    public int test7(int a) {
+        return a | (a | 0);
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
@@ -38,7 +38,7 @@ public class OrLNodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test1", "test2", "test3", "test4", "test5" })
+    @Run(test = { "test1", "test2", "test3", "test4", "test5", "test6", "test7" })
     public void runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();
@@ -57,8 +57,10 @@ public class OrLNodeIdealizationTests {
         Asserts.assertEQ((~a) | (~b), test1(a, b));
         Asserts.assertEQ((a | 3) | 6, test2(a));
         Asserts.assertEQ((a | 3) | a, test3(a));
-        Asserts.assertEQ(a | b, test4(a, b));
-        Asserts.assertEQ(a | b, test5(a, b));
+        Asserts.assertEQ(a | (b | a), test4(a, b));
+        Asserts.assertEQ((a | b) | a, test5(a, b));
+        Asserts.assertEQ((a | 0L) | a, test6(a));
+        Asserts.assertEQ(a | (a | 0L), test7(a));
     }
 
     // Checks (~a) | (~b) => ~(a & b)
@@ -97,5 +99,19 @@ public class OrLNodeIdealizationTests {
     @IR(counts = { IRNode.OR, "1" })
     public long test5(long a, long b) {
         return (a | b) | a;
+    }
+
+    // Checks (a | 0) | a => a | a => a
+    @Test
+    @IR(failOn = { IRNode.OR })
+    public long test6(long a) {
+        return (a | 0L) | a;
+    }
+
+    // Checks a | (a | 0) => a | a => a
+    @Test
+    @IR(failOn = { IRNode.OR })
+    public long test7(long a) {
+        return a | (a | 0L);
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
@@ -38,7 +38,7 @@ public class OrLNodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test1", "test2", "test3" })
+    @Run(test = { "test1", "test2", "test3", "test4", "test5" })
     public void runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();
@@ -57,6 +57,8 @@ public class OrLNodeIdealizationTests {
         Asserts.assertEQ((~a) | (~b), test1(a, b));
         Asserts.assertEQ((a | 3) | 6, test2(a));
         Asserts.assertEQ((a | 3) | a, test3(a));
+        Asserts.assertEQ(a | b, test4(a, b));
+        Asserts.assertEQ(a | b, test5(a, b));
     }
 
     // Checks (~a) | (~b) => ~(a & b)
@@ -81,5 +83,19 @@ public class OrLNodeIdealizationTests {
     @IR(counts = { IRNode.OR, "1"})
     public long test3(long a) {
         return (a | 3) | a;
+    }
+
+    // Checks a | (b | a) => a | b
+    @Test
+    @IR(counts = { IRNode.OR, "1" })
+    public long test4(long a, long b) {
+        return a | (b | a);
+    }
+
+    // Checks (a | b) | a => a | b
+    @Test
+    @IR(counts = { IRNode.OR, "1" })
+    public long test5(long a, long b) {
+        return (a | b) | a;
     }
 }


### PR DESCRIPTION
**Problem:**

C2 performs identity simplification for some `Or` nodes, but it does not simplify expressions with duplicate operands such as:

- `a | (b | a)`
- `a | (a | b)`
- `(a | b) | a`
- `(b | a) | a`

**Fix:**

Add checks to `OrINode::Identity()` and `OrLNode::Identity()` to return the existing inner OR node when either of its operands matches the other operand of the outer OR.

Also add the outer OR to the IGVN worklist when an input of the inner OR changes.

**Testing:**

- Added tests for `a | (b | a)` and `(a | b) | a` in `OrINodeIdealizationTests.java` and `OrLNodeIdealizationTests.java`.
  - Verified the computation results and checked that the C2 IR contains only one OR node.
  - Re-ran with `-XX:+StressIGVN`: 2 passed
- `compiler/c2/irTests`: 114 passed, 0 failed, 8 skipped.

**Performance:**

JMH parameters：`java -cp "<BENCHMARK_CLASSES>:<JMH_HOME>/*" org.openjdk.jmh.Main 'bench.OrIdentityV2.*' -wi 3 -i 5 -w 500ms -r 500ms -f 1 -t 1 -jvmArgs '-Xms256m -Xmx256m -XX:-TieredCompilation -XX:-UseSuperWord -XX:LoopMaxUnroll=1'`

Results:  the affected expressions showed about 20% to 30% lower time per operationafter the change (not represent application-level performance)
| Benchmark | Before | After |
|---|---:|---:|
| int dependent chain | 1.340 ns/op | 1.001 ns/op |
| long dependent chain | 1.341 ns/op | 1.001 ns/op |
| int independent streams | 0.441 ns/op | 0.353 ns/op |
| long independent streams | 0.433 ns/op | 0.324 ns/op |

[OrIdentityV2.java](https://github.com/user-attachments/files/32145950/OrIdentityV2.java)


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8373730](https://bugs.openjdk.org/browse/JDK-8373730): Missing identity optimization in arithmetic Or (**Enhancement** - P4)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32851/head:pull/32851` \
`$ git checkout pull/32851`

Update a local copy of the PR: \
`$ git checkout pull/32851` \
`$ git pull https://git.openjdk.org/jdk.git pull/32851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32851`

View PR using the GUI difftool: \
`$ git pr show -t 32851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32851.diff">https://git.openjdk.org/jdk/pull/32851.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32851#issuecomment-5646844743)
</details>
