### PR TITLE
8342708: C2: implement parallel iv for long counted loops

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4601,9 +4601,11 @@ bool PhaseIdealLoop::is_deleteable_safept(Node* sfpt) const {
 //     long iv2 = ((long) iv * stride_con2 / stride_con) + (init2 - ((long) init * stride_con2 / stride_con))
 //
 void PhaseIdealLoop::replace_parallel_iv(IdealLoopTree *loop) {
-  assert(loop->_head->is_CountedLoop(), "");
-  CountedLoopNode *cl = loop->_head->as_CountedLoop();
-  if (!cl->is_valid_counted_loop(T_INT)) {
+  assert(loop->_head->is_CountedLoop() || loop->_head->is_LongCountedLoop(), "");
+
+  BaseCountedLoopNode* cl = loop->_head->as_BaseCountedLoop();
+  BasicType bt = cl->bt();
+  if (!cl->is_valid_counted_loop(bt)) {
     return;         // skip malformed counted loop
   }
   Node *incr = cl->incr();
@@ -4666,6 +4668,33 @@ void PhaseIdealLoop::replace_parallel_iv(IdealLoopTree *loop) {
     // also easy to handle.
     jlong ratio_con = stride_con2 / stride_con;
 
+    // Our ultimate goal is to know if above division is exact (i.e., remainder = 0), we verify this
+    // by reversing it into multiplication and check for exact equal.
+    //
+    // However, we need to first prove there is no overflow by reversing the division:
+    //         stride_con2 = ratio_con * stride_con + remainder
+    //
+    // with known properties:
+    //     (1) |remainder| < |stride_con|
+    //     (2) remainder has the same sign as stride_con2 (truncation towards zero)
+    //
+    // after rearranging, we have:
+    //     (3) stride_con2 - remainder = ratio_con * stride_con
+    //
+    // Because of (2), subtracting remainder moves the result towards zero:
+    //     (a)    stride_con2 >= 0 && remainder >= 0
+    //         -> 0 <= stride_con2 - remainder <= stride_con2
+    //     (b)    stride_con2 < 0 && remainder <= 0
+    //         -> 0 >  stride_con2 - remainder >= stride_con2
+    // Or:
+    //     (4) |stride_con2 - remainder| <= |stride_con2|
+    //
+    // Substitute (3) into (4):
+    //         |ratio_con * stride_con| <= |stride_con2|
+    //
+    // Because stride_con2 is always within jlong range, we have proven ratio_con * stride_con is
+    // also always within jlong range, enabling us to check for exact division naively without
+    // overflowing:
     if ((ratio_con * stride_con) != stride_con2) { // Check for exact (no remainder)
         continue;
     }
@@ -4779,6 +4808,29 @@ void IdealLoopTree::counted_loop( PhaseIdealLoop *phase ) {
     phase->replace_parallel_iv(this);
   } else if (_head->is_LongCountedLoop() || phase->try_convert_to_counted_loop(_head, loop, T_LONG)) {
     remove_safepoints(phase, true);
+#ifndef PRODUCT
+    if (TraceLoopOpts) {
+      tty->print_cr("=== LongCountedLoop shape ===");
+      dump_head();
+      tty->print_cr("--- head and outs (depth 2) ---");
+      _head->dump(2);
+      tty->print_cr("--- all phis ---");
+      for (DUIterator i = _head->outs(); _head->has_out(i); i++) {
+        Node* out = _head->out(i);
+        if (out->is_Phi()) {
+          tty->print("  phi: ");
+          out->dump();
+          tty->print("    back edge: ");
+          out->in(LoopNode::LoopBackControl)->dump();
+        }
+      }
+      tty->print_cr("=== end LongCountedLoop shape ===");
+    }
+#endif
+
+    //if (UseNewCode) {
+    phase->replace_parallel_iv(this);
+    //}
   } else {
     // When StressCountedLoop is enabled, this loop may intentionally avoid a counted loop conversion.
     // This is expected behavior for the stress mode, which exercises alternative compilation paths.

--- a/test/hotspot/jtreg/compiler/loopopts/parallel_iv/TestLongParallelIVShape.java
+++ b/test/hotspot/jtreg/compiler/loopopts/parallel_iv/TestLongParallelIVShape.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 IBM and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Dump long counted loop shape for parallel IV analysis
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+TraceLoopOpts
+ *                   -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,TestLongParallelIVShape::test*
+ *                   TestLongParallelIVShape
+ */
+public class TestLongParallelIVShape {
+
+    static volatile long stopField = 1000;
+
+    static long testLongLoopLongIV(long stop) {
+        long a = 0;
+        for (long i = 0; i < stop; i++) {
+            a += 42;
+        }
+        return a;
+    }
+
+    static int testLongLoopIntIV(long stop) {
+        int a = 0;
+        for (long i = 0; i < stop; i++) {
+            a += 42;
+        }
+        return a;
+    }
+
+    static long testLongLoopTwoIVs(long stop) {
+        long a = 0;
+        long b = 0;
+        for (long i = 0; i < stop; i++) {
+            a += 42;
+            b += 7;
+        }
+        return a + b;
+    }
+
+    static long testLongLoopHugeStride(long stop) {
+        long a = 0;
+        for (long i = 0; i < stop; i++) {
+            a += 3_000_000_000L;
+        }
+        return a;
+    }
+
+    public static void main(String[] args) {
+        long stop = stopField;
+        for (int i = 0; i < 20_000; i++) {
+            testLongLoopLongIV(stop);
+            // testLongLoopIntIV(stop);
+            // testLongLoopTwoIVs(stop);
+            // testLongLoopHugeStride(stop);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements both int and long parallel IVs for long counted loops. Existing code for parallel iv replacement is sufficient to handle long counted loops without overflow. This PR generalize counted loop handling and add comments to clarify.

---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8342708](https://bugs.openjdk.org/browse/JDK-8342708): C2: implement parallel iv for long counted loops (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/32989/head:pull/32989` \
`$ git checkout pull/32989`

Update a local copy of the PR: \
`$ git checkout pull/32989` \
`$ git pull https://git.openjdk.org/jdk.git pull/32989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32989`

View PR using the GUI difftool: \
`$ git pr show -t 32989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/32989.diff">https://git.openjdk.org/jdk/pull/32989.diff</a>

</details>
