### PR TITLE
8392322: RISC-V: Elide memory barriers in C++ atomics under Ztso

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/atomicAccess_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/atomicAccess_linux_riscv.hpp
@@ -32,6 +32,12 @@
 
 // Note that memory_order_conservative requires a full barrier after atomic stores.
 // See https://patchwork.kernel.org/patch/3575821/
+//
+// Under Ztso, loads and stores already have acquire and release semantics
+// respectively, and AMO/LR/SC instructions are inherently sequentially
+// consistent (equivalent to .aqrl).  Only a compiler barrier is needed to
+// prevent the C++ compiler from reordering memory accesses across the
+// atomic operation.
 
 #if defined(__clang_major__)
 #define FULL_COMPILER_ATOMIC_SUPPORT
@@ -51,13 +57,21 @@ struct AtomicAccess::PlatformAdd {
 #endif
 
     if (order != memory_order_relaxed) {
-      FULL_MEM_BARRIER;
+      if (UseZtso) {
+        compiler_barrier();
+      } else {
+        FULL_MEM_BARRIER;
+      }
     }
 
     D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELAXED);
 
     if (order != memory_order_relaxed) {
-      FULL_MEM_BARRIER;
+      if (UseZtso) {
+        compiler_barrier();
+      } else {
+        FULL_MEM_BARRIER;
+      }
     }
     return res;
   }
@@ -78,7 +92,11 @@ inline T AtomicAccess::PlatformCmpxchg<1>::operator()(T volatile* dest __attribu
   STATIC_ASSERT(1 == sizeof(T));
 
   if (order != memory_order_relaxed) {
-    FULL_MEM_BARRIER;
+    if (UseZtso) {
+      compiler_barrier();
+    } else {
+      FULL_MEM_BARRIER;
+    }
   }
 
   uint32_t volatile* aligned_dst = (uint32_t volatile*)(((uintptr_t)dest) & (~((uintptr_t)0x3)));
@@ -107,7 +125,11 @@ inline T AtomicAccess::PlatformCmpxchg<1>::operator()(T volatile* dest __attribu
     : "memory" );
 
   if (order != memory_order_relaxed) {
-    FULL_MEM_BARRIER;
+    if (UseZtso) {
+      compiler_barrier();
+    } else {
+      FULL_MEM_BARRIER;
+    }
   }
 
   return (T)((old_value & mask) >> shift);
@@ -132,7 +154,11 @@ inline T AtomicAccess::PlatformCmpxchg<4>::operator()(T volatile* dest __attribu
   uint64_t rc_temp;
 
   if (order != memory_order_relaxed) {
-    FULL_MEM_BARRIER;
+    if (UseZtso) {
+      compiler_barrier();
+    } else {
+      FULL_MEM_BARRIER;
+    }
   }
 
   __asm__ __volatile__ (
@@ -146,7 +172,11 @@ inline T AtomicAccess::PlatformCmpxchg<4>::operator()(T volatile* dest __attribu
     : "memory" );
 
   if (order != memory_order_relaxed) {
-    FULL_MEM_BARRIER;
+    if (UseZtso) {
+      compiler_barrier();
+    } else {
+      FULL_MEM_BARRIER;
+    }
   }
   return (T)old_value;
 }
@@ -170,13 +200,21 @@ inline T AtomicAccess::PlatformXchg<byte_size>::operator()(T volatile* dest,
   STATIC_ASSERT(byte_size == 4 || byte_size == 8);
 
   if (order != memory_order_relaxed) {
-    FULL_MEM_BARRIER;
+    if (UseZtso) {
+      compiler_barrier();
+    } else {
+      FULL_MEM_BARRIER;
+    }
   }
 
   T res = __atomic_exchange_n(dest, exchange_value, __ATOMIC_RELAXED);
 
   if (order != memory_order_relaxed) {
-    FULL_MEM_BARRIER;
+    if (UseZtso) {
+      compiler_barrier();
+    } else {
+      FULL_MEM_BARRIER;
+    }
   }
   return res;
 }
@@ -195,14 +233,22 @@ inline T AtomicAccess::PlatformCmpxchg<byte_size>::operator()(T volatile* dest _
 
   STATIC_ASSERT(byte_size == sizeof(T));
   if (order != memory_order_relaxed) {
-    FULL_MEM_BARRIER;
+    if (UseZtso) {
+      compiler_barrier();
+    } else {
+      FULL_MEM_BARRIER;
+    }
   }
 
   __atomic_compare_exchange(dest, &compare_value, &exchange_value, /* weak */ false,
                             __ATOMIC_RELAXED, __ATOMIC_RELAXED);
 
   if (order != memory_order_relaxed) {
-    FULL_MEM_BARRIER;
+    if (UseZtso) {
+      compiler_barrier();
+    } else {
+      FULL_MEM_BARRIER;
+    }
   }
   return compare_value;
 }
@@ -211,14 +257,22 @@ template<size_t byte_size>
 struct AtomicAccess::PlatformOrderedLoad<byte_size, X_ACQUIRE>
 {
   template <typename T>
-  T operator()(const volatile T* p) const { T data; __atomic_load(const_cast<T*>(p), &data, __ATOMIC_ACQUIRE); return data; }
+  T operator()(const volatile T* p) const {
+    T data;
+    __atomic_load(const_cast<T*>(p), &data, __ATOMIC_RELAXED);
+    OrderAccess::acquire();
+    return data;
+  }
 };
 
 template<size_t byte_size>
 struct AtomicAccess::PlatformOrderedStore<byte_size, RELEASE_X>
 {
   template <typename T>
-  void operator()(volatile T* p, T v) const { __atomic_store(const_cast<T*>(p), &v, __ATOMIC_RELEASE); }
+  void operator()(volatile T* p, T v) const {
+    OrderAccess::release();
+    __atomic_store(const_cast<T*>(p), &v, __ATOMIC_RELAXED);
+  }
 };
 
 template<size_t byte_size>


### PR DESCRIPTION
Hi, please consider.
Under the Ztso (Total Store Ordering) extension, RISC-V provides much stronger memory ordering guarantees than the default WMO model:
  - All loads implicitly have acquire semantics
  - All stores implicitly have release semantics
  - AMOs behave as if they have both acquire-RCsc and release-RCsc semantics.

LR/SC operations do not receive the same RCsc ordering as AMOs. In particular, they do not provide the StoreLoad ordering required by `memory_order_conservative`.

The JIT-generated code already takes advantage of Ztso through `MacroAssembler::membar()` and `BarrierSetAssembler`. However, the C++ runtime atomic implementation in `atomicAccess_linux_riscv.hpp` still emits hardware fences around atomic operations that are already sufficiently ordered under Ztso.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392322](https://bugs.openjdk.org/browse/JDK-8392322): RISC-V: Elide memory barriers in C++ atomics under Ztso (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32852/head:pull/32852` \
`$ git checkout pull/32852`

Update a local copy of the PR: \
`$ git checkout pull/32852` \
`$ git pull https://git.openjdk.org/jdk.git pull/32852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32852`

View PR using the GUI difftool: \
`$ git pr show -t 32852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32852.diff">https://git.openjdk.org/jdk/pull/32852.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32852#issuecomment-5647392864)
</details>
