### PR TITLE
8392325: JFR parser reads empty string as null

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/StringParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/StringParser.java
@@ -59,7 +59,7 @@ public final class StringParser extends Parser {
 
     private static final class CharsetParser extends Parser {
         private final Charset charset;
-        private int lastSize;
+        private int lastSize = -1;
         private byte[] buffer = new byte[16];
         private String lastString;
 

--- a/test/jdk/jdk/jfr/api/consumer/TestParseEmptyString.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestParseEmptyString.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.api.consumer;
+
+import java.nio.file.Path;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+import jdk.jfr.consumer.RecordingFile;
+import jdk.jfr.internal.JVM;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @bug 8392325
+ * @summary Tests that an empty string is not parsed as null
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @modules jdk.jfr/jdk.jfr.internal
+ * @run main/othervm jdk.jfr.api.consumer.TestParseEmptyString
+ */
+public class TestParseEmptyString {
+
+    public static void main(String[] args) throws Exception {
+        Path file = Utils.createTempFile("empty-string", ".jfr");
+
+        try (Recording r = new Recording()) {
+            r.enable("jdk.ThreadStart");
+            r.start();
+
+            Thread t1 = new Thread(new ThreadGroup(""), "");
+            t1.start();
+            t1.join();
+
+            // Flush is needed to make the empty string appear first in the parse order
+            JVM.flush();
+
+            Thread t2 = new Thread(new ThreadGroup(""), "");
+            t2.start();
+            t2.join();
+
+            r.dump(file);
+        }
+
+        boolean found = false;
+        for (RecordedEvent e : RecordingFile.readAllEvents(file)) {
+            if (e.getEventType().getName().equals("jdk.ThreadStart")) {
+                RecordedThread t = e.getThread("thread");
+                if (t.getJavaName().isEmpty()) {
+                    Asserts.assertEquals("", t.getThreadGroup().getName());
+                    found = true;
+                }
+            }
+        }
+        Asserts.assertTrue(found, "There should be a thread with empty name");
+    }
+}


### PR DESCRIPTION
If the first string in the JFR constant pool is empty, jdk.jfr.consumer API incorrectly reads it as `null`.
This is because CharsetParser's initial state is `lastSize=0; lastString=null` which results in a false-positive hit.

The fix is to initialize `lastSize = -1` similarly to what `CharArrayParser` already does.

Added a regression test that produces a recording with an empty string in the pool. The test fails without a fix but passes with the fix applied.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392325](https://bugs.openjdk.org/browse/JDK-8392325): JFR parser reads empty string as null (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32853/head:pull/32853` \
`$ git checkout pull/32853`

Update a local copy of the PR: \
`$ git checkout pull/32853` \
`$ git pull https://git.openjdk.org/jdk.git pull/32853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32853`

View PR using the GUI difftool: \
`$ git pr show -t 32853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32853.diff">https://git.openjdk.org/jdk/pull/32853.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32853#issuecomment-5649849325)
</details>
