### PR TITLE
8066259: [macosx] Possible regression: test/java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java failure

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -246,7 +246,6 @@ java/awt/Modal/FileDialog/FileDialogTKModal4Test.java 8196430 generic-all
 java/awt/Modal/FileDialog/FileDialogTKModal5Test.java 8196430 generic-all
 java/awt/Modal/FileDialog/FileDialogTKModal6Test.java 8196430 generic-all
 java/awt/Modal/FileDialog/FileDialogTKModal7Test.java 8196430 macosx-all
-java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java 8066259 macosx-all
 java/awt/Modal/ModalExclusionTests/ApplicationExcludeFrameFileTest.java 8047179 linux-all,macosx-all
 java/awt/Modal/ModalExclusionTests/ApplicationExcludeDialogFileTest.java 8047179 linux-all,macosx-all
 java/awt/Modal/ModalExclusionTests/ApplicationExcludeDialogPageSetupTest.java 8196431 linux-all,macosx-all

--- a/test/jdk/java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java
+++ b/test/jdk/java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,10 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.event.InputEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowAdapter;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @test
@@ -43,6 +47,7 @@ public class ModalDialogOrderingTest {
 
     private static final Color DIALOG_COLOR = Color.GREEN;
     private static final Color FRAME_COLOR = Color.BLUE;
+    private static final CountDownLatch dialogOpened = new CountDownLatch(1);
 
     public static void main(String[] args) {
 
@@ -51,12 +56,19 @@ public class ModalDialogOrderingTest {
         frame.setBackground(FRAME_COLOR);
         frame.setVisible(true);
 
+
         final Dialog modalDialog = new Dialog(null, true);
         modalDialog.setTitle("Modal Dialog");
         modalDialog.setSize(400, 200);
         modalDialog.setBackground(DIALOG_COLOR);
         modalDialog.setModal(true);
 
+        modalDialog.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowOpened(WindowEvent e) {
+                dialogOpened.countDown();
+            }
+        });
         new Thread(new Runnable() {
 
             @Override
@@ -68,15 +80,23 @@ public class ModalDialogOrderingTest {
         modalDialog.setVisible(true);
     }
 
+    private static boolean isDialogColor(Color color) {
+        int tolerance = 5;
+        return Math.abs(DIALOG_COLOR.getRed() - color.getRed()) <= tolerance
+                   && Math.abs(DIALOG_COLOR.getGreen() - color.getGreen()) <= tolerance
+                   && Math.abs(DIALOG_COLOR.getBlue() - color.getBlue()) <= tolerance;
+    }
+
     private static void runTest(Dialog dialog, Frame frame) {
         try {
             ExtendedRobot robot = new ExtendedRobot();
             robot.setAutoDelay(50);
             robot.mouseMove(300, 300);
 
-            while (!dialog.isVisible()) {
-                robot.waitForIdle(1000);
+            if (!dialogOpened.await(10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Modal dialog did not gain focus");
             }
+            robot.waitForIdle(1000);
 
             Rectangle dialogBounds = dialog.getBounds();
             Rectangle frameBounds = frame.getBounds();
@@ -97,8 +117,12 @@ public class ModalDialogOrderingTest {
 
             Color color = robot.getPixelColor(colorX, colorY);
 
-
-            if (!DIALOG_COLOR.equals(color)) {
+            if (!isDialogColor(color)) {
+                System.out.println("color " + color + "frame.isActive" +
+                                    frame.isActive() +
+                                    " frame.isFocused() " + frame.isFocused() +
+                                    " dialog.isActive "+ dialog.isActive() +
+                                    " dialog.isFocused" + dialog.isFocused());
                 throw new RuntimeException("The frame is on top"
                         + " of the modal dialog!");
             }else{

--- a/test/jdk/java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java
+++ b/test/jdk/java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java
@@ -94,7 +94,7 @@ public class ModalDialogOrderingTest {
             robot.mouseMove(300, 300);
 
             if (!dialogOpened.await(10, TimeUnit.SECONDS)) {
-                throw new RuntimeException("Modal dialog did not gain focus");
+                throw new RuntimeException("Modal dialog was not opened");
             }
             robot.waitForIdle(1000);
 


### PR DESCRIPTION
Test shows a Frame and then an application-modal Dialog, clicks at middle of the frame and samples a pixel at dialog's center. 
The frame should remain blocked and behind the modal dialog so expected pixel color should be DIalog's GREEN color but fails in macos owing to minor color difference `java.awt.Color[r=3,g=255,b=0] `
so added a tolerance fix
but then found it fails 2 out of 50 iterations citing java.awt.Color[r=0,g=0,b=255] due to race
so added a CountDownLatch to make it deterministic so that it waits for the dialog to become focused/active before doing the  click which passes for 100 iterations

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8066259](https://bugs.openjdk.org/browse/JDK-8066259): [macosx] Possible regression: test/java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java failure (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32854/head:pull/32854` \
`$ git checkout pull/32854`

Update a local copy of the PR: \
`$ git checkout pull/32854` \
`$ git pull https://git.openjdk.org/jdk.git pull/32854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32854`

View PR using the GUI difftool: \
`$ git pr show -t 32854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32854.diff">https://git.openjdk.org/jdk/pull/32854.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/32854#issuecomment-5653009329)
</details>
